### PR TITLE
feature: WEOS-1365 Add default handler returned content type based on content type in example 

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -31,6 +31,7 @@ const SORTS ContextKey = "_sorts"
 const PAYLOAD ContextKey = "_payload"
 const SEQUENCE_NO string = "sequence_no"
 const RESPONSE_PREFIX string = "_httpstatus"
+const ACCEPT string = "Accept"
 
 //Path initializers are run per path and can be used to configure routes that are not defined in the open api spec
 const METHODS_FOUND ContextKey = "_methods_found"

--- a/controllers/rest/controller_standard.go
+++ b/controllers/rest/controller_standard.go
@@ -687,6 +687,9 @@ func DefaultResponseMiddleware(api *RESTAPI, projection projections.Projection, 
 								if mediaType == "text/javascript" {
 									return ctxt.String(respCode, content.Example.(string))
 								}
+								if mediaType == "text/plain" {
+									return ctxt.String(respCode, resp.Value.Content[mediaType].Example.(string))
+								}
 
 							}
 						}
@@ -710,6 +713,9 @@ func DefaultResponseMiddleware(api *RESTAPI, projection projections.Projection, 
 									return ctxt.HTML(respCode, resp.Value.Content[mediaType].Example.(string))
 								}
 								if mediaType == "text/javascript" {
+									return ctxt.String(respCode, resp.Value.Content[mediaType].Example.(string))
+								}
+								if mediaType == "text/plain" {
 									return ctxt.String(respCode, resp.Value.Content[mediaType].Example.(string))
 								}
 

--- a/controllers/rest/controller_standard.go
+++ b/controllers/rest/controller_standard.go
@@ -678,19 +678,14 @@ func DefaultResponseMiddleware(api *RESTAPI, projection projections.Projection, 
 					if len(resp.Value.Content) == 1 {
 						for mediaType, content := range resp.Value.Content {
 							if content.Example != nil {
-								if mediaType == "application/json" {
-									return ctxt.JSON(respCode, content.Example)
-								}
-								if mediaType == "text/html" {
-									return ctxt.HTML(respCode, content.Example.(string))
-								}
-								if mediaType == "text/javascript" {
-									return ctxt.String(respCode, content.Example.(string))
-								}
-								if mediaType == "text/plain" {
-									return ctxt.String(respCode, resp.Value.Content[mediaType].Example.(string))
-								}
+								var bytesArray []byte
+								bytesArray, err := json.Marshal(content.Example)
+								if err != nil {
+									api.e.Logger.Errorf("unexpected error %s ", err)
+									return NewControllerError(fmt.Sprintf("unexpected error %s ", err), err, http.StatusBadRequest)
 
+								}
+								return ctxt.Blob(respCode, mediaType, bytesArray)
 							}
 						}
 						//check for if there are multiple mediatype
@@ -706,19 +701,14 @@ func DefaultResponseMiddleware(api *RESTAPI, projection projections.Projection, 
 							return NewControllerError(fmt.Sprintf("unexpected error %s media type not found", mediaType), nil, http.StatusBadRequest)
 						} else {
 							if resp.Value.Content[mediaType].Example != nil {
-								if mediaType == "application/json" {
-									return ctxt.JSON(respCode, resp.Value.Content[mediaType].Example)
-								}
-								if mediaType == "text/html" {
-									return ctxt.HTML(respCode, resp.Value.Content[mediaType].Example.(string))
-								}
-								if mediaType == "text/javascript" {
-									return ctxt.String(respCode, resp.Value.Content[mediaType].Example.(string))
-								}
-								if mediaType == "text/plain" {
-									return ctxt.String(respCode, resp.Value.Content[mediaType].Example.(string))
-								}
+								var bytesArray []byte
+								bytesArray, err := json.Marshal(resp.Value.Content[mediaType].Example)
+								if err != nil {
+									api.e.Logger.Errorf("unexpected error %s ", err)
+									return NewControllerError(fmt.Sprintf("unexpected error %s ", err), err, http.StatusBadRequest)
 
+								}
+								return ctxt.Blob(respCode, mediaType, bytesArray)
 							}
 						}
 					}

--- a/controllers/rest/fixtures/blog.yaml
+++ b/controllers/rest/fixtures/blog.yaml
@@ -109,6 +109,57 @@ components:
           type: string
           format: date-time
 paths:
+  /:
+    get:
+      operationId: Homepage
+      responses:
+        200:
+          description: Application Homepage
+          content:
+            text/html:
+              example: |
+                <html>
+                  <head>
+                      <title>Health</title>
+                  </head>
+                  <body>
+                    This is a landing page
+                  </body>
+                </html>
+  /page:
+    get:
+      summary: Test
+      parameters:
+        - in: header
+          name: Accept
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Test Page
+          content:
+            text/html:
+              example: |
+                <html>
+                  <head>
+                      <title>Test Page</title>
+                  </head>
+                  <body>
+                    This is a test page
+                  </body>
+                </html>
+              schema:
+                type: string
+            application/json:
+              example:
+                blog:
+                  value: {
+                    "title": "API Testing",
+                    "url": "www.example.com",
+                    "email": "testing@example.com"
+                  }
+              schema:
+                $ref: "#/components/schemas/Blog"
   /health:
     summary: Health Check
     get:


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**

-Added middleware that has functionality to get content type and accept head and return the correct content type
-MediaType supported are: application/json, text/html, text/plain, text/javascript
* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**: