### PR TITLE
feat: dual-projection architecture for abstract resource types

### DIFF
--- a/application/event_handlers.go
+++ b/application/event_handlers.go
@@ -113,13 +113,10 @@ func subscribeResourceTypeHandlers(
 	)
 }
 
-// ensureProjection decides whether to create a projection table or register as a
-// subtype of an abstract parent. Abstract types get their own table. Concrete types
-// with rdfs:subClassOf pointing to an abstract parent register as subtypes (their
-// columns are merged into the parent's table). All other concrete types get their own
-// table. If the parent referenced by rdfs:subClassOf is not found, the type falls back
-// to getting its own standalone table. Infrastructure errors are propagated to avoid
-// creating the wrong table topology.
+// ensureProjection creates a projection table for the given type and, if the
+// type declares rdfs:subClassOf, also ensures the parent's table exists.
+// Every type (abstract or concrete) gets its own table. Ancestor tables are
+// populated at resource-event time via dual-projection in the repository.
 func ensureProjection(
 	ctx context.Context,
 	rtRepo repositories.ResourceTypeRepository,
@@ -127,31 +124,22 @@ func ensureProjection(
 	slug string,
 	schema, ldContext json.RawMessage,
 ) error {
-	// Abstract types always get their own projection table.
-	if jsonld.IsAbstract(ldContext) {
-		return projMgr.EnsureTable(ctx, slug, schema, ldContext)
+	if err := projMgr.EnsureTable(ctx, slug, schema, ldContext); err != nil {
+		return err
 	}
-	// Check if this type has a parent via rdfs:subClassOf.
+	// Also ensure ancestor tables exist for dual-projection.
 	parentSlug := jsonld.SubClassOf(ldContext)
-	if parentSlug != "" {
-		parent, err := rtRepo.FindBySlug(ctx, parentSlug)
-		if err == nil && jsonld.IsAbstract(parent.Context()) {
-			// Ensure the abstract parent's projection table exists before registering
-			// this type as a subtype. This makes projection setup resilient when
-			// events are replayed or processed out of order.
-			if err := projMgr.EnsureTable(ctx, parentSlug, parent.Schema(), parent.Context()); err != nil {
-				return err
-			}
-			return projMgr.RegisterSubtype(ctx, slug, parentSlug, schema, ldContext)
-		}
-		// If parent not found, fall through to standalone table.
-		// If infrastructure error, propagate to avoid wrong topology.
-		if err != nil && !errors.Is(err, repositories.ErrNotFound) {
-			return fmt.Errorf("failed to look up parent type %q: %w", parentSlug, err)
-		}
+	if parentSlug == "" {
+		return nil
 	}
-	// Concrete type with no abstract parent — gets its own table.
-	return projMgr.EnsureTable(ctx, slug, schema, ldContext)
+	parent, err := rtRepo.FindBySlug(ctx, parentSlug)
+	if err != nil {
+		if errors.Is(err, repositories.ErrNotFound) {
+			return nil // parent not yet created; will be ensured when parent type arrives
+		}
+		return fmt.Errorf("failed to look up parent type %q: %w", parentSlug, err)
+	}
+	return projMgr.EnsureTable(ctx, parentSlug, parent.Schema(), parent.Context())
 }
 
 // --- Resource projection handlers ---

--- a/application/event_handlers.go
+++ b/application/event_handlers.go
@@ -138,8 +138,13 @@ func ensureProjection(
 	if parentSlug != "" {
 		parent, err := rtRepo.FindBySlug(ctx, parentSlug)
 		if err == nil && jsonld.IsAbstract(parent.Context()) {
-			// Register as subtype — columns merge into parent's projection table.
-			return projMgr.RegisterSubtype(ctx, slug, parentSlug, schema)
+			// Ensure the abstract parent's projection table exists before registering
+			// this type as a subtype. This makes projection setup resilient when
+			// events are replayed or processed out of order.
+			if err := projMgr.EnsureTable(ctx, parentSlug, parent.Schema(), parent.Context()); err != nil {
+				return err
+			}
+			return projMgr.RegisterSubtype(ctx, slug, parentSlug, schema, ldContext)
 		}
 		// If parent not found, fall through to standalone table.
 		// If infrastructure error, propagate to avoid wrong topology.

--- a/application/event_handlers.go
+++ b/application/event_handlers.go
@@ -65,7 +65,7 @@ func subscribeResourceTypeHandlers(
 			if err := repo.Save(ctx, entity); err != nil {
 				return err
 			}
-			if err := ensureProjection(ctx, repo, projMgr, logger, p.Slug, p.Schema, p.Context); err != nil {
+			if err := ensureProjection(ctx, repo, projMgr, p.Slug, p.Schema, p.Context); err != nil {
 				logger.Error(ctx, "failed to ensure projection for type",
 					"slug", p.Slug, "error", err)
 				return err
@@ -93,7 +93,7 @@ func subscribeResourceTypeHandlers(
 			if err := repo.Update(ctx, existing); err != nil {
 				return err
 			}
-			if err := ensureProjection(ctx, repo, projMgr, logger, p.Slug, p.Schema, p.Context); err != nil {
+			if err := ensureProjection(ctx, repo, projMgr, p.Slug, p.Schema, p.Context); err != nil {
 				logger.Error(ctx, "failed to ensure projection for type",
 					"slug", p.Slug, "error", err)
 				return err
@@ -124,7 +124,6 @@ func ensureProjection(
 	ctx context.Context,
 	rtRepo repositories.ResourceTypeRepository,
 	projMgr repositories.ProjectionManager,
-	logger entities.Logger,
 	slug string,
 	schema, ldContext json.RawMessage,
 ) error {

--- a/application/event_handlers.go
+++ b/application/event_handlers.go
@@ -64,11 +64,9 @@ func subscribeResourceTypeHandlers(
 			if err := repo.Save(ctx, entity); err != nil {
 				return err
 			}
-			if !jsonld.IsAbstract(p.Context) {
-				if err := projMgr.EnsureTable(ctx, p.Slug, p.Schema, p.Context); err != nil {
-					logger.Error(ctx, "failed to create projection table",
-						"slug", p.Slug, "error", err)
-				}
+			if err := ensureProjection(ctx, repo, projMgr, logger, p.Slug, p.Schema, p.Context); err != nil {
+				logger.Error(ctx, "failed to ensure projection for type",
+					"slug", p.Slug, "error", err)
 			}
 			logger.Info(ctx, "projecting ResourceType.Created", "id", env.AggregateID)
 			return nil
@@ -93,11 +91,9 @@ func subscribeResourceTypeHandlers(
 			if err := repo.Update(ctx, existing); err != nil {
 				return err
 			}
-			if !jsonld.IsAbstract(p.Context) {
-				if err := projMgr.EnsureTable(ctx, p.Slug, p.Schema, p.Context); err != nil {
-					logger.Error(ctx, "failed to update projection table",
-						"slug", p.Slug, "error", err)
-				}
+			if err := ensureProjection(ctx, repo, projMgr, logger, p.Slug, p.Schema, p.Context); err != nil {
+				logger.Error(ctx, "failed to ensure projection for type",
+					"slug", p.Slug, "error", err)
 			}
 			logger.Info(ctx, "projecting ResourceType.Updated", "id", env.AggregateID)
 			return nil
@@ -112,6 +108,35 @@ func subscribeResourceTypeHandlers(
 			return repo.Delete(ctx, env.AggregateID)
 		},
 	)
+}
+
+// ensureProjection decides whether to create a projection table or register as a
+// subtype of an abstract parent. Abstract types get their own table. Concrete types
+// with rdfs:subClassOf pointing to an abstract parent register as subtypes (their
+// columns are merged into the parent's table). All other concrete types get their own table.
+func ensureProjection(
+	ctx context.Context,
+	rtRepo repositories.ResourceTypeRepository,
+	projMgr repositories.ProjectionManager,
+	logger entities.Logger,
+	slug string,
+	schema, ldContext json.RawMessage,
+) error {
+	// Abstract types always get their own projection table.
+	if jsonld.IsAbstract(ldContext) {
+		return projMgr.EnsureTable(ctx, slug, schema, ldContext)
+	}
+	// Check if this type has a parent via rdfs:subClassOf.
+	parentSlug := jsonld.SubClassOf(ldContext)
+	if parentSlug != "" {
+		parent, err := rtRepo.FindBySlug(ctx, parentSlug)
+		if err == nil && jsonld.IsAbstract(parent.Context()) {
+			// Register as subtype — columns merge into parent's projection table.
+			return projMgr.RegisterSubtype(ctx, slug, parentSlug, schema)
+		}
+	}
+	// Concrete type with no abstract parent — gets its own table.
+	return projMgr.EnsureTable(ctx, slug, schema, ldContext)
 }
 
 // --- Resource projection handlers ---

--- a/application/event_handlers.go
+++ b/application/event_handlers.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
 	"go.uber.org/fx"
-	"gorm.io/gorm"
 )
 
 // subscribeEventHandlers registers all projection event handlers with the dispatcher.
@@ -148,7 +147,7 @@ func ensureProjection(
 		}
 		// If parent not found, fall through to standalone table.
 		// If infrastructure error, propagate to avoid wrong topology.
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		if err != nil && !errors.Is(err, repositories.ErrNotFound) {
 			return fmt.Errorf("failed to look up parent type %q: %w", parentSlug, err)
 		}
 	}

--- a/application/event_handlers.go
+++ b/application/event_handlers.go
@@ -3,6 +3,7 @@ package application
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
 	"go.uber.org/fx"
+	"gorm.io/gorm"
 )
 
 // subscribeEventHandlers registers all projection event handlers with the dispatcher.
@@ -67,6 +69,7 @@ func subscribeResourceTypeHandlers(
 			if err := ensureProjection(ctx, repo, projMgr, logger, p.Slug, p.Schema, p.Context); err != nil {
 				logger.Error(ctx, "failed to ensure projection for type",
 					"slug", p.Slug, "error", err)
+				return err
 			}
 			logger.Info(ctx, "projecting ResourceType.Created", "id", env.AggregateID)
 			return nil
@@ -94,6 +97,7 @@ func subscribeResourceTypeHandlers(
 			if err := ensureProjection(ctx, repo, projMgr, logger, p.Slug, p.Schema, p.Context); err != nil {
 				logger.Error(ctx, "failed to ensure projection for type",
 					"slug", p.Slug, "error", err)
+				return err
 			}
 			logger.Info(ctx, "projecting ResourceType.Updated", "id", env.AggregateID)
 			return nil
@@ -113,7 +117,10 @@ func subscribeResourceTypeHandlers(
 // ensureProjection decides whether to create a projection table or register as a
 // subtype of an abstract parent. Abstract types get their own table. Concrete types
 // with rdfs:subClassOf pointing to an abstract parent register as subtypes (their
-// columns are merged into the parent's table). All other concrete types get their own table.
+// columns are merged into the parent's table). All other concrete types get their own
+// table. If the parent referenced by rdfs:subClassOf is not found, the type falls back
+// to getting its own standalone table. Infrastructure errors are propagated to avoid
+// creating the wrong table topology.
 func ensureProjection(
 	ctx context.Context,
 	rtRepo repositories.ResourceTypeRepository,
@@ -133,6 +140,11 @@ func ensureProjection(
 		if err == nil && jsonld.IsAbstract(parent.Context()) {
 			// Register as subtype — columns merge into parent's projection table.
 			return projMgr.RegisterSubtype(ctx, slug, parentSlug, schema)
+		}
+		// If parent not found, fall through to standalone table.
+		// If infrastructure error, propagate to avoid wrong topology.
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("failed to look up parent type %q: %w", parentSlug, err)
 		}
 	}
 	// Concrete type with no abstract parent — gets its own table.

--- a/application/event_handlers.go
+++ b/application/event_handlers.go
@@ -65,6 +65,9 @@ func subscribeResourceTypeHandlers(
 			if err := repo.Save(ctx, entity); err != nil {
 				return err
 			}
+			// ensureProjection is idempotent (CREATE TABLE IF NOT EXISTS).
+			// If it fails and the event is retried, repo.Save will fail with a
+			// duplicate key, which the event dispatcher treats as already-processed.
 			if err := ensureProjection(ctx, repo, projMgr, p.Slug, p.Schema, p.Context); err != nil {
 				logger.Error(ctx, "failed to ensure projection for type",
 					"slug", p.Slug, "error", err)

--- a/application/event_handlers_test.go
+++ b/application/event_handlers_test.go
@@ -1,0 +1,222 @@
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"weos/domain/entities"
+	"weos/domain/repositories"
+
+	"gorm.io/gorm"
+)
+
+// stubProjMgr records which ProjectionManager methods were called.
+type stubProjMgr struct {
+	ensuredSlugs   []string
+	subtypeCalls   []subtypeCall
+	ensureTableErr error
+	registerSubErr error
+	tables         map[string]bool
+	parentMap      map[string]string
+	reverseRefs    map[string][]repositories.ReverseReference
+}
+
+type subtypeCall struct {
+	childSlug, parentSlug string
+}
+
+func (s *stubProjMgr) EnsureTable(_ context.Context, slug string, _, _ json.RawMessage) error {
+	s.ensuredSlugs = append(s.ensuredSlugs, slug)
+	return s.ensureTableErr
+}
+
+func (s *stubProjMgr) HasProjectionTable(slug string) bool {
+	return s.tables[slug]
+}
+
+func (s *stubProjMgr) TableName(slug string) string     { return slug + "_table" }
+func (s *stubProjMgr) Context(_ string) json.RawMessage { return nil }
+
+func (s *stubProjMgr) EnsureExistingTables(_ context.Context) error { return nil }
+
+func (s *stubProjMgr) UpdateColumn(context.Context, string, string, string, any) error {
+	return nil
+}
+
+func (s *stubProjMgr) UpdateColumnByFK(context.Context, string, string, string, string, any) error {
+	return nil
+}
+
+func (s *stubProjMgr) ReverseReferences(slug string) []repositories.ReverseReference {
+	return s.reverseRefs[slug]
+}
+
+func (s *stubProjMgr) RegisterSubtype(
+	_ context.Context, childSlug, parentSlug string, _ json.RawMessage,
+) error {
+	s.subtypeCalls = append(s.subtypeCalls, subtypeCall{childSlug, parentSlug})
+	return s.registerSubErr
+}
+
+func (s *stubProjMgr) IsSubtype(slug string) bool {
+	_, ok := s.parentMap[slug]
+	return ok
+}
+
+func (s *stubProjMgr) ParentSlug(slug string) string {
+	return s.parentMap[slug]
+}
+
+func makeRT(slug, ctxJSON string) *entities.ResourceType {
+	rt := &entities.ResourceType{}
+	_ = rt.Restore("id-"+slug, slug, slug, "desc", "active",
+		json.RawMessage(ctxJSON), nil, rt.CreatedAt(), 1)
+	return rt
+}
+
+func TestEnsureProjection_AbstractType(t *testing.T) {
+	t.Parallel()
+	pm := &stubProjMgr{}
+	repo := &stubTypeRepo{types: map[string]*entities.ResourceType{}}
+	ctx := context.Background()
+
+	abstractCtx := json.RawMessage(`{"@vocab":"https://schema.org/","weos:abstract":true}`)
+	err := ensureProjection(ctx, repo, pm, noopLogger{}, "instrument", nil, abstractCtx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pm.ensuredSlugs) != 1 || pm.ensuredSlugs[0] != "instrument" {
+		t.Fatalf("expected EnsureTable for 'instrument', got %v", pm.ensuredSlugs)
+	}
+	if len(pm.subtypeCalls) != 0 {
+		t.Fatalf("expected no RegisterSubtype calls, got %v", pm.subtypeCalls)
+	}
+}
+
+func TestEnsureProjection_ConcreteWithAbstractParent(t *testing.T) {
+	t.Parallel()
+	pm := &stubProjMgr{}
+	parentRT := makeRT("instrument", `{"@vocab":"https://schema.org/","weos:abstract":true}`)
+	repo := &stubTypeRepo{types: map[string]*entities.ResourceType{
+		"instrument": parentRT,
+	}}
+	ctx := context.Background()
+
+	childCtx := json.RawMessage(`{"@vocab":"https://schema.org/","rdfs:subClassOf":"instrument"}`)
+	err := ensureProjection(ctx, repo, pm, noopLogger{}, "loan", nil, childCtx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pm.subtypeCalls) != 1 {
+		t.Fatalf("expected 1 RegisterSubtype call, got %d", len(pm.subtypeCalls))
+	}
+	if pm.subtypeCalls[0].childSlug != "loan" || pm.subtypeCalls[0].parentSlug != "instrument" {
+		t.Fatalf("unexpected call: %v", pm.subtypeCalls[0])
+	}
+	if len(pm.ensuredSlugs) != 0 {
+		t.Fatalf("expected no EnsureTable calls, got %v", pm.ensuredSlugs)
+	}
+}
+
+func TestEnsureProjection_ConcreteWithNonAbstractParent(t *testing.T) {
+	t.Parallel()
+	pm := &stubProjMgr{}
+	parentRT := makeRT("vehicle", `{"@vocab":"https://schema.org/"}`)
+	repo := &stubTypeRepo{types: map[string]*entities.ResourceType{
+		"vehicle": parentRT,
+	}}
+	ctx := context.Background()
+
+	childCtx := json.RawMessage(`{"@vocab":"https://schema.org/","rdfs:subClassOf":"vehicle"}`)
+	err := ensureProjection(ctx, repo, pm, noopLogger{}, "car", nil, childCtx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pm.ensuredSlugs) != 1 || pm.ensuredSlugs[0] != "car" {
+		t.Fatalf("expected EnsureTable for 'car', got %v", pm.ensuredSlugs)
+	}
+	if len(pm.subtypeCalls) != 0 {
+		t.Fatalf("expected no RegisterSubtype calls, got %v", pm.subtypeCalls)
+	}
+}
+
+func TestEnsureProjection_ConcreteNoParent(t *testing.T) {
+	t.Parallel()
+	pm := &stubProjMgr{}
+	repo := &stubTypeRepo{types: map[string]*entities.ResourceType{}}
+	ctx := context.Background()
+
+	simpleCtx := json.RawMessage(`{"@vocab":"https://schema.org/"}`)
+	err := ensureProjection(ctx, repo, pm, noopLogger{}, "product", nil, simpleCtx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pm.ensuredSlugs) != 1 || pm.ensuredSlugs[0] != "product" {
+		t.Fatalf("expected EnsureTable for 'product', got %v", pm.ensuredSlugs)
+	}
+}
+
+func TestEnsureProjection_ParentNotFound_FallsBackToStandalone(t *testing.T) {
+	t.Parallel()
+	pm := &stubProjMgr{}
+	// Simulate "not found" as the real repo does: wrapping gorm.ErrRecordNotFound.
+	notFoundRepo := &infraErrorRepo{err: gorm.ErrRecordNotFound}
+	ctx := context.Background()
+
+	childCtx := json.RawMessage(`{"@vocab":"https://schema.org/","rdfs:subClassOf":"missing-parent"}`)
+	err := ensureProjection(ctx, notFoundRepo, pm, noopLogger{}, "orphan", nil, childCtx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pm.ensuredSlugs) != 1 || pm.ensuredSlugs[0] != "orphan" {
+		t.Fatalf("expected EnsureTable for 'orphan', got %v", pm.ensuredSlugs)
+	}
+}
+
+func TestEnsureProjection_InfraError_PropagatesError(t *testing.T) {
+	t.Parallel()
+	pm := &stubProjMgr{}
+	infraErr := errors.New("connection refused")
+	infraRepo := &infraErrorRepo{err: infraErr}
+	ctx := context.Background()
+
+	childCtx := json.RawMessage(`{"@vocab":"https://schema.org/","rdfs:subClassOf":"parent"}`)
+	err := ensureProjection(ctx, infraRepo, pm, noopLogger{}, "child", nil, childCtx)
+	if err == nil {
+		t.Fatal("expected error to be propagated")
+	}
+	if !errors.Is(err, infraErr) {
+		t.Fatalf("expected wrapped infra error, got: %v", err)
+	}
+}
+
+// infraErrorRepo returns an infrastructure error that is NOT gorm.ErrRecordNotFound.
+type infraErrorRepo struct {
+	stubTypeRepo
+	err error
+}
+
+func (r *infraErrorRepo) FindBySlug(_ context.Context, _ string) (*entities.ResourceType, error) {
+	return nil, r.err
+}
+
+func TestEnsureProjection_GormNotFoundError_FallsBack(t *testing.T) {
+	t.Parallel()
+	pm := &stubProjMgr{}
+	// Wrap gorm.ErrRecordNotFound like the real repo does.
+	notFoundRepo := &infraErrorRepo{
+		err: gorm.ErrRecordNotFound,
+	}
+	ctx := context.Background()
+
+	childCtx := json.RawMessage(`{"@vocab":"https://schema.org/","rdfs:subClassOf":"parent"}`)
+	err := ensureProjection(ctx, notFoundRepo, pm, noopLogger{}, "child", nil, childCtx)
+	if err != nil {
+		t.Fatalf("expected no error for not-found parent, got: %v", err)
+	}
+	if len(pm.ensuredSlugs) != 1 || pm.ensuredSlugs[0] != "child" {
+		t.Fatalf("expected fallback to EnsureTable, got: %v", pm.ensuredSlugs)
+	}
+}

--- a/application/event_handlers_test.go
+++ b/application/event_handlers_test.go
@@ -81,7 +81,7 @@ func TestEnsureProjection_AbstractType(t *testing.T) {
 	ctx := context.Background()
 
 	abstractCtx := json.RawMessage(`{"@vocab":"https://schema.org/","weos:abstract":true}`)
-	err := ensureProjection(ctx, repo, pm, noopLogger{}, "instrument", nil, abstractCtx)
+	err := ensureProjection(ctx, repo, pm, "instrument", nil, abstractCtx)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestEnsureProjection_ConcreteWithAbstractParent(t *testing.T) {
 	ctx := context.Background()
 
 	childCtx := json.RawMessage(`{"@vocab":"https://schema.org/","rdfs:subClassOf":"instrument"}`)
-	err := ensureProjection(ctx, repo, pm, noopLogger{}, "loan", nil, childCtx)
+	err := ensureProjection(ctx, repo, pm, "loan", nil, childCtx)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestEnsureProjection_ConcreteWithNonAbstractParent(t *testing.T) {
 	ctx := context.Background()
 
 	childCtx := json.RawMessage(`{"@vocab":"https://schema.org/","rdfs:subClassOf":"vehicle"}`)
-	err := ensureProjection(ctx, repo, pm, noopLogger{}, "car", nil, childCtx)
+	err := ensureProjection(ctx, repo, pm, "car", nil, childCtx)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestEnsureProjection_ConcreteNoParent(t *testing.T) {
 	ctx := context.Background()
 
 	simpleCtx := json.RawMessage(`{"@vocab":"https://schema.org/"}`)
-	err := ensureProjection(ctx, repo, pm, noopLogger{}, "product", nil, simpleCtx)
+	err := ensureProjection(ctx, repo, pm, "product", nil, simpleCtx)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestEnsureProjection_ParentNotFound_FallsBackToStandalone(t *testing.T) {
 	ctx := context.Background()
 
 	childCtx := json.RawMessage(`{"@vocab":"https://schema.org/","rdfs:subClassOf":"missing-parent"}`)
-	err := ensureProjection(ctx, notFoundRepo, pm, noopLogger{}, "orphan", nil, childCtx)
+	err := ensureProjection(ctx, notFoundRepo, pm, "orphan", nil, childCtx)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -182,7 +182,7 @@ func TestEnsureProjection_InfraError_PropagatesError(t *testing.T) {
 	ctx := context.Background()
 
 	childCtx := json.RawMessage(`{"@vocab":"https://schema.org/","rdfs:subClassOf":"parent"}`)
-	err := ensureProjection(ctx, infraRepo, pm, noopLogger{}, "child", nil, childCtx)
+	err := ensureProjection(ctx, infraRepo, pm, "child", nil, childCtx)
 	if err == nil {
 		t.Fatal("expected error to be propagated")
 	}
@@ -211,7 +211,7 @@ func TestEnsureProjection_GormNotFoundError_FallsBack(t *testing.T) {
 	ctx := context.Background()
 
 	childCtx := json.RawMessage(`{"@vocab":"https://schema.org/","rdfs:subClassOf":"parent"}`)
-	err := ensureProjection(ctx, notFoundRepo, pm, noopLogger{}, "child", nil, childCtx)
+	err := ensureProjection(ctx, notFoundRepo, pm, "child", nil, childCtx)
 	if err != nil {
 		t.Fatalf("expected no error for not-found parent, got: %v", err)
 	}

--- a/application/event_handlers_test.go
+++ b/application/event_handlers_test.go
@@ -13,16 +13,10 @@ import (
 // stubProjMgr records which ProjectionManager methods were called.
 type stubProjMgr struct {
 	ensuredSlugs   []string
-	subtypeCalls   []subtypeCall
 	ensureTableErr error
-	registerSubErr error
 	tables         map[string]bool
-	parentMap      map[string]string
+	ancestorMap    map[string][]string
 	reverseRefs    map[string][]repositories.ReverseReference
-}
-
-type subtypeCall struct {
-	childSlug, parentSlug string
 }
 
 func (s *stubProjMgr) EnsureTable(_ context.Context, slug string, _, _ json.RawMessage) error {
@@ -51,20 +45,8 @@ func (s *stubProjMgr) ReverseReferences(slug string) []repositories.ReverseRefer
 	return s.reverseRefs[slug]
 }
 
-func (s *stubProjMgr) RegisterSubtype(
-	_ context.Context, childSlug, parentSlug string, _, _ json.RawMessage,
-) error {
-	s.subtypeCalls = append(s.subtypeCalls, subtypeCall{childSlug, parentSlug})
-	return s.registerSubErr
-}
-
-func (s *stubProjMgr) IsSubtype(slug string) bool {
-	_, ok := s.parentMap[slug]
-	return ok
-}
-
-func (s *stubProjMgr) ParentSlug(slug string) string {
-	return s.parentMap[slug]
+func (s *stubProjMgr) AncestorSlugs(slug string) []string {
+	return s.ancestorMap[slug]
 }
 
 func makeRT(slug, ctxJSON string) *entities.ResourceType {
@@ -88,12 +70,9 @@ func TestEnsureProjection_AbstractType(t *testing.T) {
 	if len(pm.ensuredSlugs) != 1 || pm.ensuredSlugs[0] != "instrument" {
 		t.Fatalf("expected EnsureTable for 'instrument', got %v", pm.ensuredSlugs)
 	}
-	if len(pm.subtypeCalls) != 0 {
-		t.Fatalf("expected no RegisterSubtype calls, got %v", pm.subtypeCalls)
-	}
 }
 
-func TestEnsureProjection_ConcreteWithAbstractParent(t *testing.T) {
+func TestEnsureProjection_ConcreteWithParent_EnsuresBothTables(t *testing.T) {
 	t.Parallel()
 	pm := &stubProjMgr{}
 	parentRT := makeRT("instrument", `{"@vocab":"https://schema.org/","weos:abstract":true}`)
@@ -107,15 +86,15 @@ func TestEnsureProjection_ConcreteWithAbstractParent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(pm.subtypeCalls) != 1 {
-		t.Fatalf("expected 1 RegisterSubtype call, got %d", len(pm.subtypeCalls))
+	// Both child and parent should get EnsureTable calls.
+	if len(pm.ensuredSlugs) != 2 {
+		t.Fatalf("expected 2 EnsureTable calls, got %v", pm.ensuredSlugs)
 	}
-	if pm.subtypeCalls[0].childSlug != "loan" || pm.subtypeCalls[0].parentSlug != "instrument" {
-		t.Fatalf("unexpected call: %v", pm.subtypeCalls[0])
+	if pm.ensuredSlugs[0] != "loan" {
+		t.Fatalf("first EnsureTable should be for child 'loan', got %q", pm.ensuredSlugs[0])
 	}
-	// EnsureTable is called for the parent first to handle out-of-order event replay.
-	if len(pm.ensuredSlugs) != 1 || pm.ensuredSlugs[0] != "instrument" {
-		t.Fatalf("expected EnsureTable for parent 'instrument', got %v", pm.ensuredSlugs)
+	if pm.ensuredSlugs[1] != "instrument" {
+		t.Fatalf("second EnsureTable should be for parent 'instrument', got %q", pm.ensuredSlugs[1])
 	}
 }
 
@@ -133,11 +112,9 @@ func TestEnsureProjection_ConcreteWithNonAbstractParent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(pm.ensuredSlugs) != 1 || pm.ensuredSlugs[0] != "car" {
-		t.Fatalf("expected EnsureTable for 'car', got %v", pm.ensuredSlugs)
-	}
-	if len(pm.subtypeCalls) != 0 {
-		t.Fatalf("expected no RegisterSubtype calls, got %v", pm.subtypeCalls)
+	// Both child and non-abstract parent get EnsureTable.
+	if len(pm.ensuredSlugs) != 2 {
+		t.Fatalf("expected 2 EnsureTable calls, got %v", pm.ensuredSlugs)
 	}
 }
 
@@ -157,10 +134,9 @@ func TestEnsureProjection_ConcreteNoParent(t *testing.T) {
 	}
 }
 
-func TestEnsureProjection_ParentNotFound_FallsBackToStandalone(t *testing.T) {
+func TestEnsureProjection_ParentNotFound_ChildStillGetTable(t *testing.T) {
 	t.Parallel()
 	pm := &stubProjMgr{}
-	// Simulate "not found" as the real repo does: wrapping repositories.ErrNotFound.
 	notFoundRepo := &infraErrorRepo{err: repositories.ErrNotFound}
 	ctx := context.Background()
 
@@ -186,12 +162,13 @@ func TestEnsureProjection_InfraError_PropagatesError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error to be propagated")
 	}
-	if !errors.Is(err, infraErr) {
-		t.Fatalf("expected wrapped infra error, got: %v", err)
+	// Child's own table should still have been ensured before the parent lookup failed.
+	if len(pm.ensuredSlugs) != 1 || pm.ensuredSlugs[0] != "child" {
+		t.Fatalf("expected EnsureTable for 'child' before error, got %v", pm.ensuredSlugs)
 	}
 }
 
-// infraErrorRepo returns an infrastructure error that is NOT repositories.ErrNotFound.
+// infraErrorRepo returns an infrastructure error for FindBySlug.
 type infraErrorRepo struct {
 	stubTypeRepo
 	err error
@@ -199,23 +176,4 @@ type infraErrorRepo struct {
 
 func (r *infraErrorRepo) FindBySlug(_ context.Context, _ string) (*entities.ResourceType, error) {
 	return nil, r.err
-}
-
-func TestEnsureProjection_GormNotFoundError_FallsBack(t *testing.T) {
-	t.Parallel()
-	pm := &stubProjMgr{}
-	// Wrap repositories.ErrNotFound like the real repo does.
-	notFoundRepo := &infraErrorRepo{
-		err: repositories.ErrNotFound,
-	}
-	ctx := context.Background()
-
-	childCtx := json.RawMessage(`{"@vocab":"https://schema.org/","rdfs:subClassOf":"parent"}`)
-	err := ensureProjection(ctx, notFoundRepo, pm, "child", nil, childCtx)
-	if err != nil {
-		t.Fatalf("expected no error for not-found parent, got: %v", err)
-	}
-	if len(pm.ensuredSlugs) != 1 || pm.ensuredSlugs[0] != "child" {
-		t.Fatalf("expected fallback to EnsureTable, got: %v", pm.ensuredSlugs)
-	}
 }

--- a/application/event_handlers_test.go
+++ b/application/event_handlers_test.go
@@ -8,8 +8,6 @@ import (
 
 	"weos/domain/entities"
 	"weos/domain/repositories"
-
-	"gorm.io/gorm"
 )
 
 // stubProjMgr records which ProjectionManager methods were called.
@@ -162,8 +160,8 @@ func TestEnsureProjection_ConcreteNoParent(t *testing.T) {
 func TestEnsureProjection_ParentNotFound_FallsBackToStandalone(t *testing.T) {
 	t.Parallel()
 	pm := &stubProjMgr{}
-	// Simulate "not found" as the real repo does: wrapping gorm.ErrRecordNotFound.
-	notFoundRepo := &infraErrorRepo{err: gorm.ErrRecordNotFound}
+	// Simulate "not found" as the real repo does: wrapping repositories.ErrNotFound.
+	notFoundRepo := &infraErrorRepo{err: repositories.ErrNotFound}
 	ctx := context.Background()
 
 	childCtx := json.RawMessage(`{"@vocab":"https://schema.org/","rdfs:subClassOf":"missing-parent"}`)
@@ -193,7 +191,7 @@ func TestEnsureProjection_InfraError_PropagatesError(t *testing.T) {
 	}
 }
 
-// infraErrorRepo returns an infrastructure error that is NOT gorm.ErrRecordNotFound.
+// infraErrorRepo returns an infrastructure error that is NOT repositories.ErrNotFound.
 type infraErrorRepo struct {
 	stubTypeRepo
 	err error
@@ -206,9 +204,9 @@ func (r *infraErrorRepo) FindBySlug(_ context.Context, _ string) (*entities.Reso
 func TestEnsureProjection_GormNotFoundError_FallsBack(t *testing.T) {
 	t.Parallel()
 	pm := &stubProjMgr{}
-	// Wrap gorm.ErrRecordNotFound like the real repo does.
+	// Wrap repositories.ErrNotFound like the real repo does.
 	notFoundRepo := &infraErrorRepo{
-		err: gorm.ErrRecordNotFound,
+		err: repositories.ErrNotFound,
 	}
 	ctx := context.Background()
 

--- a/application/event_handlers_test.go
+++ b/application/event_handlers_test.go
@@ -49,6 +49,8 @@ func (s *stubProjMgr) AncestorSlugs(slug string) []string {
 	return s.ancestorMap[slug]
 }
 
+func (s *stubProjMgr) HasColumn(_, _ string) bool { return false }
+
 func makeRT(slug, ctxJSON string) *entities.ResourceType {
 	rt := &entities.ResourceType{}
 	_ = rt.Restore("id-"+slug, slug, slug, "desc", "active",

--- a/application/event_handlers_test.go
+++ b/application/event_handlers_test.go
@@ -54,7 +54,7 @@ func (s *stubProjMgr) ReverseReferences(slug string) []repositories.ReverseRefer
 }
 
 func (s *stubProjMgr) RegisterSubtype(
-	_ context.Context, childSlug, parentSlug string, _ json.RawMessage,
+	_ context.Context, childSlug, parentSlug string, _, _ json.RawMessage,
 ) error {
 	s.subtypeCalls = append(s.subtypeCalls, subtypeCall{childSlug, parentSlug})
 	return s.registerSubErr
@@ -115,8 +115,9 @@ func TestEnsureProjection_ConcreteWithAbstractParent(t *testing.T) {
 	if pm.subtypeCalls[0].childSlug != "loan" || pm.subtypeCalls[0].parentSlug != "instrument" {
 		t.Fatalf("unexpected call: %v", pm.subtypeCalls[0])
 	}
-	if len(pm.ensuredSlugs) != 0 {
-		t.Fatalf("expected no EnsureTable calls, got %v", pm.ensuredSlugs)
+	// EnsureTable is called for the parent first to handle out-of-order event replay.
+	if len(pm.ensuredSlugs) != 1 || pm.ensuredSlugs[0] != "instrument" {
+		t.Fatalf("expected EnsureTable for parent 'instrument', got %v", pm.ensuredSlugs)
 	}
 }
 

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -90,28 +90,28 @@ func (r *PresetRegistry) Add(def PresetDefinition) error {
 }
 
 // MustAdd registers a preset and panics if the definition is invalid.
-// Use for compile-time registration of known-good preset data.
+// Use for init-time registration of known-good preset data.
 func (r *PresetRegistry) MustAdd(def PresetDefinition) {
 	if err := r.Add(def); err != nil {
 		panic(fmt.Sprintf("preset registration failed: %v", err))
 	}
 }
 
-// Get returns a preset by name.
+// Get returns a preset by name. The returned value is a deep copy safe to mutate.
 func (r *PresetRegistry) Get(name string) (PresetDefinition, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	def, ok := r.presets[name]
-	return def, ok
+	return def.clone(), ok
 }
 
-// List returns all registered presets sorted by name.
+// List returns all registered presets sorted by name. Returned values are deep copies.
 func (r *PresetRegistry) List() []PresetDefinition {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	result := make([]PresetDefinition, 0, len(r.presets))
 	for _, def := range r.presets {
-		result = append(result, def)
+		result = append(result, def.clone())
 	}
 	sort.Slice(result, func(i, j int) bool {
 		return result[i].Name < result[j].Name
@@ -119,8 +119,26 @@ func (r *PresetRegistry) List() []PresetDefinition {
 	return result
 }
 
+// clone returns a deep copy of the definition, so callers cannot mutate registry internals.
+func (d PresetDefinition) clone() PresetDefinition {
+	if d.Types != nil {
+		types := make([]PresetResourceType, len(d.Types))
+		copy(types, d.Types)
+		d.Types = types
+	}
+	if d.Behaviors != nil {
+		behaviors := make(map[string]entities.ResourceBehavior, len(d.Behaviors))
+		for k, v := range d.Behaviors {
+			behaviors[k] = v
+		}
+		d.Behaviors = behaviors
+	}
+	return d
+}
+
 // Behaviors returns a merged ResourceBehaviorRegistry from all registered presets.
-// Presets are processed in alphabetical order for deterministic conflict resolution.
+// Presets are processed in alphabetical order; if multiple presets declare a behavior
+// for the same slug, the last preset alphabetically wins (silent overwrite).
 func (r *PresetRegistry) Behaviors() ResourceBehaviorRegistry {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -123,7 +123,15 @@ func (r *PresetRegistry) List() []PresetDefinition {
 func (d PresetDefinition) clone() PresetDefinition {
 	if d.Types != nil {
 		types := make([]PresetResourceType, len(d.Types))
-		copy(types, d.Types)
+		for i, t := range d.Types {
+			types[i] = t
+			if t.Context != nil {
+				types[i].Context = append(json.RawMessage(nil), t.Context...)
+			}
+			if t.Schema != nil {
+				types[i].Schema = append(json.RawMessage(nil), t.Schema...)
+			}
+		}
 		d.Types = types
 	}
 	if d.Behaviors != nil {
@@ -132,6 +140,22 @@ func (d PresetDefinition) clone() PresetDefinition {
 			behaviors[k] = v
 		}
 		d.Behaviors = behaviors
+	}
+	if d.Sidebar != nil {
+		s := *d.Sidebar
+		if s.HiddenSlugs != nil {
+			hs := make([]string, len(s.HiddenSlugs))
+			copy(hs, s.HiddenSlugs)
+			s.HiddenSlugs = hs
+		}
+		if s.MenuGroups != nil {
+			mg := make(map[string]string, len(s.MenuGroups))
+			for k, v := range s.MenuGroups {
+				mg[k] = v
+			}
+			s.MenuGroups = mg
+		}
+		d.Sidebar = &s
 	}
 	return d
 }

--- a/application/presets/auth/preset.go
+++ b/application/presets/auth/preset.go
@@ -1,5 +1,5 @@
-// Package auth provides resource types for authentication and authorization,
-// wrapping the pericarp auth concepts (User, Role, Account) as WeOS resource types.
+// Package auth provides resource types for user identity and access management
+// (users, roles, and accounts).
 package auth
 
 import "weos/application"

--- a/application/presets/core/preset.go
+++ b/application/presets/core/preset.go
@@ -50,25 +50,25 @@ func Register(registry *application.PresetRegistry) {
 			),
 		},
 		Behaviors: map[string]entities.ResourceBehavior{
-			"person":       &PersonBehavior{},
-			"organization": &OrganizationBehavior{},
+			"person":       &personBehavior{},
+			"organization": &organizationBehavior{},
 		},
 		AutoInstall: true,
 	})
 }
 
-// PersonBehavior computes a full "name" field from givenName and familyName.
-type PersonBehavior struct {
+// personBehavior computes a full "name" field from givenName and familyName.
+type personBehavior struct {
 	entities.DefaultBehavior
 }
 
-func (b *PersonBehavior) BeforeCreate(
+func (b *personBehavior) BeforeCreate(
 	ctx context.Context, data json.RawMessage, rt *entities.ResourceType,
 ) (json.RawMessage, error) {
 	return injectPersonName(data)
 }
 
-func (b *PersonBehavior) BeforeUpdate(
+func (b *personBehavior) BeforeUpdate(
 	ctx context.Context, _ *entities.Resource, data json.RawMessage, rt *entities.ResourceType,
 ) (json.RawMessage, error) {
 	return injectPersonName(data)
@@ -85,7 +85,8 @@ func injectPersonName(data json.RawMessage) (json.RawMessage, error) {
 	return json.Marshal(m)
 }
 
-// OrganizationBehavior provides custom logic for the "organization" resource type.
-type OrganizationBehavior struct {
+// organizationBehavior is a no-op placeholder ensuring the organization type is
+// represented in the behavior registry. Custom logic can be added here later.
+type organizationBehavior struct {
 	entities.DefaultBehavior
 }

--- a/application/presets/ecommerce/preset.go
+++ b/application/presets/ecommerce/preset.go
@@ -1,0 +1,42 @@
+// Package ecommerce provides resource types for e-commerce: products, offers, reviews, and services.
+package ecommerce
+
+import "weos/application"
+
+// Register adds the ecommerce preset to the registry.
+func Register(registry *application.PresetRegistry) {
+	registry.MustAdd(application.PresetDefinition{
+		Name:        "ecommerce",
+		Description: "E-commerce types: products, offers, reviews, and services",
+		Types: []application.PresetResourceType{
+			application.NewPresetType("Product", "product",
+				"A product offered for sale",
+				`{"@vocab":"https://schema.org/","@type":"Product"}`,
+				`{"type":"object","properties":{"name":{"type":"string"},"description":{"type":"string"},`+
+					`"sku":{"type":"string"},"brand":{"type":"string"},`+
+					`"image":{"type":"string","format":"uri"}},"required":["name"]}`,
+			),
+			application.NewPresetType("Offer", "offer",
+				"A price or availability offer for a product or service",
+				`{"@vocab":"https://schema.org/","gr":"http://purl.org/goodrelations/v1#","@type":"Offer"}`,
+				`{"type":"object","properties":{"name":{"type":"string"},"price":{"type":"number"},`+
+					`"priceCurrency":{"type":"string"},"availability":{"type":"string"}},`+
+					`"required":["name","price"]}`,
+			),
+			application.NewPresetType("Review", "review",
+				"A user review or rating for a product or service",
+				`{"@vocab":"https://schema.org/","@type":"Review"}`,
+				`{"type":"object","properties":{"name":{"type":"string"},"reviewBody":{"type":"string"},`+
+					`"reviewRating":{"type":"integer"},"author":{"type":"string"}},`+
+					`"required":["name"]}`,
+			),
+			application.NewPresetType("Service", "service",
+				"A service offered by an organization or individual",
+				`{"@vocab":"https://schema.org/","@type":"Service"}`,
+				`{"type":"object","properties":{"name":{"type":"string"},"description":{"type":"string"},`+
+					`"provider":{"type":"string"},"serviceType":{"type":"string"}},`+
+					`"required":["name"]}`,
+			),
+		},
+	})
+}

--- a/application/presets/register.go
+++ b/application/presets/register.go
@@ -1,10 +1,12 @@
-// Package presets provides a convenience function to register all built-in presets.
+// Package presets provides functions to register all built-in presets and create a
+// fully populated registry.
 package presets
 
 import (
 	"weos/application"
 	"weos/application/presets/auth"
 	"weos/application/presets/core"
+	"weos/application/presets/ecommerce"
 	"weos/application/presets/events"
 	"weos/application/presets/knowledge"
 	"weos/application/presets/tasks"
@@ -15,6 +17,7 @@ import (
 func RegisterAll(registry *application.PresetRegistry) {
 	core.Register(registry)
 	auth.Register(registry)
+	ecommerce.Register(registry)
 	tasks.Register(registry)
 	website.Register(registry)
 	events.Register(registry)

--- a/application/resource_type_presets_test.go
+++ b/application/resource_type_presets_test.go
@@ -29,7 +29,7 @@ func testRegistry() *application.PresetRegistry {
 
 func TestPresets_AllPresetsExist(t *testing.T) {
 	t.Parallel()
-	expected := []string{"auth", "core", "events", "knowledge", "tasks", "website"}
+	expected := []string{"auth", "core", "ecommerce", "events", "knowledge", "tasks", "website"}
 	defs := testRegistry().List()
 	if len(defs) != len(expected) {
 		t.Fatalf("expected %d presets, got %d", len(expected), len(defs))

--- a/domain/repositories/projection_manager.go
+++ b/domain/repositories/projection_manager.go
@@ -54,20 +54,11 @@ type ProjectionManager interface {
 	// Each entry describes a FK column and its corresponding display column.
 	ReverseReferences(targetTypeSlug string) []ReverseReference
 
-	// RegisterSubtype registers a concrete child type as a subtype of an abstract parent.
-	// This merges the child's schema columns into the parent's projection table and
-	// records the child-to-parent mapping so that TableName resolution routes the child
-	// to the parent's table. The child's JSON-LD context is cached so that Context()
-	// returns the child's own context (not the parent's). The parent table must already
-	// exist via EnsureTable.
-	RegisterSubtype(ctx context.Context, childSlug, parentSlug string,
-		childSchema, childLdContext json.RawMessage) error
-
-	// IsSubtype reports whether a slug is registered as a subtype of an abstract parent.
-	IsSubtype(slug string) bool
-
-	// ParentSlug returns the abstract parent slug for a subtype, or empty string if not a subtype.
-	ParentSlug(slug string) string
+	// AncestorSlugs returns the ordered chain of ancestor type slugs for a type,
+	// derived from rdfs:subClassOf declarations cached during EnsureTable.
+	// For "loan" with subClassOf "financial-instrument", returns ["financial-instrument"].
+	// Returns nil for types with no parent. Circular references are safely broken.
+	AncestorSlugs(slug string) []string
 }
 
 // ReverseReference describes a resource type that references another via a FK column.

--- a/domain/repositories/projection_manager.go
+++ b/domain/repositories/projection_manager.go
@@ -54,6 +54,10 @@ type ProjectionManager interface {
 	// Each entry describes a FK column and its corresponding display column.
 	ReverseReferences(targetTypeSlug string) []ReverseReference
 
+	// HasColumn reports whether a projection table has a specific column.
+	// Uses the column set cached during EnsureTable for fast lookup without DB queries.
+	HasColumn(slug, column string) bool
+
 	// AncestorSlugs returns the ordered chain of ancestor type slugs for a type,
 	// derived from rdfs:subClassOf declarations cached during EnsureTable.
 	// For "loan" with subClassOf "financial-instrument", returns ["financial-instrument"].

--- a/domain/repositories/projection_manager.go
+++ b/domain/repositories/projection_manager.go
@@ -53,6 +53,17 @@ type ProjectionManager interface {
 	// ReverseReferences returns the list of resource types that reference a given target type.
 	// Each entry describes a FK column and its corresponding display column.
 	ReverseReferences(targetTypeSlug string) []ReverseReference
+
+	// RegisterSubtype registers a concrete child type as a subtype of an abstract
+	// parent. The child's resources will be stored in the parent's projection table
+	// and the child's schema columns are merged into the parent table.
+	RegisterSubtype(ctx context.Context, childSlug, parentSlug string, childSchema json.RawMessage) error
+
+	// IsSubtype reports whether a slug is registered as a subtype of an abstract parent.
+	IsSubtype(slug string) bool
+
+	// ParentSlug returns the abstract parent slug for a subtype, or empty string if not a subtype.
+	ParentSlug(slug string) string
 }
 
 // ReverseReference describes a resource type that references another via a FK column.

--- a/domain/repositories/projection_manager.go
+++ b/domain/repositories/projection_manager.go
@@ -57,8 +57,11 @@ type ProjectionManager interface {
 	// RegisterSubtype registers a concrete child type as a subtype of an abstract parent.
 	// This merges the child's schema columns into the parent's projection table and
 	// records the child-to-parent mapping so that TableName resolution routes the child
-	// to the parent's table. The parent table must already exist via EnsureTable.
-	RegisterSubtype(ctx context.Context, childSlug, parentSlug string, childSchema json.RawMessage) error
+	// to the parent's table. The child's JSON-LD context is cached so that Context()
+	// returns the child's own context (not the parent's). The parent table must already
+	// exist via EnsureTable.
+	RegisterSubtype(ctx context.Context, childSlug, parentSlug string,
+		childSchema, childLdContext json.RawMessage) error
 
 	// IsSubtype reports whether a slug is registered as a subtype of an abstract parent.
 	IsSubtype(slug string) bool

--- a/domain/repositories/projection_manager.go
+++ b/domain/repositories/projection_manager.go
@@ -54,9 +54,10 @@ type ProjectionManager interface {
 	// Each entry describes a FK column and its corresponding display column.
 	ReverseReferences(targetTypeSlug string) []ReverseReference
 
-	// RegisterSubtype registers a concrete child type as a subtype of an abstract
-	// parent. The child's resources will be stored in the parent's projection table
-	// and the child's schema columns are merged into the parent table.
+	// RegisterSubtype registers a concrete child type as a subtype of an abstract parent.
+	// This merges the child's schema columns into the parent's projection table and
+	// records the child-to-parent mapping so that TableName resolution routes the child
+	// to the parent's table. The parent table must already exist via EnsureTable.
 	RegisterSubtype(ctx context.Context, childSlug, parentSlug string, childSchema json.RawMessage) error
 
 	// IsSubtype reports whether a slug is registered as a subtype of an abstract parent.

--- a/domain/repositories/resource_type_repository.go
+++ b/domain/repositories/resource_type_repository.go
@@ -17,9 +17,13 @@ package repositories
 
 import (
 	"context"
+	"errors"
 
 	"weos/domain/entities"
 )
+
+// ErrNotFound is returned when a requested entity does not exist.
+var ErrNotFound = errors.New("not found")
 
 type ResourceTypeRepository interface {
 	Save(ctx context.Context, entity *entities.ResourceType) error

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -18,6 +18,7 @@ package gorm
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -38,7 +39,8 @@ type columnDef struct {
 	SQLType string
 }
 
-// standardColumns are always present in every projection table.
+// standardColumnNames lists column names already part of the projection table DDL
+// and should be skipped when extracting columns from JSON Schema.
 var standardColumnNames = map[string]bool{
 	"id":          true,
 	"type_slug":   true,
@@ -66,9 +68,10 @@ type tableInfo struct {
 type projectionManager struct {
 	db            *gorm.DB
 	logger        entities.Logger
-	tables        sync.Map // slug → tableInfo
-	reverseRe     sync.Map // targetTypeSlug → []repositories.ReverseReference
-	childToParent sync.Map // childSlug → parentSlug (for abstract type inheritance)
+	tables        sync.Map   // slug → tableInfo
+	reverseRe     sync.Map   // targetTypeSlug → []repositories.ReverseReference
+	reverseReMu   sync.Mutex // guards reverseRe writes
+	childToParent sync.Map   // childSlug → parentSlug (subtypes sharing parent's projection table)
 }
 
 type ProjectionManagerResult struct {
@@ -119,6 +122,11 @@ func (pm *projectionManager) HasProjectionTable(slug string) bool {
 	// Lazy registration: another process may have created the type after startup.
 	var rt models.ResourceType
 	if err := pm.db.Where("slug = ?", slug).First(&rt).Error; err != nil {
+		// TODO: add context parameter to HasProjectionTable in a future refactor.
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			pm.logger.Warn(context.Background(), "failed to look up resource type for projection",
+				"slug", slug, "error", err)
+		}
 		return false
 	}
 	var schema json.RawMessage
@@ -139,20 +147,30 @@ func (pm *projectionManager) HasProjectionTable(slug string) bool {
 	if jsonld.IsAbstract(ldContext) {
 		// Abstract types get their own projection table.
 		if err := pm.EnsureTable(context.Background(), slug, schema, ldContext); err != nil {
+			pm.logger.Warn(context.Background(), "failed to lazily create abstract projection table",
+				"slug", slug, "error", err)
 			return false
 		}
 		return true
 	}
 	if err := pm.EnsureTable(context.Background(), slug, schema, ldContext); err != nil {
+		pm.logger.Warn(context.Background(), "failed to lazily create projection table",
+			"slug", slug, "error", err)
 		return false
 	}
 	return true
 }
 
 // lazyRegisterSubtype checks if the parent is abstract and registers the child as a subtype.
+// A sentinel is stored in childToParent before recursing into HasProjectionTable to
+// prevent infinite recursion when circular rdfs:subClassOf relationships exist.
 func (pm *projectionManager) lazyRegisterSubtype(childSlug, parentSlug string, childSchema json.RawMessage) bool {
 	var parent models.ResourceType
 	if err := pm.db.Where("slug = ?", parentSlug).First(&parent).Error; err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			pm.logger.Warn(context.Background(), "failed to look up parent type for subtype registration",
+				"child", childSlug, "parent", parentSlug, "error", err)
+		}
 		return false
 	}
 	var parentCtx json.RawMessage
@@ -162,11 +180,16 @@ func (pm *projectionManager) lazyRegisterSubtype(childSlug, parentSlug string, c
 	if !jsonld.IsAbstract(parentCtx) {
 		return false
 	}
-	// Ensure parent table exists first.
+	// Store sentinel to break potential circular recursion.
+	pm.childToParent.Store(childSlug, parentSlug)
 	if !pm.HasProjectionTable(parentSlug) {
+		pm.childToParent.Delete(childSlug)
 		return false
 	}
 	if err := pm.RegisterSubtype(context.Background(), childSlug, parentSlug, childSchema); err != nil {
+		pm.childToParent.Delete(childSlug)
+		pm.logger.Warn(context.Background(), "failed to lazily register subtype",
+			"child", childSlug, "parent", parentSlug, "error", err)
 		return false
 	}
 	return true
@@ -236,8 +259,10 @@ func (pm *projectionManager) ReverseReferences(targetTypeSlug string) []reposito
 func (pm *projectionManager) RegisterSubtype(
 	ctx context.Context, childSlug, parentSlug string, childSchema json.RawMessage,
 ) error {
+	if _, ok := pm.tables.Load(parentSlug); !ok {
+		return fmt.Errorf("parent type %q has no projection table; call EnsureTable first", parentSlug)
+	}
 	parentTableName := pm.TableName(parentSlug)
-	// Merge child schema columns into the parent projection table.
 	columns := schemaToColumns(childSchema)
 	if err := pm.addMissingColumns(ctx, parentTableName, columns); err != nil {
 		return fmt.Errorf("failed to add subtype columns to %q: %w", parentTableName, err)
@@ -294,13 +319,13 @@ func (pm *projectionManager) registerReverseReferences(slug string, schema json.
 			DisplayProperty: displayProp,
 		}
 
-		// Append to existing slice or create new.
+		// Append to existing slice or create new, under lock to prevent TOCTOU races.
+		pm.reverseReMu.Lock()
 		existing, _ := pm.reverseRe.Load(prop.XResourceType)
 		var refs []repositories.ReverseReference
 		if existing != nil {
 			refs = existing.([]repositories.ReverseReference)
 		}
-		// Avoid duplicates on re-registration.
 		found := false
 		for _, r := range refs {
 			if r.TypeSlug == ref.TypeSlug && r.FKColumn == ref.FKColumn {
@@ -312,6 +337,7 @@ func (pm *projectionManager) registerReverseReferences(slug string, schema json.
 			refs = append(refs, ref)
 			pm.reverseRe.Store(prop.XResourceType, refs)
 		}
+		pm.reverseReMu.Unlock()
 	}
 }
 

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -120,6 +120,8 @@ func (pm *projectionManager) EnsureTable(
 	pm.tables.Store(slug, tableInfo{name: tableName, context: ldContext, columns: colSet})
 	if parentSlug := jsonld.SubClassOf(ldContext); parentSlug != "" {
 		pm.parentOf.Store(slug, parentSlug)
+	} else {
+		pm.parentOf.Delete(slug)
 	}
 	pm.registerReverseReferences(slug, schema)
 	return nil

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"hash/fnv"
 	"strings"
 	"sync"
 
@@ -67,13 +66,12 @@ type tableInfo struct {
 }
 
 type projectionManager struct {
-	db            *gorm.DB
-	logger        entities.Logger
-	tables        sync.Map   // slug → tableInfo
-	reverseRe     sync.Map   // targetTypeSlug → []repositories.ReverseReference
-	reverseReMu   sync.Mutex // guards reverseRe writes
-	childToParent sync.Map   // childSlug → parentSlug (subtypes sharing parent's projection table)
-	childContexts sync.Map   // childSlug → json.RawMessage (child's own JSON-LD context)
+	db          *gorm.DB
+	logger      entities.Logger
+	tables      sync.Map   // slug → tableInfo
+	reverseRe   sync.Map   // targetTypeSlug → []repositories.ReverseReference
+	reverseReMu sync.Mutex // guards reverseRe writes
+	parentOf    sync.Map   // slug → parentSlug (from rdfs:subClassOf, for ancestor chain)
 }
 
 type ProjectionManagerResult struct {
@@ -110,6 +108,9 @@ func (pm *projectionManager) EnsureTable(
 	}
 
 	pm.tables.Store(slug, tableInfo{name: tableName, context: ldContext})
+	if parentSlug := jsonld.SubClassOf(ldContext); parentSlug != "" {
+		pm.parentOf.Store(slug, parentSlug)
+	}
 	pm.registerReverseReferences(slug, schema)
 	return nil
 }
@@ -118,18 +119,9 @@ func (pm *projectionManager) HasProjectionTable(slug string) bool {
 	if _, ok := pm.tables.Load(slug); ok {
 		return true
 	}
-	if v, ok := pm.childToParent.Load(slug); ok {
-		// Only return true if the parent's table is actually ready (not just a sentinel).
-		if parentSlug, ok := v.(string); ok && parentSlug != "" {
-			if _, parentReady := pm.tables.Load(parentSlug); parentReady {
-				return true
-			}
-		}
-	}
-	// Lazy registration: another process may have created the type after startup.
+	// Lazy creation: another process may have created the type after startup.
 	var rt models.ResourceType
-	if err := pm.db.Where("slug = ?", slug).First(&rt).Error; err != nil {
-		// TODO: add context parameter to HasProjectionTable in a future refactor.
+	if err := pm.db.Where("slug = ? AND deleted_at IS NULL", slug).First(&rt).Error; err != nil {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			pm.logger.Warn(context.Background(), "failed to look up resource type for projection",
 				"slug", slug, "error", err)
@@ -144,23 +136,6 @@ func (pm *projectionManager) HasProjectionTable(slug string) bool {
 	if rt.Context != "" {
 		ldContext = json.RawMessage(rt.Context)
 	}
-	// Abstract types always get their own projection table, even if they also
-	// declare rdfs:subClassOf. Check this before subtype registration.
-	if jsonld.IsAbstract(ldContext) {
-		if err := pm.EnsureTable(context.Background(), slug, schema, ldContext); err != nil {
-			pm.logger.Warn(context.Background(), "failed to lazily create abstract projection table",
-				"slug", slug, "error", err)
-			return false
-		}
-		return true
-	}
-	// Check if this type is a subtype of an abstract parent.
-	parentSlug := jsonld.SubClassOf(ldContext)
-	if parentSlug != "" {
-		if pm.lazyRegisterSubtype(slug, parentSlug, schema, ldContext) {
-			return true
-		}
-	}
 	if err := pm.EnsureTable(context.Background(), slug, schema, ldContext); err != nil {
 		pm.logger.Warn(context.Background(), "failed to lazily create projection table",
 			"slug", slug, "error", err)
@@ -169,62 +144,17 @@ func (pm *projectionManager) HasProjectionTable(slug string) bool {
 	return true
 }
 
-// lazyRegisterSubtype checks if the parent is abstract and registers the child as a subtype.
-// A sentinel is stored in childToParent before recursing into HasProjectionTable to
-// prevent infinite recursion when circular rdfs:subClassOf relationships exist.
-func (pm *projectionManager) lazyRegisterSubtype(
-	childSlug, parentSlug string, childSchema, childLdContext json.RawMessage,
-) bool {
-	var parent models.ResourceType
-	if err := pm.db.Where("slug = ?", parentSlug).First(&parent).Error; err != nil {
-		if !errors.Is(err, gorm.ErrRecordNotFound) {
-			pm.logger.Warn(context.Background(), "failed to look up parent type for subtype registration",
-				"child", childSlug, "parent", parentSlug, "error", err)
-		}
-		return false
-	}
-	var parentCtx json.RawMessage
-	if parent.Context != "" {
-		parentCtx = json.RawMessage(parent.Context)
-	}
-	if !jsonld.IsAbstract(parentCtx) {
-		return false
-	}
-	// Store empty sentinel to break circular recursion. HasProjectionTable rejects
-	// empty parent slugs, so concurrent callers won't treat this as ready.
-	pm.childToParent.Store(childSlug, "")
-	if !pm.HasProjectionTable(parentSlug) {
-		pm.childToParent.Delete(childSlug)
-		return false
-	}
-	if err := pm.RegisterSubtype(context.Background(), childSlug, parentSlug, childSchema, childLdContext); err != nil {
-		pm.childToParent.Delete(childSlug)
-		pm.logger.Warn(context.Background(), "failed to lazily register subtype",
-			"child", childSlug, "parent", parentSlug, "error", err)
-		return false
-	}
-	return true
-}
-
 func (pm *projectionManager) TableName(slug string) string {
-	resolved := pm.resolveSlug(slug)
-	if v, ok := pm.tables.Load(resolved); ok {
+	if v, ok := pm.tables.Load(slug); ok {
 		if info, ok := v.(tableInfo); ok {
 			return info.name
 		}
 	}
-	return slugToTableName(resolved)
+	return slugToTableName(slug)
 }
 
 func (pm *projectionManager) Context(slug string) json.RawMessage {
-	// Return the child's own context if it's a registered subtype.
-	if v, ok := pm.childContexts.Load(slug); ok {
-		if ctx, ok := v.(json.RawMessage); ok {
-			return ctx
-		}
-	}
-	resolved := pm.resolveSlug(slug)
-	if v, ok := pm.tables.Load(resolved); ok {
+	if v, ok := pm.tables.Load(slug); ok {
 		if info, ok := v.(tableInfo); ok {
 			return info.context
 		}
@@ -232,25 +162,30 @@ func (pm *projectionManager) Context(slug string) json.RawMessage {
 	return nil
 }
 
-// resolveSlug returns the parent slug if slug is a fully registered subtype, otherwise slug itself.
-// Empty parent slugs (used as recursion sentinels) are treated as unresolved.
-func (pm *projectionManager) resolveSlug(slug string) string {
-	if v, ok := pm.childToParent.Load(slug); ok {
-		if parentSlug, ok := v.(string); ok && parentSlug != "" {
-			return parentSlug
-		}
-	}
-	return slug
-}
-
 func (pm *projectionManager) UpdateColumn(ctx context.Context, typeSlug, resourceID, column string, value any) error {
 	if !pm.HasProjectionTable(typeSlug) {
 		return nil
 	}
 	tableName := pm.TableName(typeSlug)
-	return pm.db.WithContext(ctx).Table(tableName).
-		Where("id = ?", resourceID).
-		Update(column, value).Error
+	if err := pm.db.WithContext(ctx).Table(tableName).
+		Where("id = ?", resourceID).Update(column, value).Error; err != nil {
+		return err
+	}
+	// Propagate to ancestor tables if the column exists there.
+	for _, ancestorSlug := range pm.AncestorSlugs(typeSlug) {
+		if !pm.HasProjectionTable(ancestorSlug) {
+			continue
+		}
+		aTable := pm.TableName(ancestorSlug)
+		if !pm.db.Migrator().HasColumn(aTable, column) {
+			continue
+		}
+		if err := pm.db.WithContext(ctx).Table(aTable).
+			Where("id = ?", resourceID).Update(column, value).Error; err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (pm *projectionManager) UpdateColumnByFK(
@@ -260,19 +195,14 @@ func (pm *projectionManager) UpdateColumnByFK(
 		return nil
 	}
 	tableName := pm.TableName(typeSlug)
-	query := pm.db.WithContext(ctx).Table(tableName).
-		Where(fkColumn+" = ?", fkValue)
-	// Add type_slug discriminator for shared tables to avoid updating other subtypes' rows.
-	if pm.IsSubtype(typeSlug) {
-		query = query.Where("type_slug = ?", typeSlug)
-	}
-	return query.Update(targetColumn, targetValue).Error
+	return pm.db.WithContext(ctx).Table(tableName).
+		Where(fkColumn+" = ?", fkValue).
+		Update(targetColumn, targetValue).Error
 }
 
 func (pm *projectionManager) ReverseReferences(targetTypeSlug string) []repositories.ReverseReference {
 	if v, ok := pm.reverseRe.Load(targetTypeSlug); ok {
 		if refs, ok := v.([]repositories.ReverseReference); ok {
-			// Return a copy to avoid data races with concurrent writes.
 			cp := make([]repositories.ReverseReference, len(refs))
 			copy(cp, refs)
 			return cp
@@ -281,42 +211,26 @@ func (pm *projectionManager) ReverseReferences(targetTypeSlug string) []reposito
 	return nil
 }
 
-func (pm *projectionManager) RegisterSubtype(
-	ctx context.Context, childSlug, parentSlug string,
-	childSchema, childLdContext json.RawMessage,
-) error {
-	if _, ok := pm.tables.Load(parentSlug); !ok {
-		return fmt.Errorf("parent type %q has no projection table; call EnsureTable first", parentSlug)
-	}
-	parentTableName := pm.TableName(parentSlug)
-	columns := schemaToColumns(childSchema)
-	if err := pm.addMissingColumns(ctx, parentTableName, columns); err != nil {
-		return fmt.Errorf("failed to add subtype columns to %q: %w", parentTableName, err)
-	}
-	pm.childToParent.Store(childSlug, parentSlug)
-	if len(childLdContext) > 0 {
-		pm.childContexts.Store(childSlug, childLdContext)
-	}
-	pm.registerReverseReferences(childSlug, childSchema)
-	return nil
-}
-
-func (pm *projectionManager) IsSubtype(slug string) bool {
-	if v, ok := pm.childToParent.Load(slug); ok {
-		if ps, ok := v.(string); ok && ps != "" {
-			return true
+// AncestorSlugs returns the ordered chain of ancestor type slugs by walking
+// rdfs:subClassOf relationships cached during EnsureTable.
+func (pm *projectionManager) AncestorSlugs(slug string) []string {
+	var chain []string
+	visited := map[string]bool{slug: true}
+	current := slug
+	for {
+		v, ok := pm.parentOf.Load(current)
+		if !ok {
+			break
 		}
-	}
-	return false
-}
-
-func (pm *projectionManager) ParentSlug(slug string) string {
-	if v, ok := pm.childToParent.Load(slug); ok {
-		if ps, ok := v.(string); ok {
-			return ps
+		parent, ok := v.(string)
+		if !ok || parent == "" || visited[parent] {
+			break
 		}
+		visited[parent] = true
+		chain = append(chain, parent)
+		current = parent
 	}
-	return ""
+	return chain
 }
 
 // registerReverseReferences parses a schema for x-resource-type properties and
@@ -379,79 +293,22 @@ func (pm *projectionManager) registerReverseReferences(slug string, schema json.
 
 func (pm *projectionManager) EnsureExistingTables(ctx context.Context) error {
 	var types []models.ResourceType
-	if err := pm.db.WithContext(ctx).Find(&types).Error; err != nil {
+	if err := pm.db.WithContext(ctx).
+		Where("deleted_at IS NULL").Find(&types).Error; err != nil {
 		return fmt.Errorf("failed to load existing resource types: %w", err)
 	}
-
-	// Build a slug→context lookup for parent resolution.
-	typeBySlug := make(map[string]models.ResourceType, len(types))
 	for _, rt := range types {
-		typeBySlug[rt.Slug] = rt
-	}
-
-	// Pass 1: Create projection tables for abstract types and concrete types without abstract parents.
-	for _, rt := range types {
-		schema := json.RawMessage(nil)
+		var schema json.RawMessage
 		if rt.Schema != "" {
 			schema = json.RawMessage(rt.Schema)
 		}
 		var ldContext json.RawMessage
 		if rt.Context != "" {
 			ldContext = json.RawMessage(rt.Context)
-		}
-		// If this concrete type has an abstract parent, skip — handled in pass 2.
-		// Abstract types always get their own table even if they declare subClassOf.
-		if !jsonld.IsAbstract(ldContext) {
-			parentSlug := jsonld.SubClassOf(ldContext)
-			if parentSlug != "" {
-				if parent, ok := typeBySlug[parentSlug]; ok {
-					var parentCtx json.RawMessage
-					if parent.Context != "" {
-						parentCtx = json.RawMessage(parent.Context)
-					}
-					if jsonld.IsAbstract(parentCtx) {
-						continue
-					}
-				}
-			}
 		}
 		if err := pm.EnsureTable(ctx, rt.Slug, schema, ldContext); err != nil {
-			pm.logger.Error(ctx, "failed to ensure projection table for existing type",
+			pm.logger.Error(ctx, "failed to ensure projection table",
 				"slug", rt.Slug, "error", err)
-		}
-	}
-
-	// Pass 2: Register concrete subtypes of abstract parents (abstract children got their own tables).
-	for _, rt := range types {
-		var ldContext json.RawMessage
-		if rt.Context != "" {
-			ldContext = json.RawMessage(rt.Context)
-		}
-		if jsonld.IsAbstract(ldContext) {
-			continue
-		}
-		parentSlug := jsonld.SubClassOf(ldContext)
-		if parentSlug == "" {
-			continue
-		}
-		parent, ok := typeBySlug[parentSlug]
-		if !ok {
-			continue
-		}
-		var parentCtx json.RawMessage
-		if parent.Context != "" {
-			parentCtx = json.RawMessage(parent.Context)
-		}
-		if !jsonld.IsAbstract(parentCtx) {
-			continue
-		}
-		schema := json.RawMessage(nil)
-		if rt.Schema != "" {
-			schema = json.RawMessage(rt.Schema)
-		}
-		if err := pm.RegisterSubtype(ctx, rt.Slug, parentSlug, schema, ldContext); err != nil {
-			pm.logger.Error(ctx, "failed to register subtype projection",
-				"child", rt.Slug, "parent", parentSlug, "error", err)
 		}
 	}
 	return nil
@@ -483,22 +340,7 @@ func (pm *projectionManager) createTableIfNotExists(ctx context.Context, tableNa
 	ddl := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n  %s\n)",
 		tableName, strings.Join(colDefs, ",\n  "))
 
-	if err := pm.db.WithContext(ctx).Exec(ddl).Error; err != nil {
-		return err
-	}
-
-	// Index on type_slug for efficient subtype queries on shared tables.
-	// Use hash suffix to avoid Postgres' 63-byte identifier limit and collisions.
-	h := fnv.New32a()
-	h.Write([]byte(tableName))
-	idxName := fmt.Sprintf("idx_%s_ts_%08x", tableName, h.Sum32())
-	if len(idxName) > 63 {
-		idxName = fmt.Sprintf("idx_ts_%08x", h.Sum32())
-	}
-	idxDDL := fmt.Sprintf(
-		"CREATE INDEX IF NOT EXISTS %s ON %s (type_slug)",
-		idxName, tableName)
-	return pm.db.WithContext(ctx).Exec(idxDDL).Error
+	return pm.db.WithContext(ctx).Exec(ddl).Error
 }
 
 func (pm *projectionManager) addMissingColumns(ctx context.Context, tableName string, columns []columnDef) error {

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -63,6 +63,7 @@ var jsonLDKeys = map[string]bool{
 type tableInfo struct {
 	name    string
 	context json.RawMessage
+	columns map[string]bool // cached column names for fast lookup
 }
 
 type projectionManager struct {
@@ -107,7 +108,16 @@ func (pm *projectionManager) EnsureTable(
 		return fmt.Errorf("failed to add columns to %q: %w", tableName, err)
 	}
 
-	pm.tables.Store(slug, tableInfo{name: tableName, context: ldContext})
+	colSet := make(map[string]bool, len(columns)+len(standardColumnNames))
+	for col := range standardColumnNames {
+		if col != "data" { // data lives in resources table, not projection
+			colSet[col] = true
+		}
+	}
+	for _, col := range columns {
+		colSet[col.Name] = true
+	}
+	pm.tables.Store(slug, tableInfo{name: tableName, context: ldContext, columns: colSet})
 	if parentSlug := jsonld.SubClassOf(ldContext); parentSlug != "" {
 		pm.parentOf.Store(slug, parentSlug)
 	}
@@ -162,6 +172,15 @@ func (pm *projectionManager) Context(slug string) json.RawMessage {
 	return nil
 }
 
+func (pm *projectionManager) HasColumn(slug, column string) bool {
+	if v, ok := pm.tables.Load(slug); ok {
+		if info, ok := v.(tableInfo); ok {
+			return info.columns[column]
+		}
+	}
+	return false
+}
+
 func (pm *projectionManager) UpdateColumn(ctx context.Context, typeSlug, resourceID, column string, value any) error {
 	if !pm.HasProjectionTable(typeSlug) {
 		return nil
@@ -176,10 +195,10 @@ func (pm *projectionManager) UpdateColumn(ctx context.Context, typeSlug, resourc
 		if !pm.HasProjectionTable(ancestorSlug) {
 			continue
 		}
-		aTable := pm.TableName(ancestorSlug)
-		if !pm.db.Migrator().HasColumn(aTable, column) {
+		if !pm.HasColumn(ancestorSlug, column) {
 			continue
 		}
+		aTable := pm.TableName(ancestorSlug)
 		if err := pm.db.WithContext(ctx).Table(aTable).
 			Where("id = ?", resourceID).Update(column, value).Error; err != nil {
 			return err

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -302,8 +302,12 @@ func (pm *projectionManager) RegisterSubtype(
 }
 
 func (pm *projectionManager) IsSubtype(slug string) bool {
-	_, ok := pm.childToParent.Load(slug)
-	return ok
+	if v, ok := pm.childToParent.Load(slug); ok {
+		if ps, ok := v.(string); ok && ps != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func (pm *projectionManager) ParentSlug(slug string) string {

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"strings"
 	"sync"
 
@@ -189,8 +190,9 @@ func (pm *projectionManager) lazyRegisterSubtype(
 	if !jsonld.IsAbstract(parentCtx) {
 		return false
 	}
-	// Store sentinel to break potential circular recursion.
-	pm.childToParent.Store(childSlug, parentSlug)
+	// Store empty sentinel to break circular recursion. HasProjectionTable rejects
+	// empty parent slugs, so concurrent callers won't treat this as ready.
+	pm.childToParent.Store(childSlug, "")
 	if !pm.HasProjectionTable(parentSlug) {
 		pm.childToParent.Delete(childSlug)
 		return false
@@ -475,10 +477,12 @@ func (pm *projectionManager) createTableIfNotExists(ctx context.Context, tableNa
 	}
 
 	// Index on type_slug for efficient subtype queries on shared tables.
-	// Truncate index name to stay under Postgres' 63-byte identifier limit.
-	idxName := fmt.Sprintf("idx_%s_type_slug", tableName)
+	// Use hash suffix to avoid Postgres' 63-byte identifier limit and collisions.
+	h := fnv.New32a()
+	h.Write([]byte(tableName))
+	idxName := fmt.Sprintf("idx_%s_ts_%08x", tableName, h.Sum32())
 	if len(idxName) > 63 {
-		idxName = idxName[:63]
+		idxName = fmt.Sprintf("idx_ts_%08x", h.Sum32())
 	}
 	idxDDL := fmt.Sprintf(
 		"CREATE INDEX IF NOT EXISTS %s ON %s (type_slug)",

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -191,6 +191,8 @@ func (pm *projectionManager) UpdateColumn(ctx context.Context, typeSlug, resourc
 		return err
 	}
 	// Propagate to ancestor tables if the column exists there.
+	// If the ancestor row doesn't exist (e.g., ancestor table added after resource creation),
+	// the update is a no-op (0 rows affected), which is acceptable for display value propagation.
 	for _, ancestorSlug := range pm.AncestorSlugs(typeSlug) {
 		if !pm.HasProjectionTable(ancestorSlug) {
 			continue

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -232,10 +232,11 @@ func (pm *projectionManager) Context(slug string) json.RawMessage {
 	return nil
 }
 
-// resolveSlug returns the parent slug if slug is a registered subtype, otherwise slug itself.
+// resolveSlug returns the parent slug if slug is a fully registered subtype, otherwise slug itself.
+// Empty parent slugs (used as recursion sentinels) are treated as unresolved.
 func (pm *projectionManager) resolveSlug(slug string) string {
 	if v, ok := pm.childToParent.Load(slug); ok {
-		if parentSlug, ok := v.(string); ok {
+		if parentSlug, ok := v.(string); ok && parentSlug != "" {
 			return parentSlug
 		}
 	}
@@ -271,7 +272,10 @@ func (pm *projectionManager) UpdateColumnByFK(
 func (pm *projectionManager) ReverseReferences(targetTypeSlug string) []repositories.ReverseReference {
 	if v, ok := pm.reverseRe.Load(targetTypeSlug); ok {
 		if refs, ok := v.([]repositories.ReverseReference); ok {
-			return refs
+			// Return a copy to avoid data races with concurrent writes.
+			cp := make([]repositories.ReverseReference, len(refs))
+			copy(cp, refs)
+			return cp
 		}
 	}
 	return nil
@@ -344,23 +348,26 @@ func (pm *projectionManager) registerReverseReferences(slug string, schema json.
 			DisplayProperty: displayProp,
 		}
 
-		// Append to existing slice or create new, under lock to prevent TOCTOU races.
+		// Append using copy-on-write under lock to prevent TOCTOU races and
+		// avoid data races with concurrent readers of ReverseReferences().
 		pm.reverseReMu.Lock()
 		existing, _ := pm.reverseRe.Load(prop.XResourceType)
-		var refs []repositories.ReverseReference
+		var old []repositories.ReverseReference
 		if existing != nil {
-			refs = existing.([]repositories.ReverseReference)
+			old = existing.([]repositories.ReverseReference)
 		}
 		found := false
-		for _, r := range refs {
+		for _, r := range old {
 			if r.TypeSlug == ref.TypeSlug && r.FKColumn == ref.FKColumn {
 				found = true
 				break
 			}
 		}
 		if !found {
-			refs = append(refs, ref)
-			pm.reverseRe.Store(prop.XResourceType, refs)
+			updated := make([]repositories.ReverseReference, len(old)+1)
+			copy(updated, old)
+			updated[len(old)] = ref
+			pm.reverseRe.Store(prop.XResourceType, updated)
 		}
 		pm.reverseReMu.Unlock()
 	}

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -64,10 +64,11 @@ type tableInfo struct {
 }
 
 type projectionManager struct {
-	db        *gorm.DB
-	logger    entities.Logger
-	tables    sync.Map // slug → tableInfo
-	reverseRe sync.Map // targetTypeSlug → []repositories.ReverseReference
+	db            *gorm.DB
+	logger        entities.Logger
+	tables        sync.Map // slug → tableInfo
+	reverseRe     sync.Map // targetTypeSlug → []repositories.ReverseReference
+	childToParent sync.Map // childSlug → parentSlug (for abstract type inheritance)
 }
 
 type ProjectionManagerResult struct {
@@ -112,6 +113,9 @@ func (pm *projectionManager) HasProjectionTable(slug string) bool {
 	if _, ok := pm.tables.Load(slug); ok {
 		return true
 	}
+	if _, ok := pm.childToParent.Load(slug); ok {
+		return true
+	}
 	// Lazy registration: another process may have created the type after startup.
 	var rt models.ResourceType
 	if err := pm.db.Where("slug = ?", slug).First(&rt).Error; err != nil {
@@ -125,28 +129,77 @@ func (pm *projectionManager) HasProjectionTable(slug string) bool {
 	if rt.Context != "" {
 		ldContext = json.RawMessage(rt.Context)
 	}
+	// Check if this type is a subtype of an abstract parent.
+	parentSlug := jsonld.SubClassOf(ldContext)
+	if parentSlug != "" {
+		if pm.lazyRegisterSubtype(slug, parentSlug, schema) {
+			return true
+		}
+	}
+	if jsonld.IsAbstract(ldContext) {
+		// Abstract types get their own projection table.
+		if err := pm.EnsureTable(context.Background(), slug, schema, ldContext); err != nil {
+			return false
+		}
+		return true
+	}
 	if err := pm.EnsureTable(context.Background(), slug, schema, ldContext); err != nil {
 		return false
 	}
 	return true
 }
 
+// lazyRegisterSubtype checks if the parent is abstract and registers the child as a subtype.
+func (pm *projectionManager) lazyRegisterSubtype(childSlug, parentSlug string, childSchema json.RawMessage) bool {
+	var parent models.ResourceType
+	if err := pm.db.Where("slug = ?", parentSlug).First(&parent).Error; err != nil {
+		return false
+	}
+	var parentCtx json.RawMessage
+	if parent.Context != "" {
+		parentCtx = json.RawMessage(parent.Context)
+	}
+	if !jsonld.IsAbstract(parentCtx) {
+		return false
+	}
+	// Ensure parent table exists first.
+	if !pm.HasProjectionTable(parentSlug) {
+		return false
+	}
+	if err := pm.RegisterSubtype(context.Background(), childSlug, parentSlug, childSchema); err != nil {
+		return false
+	}
+	return true
+}
+
 func (pm *projectionManager) TableName(slug string) string {
-	if v, ok := pm.tables.Load(slug); ok {
+	resolved := pm.resolveSlug(slug)
+	if v, ok := pm.tables.Load(resolved); ok {
 		if info, ok := v.(tableInfo); ok {
 			return info.name
 		}
 	}
-	return slugToTableName(slug)
+	return slugToTableName(resolved)
 }
 
 func (pm *projectionManager) Context(slug string) json.RawMessage {
-	if v, ok := pm.tables.Load(slug); ok {
+	resolved := pm.resolveSlug(slug)
+	if v, ok := pm.tables.Load(resolved); ok {
 		if info, ok := v.(tableInfo); ok {
 			return info.context
 		}
 	}
 	return nil
+}
+
+// resolveSlug returns the parent slug if slug is a registered subtype, otherwise slug itself.
+func (pm *projectionManager) resolveSlug(slug string) string {
+	if v, ok := pm.childToParent.Load(slug); ok {
+		if parentSlug, ok := v.(string); ok {
+			return parentSlug
+		}
+	}
+	return slug
 }
 
 func (pm *projectionManager) UpdateColumn(ctx context.Context, typeSlug, resourceID, column string, value any) error {
@@ -178,6 +231,34 @@ func (pm *projectionManager) ReverseReferences(targetTypeSlug string) []reposito
 		}
 	}
 	return nil
+}
+
+func (pm *projectionManager) RegisterSubtype(
+	ctx context.Context, childSlug, parentSlug string, childSchema json.RawMessage,
+) error {
+	parentTableName := pm.TableName(parentSlug)
+	// Merge child schema columns into the parent projection table.
+	columns := schemaToColumns(childSchema)
+	if err := pm.addMissingColumns(ctx, parentTableName, columns); err != nil {
+		return fmt.Errorf("failed to add subtype columns to %q: %w", parentTableName, err)
+	}
+	pm.childToParent.Store(childSlug, parentSlug)
+	pm.registerReverseReferences(childSlug, childSchema)
+	return nil
+}
+
+func (pm *projectionManager) IsSubtype(slug string) bool {
+	_, ok := pm.childToParent.Load(slug)
+	return ok
+}
+
+func (pm *projectionManager) ParentSlug(slug string) string {
+	if v, ok := pm.childToParent.Load(slug); ok {
+		if ps, ok := v.(string); ok {
+			return ps
+		}
+	}
+	return ""
 }
 
 // registerReverseReferences parses a schema for x-resource-type properties and
@@ -240,6 +321,13 @@ func (pm *projectionManager) EnsureExistingTables(ctx context.Context) error {
 		return fmt.Errorf("failed to load existing resource types: %w", err)
 	}
 
+	// Build a slug→context lookup for parent resolution.
+	typeBySlug := make(map[string]models.ResourceType, len(types))
+	for _, rt := range types {
+		typeBySlug[rt.Slug] = rt
+	}
+
+	// Pass 1: Create projection tables for abstract types and concrete types without abstract parents.
 	for _, rt := range types {
 		schema := json.RawMessage(nil)
 		if rt.Schema != "" {
@@ -249,12 +337,53 @@ func (pm *projectionManager) EnsureExistingTables(ctx context.Context) error {
 		if rt.Context != "" {
 			ldContext = json.RawMessage(rt.Context)
 		}
-		if jsonld.IsAbstract(ldContext) {
-			continue
+		// If this type has an abstract parent, skip it for now (handled in pass 2).
+		parentSlug := jsonld.SubClassOf(ldContext)
+		if parentSlug != "" {
+			if parent, ok := typeBySlug[parentSlug]; ok {
+				var parentCtx json.RawMessage
+				if parent.Context != "" {
+					parentCtx = json.RawMessage(parent.Context)
+				}
+				if jsonld.IsAbstract(parentCtx) {
+					continue
+				}
+			}
 		}
 		if err := pm.EnsureTable(ctx, rt.Slug, schema, ldContext); err != nil {
 			pm.logger.Error(ctx, "failed to ensure projection table for existing type",
 				"slug", rt.Slug, "error", err)
+		}
+	}
+
+	// Pass 2: Register subtypes of abstract parents (parent tables exist from pass 1).
+	for _, rt := range types {
+		var ldContext json.RawMessage
+		if rt.Context != "" {
+			ldContext = json.RawMessage(rt.Context)
+		}
+		parentSlug := jsonld.SubClassOf(ldContext)
+		if parentSlug == "" {
+			continue
+		}
+		parent, ok := typeBySlug[parentSlug]
+		if !ok {
+			continue
+		}
+		var parentCtx json.RawMessage
+		if parent.Context != "" {
+			parentCtx = json.RawMessage(parent.Context)
+		}
+		if !jsonld.IsAbstract(parentCtx) {
+			continue
+		}
+		schema := json.RawMessage(nil)
+		if rt.Schema != "" {
+			schema = json.RawMessage(rt.Schema)
+		}
+		if err := pm.RegisterSubtype(ctx, rt.Slug, parentSlug, schema); err != nil {
+			pm.logger.Error(ctx, "failed to register subtype projection",
+				"child", rt.Slug, "parent", parentSlug, "error", err)
 		}
 	}
 	return nil

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -72,6 +72,7 @@ type projectionManager struct {
 	reverseRe     sync.Map   // targetTypeSlug → []repositories.ReverseReference
 	reverseReMu   sync.Mutex // guards reverseRe writes
 	childToParent sync.Map   // childSlug → parentSlug (subtypes sharing parent's projection table)
+	childContexts sync.Map   // childSlug → json.RawMessage (child's own JSON-LD context)
 }
 
 type ProjectionManagerResult struct {
@@ -137,21 +138,22 @@ func (pm *projectionManager) HasProjectionTable(slug string) bool {
 	if rt.Context != "" {
 		ldContext = json.RawMessage(rt.Context)
 	}
-	// Check if this type is a subtype of an abstract parent.
-	parentSlug := jsonld.SubClassOf(ldContext)
-	if parentSlug != "" {
-		if pm.lazyRegisterSubtype(slug, parentSlug, schema) {
-			return true
-		}
-	}
+	// Abstract types always get their own projection table, even if they also
+	// declare rdfs:subClassOf. Check this before subtype registration.
 	if jsonld.IsAbstract(ldContext) {
-		// Abstract types get their own projection table.
 		if err := pm.EnsureTable(context.Background(), slug, schema, ldContext); err != nil {
 			pm.logger.Warn(context.Background(), "failed to lazily create abstract projection table",
 				"slug", slug, "error", err)
 			return false
 		}
 		return true
+	}
+	// Check if this type is a subtype of an abstract parent.
+	parentSlug := jsonld.SubClassOf(ldContext)
+	if parentSlug != "" {
+		if pm.lazyRegisterSubtype(slug, parentSlug, schema, ldContext) {
+			return true
+		}
 	}
 	if err := pm.EnsureTable(context.Background(), slug, schema, ldContext); err != nil {
 		pm.logger.Warn(context.Background(), "failed to lazily create projection table",
@@ -164,7 +166,9 @@ func (pm *projectionManager) HasProjectionTable(slug string) bool {
 // lazyRegisterSubtype checks if the parent is abstract and registers the child as a subtype.
 // A sentinel is stored in childToParent before recursing into HasProjectionTable to
 // prevent infinite recursion when circular rdfs:subClassOf relationships exist.
-func (pm *projectionManager) lazyRegisterSubtype(childSlug, parentSlug string, childSchema json.RawMessage) bool {
+func (pm *projectionManager) lazyRegisterSubtype(
+	childSlug, parentSlug string, childSchema, childLdContext json.RawMessage,
+) bool {
 	var parent models.ResourceType
 	if err := pm.db.Where("slug = ?", parentSlug).First(&parent).Error; err != nil {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
@@ -186,7 +190,7 @@ func (pm *projectionManager) lazyRegisterSubtype(childSlug, parentSlug string, c
 		pm.childToParent.Delete(childSlug)
 		return false
 	}
-	if err := pm.RegisterSubtype(context.Background(), childSlug, parentSlug, childSchema); err != nil {
+	if err := pm.RegisterSubtype(context.Background(), childSlug, parentSlug, childSchema, childLdContext); err != nil {
 		pm.childToParent.Delete(childSlug)
 		pm.logger.Warn(context.Background(), "failed to lazily register subtype",
 			"child", childSlug, "parent", parentSlug, "error", err)
@@ -206,6 +210,12 @@ func (pm *projectionManager) TableName(slug string) string {
 }
 
 func (pm *projectionManager) Context(slug string) json.RawMessage {
+	// Return the child's own context if it's a registered subtype.
+	if v, ok := pm.childContexts.Load(slug); ok {
+		if ctx, ok := v.(json.RawMessage); ok {
+			return ctx
+		}
+	}
 	resolved := pm.resolveSlug(slug)
 	if v, ok := pm.tables.Load(resolved); ok {
 		if info, ok := v.(tableInfo); ok {
@@ -242,9 +252,13 @@ func (pm *projectionManager) UpdateColumnByFK(
 		return nil
 	}
 	tableName := pm.TableName(typeSlug)
-	return pm.db.WithContext(ctx).Table(tableName).
-		Where(fkColumn+" = ?", fkValue).
-		Update(targetColumn, targetValue).Error
+	query := pm.db.WithContext(ctx).Table(tableName).
+		Where(fkColumn+" = ?", fkValue)
+	// Add type_slug discriminator for shared tables to avoid updating other subtypes' rows.
+	if pm.IsSubtype(typeSlug) {
+		query = query.Where("type_slug = ?", typeSlug)
+	}
+	return query.Update(targetColumn, targetValue).Error
 }
 
 func (pm *projectionManager) ReverseReferences(targetTypeSlug string) []repositories.ReverseReference {
@@ -257,7 +271,8 @@ func (pm *projectionManager) ReverseReferences(targetTypeSlug string) []reposito
 }
 
 func (pm *projectionManager) RegisterSubtype(
-	ctx context.Context, childSlug, parentSlug string, childSchema json.RawMessage,
+	ctx context.Context, childSlug, parentSlug string,
+	childSchema, childLdContext json.RawMessage,
 ) error {
 	if _, ok := pm.tables.Load(parentSlug); !ok {
 		return fmt.Errorf("parent type %q has no projection table; call EnsureTable first", parentSlug)
@@ -268,6 +283,9 @@ func (pm *projectionManager) RegisterSubtype(
 		return fmt.Errorf("failed to add subtype columns to %q: %w", parentTableName, err)
 	}
 	pm.childToParent.Store(childSlug, parentSlug)
+	if len(childLdContext) > 0 {
+		pm.childContexts.Store(childSlug, childLdContext)
+	}
 	pm.registerReverseReferences(childSlug, childSchema)
 	return nil
 }
@@ -407,7 +425,7 @@ func (pm *projectionManager) EnsureExistingTables(ctx context.Context) error {
 		if rt.Schema != "" {
 			schema = json.RawMessage(rt.Schema)
 		}
-		if err := pm.RegisterSubtype(ctx, rt.Slug, parentSlug, schema); err != nil {
+		if err := pm.RegisterSubtype(ctx, rt.Slug, parentSlug, schema, ldContext); err != nil {
 			pm.logger.Error(ctx, "failed to register subtype projection",
 				"child", rt.Slug, "parent", parentSlug, "error", err)
 		}
@@ -441,7 +459,15 @@ func (pm *projectionManager) createTableIfNotExists(ctx context.Context, tableNa
 	ddl := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n  %s\n)",
 		tableName, strings.Join(colDefs, ",\n  "))
 
-	return pm.db.WithContext(ctx).Exec(ddl).Error
+	if err := pm.db.WithContext(ctx).Exec(ddl).Error; err != nil {
+		return err
+	}
+
+	// Index on type_slug for efficient subtype queries on shared tables.
+	idxDDL := fmt.Sprintf(
+		"CREATE INDEX IF NOT EXISTS idx_%s_type_slug ON %s (type_slug)",
+		tableName, tableName)
+	return pm.db.WithContext(ctx).Exec(idxDDL).Error
 }
 
 func (pm *projectionManager) addMissingColumns(ctx context.Context, tableName string, columns []columnDef) error {

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -117,8 +117,13 @@ func (pm *projectionManager) HasProjectionTable(slug string) bool {
 	if _, ok := pm.tables.Load(slug); ok {
 		return true
 	}
-	if _, ok := pm.childToParent.Load(slug); ok {
-		return true
+	if v, ok := pm.childToParent.Load(slug); ok {
+		// Only return true if the parent's table is actually ready (not just a sentinel).
+		if parentSlug, ok := v.(string); ok && parentSlug != "" {
+			if _, parentReady := pm.tables.Load(parentSlug); parentReady {
+				return true
+			}
+		}
 	}
 	// Lazy registration: another process may have created the type after startup.
 	var rt models.ResourceType
@@ -381,16 +386,19 @@ func (pm *projectionManager) EnsureExistingTables(ctx context.Context) error {
 		if rt.Context != "" {
 			ldContext = json.RawMessage(rt.Context)
 		}
-		// If this type has an abstract parent, skip it for now (handled in pass 2).
-		parentSlug := jsonld.SubClassOf(ldContext)
-		if parentSlug != "" {
-			if parent, ok := typeBySlug[parentSlug]; ok {
-				var parentCtx json.RawMessage
-				if parent.Context != "" {
-					parentCtx = json.RawMessage(parent.Context)
-				}
-				if jsonld.IsAbstract(parentCtx) {
-					continue
+		// If this concrete type has an abstract parent, skip — handled in pass 2.
+		// Abstract types always get their own table even if they declare subClassOf.
+		if !jsonld.IsAbstract(ldContext) {
+			parentSlug := jsonld.SubClassOf(ldContext)
+			if parentSlug != "" {
+				if parent, ok := typeBySlug[parentSlug]; ok {
+					var parentCtx json.RawMessage
+					if parent.Context != "" {
+						parentCtx = json.RawMessage(parent.Context)
+					}
+					if jsonld.IsAbstract(parentCtx) {
+						continue
+					}
 				}
 			}
 		}
@@ -400,11 +408,14 @@ func (pm *projectionManager) EnsureExistingTables(ctx context.Context) error {
 		}
 	}
 
-	// Pass 2: Register subtypes of abstract parents (parent tables exist from pass 1).
+	// Pass 2: Register concrete subtypes of abstract parents (abstract children got their own tables).
 	for _, rt := range types {
 		var ldContext json.RawMessage
 		if rt.Context != "" {
 			ldContext = json.RawMessage(rt.Context)
+		}
+		if jsonld.IsAbstract(ldContext) {
+			continue
 		}
 		parentSlug := jsonld.SubClassOf(ldContext)
 		if parentSlug == "" {
@@ -464,9 +475,14 @@ func (pm *projectionManager) createTableIfNotExists(ctx context.Context, tableNa
 	}
 
 	// Index on type_slug for efficient subtype queries on shared tables.
+	// Truncate index name to stay under Postgres' 63-byte identifier limit.
+	idxName := fmt.Sprintf("idx_%s_type_slug", tableName)
+	if len(idxName) > 63 {
+		idxName = idxName[:63]
+	}
 	idxDDL := fmt.Sprintf(
-		"CREATE INDEX IF NOT EXISTS idx_%s_type_slug ON %s (type_slug)",
-		tableName, tableName)
+		"CREATE INDEX IF NOT EXISTS %s ON %s (type_slug)",
+		idxName, tableName)
 	return pm.db.WithContext(ctx).Exec(idxDDL).Error
 }
 

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -127,6 +127,9 @@ func (pm *projectionManager) EnsureTable(
 	return nil
 }
 
+// HasProjectionTable reports whether a projection table exists. Cached entries are not
+// invalidated on type deletion; this is acceptable because type deletion is rare and
+// projection tables are retained even after the type is soft-deleted (for data access).
 func (pm *projectionManager) HasProjectionTable(slug string) bool {
 	if _, ok := pm.tables.Load(slug); ok {
 		return true

--- a/infrastructure/database/gorm/projection_manager_test.go
+++ b/infrastructure/database/gorm/projection_manager_test.go
@@ -360,7 +360,7 @@ func TestRegisterSubtype_MergesColumnsIntoParent(t *testing.T) {
 		"name":{"type":"string"},
 		"interestRate":{"type":"number"}
 	}}`)
-	if err := pm.RegisterSubtype(ctx, "loan", "financial-instrument", childSchema); err != nil {
+	if err := pm.RegisterSubtype(ctx, "loan", "financial-instrument", childSchema, nil); err != nil {
 		t.Fatalf("RegisterSubtype failed: %v", err)
 	}
 
@@ -387,7 +387,7 @@ func TestIsSubtype(t *testing.T) {
 	if err := pm.EnsureTable(ctx, "commitment", nil, nil); err != nil {
 		t.Fatalf("EnsureTable failed: %v", err)
 	}
-	if err := pm.RegisterSubtype(ctx, "invoice", "commitment", nil); err != nil {
+	if err := pm.RegisterSubtype(ctx, "invoice", "commitment", nil, nil); err != nil {
 		t.Fatalf("RegisterSubtype failed: %v", err)
 	}
 
@@ -411,7 +411,7 @@ func TestParentSlug(t *testing.T) {
 	if err := pm.EnsureTable(ctx, "commitment", nil, nil); err != nil {
 		t.Fatalf("EnsureTable failed: %v", err)
 	}
-	if err := pm.RegisterSubtype(ctx, "invoice", "commitment", nil); err != nil {
+	if err := pm.RegisterSubtype(ctx, "invoice", "commitment", nil, nil); err != nil {
 		t.Fatalf("RegisterSubtype failed: %v", err)
 	}
 
@@ -432,7 +432,7 @@ func TestSubtype_TableNameResolvesToParent(t *testing.T) {
 	if err := pm.EnsureTable(ctx, "financial-instrument", nil, nil); err != nil {
 		t.Fatalf("EnsureTable failed: %v", err)
 	}
-	if err := pm.RegisterSubtype(ctx, "loan", "financial-instrument", nil); err != nil {
+	if err := pm.RegisterSubtype(ctx, "loan", "financial-instrument", nil, nil); err != nil {
 		t.Fatalf("RegisterSubtype failed: %v", err)
 	}
 
@@ -455,7 +455,7 @@ func TestSubtype_HasProjectionTable(t *testing.T) {
 	if err := pm.EnsureTable(ctx, "commitment", nil, nil); err != nil {
 		t.Fatalf("EnsureTable failed: %v", err)
 	}
-	if err := pm.RegisterSubtype(ctx, "invoice", "commitment", nil); err != nil {
+	if err := pm.RegisterSubtype(ctx, "invoice", "commitment", nil, nil); err != nil {
 		t.Fatalf("RegisterSubtype failed: %v", err)
 	}
 
@@ -483,10 +483,10 @@ func TestSubtype_MultipleChildrenShareParentTable(t *testing.T) {
 	depositSchema := json.RawMessage(`{"type":"object","properties":{
 		"name":{"type":"string"},"balance":{"type":"number"}}}`)
 
-	if err := pm.RegisterSubtype(ctx, "loan", "financial-instrument", loanSchema); err != nil {
+	if err := pm.RegisterSubtype(ctx, "loan", "financial-instrument", loanSchema, nil); err != nil {
 		t.Fatalf("RegisterSubtype(loan) failed: %v", err)
 	}
-	if err := pm.RegisterSubtype(ctx, "deposit-account", "financial-instrument", depositSchema); err != nil {
+	if err := pm.RegisterSubtype(ctx, "deposit-account", "financial-instrument", depositSchema, nil); err != nil {
 		t.Fatalf("RegisterSubtype(deposit-account) failed: %v", err)
 	}
 
@@ -671,7 +671,7 @@ func TestRegisterSubtype_FailsWithoutParentTable(t *testing.T) {
 	ctx := context.Background()
 
 	childSchema := json.RawMessage(`{"type":"object","properties":{"rate":{"type":"number"}}}`)
-	err := pm.RegisterSubtype(ctx, "loan", "nonexistent-parent", childSchema)
+	err := pm.RegisterSubtype(ctx, "loan", "nonexistent-parent", childSchema, nil)
 	if err == nil {
 		t.Fatal("expected error when parent table doesn't exist")
 	}

--- a/infrastructure/database/gorm/projection_manager_test.go
+++ b/infrastructure/database/gorm/projection_manager_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"weos/infrastructure/models"
 	"weos/pkg/utils"
@@ -343,187 +344,6 @@ func TestExtractFlatColumns(t *testing.T) {
 	}
 }
 
-func TestRegisterSubtype_MergesColumnsIntoParent(t *testing.T) {
-	t.Parallel()
-	db := newTestDB(t)
-	pm := &projectionManager{db: db, logger: &testLogger{}}
-	ctx := context.Background()
-
-	// Create abstract parent projection table with a "name" column.
-	parentSchema := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`)
-	if err := pm.EnsureTable(ctx, "financial-instrument", parentSchema, nil); err != nil {
-		t.Fatalf("EnsureTable for parent failed: %v", err)
-	}
-
-	// Register "loan" as subtype with extra "interestRate" column.
-	childSchema := json.RawMessage(`{"type":"object","properties":{
-		"name":{"type":"string"},
-		"interestRate":{"type":"number"}
-	}}`)
-	if err := pm.RegisterSubtype(ctx, "loan", "financial-instrument", childSchema, nil); err != nil {
-		t.Fatalf("RegisterSubtype failed: %v", err)
-	}
-
-	// Verify the child column was added to the parent table.
-	err := db.Exec(`INSERT INTO financial_instruments (id, type_slug, status, name, interest_rate)
-		VALUES ('loan-1', 'loan', 'active', 'Home Loan', 3.5)`).Error
-	if err != nil {
-		t.Fatalf("insert with child column failed: %v", err)
-	}
-
-	var result map[string]any
-	err = db.Table("financial_instruments").Where("id = ?", "loan-1").Take(&result).Error
-	if err != nil {
-		t.Fatalf("read back failed: %v", err)
-	}
-}
-
-func TestIsSubtype(t *testing.T) {
-	t.Parallel()
-	db := newTestDB(t)
-	pm := &projectionManager{db: db, logger: &testLogger{}}
-	ctx := context.Background()
-
-	if err := pm.EnsureTable(ctx, "commitment", nil, nil); err != nil {
-		t.Fatalf("EnsureTable failed: %v", err)
-	}
-	if err := pm.RegisterSubtype(ctx, "invoice", "commitment", nil, nil); err != nil {
-		t.Fatalf("RegisterSubtype failed: %v", err)
-	}
-
-	if !pm.IsSubtype("invoice") {
-		t.Fatal("expected invoice to be a subtype")
-	}
-	if pm.IsSubtype("commitment") {
-		t.Fatal("expected commitment NOT to be a subtype")
-	}
-	if pm.IsSubtype("unknown") {
-		t.Fatal("expected unknown NOT to be a subtype")
-	}
-}
-
-func TestParentSlug(t *testing.T) {
-	t.Parallel()
-	db := newTestDB(t)
-	pm := &projectionManager{db: db, logger: &testLogger{}}
-	ctx := context.Background()
-
-	if err := pm.EnsureTable(ctx, "commitment", nil, nil); err != nil {
-		t.Fatalf("EnsureTable failed: %v", err)
-	}
-	if err := pm.RegisterSubtype(ctx, "invoice", "commitment", nil, nil); err != nil {
-		t.Fatalf("RegisterSubtype failed: %v", err)
-	}
-
-	if got := pm.ParentSlug("invoice"); got != "commitment" {
-		t.Fatalf("ParentSlug(invoice) = %q, want %q", got, "commitment")
-	}
-	if got := pm.ParentSlug("commitment"); got != "" {
-		t.Fatalf("ParentSlug(commitment) = %q, want empty", got)
-	}
-}
-
-func TestSubtype_TableNameResolvesToParent(t *testing.T) {
-	t.Parallel()
-	db := newTestDB(t)
-	pm := &projectionManager{db: db, logger: &testLogger{}}
-	ctx := context.Background()
-
-	if err := pm.EnsureTable(ctx, "financial-instrument", nil, nil); err != nil {
-		t.Fatalf("EnsureTable failed: %v", err)
-	}
-	if err := pm.RegisterSubtype(ctx, "loan", "financial-instrument", nil, nil); err != nil {
-		t.Fatalf("RegisterSubtype failed: %v", err)
-	}
-
-	// TableName for the subtype should resolve to the parent's table.
-	if got := pm.TableName("loan"); got != "financial_instruments" {
-		t.Fatalf("TableName(loan) = %q, want %q", got, "financial_instruments")
-	}
-	// Parent's own TableName should still work.
-	if got := pm.TableName("financial-instrument"); got != "financial_instruments" {
-		t.Fatalf("TableName(financial-instrument) = %q, want %q", got, "financial_instruments")
-	}
-}
-
-func TestSubtype_HasProjectionTable(t *testing.T) {
-	t.Parallel()
-	db := newTestDB(t)
-	pm := &projectionManager{db: db, logger: &testLogger{}}
-	ctx := context.Background()
-
-	if err := pm.EnsureTable(ctx, "commitment", nil, nil); err != nil {
-		t.Fatalf("EnsureTable failed: %v", err)
-	}
-	if err := pm.RegisterSubtype(ctx, "invoice", "commitment", nil, nil); err != nil {
-		t.Fatalf("RegisterSubtype failed: %v", err)
-	}
-
-	if !pm.HasProjectionTable("invoice") {
-		t.Fatal("expected HasProjectionTable(invoice) = true")
-	}
-	if !pm.HasProjectionTable("commitment") {
-		t.Fatal("expected HasProjectionTable(commitment) = true")
-	}
-}
-
-func TestSubtype_MultipleChildrenShareParentTable(t *testing.T) {
-	t.Parallel()
-	db := newTestDB(t)
-	pm := &projectionManager{db: db, logger: &testLogger{}}
-	ctx := context.Background()
-
-	parentSchema := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`)
-	if err := pm.EnsureTable(ctx, "financial-instrument", parentSchema, nil); err != nil {
-		t.Fatalf("EnsureTable failed: %v", err)
-	}
-
-	loanSchema := json.RawMessage(`{"type":"object","properties":{
-		"name":{"type":"string"},"interestRate":{"type":"number"}}}`)
-	depositSchema := json.RawMessage(`{"type":"object","properties":{
-		"name":{"type":"string"},"balance":{"type":"number"}}}`)
-
-	if err := pm.RegisterSubtype(ctx, "loan", "financial-instrument", loanSchema, nil); err != nil {
-		t.Fatalf("RegisterSubtype(loan) failed: %v", err)
-	}
-	if err := pm.RegisterSubtype(ctx, "deposit-account", "financial-instrument", depositSchema, nil); err != nil {
-		t.Fatalf("RegisterSubtype(deposit-account) failed: %v", err)
-	}
-
-	// Insert rows for both subtypes in the same table.
-	err := db.Exec(`INSERT INTO financial_instruments (id, type_slug, status, name, interest_rate)
-		VALUES ('loan-1', 'loan', 'active', 'Home Loan', 3.5)`).Error
-	if err != nil {
-		t.Fatalf("insert loan failed: %v", err)
-	}
-	err = db.Exec(`INSERT INTO financial_instruments (id, type_slug, status, name, balance)
-		VALUES ('dep-1', 'deposit-account', 'active', 'Savings', 1000.0)`).Error
-	if err != nil {
-		t.Fatalf("insert deposit failed: %v", err)
-	}
-
-	// Both should be in the same table with different type_slug values.
-	var count int64
-	db.Table("financial_instruments").Count(&count)
-	if count != 2 {
-		t.Fatalf("expected 2 rows in financial_instruments, got %d", count)
-	}
-
-	// Filter by type_slug = 'loan' should return 1.
-	var loanCount int64
-	db.Table("financial_instruments").Where("type_slug = ?", "loan").Count(&loanCount)
-	if loanCount != 1 {
-		t.Fatalf("expected 1 loan row, got %d", loanCount)
-	}
-
-	// Filter by type_slug = 'deposit-account' should return 1.
-	var depCount int64
-	db.Table("financial_instruments").Where("type_slug = ?", "deposit-account").Count(&depCount)
-	if depCount != 1 {
-		t.Fatalf("expected 1 deposit-account row, got %d", depCount)
-	}
-}
-
 func newTestDBWithTypes(t *testing.T) *gorm.DB {
 	t.Helper()
 	db := newTestDB(t)
@@ -533,146 +353,184 @@ func newTestDBWithTypes(t *testing.T) *gorm.DB {
 	return db
 }
 
-func TestEnsureExistingTables_TwoPassOrdering(t *testing.T) {
-	t.Parallel()
-	db := newTestDBWithTypes(t)
-	pm := &projectionManager{db: db, logger: &testLogger{}}
-	ctx := context.Background()
-
-	abstractCtx := `{"@vocab":"https://schema.org/","weos:abstract":true}`
-	childCtx := `{"@vocab":"https://schema.org/","rdfs:subClassOf":"instrument"}`
-
-	// Insert types: child BEFORE parent to test ordering resilience.
-	db.Create(&models.ResourceType{
-		ID: "child-1", Name: "Loan", Slug: "loan", Status: "active",
-		Context: childCtx,
-		Schema:  `{"type":"object","properties":{"interestRate":{"type":"number"}}}`,
-	})
-	db.Create(&models.ResourceType{
-		ID: "parent-1", Name: "Instrument", Slug: "instrument", Status: "active",
-		Context: abstractCtx,
-		Schema:  `{"type":"object","properties":{"name":{"type":"string"}}}`,
-	})
-
-	if err := pm.EnsureExistingTables(ctx); err != nil {
-		t.Fatalf("EnsureExistingTables failed: %v", err)
-	}
-
-	// Abstract parent should have its own table.
-	if !pm.HasProjectionTable("instrument") {
-		t.Fatal("expected instrument to have a projection table")
-	}
-
-	// Child should be registered as a subtype.
-	if !pm.IsSubtype("loan") {
-		t.Fatal("expected loan to be registered as subtype")
-	}
-	if pm.ParentSlug("loan") != "instrument" {
-		t.Fatalf("expected loan's parent to be 'instrument', got %q", pm.ParentSlug("loan"))
-	}
-
-	// Verify child columns were merged into parent table.
-	err := db.Exec(`INSERT INTO instruments (id, type_slug, status, interest_rate)
-		VALUES ('l1', 'loan', 'active', 5.5)`).Error
-	if err != nil {
-		t.Fatalf("insert with child column failed: %v", err)
-	}
-}
-
-func TestEnsureExistingTables_OrphanedSubClassOf(t *testing.T) {
-	t.Parallel()
-	db := newTestDBWithTypes(t)
-	pm := &projectionManager{db: db, logger: &testLogger{}}
-	ctx := context.Background()
-
-	// Child references a parent that doesn't exist in the DB.
-	orphanCtx := `{"@vocab":"https://schema.org/","rdfs:subClassOf":"nonexistent"}`
-	db.Create(&models.ResourceType{
-		ID: "orphan-1", Name: "Orphan", Slug: "orphan", Status: "active",
-		Context: orphanCtx,
-		Schema:  `{"type":"object","properties":{"name":{"type":"string"}}}`,
-	})
-
-	// Should not error — orphan gets its own standalone table.
-	if err := pm.EnsureExistingTables(ctx); err != nil {
-		t.Fatalf("EnsureExistingTables failed: %v", err)
-	}
-
-	if !pm.HasProjectionTable("orphan") {
-		t.Fatal("orphan should have its own projection table")
-	}
-	if pm.IsSubtype("orphan") {
-		t.Fatal("orphan should NOT be registered as a subtype")
-	}
-}
-
-func TestEnsureExistingTables_AbstractGetsOwnTable(t *testing.T) {
-	t.Parallel()
-	db := newTestDBWithTypes(t)
-	pm := &projectionManager{db: db, logger: &testLogger{}}
-	ctx := context.Background()
-
-	abstractCtx := `{"@vocab":"https://schema.org/","weos:abstract":true}`
-	db.Create(&models.ResourceType{
-		ID: "abs-1", Name: "Shape", Slug: "shape", Status: "active",
-		Context: abstractCtx,
-		Schema:  `{"type":"object","properties":{"color":{"type":"string"}}}`,
-	})
-
-	if err := pm.EnsureExistingTables(ctx); err != nil {
-		t.Fatalf("EnsureExistingTables failed: %v", err)
-	}
-
-	if !pm.HasProjectionTable("shape") {
-		t.Fatal("abstract type 'shape' should have its own projection table")
-	}
-
-	// Verify table was actually created.
-	err := db.Exec(`INSERT INTO shapes (id, type_slug, status, color)
-		VALUES ('s1', 'shape', 'active', 'red')`).Error
-	if err != nil {
-		t.Fatalf("insert into shapes failed: %v", err)
-	}
-}
-
-func TestCircularSubClassOf_NoPanic(t *testing.T) {
-	t.Parallel()
-	db := newTestDBWithTypes(t)
-	pm := &projectionManager{db: db, logger: &testLogger{}}
-
-	// Create circular reference: A -> B -> A, both abstract.
-	db.Create(&models.ResourceType{
-		ID: "a-1", Name: "TypeA", Slug: "type-a", Status: "active",
-		Context: `{"@vocab":"https://schema.org/","weos:abstract":true,"rdfs:subClassOf":"type-b"}`,
-		Schema:  `{"type":"object","properties":{"fieldA":{"type":"string"}}}`,
-	})
-	db.Create(&models.ResourceType{
-		ID: "b-1", Name: "TypeB", Slug: "type-b", Status: "active",
-		Context: `{"@vocab":"https://schema.org/","weos:abstract":true,"rdfs:subClassOf":"type-a"}`,
-		Schema:  `{"type":"object","properties":{"fieldB":{"type":"string"}}}`,
-	})
-
-	// Should not stack overflow. HasProjectionTable should return false or true
-	// but must not panic.
-	_ = pm.HasProjectionTable("type-a")
-	_ = pm.HasProjectionTable("type-b")
-
-	// Also test via EnsureExistingTables which processes all types.
-	ctx := context.Background()
-	if err := pm.EnsureExistingTables(ctx); err != nil {
-		t.Fatalf("EnsureExistingTables with circular refs should not error: %v", err)
-	}
-}
-
-func TestRegisterSubtype_FailsWithoutParentTable(t *testing.T) {
+func TestAncestorSlugs_SingleLevel(t *testing.T) {
 	t.Parallel()
 	db := newTestDB(t)
 	pm := &projectionManager{db: db, logger: &testLogger{}}
 	ctx := context.Background()
 
-	childSchema := json.RawMessage(`{"type":"object","properties":{"rate":{"type":"number"}}}`)
-	err := pm.RegisterSubtype(ctx, "loan", "nonexistent-parent", childSchema, nil)
-	if err == nil {
-		t.Fatal("expected error when parent table doesn't exist")
+	parentCtx := json.RawMessage(`{"@vocab":"https://schema.org/","weos:abstract":true}`)
+	childCtx := json.RawMessage(`{"@vocab":"https://schema.org/","rdfs:subClassOf":"financial-instrument"}`)
+
+	if err := pm.EnsureTable(ctx, "financial-instrument", nil, parentCtx); err != nil {
+		t.Fatalf("EnsureTable parent: %v", err)
+	}
+	if err := pm.EnsureTable(ctx, "loan", nil, childCtx); err != nil {
+		t.Fatalf("EnsureTable child: %v", err)
+	}
+
+	ancestors := pm.AncestorSlugs("loan")
+	if len(ancestors) != 1 || ancestors[0] != "financial-instrument" {
+		t.Fatalf("AncestorSlugs(loan) = %v, want [financial-instrument]", ancestors)
+	}
+}
+
+func TestAncestorSlugs_MultiLevel(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	ctxC := json.RawMessage(`{"@vocab":"https://schema.org/"}`)
+	ctxB := json.RawMessage(`{"@vocab":"https://schema.org/","rdfs:subClassOf":"type-c"}`)
+	ctxA := json.RawMessage(`{"@vocab":"https://schema.org/","rdfs:subClassOf":"type-b"}`)
+
+	if err := pm.EnsureTable(ctx, "type-c", nil, ctxC); err != nil {
+		t.Fatal(err)
+	}
+	if err := pm.EnsureTable(ctx, "type-b", nil, ctxB); err != nil {
+		t.Fatal(err)
+	}
+	if err := pm.EnsureTable(ctx, "type-a", nil, ctxA); err != nil {
+		t.Fatal(err)
+	}
+
+	ancestors := pm.AncestorSlugs("type-a")
+	if len(ancestors) != 2 || ancestors[0] != "type-b" || ancestors[1] != "type-c" {
+		t.Fatalf("AncestorSlugs(type-a) = %v, want [type-b, type-c]", ancestors)
+	}
+}
+
+func TestAncestorSlugs_NoParent(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	if err := pm.EnsureTable(ctx, "product", nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	ancestors := pm.AncestorSlugs("product")
+	if len(ancestors) != 0 {
+		t.Fatalf("AncestorSlugs(product) = %v, want nil", ancestors)
+	}
+}
+
+func TestAncestorSlugs_CircularBreaks(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	ctxA := json.RawMessage(`{"@vocab":"https://schema.org/","rdfs:subClassOf":"type-b"}`)
+	ctxB := json.RawMessage(`{"@vocab":"https://schema.org/","rdfs:subClassOf":"type-a"}`)
+
+	if err := pm.EnsureTable(ctx, "type-a", nil, ctxA); err != nil {
+		t.Fatal(err)
+	}
+	if err := pm.EnsureTable(ctx, "type-b", nil, ctxB); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should not infinite loop — visited set breaks the cycle.
+	ancestors := pm.AncestorSlugs("type-a")
+	if len(ancestors) != 1 || ancestors[0] != "type-b" {
+		t.Fatalf("AncestorSlugs(type-a) = %v, want [type-b]", ancestors)
+	}
+}
+
+func TestEnsureTable_EachTypeGetsOwnTable(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	abstractCtx := json.RawMessage(`{"@vocab":"https://schema.org/","weos:abstract":true}`)
+	parentSchema := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`)
+	childCtx := json.RawMessage(`{"@vocab":"https://schema.org/","rdfs:subClassOf":"instrument"}`)
+	childSchema := json.RawMessage(`{"type":"object","properties":{` +
+		`"name":{"type":"string"},"interestRate":{"type":"number"}}}`)
+
+	if err := pm.EnsureTable(ctx, "instrument", parentSchema, abstractCtx); err != nil {
+		t.Fatal(err)
+	}
+	if err := pm.EnsureTable(ctx, "loan", childSchema, childCtx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Both types should have their OWN tables (not shared).
+	if pm.TableName("instrument") != "instruments" {
+		t.Fatalf("TableName(instrument) = %q", pm.TableName("instrument"))
+	}
+	if pm.TableName("loan") != "loans" {
+		t.Fatalf("TableName(loan) = %q, want loans", pm.TableName("loan"))
+	}
+
+	// Verify both tables exist and have their own columns.
+	if err := db.Exec(`INSERT INTO instruments (id, type_slug, status, name)
+		VALUES ('i1', 'instrument', 'active', 'Test')`).Error; err != nil {
+		t.Fatalf("insert into instruments: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO loans (id, type_slug, status, name, interest_rate)
+		VALUES ('l1', 'loan', 'active', 'Home Loan', 3.5)`).Error; err != nil {
+		t.Fatalf("insert into loans: %v", err)
+	}
+}
+
+func TestEnsureExistingTables_AllTypesGetTables(t *testing.T) {
+	t.Parallel()
+	db := newTestDBWithTypes(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	db.Create(&models.ResourceType{
+		ID: "1", Name: "Shape", Slug: "shape", Status: "active",
+		Context: `{"@vocab":"https://schema.org/","weos:abstract":true}`,
+		Schema:  `{"type":"object","properties":{"color":{"type":"string"}}}`,
+	})
+	db.Create(&models.ResourceType{
+		ID: "2", Name: "Circle", Slug: "circle", Status: "active",
+		Context: `{"@vocab":"https://schema.org/","rdfs:subClassOf":"shape"}`,
+		Schema:  `{"type":"object","properties":{"color":{"type":"string"},"radius":{"type":"number"}}}`,
+	})
+
+	if err := pm.EnsureExistingTables(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if !pm.HasProjectionTable("shape") {
+		t.Fatal("shape should have projection table")
+	}
+	if !pm.HasProjectionTable("circle") {
+		t.Fatal("circle should have its own projection table")
+	}
+
+	// Verify ancestor chain.
+	ancestors := pm.AncestorSlugs("circle")
+	if len(ancestors) != 1 || ancestors[0] != "shape" {
+		t.Fatalf("AncestorSlugs(circle) = %v, want [shape]", ancestors)
+	}
+}
+
+func TestEnsureExistingTables_SkipsDeletedTypes(t *testing.T) {
+	t.Parallel()
+	db := newTestDBWithTypes(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	now := time.Now()
+	db.Create(&models.ResourceType{
+		ID: "1", Name: "Deleted", Slug: "deleted-type", Status: "active",
+		Schema:    `{"type":"object","properties":{"name":{"type":"string"}}}`,
+		DeletedAt: &now,
+	})
+
+	if err := pm.EnsureExistingTables(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if pm.HasProjectionTable("deleted-type") {
+		t.Fatal("deleted type should not have a projection table")
 	}
 }

--- a/infrastructure/database/gorm/projection_manager_test.go
+++ b/infrastructure/database/gorm/projection_manager_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"weos/infrastructure/models"
 	"weos/pkg/utils"
 
 	"gorm.io/driver/sqlite"
@@ -520,5 +521,158 @@ func TestSubtype_MultipleChildrenShareParentTable(t *testing.T) {
 	db.Table("financial_instruments").Where("type_slug = ?", "deposit-account").Count(&depCount)
 	if depCount != 1 {
 		t.Fatalf("expected 1 deposit-account row, got %d", depCount)
+	}
+}
+
+func newTestDBWithTypes(t *testing.T) *gorm.DB {
+	t.Helper()
+	db := newTestDB(t)
+	if err := db.AutoMigrate(&models.ResourceType{}); err != nil {
+		t.Fatalf("failed to migrate resource_types: %v", err)
+	}
+	return db
+}
+
+func TestEnsureExistingTables_TwoPassOrdering(t *testing.T) {
+	t.Parallel()
+	db := newTestDBWithTypes(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	abstractCtx := `{"@vocab":"https://schema.org/","weos:abstract":true}`
+	childCtx := `{"@vocab":"https://schema.org/","rdfs:subClassOf":"instrument"}`
+
+	// Insert types: child BEFORE parent to test ordering resilience.
+	db.Create(&models.ResourceType{
+		ID: "child-1", Name: "Loan", Slug: "loan", Status: "active",
+		Context: childCtx,
+		Schema:  `{"type":"object","properties":{"interestRate":{"type":"number"}}}`,
+	})
+	db.Create(&models.ResourceType{
+		ID: "parent-1", Name: "Instrument", Slug: "instrument", Status: "active",
+		Context: abstractCtx,
+		Schema:  `{"type":"object","properties":{"name":{"type":"string"}}}`,
+	})
+
+	if err := pm.EnsureExistingTables(ctx); err != nil {
+		t.Fatalf("EnsureExistingTables failed: %v", err)
+	}
+
+	// Abstract parent should have its own table.
+	if !pm.HasProjectionTable("instrument") {
+		t.Fatal("expected instrument to have a projection table")
+	}
+
+	// Child should be registered as a subtype.
+	if !pm.IsSubtype("loan") {
+		t.Fatal("expected loan to be registered as subtype")
+	}
+	if pm.ParentSlug("loan") != "instrument" {
+		t.Fatalf("expected loan's parent to be 'instrument', got %q", pm.ParentSlug("loan"))
+	}
+
+	// Verify child columns were merged into parent table.
+	err := db.Exec(`INSERT INTO instruments (id, type_slug, status, interest_rate)
+		VALUES ('l1', 'loan', 'active', 5.5)`).Error
+	if err != nil {
+		t.Fatalf("insert with child column failed: %v", err)
+	}
+}
+
+func TestEnsureExistingTables_OrphanedSubClassOf(t *testing.T) {
+	t.Parallel()
+	db := newTestDBWithTypes(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	// Child references a parent that doesn't exist in the DB.
+	orphanCtx := `{"@vocab":"https://schema.org/","rdfs:subClassOf":"nonexistent"}`
+	db.Create(&models.ResourceType{
+		ID: "orphan-1", Name: "Orphan", Slug: "orphan", Status: "active",
+		Context: orphanCtx,
+		Schema:  `{"type":"object","properties":{"name":{"type":"string"}}}`,
+	})
+
+	// Should not error — orphan gets its own standalone table.
+	if err := pm.EnsureExistingTables(ctx); err != nil {
+		t.Fatalf("EnsureExistingTables failed: %v", err)
+	}
+
+	if !pm.HasProjectionTable("orphan") {
+		t.Fatal("orphan should have its own projection table")
+	}
+	if pm.IsSubtype("orphan") {
+		t.Fatal("orphan should NOT be registered as a subtype")
+	}
+}
+
+func TestEnsureExistingTables_AbstractGetsOwnTable(t *testing.T) {
+	t.Parallel()
+	db := newTestDBWithTypes(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	abstractCtx := `{"@vocab":"https://schema.org/","weos:abstract":true}`
+	db.Create(&models.ResourceType{
+		ID: "abs-1", Name: "Shape", Slug: "shape", Status: "active",
+		Context: abstractCtx,
+		Schema:  `{"type":"object","properties":{"color":{"type":"string"}}}`,
+	})
+
+	if err := pm.EnsureExistingTables(ctx); err != nil {
+		t.Fatalf("EnsureExistingTables failed: %v", err)
+	}
+
+	if !pm.HasProjectionTable("shape") {
+		t.Fatal("abstract type 'shape' should have its own projection table")
+	}
+
+	// Verify table was actually created.
+	err := db.Exec(`INSERT INTO shapes (id, type_slug, status, color)
+		VALUES ('s1', 'shape', 'active', 'red')`).Error
+	if err != nil {
+		t.Fatalf("insert into shapes failed: %v", err)
+	}
+}
+
+func TestCircularSubClassOf_NoPanic(t *testing.T) {
+	t.Parallel()
+	db := newTestDBWithTypes(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+
+	// Create circular reference: A -> B -> A, both abstract.
+	db.Create(&models.ResourceType{
+		ID: "a-1", Name: "TypeA", Slug: "type-a", Status: "active",
+		Context: `{"@vocab":"https://schema.org/","weos:abstract":true,"rdfs:subClassOf":"type-b"}`,
+		Schema:  `{"type":"object","properties":{"fieldA":{"type":"string"}}}`,
+	})
+	db.Create(&models.ResourceType{
+		ID: "b-1", Name: "TypeB", Slug: "type-b", Status: "active",
+		Context: `{"@vocab":"https://schema.org/","weos:abstract":true,"rdfs:subClassOf":"type-a"}`,
+		Schema:  `{"type":"object","properties":{"fieldB":{"type":"string"}}}`,
+	})
+
+	// Should not stack overflow. HasProjectionTable should return false or true
+	// but must not panic.
+	_ = pm.HasProjectionTable("type-a")
+	_ = pm.HasProjectionTable("type-b")
+
+	// Also test via EnsureExistingTables which processes all types.
+	ctx := context.Background()
+	if err := pm.EnsureExistingTables(ctx); err != nil {
+		t.Fatalf("EnsureExistingTables with circular refs should not error: %v", err)
+	}
+}
+
+func TestRegisterSubtype_FailsWithoutParentTable(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	childSchema := json.RawMessage(`{"type":"object","properties":{"rate":{"type":"number"}}}`)
+	err := pm.RegisterSubtype(ctx, "loan", "nonexistent-parent", childSchema)
+	if err == nil {
+		t.Fatal("expected error when parent table doesn't exist")
 	}
 }

--- a/infrastructure/database/gorm/projection_manager_test.go
+++ b/infrastructure/database/gorm/projection_manager_test.go
@@ -341,3 +341,184 @@ func TestExtractFlatColumns(t *testing.T) {
 		t.Error("expected metadata column")
 	}
 }
+
+func TestRegisterSubtype_MergesColumnsIntoParent(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	// Create abstract parent projection table with a "name" column.
+	parentSchema := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`)
+	if err := pm.EnsureTable(ctx, "financial-instrument", parentSchema, nil); err != nil {
+		t.Fatalf("EnsureTable for parent failed: %v", err)
+	}
+
+	// Register "loan" as subtype with extra "interestRate" column.
+	childSchema := json.RawMessage(`{"type":"object","properties":{
+		"name":{"type":"string"},
+		"interestRate":{"type":"number"}
+	}}`)
+	if err := pm.RegisterSubtype(ctx, "loan", "financial-instrument", childSchema); err != nil {
+		t.Fatalf("RegisterSubtype failed: %v", err)
+	}
+
+	// Verify the child column was added to the parent table.
+	err := db.Exec(`INSERT INTO financial_instruments (id, type_slug, status, name, interest_rate)
+		VALUES ('loan-1', 'loan', 'active', 'Home Loan', 3.5)`).Error
+	if err != nil {
+		t.Fatalf("insert with child column failed: %v", err)
+	}
+
+	var result map[string]any
+	err = db.Table("financial_instruments").Where("id = ?", "loan-1").Take(&result).Error
+	if err != nil {
+		t.Fatalf("read back failed: %v", err)
+	}
+}
+
+func TestIsSubtype(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	if err := pm.EnsureTable(ctx, "commitment", nil, nil); err != nil {
+		t.Fatalf("EnsureTable failed: %v", err)
+	}
+	if err := pm.RegisterSubtype(ctx, "invoice", "commitment", nil); err != nil {
+		t.Fatalf("RegisterSubtype failed: %v", err)
+	}
+
+	if !pm.IsSubtype("invoice") {
+		t.Fatal("expected invoice to be a subtype")
+	}
+	if pm.IsSubtype("commitment") {
+		t.Fatal("expected commitment NOT to be a subtype")
+	}
+	if pm.IsSubtype("unknown") {
+		t.Fatal("expected unknown NOT to be a subtype")
+	}
+}
+
+func TestParentSlug(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	if err := pm.EnsureTable(ctx, "commitment", nil, nil); err != nil {
+		t.Fatalf("EnsureTable failed: %v", err)
+	}
+	if err := pm.RegisterSubtype(ctx, "invoice", "commitment", nil); err != nil {
+		t.Fatalf("RegisterSubtype failed: %v", err)
+	}
+
+	if got := pm.ParentSlug("invoice"); got != "commitment" {
+		t.Fatalf("ParentSlug(invoice) = %q, want %q", got, "commitment")
+	}
+	if got := pm.ParentSlug("commitment"); got != "" {
+		t.Fatalf("ParentSlug(commitment) = %q, want empty", got)
+	}
+}
+
+func TestSubtype_TableNameResolvesToParent(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	if err := pm.EnsureTable(ctx, "financial-instrument", nil, nil); err != nil {
+		t.Fatalf("EnsureTable failed: %v", err)
+	}
+	if err := pm.RegisterSubtype(ctx, "loan", "financial-instrument", nil); err != nil {
+		t.Fatalf("RegisterSubtype failed: %v", err)
+	}
+
+	// TableName for the subtype should resolve to the parent's table.
+	if got := pm.TableName("loan"); got != "financial_instruments" {
+		t.Fatalf("TableName(loan) = %q, want %q", got, "financial_instruments")
+	}
+	// Parent's own TableName should still work.
+	if got := pm.TableName("financial-instrument"); got != "financial_instruments" {
+		t.Fatalf("TableName(financial-instrument) = %q, want %q", got, "financial_instruments")
+	}
+}
+
+func TestSubtype_HasProjectionTable(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	if err := pm.EnsureTable(ctx, "commitment", nil, nil); err != nil {
+		t.Fatalf("EnsureTable failed: %v", err)
+	}
+	if err := pm.RegisterSubtype(ctx, "invoice", "commitment", nil); err != nil {
+		t.Fatalf("RegisterSubtype failed: %v", err)
+	}
+
+	if !pm.HasProjectionTable("invoice") {
+		t.Fatal("expected HasProjectionTable(invoice) = true")
+	}
+	if !pm.HasProjectionTable("commitment") {
+		t.Fatal("expected HasProjectionTable(commitment) = true")
+	}
+}
+
+func TestSubtype_MultipleChildrenShareParentTable(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	parentSchema := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`)
+	if err := pm.EnsureTable(ctx, "financial-instrument", parentSchema, nil); err != nil {
+		t.Fatalf("EnsureTable failed: %v", err)
+	}
+
+	loanSchema := json.RawMessage(`{"type":"object","properties":{
+		"name":{"type":"string"},"interestRate":{"type":"number"}}}`)
+	depositSchema := json.RawMessage(`{"type":"object","properties":{
+		"name":{"type":"string"},"balance":{"type":"number"}}}`)
+
+	if err := pm.RegisterSubtype(ctx, "loan", "financial-instrument", loanSchema); err != nil {
+		t.Fatalf("RegisterSubtype(loan) failed: %v", err)
+	}
+	if err := pm.RegisterSubtype(ctx, "deposit-account", "financial-instrument", depositSchema); err != nil {
+		t.Fatalf("RegisterSubtype(deposit-account) failed: %v", err)
+	}
+
+	// Insert rows for both subtypes in the same table.
+	err := db.Exec(`INSERT INTO financial_instruments (id, type_slug, status, name, interest_rate)
+		VALUES ('loan-1', 'loan', 'active', 'Home Loan', 3.5)`).Error
+	if err != nil {
+		t.Fatalf("insert loan failed: %v", err)
+	}
+	err = db.Exec(`INSERT INTO financial_instruments (id, type_slug, status, name, balance)
+		VALUES ('dep-1', 'deposit-account', 'active', 'Savings', 1000.0)`).Error
+	if err != nil {
+		t.Fatalf("insert deposit failed: %v", err)
+	}
+
+	// Both should be in the same table with different type_slug values.
+	var count int64
+	db.Table("financial_instruments").Count(&count)
+	if count != 2 {
+		t.Fatalf("expected 2 rows in financial_instruments, got %d", count)
+	}
+
+	// Filter by type_slug = 'loan' should return 1.
+	var loanCount int64
+	db.Table("financial_instruments").Where("type_slug = ?", "loan").Count(&loanCount)
+	if loanCount != 1 {
+		t.Fatalf("expected 1 loan row, got %d", loanCount)
+	}
+
+	// Filter by type_slug = 'deposit-account' should return 1.
+	var depCount int64
+	db.Table("financial_instruments").Where("type_slug = ?", "deposit-account").Count(&depCount)
+	if depCount != 1 {
+		t.Fatalf("expected 1 deposit-account row, got %d", depCount)
+	}
+}

--- a/infrastructure/database/gorm/resource_repository.go
+++ b/infrastructure/database/gorm/resource_repository.go
@@ -244,7 +244,7 @@ func (r *ResourceRepository) findAllFromProjection(
 	query := r.db.WithContext(ctx).Table(tableName).
 		Select(selectCols).
 		Joins(fmt.Sprintf("JOIN resources ON %s.id = resources.id", tbl)).
-		Where("1=1")
+		Where(tbl+".type_slug = ?", typeSlug)
 	query = applyVisibilityScope(query, scope, tbl)
 	if cursor != "" {
 		cd, err := decodeCursor(cursor)
@@ -430,6 +430,7 @@ func (r *ResourceRepository) findAllByFieldFromProjection(
 		Select(fmt.Sprintf("%s.id, %s.type_slug, resources.data, %s.status, resources.created_by, resources.account_id, %s.sequence_no, %s.created_at",
 			tbl, tbl, tbl, tbl, tbl)).
 		Joins(fmt.Sprintf("JOIN resources ON %s.id = resources.id", tbl)).
+		Where(tbl+".type_slug = ?", typeSlug).
 		Where(tbl+"."+colName+" = ? ", fieldValue).
 		Find(&rows).Error
 	if err != nil {
@@ -514,7 +515,7 @@ func (r *ResourceRepository) findAllFromProjectionWithFilters(
 	qualifiedCol := tbl + "." + colName
 	query := r.db.WithContext(ctx).Table(tableName).Select(selectCols).
 		Joins(fmt.Sprintf("JOIN resources ON %s.id = resources.id", tbl)).
-		Where("1=1")
+		Where(tbl+".type_slug = ?", typeSlug)
 	query = applyVisibilityScope(query, scope, tbl)
 
 	for _, f := range filters {
@@ -620,7 +621,7 @@ func (r *ResourceRepository) findAllFlatFromProjection(
 		}
 	}
 
-	query := r.db.WithContext(ctx).Table(tableName).Where("1=1")
+	query := r.db.WithContext(ctx).Table(tableName).Where("type_slug = ?", typeSlug)
 	query = applyVisibilityScope(query, scope, "")
 
 	for _, f := range filters {

--- a/infrastructure/database/gorm/resource_repository.go
+++ b/infrastructure/database/gorm/resource_repository.go
@@ -170,9 +170,17 @@ func (r *ResourceRepository) updateProjectionBySlug(
 	if result.Error != nil {
 		return fmt.Errorf("failed to update resource in %s: %w", tableName, result.Error)
 	}
-	// If no row was updated, fall back to insert (ancestor row may not exist yet).
+	// RowsAffected==0 can mean row missing OR no-op update (values unchanged).
+	// Check existence before inserting to avoid duplicate PK errors.
 	if result.RowsAffected == 0 {
-		return r.saveToProjection(ctx, entity, targetSlug)
+		var count int64
+		if err := r.db.WithContext(ctx).Table(tableName).
+			Where("id = ?", entity.GetID()).Count(&count).Error; err != nil {
+			return fmt.Errorf("failed to check existence in %s: %w", tableName, err)
+		}
+		if count == 0 {
+			return r.saveToProjection(ctx, entity, targetSlug)
+		}
 	}
 	return nil
 }
@@ -865,10 +873,12 @@ func (r *ResourceRepository) updateDataInProjection(
 	if len(row) == 0 {
 		return nil
 	}
-	if err := r.db.WithContext(ctx).Table(tableName).
-		Where("id = ?", id).Updates(row).Error; err != nil {
-		return fmt.Errorf("failed to update projection data in %s: %w", tableName, err)
+	result := r.db.WithContext(ctx).Table(tableName).
+		Where("id = ?", id).Updates(row)
+	if result.Error != nil {
+		return fmt.Errorf("failed to update projection data in %s: %w", tableName, result.Error)
 	}
+	// If ancestor row doesn't exist yet, skip (UpdateData is a partial update).
 	return nil
 }
 

--- a/infrastructure/database/gorm/resource_repository.go
+++ b/infrastructure/database/gorm/resource_repository.go
@@ -144,7 +144,7 @@ func (r *ResourceRepository) saveToProjection(
 	}
 	ldCtx := r.projMgr.Context(targetSlug)
 	ExtractFlatColumns(entity.Data(), ldCtx, row)
-	r.dropMissingColumns(tableName, row)
+	r.dropMissingColumns(targetSlug, row)
 	if err := r.db.WithContext(ctx).Table(tableName).Create(row).Error; err != nil {
 		return fmt.Errorf("failed to save resource to projection %s: %w", tableName, err)
 	}
@@ -152,6 +152,7 @@ func (r *ResourceRepository) saveToProjection(
 }
 
 // updateProjectionBySlug updates a resource's projection row in the table identified by targetSlug.
+// If the row doesn't exist (e.g., ancestor table created after initial save), falls back to insert.
 func (r *ResourceRepository) updateProjectionBySlug(
 	ctx context.Context, entity *entities.Resource, targetSlug string,
 ) error {
@@ -163,23 +164,27 @@ func (r *ResourceRepository) updateProjectionBySlug(
 	}
 	ldCtx := r.projMgr.Context(targetSlug)
 	ExtractFlatColumns(entity.Data(), ldCtx, row)
-	r.dropMissingColumns(tableName, row)
-	if err := r.db.WithContext(ctx).Table(tableName).
-		Where("id = ?", entity.GetID()).Updates(row).Error; err != nil {
-		return fmt.Errorf("failed to update resource in %s: %w", tableName, err)
+	r.dropMissingColumns(targetSlug, row)
+	result := r.db.WithContext(ctx).Table(tableName).
+		Where("id = ?", entity.GetID()).Updates(row)
+	if result.Error != nil {
+		return fmt.Errorf("failed to update resource in %s: %w", tableName, result.Error)
+	}
+	// If no row was updated, fall back to insert (ancestor row may not exist yet).
+	if result.RowsAffected == 0 {
+		return r.saveToProjection(ctx, entity, targetSlug)
 	}
 	return nil
 }
 
 // dropMissingColumns removes keys from row that don't exist as columns in the target table.
-// This prevents INSERT/UPDATE errors when dual-projecting to ancestor tables that don't
-// have child-specific columns.
-func (r *ResourceRepository) dropMissingColumns(tableName string, row map[string]any) {
+// Uses the column set cached in ProjectionManager for fast lookup without DB queries.
+func (r *ResourceRepository) dropMissingColumns(targetSlug string, row map[string]any) {
 	for col := range row {
 		if standardColumnNames[col] {
 			continue
 		}
-		if !r.db.Migrator().HasColumn(tableName, col) {
+		if !r.projMgr.HasColumn(targetSlug, col) {
 			delete(row, col)
 		}
 	}
@@ -275,8 +280,11 @@ func (r *ResourceRepository) findAllFromProjection(
 	sortBy, sortOrder := normalizeSortOptions(sort)
 	colName := utils.CamelToSnake(sortBy)
 
-	// Validate that the column exists; fall back to id.
-	if colName != "id" && !standardColumnNames[colName] {
+	// Validate that the column exists in the projection table; fall back to id.
+	// "data" is in standardColumnNames but lives in the resources table, not projection.
+	if colName == "data" {
+		colName = "id"
+	} else if colName != "id" && !standardColumnNames[colName] {
 		if !r.db.Migrator().HasColumn(tableName, colName) {
 			colName = "id"
 		}
@@ -555,7 +563,9 @@ func (r *ResourceRepository) findAllFromProjectionWithFilters(
 	sortBy, sortOrder := normalizeSortOptions(sort)
 	colName := utils.CamelToSnake(sortBy)
 
-	if colName != "id" && !standardColumnNames[colName] {
+	if colName == "data" {
+		colName = "id"
+	} else if colName != "id" && !standardColumnNames[colName] {
 		if !r.db.Migrator().HasColumn(tableName, colName) {
 			colName = "id"
 		}
@@ -672,7 +682,9 @@ func (r *ResourceRepository) findAllFlatFromProjection(
 	sortBy, sortOrder := normalizeSortOptions(sort)
 	colName := utils.CamelToSnake(sortBy)
 
-	if colName != "id" && !standardColumnNames[colName] {
+	if colName == "data" {
+		colName = "id"
+	} else if colName != "id" && !standardColumnNames[colName] {
 		if !r.db.Migrator().HasColumn(tableName, colName) {
 			colName = "id"
 		}
@@ -849,7 +861,7 @@ func (r *ResourceRepository) updateDataInProjection(
 	}
 	ldCtx := r.projMgr.Context(targetSlug)
 	ExtractFlatColumns(data, ldCtx, row)
-	r.dropMissingColumns(tableName, row)
+	r.dropMissingColumns(targetSlug, row)
 	if len(row) == 0 {
 		return nil
 	}

--- a/infrastructure/database/gorm/resource_repository.go
+++ b/infrastructure/database/gorm/resource_repository.go
@@ -110,17 +110,29 @@ func (r *ResourceRepository) Save(
 	}
 	// Also save to the projection table (denormalized read model) if one exists.
 	if r.projMgr.HasProjectionTable(entity.TypeSlug()) {
-		if err := r.saveToProjection(ctx, entity); err != nil {
+		if err := r.saveToProjection(ctx, entity, entity.TypeSlug()); err != nil {
+			return err
+		}
+	}
+	// Dual-projection: also save to ancestor tables.
+	for _, ancestorSlug := range r.projMgr.AncestorSlugs(entity.TypeSlug()) {
+		if !r.projMgr.HasProjectionTable(ancestorSlug) {
+			continue
+		}
+		if err := r.saveToProjection(ctx, entity, ancestorSlug); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
+// saveToProjection inserts a resource into the projection table identified by targetSlug.
+// The targetSlug may be the entity's own type or an ancestor type for dual-projection.
+// Columns extracted from data that don't exist in the target table are silently dropped.
 func (r *ResourceRepository) saveToProjection(
-	ctx context.Context, entity *entities.Resource,
+	ctx context.Context, entity *entities.Resource, targetSlug string,
 ) error {
-	tableName := r.projMgr.TableName(entity.TypeSlug())
+	tableName := r.projMgr.TableName(targetSlug)
 	row := map[string]any{
 		"id":          entity.GetID(),
 		"type_slug":   entity.TypeSlug(),
@@ -130,12 +142,47 @@ func (r *ResourceRepository) saveToProjection(
 		"sequence_no": entity.GetSequenceNo(),
 		"created_at":  entity.CreatedAt(),
 	}
-	ldCtx := r.projMgr.Context(entity.TypeSlug())
+	ldCtx := r.projMgr.Context(targetSlug)
 	ExtractFlatColumns(entity.Data(), ldCtx, row)
+	r.dropMissingColumns(tableName, row)
 	if err := r.db.WithContext(ctx).Table(tableName).Create(row).Error; err != nil {
 		return fmt.Errorf("failed to save resource to projection %s: %w", tableName, err)
 	}
 	return nil
+}
+
+// updateProjectionBySlug updates a resource's projection row in the table identified by targetSlug.
+func (r *ResourceRepository) updateProjectionBySlug(
+	ctx context.Context, entity *entities.Resource, targetSlug string,
+) error {
+	tableName := r.projMgr.TableName(targetSlug)
+	row := map[string]any{
+		"status":      entity.Status(),
+		"sequence_no": entity.GetSequenceNo(),
+		"updated_at":  time.Now(),
+	}
+	ldCtx := r.projMgr.Context(targetSlug)
+	ExtractFlatColumns(entity.Data(), ldCtx, row)
+	r.dropMissingColumns(tableName, row)
+	if err := r.db.WithContext(ctx).Table(tableName).
+		Where("id = ?", entity.GetID()).Updates(row).Error; err != nil {
+		return fmt.Errorf("failed to update resource in %s: %w", tableName, err)
+	}
+	return nil
+}
+
+// dropMissingColumns removes keys from row that don't exist as columns in the target table.
+// This prevents INSERT/UPDATE errors when dual-projecting to ancestor tables that don't
+// have child-specific columns.
+func (r *ResourceRepository) dropMissingColumns(tableName string, row map[string]any) {
+	for col := range row {
+		if standardColumnNames[col] {
+			continue
+		}
+		if !r.db.Migrator().HasColumn(tableName, col) {
+			delete(row, col)
+		}
+	}
 }
 
 func (r *ResourceRepository) FindByID(
@@ -248,8 +295,7 @@ func (r *ResourceRepository) findAllFromProjection(
 	qualifiedCol := tbl + "." + colName
 	query := r.db.WithContext(ctx).Table(tableName).
 		Select(selectCols).
-		Joins(fmt.Sprintf("JOIN resources ON %s.id = resources.id", tbl)).
-		Where(tbl+".type_slug = ?", typeSlug)
+		Joins(fmt.Sprintf("JOIN resources ON %s.id = resources.id", tbl))
 	query = applyVisibilityScope(query, scope, tbl)
 	if cursor != "" {
 		cd, err := decodeCursor(cursor)
@@ -441,7 +487,6 @@ func (r *ResourceRepository) findAllByFieldFromProjection(
 		Select(fmt.Sprintf("%s.id, %s.type_slug, resources.data, %s.status, resources.created_by, resources.account_id, %s.sequence_no, %s.created_at",
 			tbl, tbl, tbl, tbl, tbl)).
 		Joins(fmt.Sprintf("JOIN resources ON %s.id = resources.id", tbl)).
-		Where(tbl+".type_slug = ?", typeSlug).
 		Where(tbl+"."+colName+" = ? ", fieldValue).
 		Find(&rows).Error
 	if err != nil {
@@ -527,8 +572,7 @@ func (r *ResourceRepository) findAllFromProjectionWithFilters(
 
 	qualifiedCol := tbl + "." + colName
 	query := r.db.WithContext(ctx).Table(tableName).Select(selectCols).
-		Joins(fmt.Sprintf("JOIN resources ON %s.id = resources.id", tbl)).
-		Where(tbl+".type_slug = ?", typeSlug)
+		Joins(fmt.Sprintf("JOIN resources ON %s.id = resources.id", tbl))
 	query = applyVisibilityScope(query, scope, tbl)
 
 	for _, f := range filters {
@@ -634,7 +678,7 @@ func (r *ResourceRepository) findAllFlatFromProjection(
 		}
 	}
 
-	query := r.db.WithContext(ctx).Table(tableName).Where("type_slug = ?", typeSlug)
+	query := r.db.WithContext(ctx).Table(tableName)
 	query = applyVisibilityScope(query, scope, "")
 
 	for _, f := range filters {
@@ -774,20 +818,44 @@ func (r *ResourceRepository) UpdateData(
 	}
 
 	typeSlug := identity.ExtractResourceTypeSlug(id)
-	if typeSlug != "" && r.projMgr.HasProjectionTable(typeSlug) {
-		tableName := r.projMgr.TableName(typeSlug)
-		row := map[string]any{}
-		if sequenceNo > 0 {
-			row["sequence_no"] = sequenceNo
+	if typeSlug == "" {
+		return nil
+	}
+	// Update own projection table.
+	if r.projMgr.HasProjectionTable(typeSlug) {
+		if err := r.updateDataInProjection(ctx, id, data, sequenceNo, typeSlug); err != nil {
+			return err
 		}
-		ldCtx := r.projMgr.Context(typeSlug)
-		ExtractFlatColumns(data, ldCtx, row)
-		if len(row) > 0 {
-			if err := r.db.WithContext(ctx).Table(tableName).
-				Where("id = ?", id).Updates(row).Error; err != nil {
-				return fmt.Errorf("failed to update projection data in %s: %w", tableName, err)
-			}
+	}
+	// Dual-projection: also update ancestor tables.
+	for _, ancestorSlug := range r.projMgr.AncestorSlugs(typeSlug) {
+		if !r.projMgr.HasProjectionTable(ancestorSlug) {
+			continue
 		}
+		if err := r.updateDataInProjection(ctx, id, data, sequenceNo, ancestorSlug); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *ResourceRepository) updateDataInProjection(
+	ctx context.Context, id string, data json.RawMessage, sequenceNo int, targetSlug string,
+) error {
+	tableName := r.projMgr.TableName(targetSlug)
+	row := map[string]any{}
+	if sequenceNo > 0 {
+		row["sequence_no"] = sequenceNo
+	}
+	ldCtx := r.projMgr.Context(targetSlug)
+	ExtractFlatColumns(data, ldCtx, row)
+	r.dropMissingColumns(tableName, row)
+	if len(row) == 0 {
+		return nil
+	}
+	if err := r.db.WithContext(ctx).Table(tableName).
+		Where("id = ?", id).Updates(row).Error; err != nil {
+		return fmt.Errorf("failed to update projection data in %s: %w", tableName, err)
 	}
 	return nil
 }
@@ -802,28 +870,18 @@ func (r *ResourceRepository) Update(
 	}
 	// Also update the projection table if one exists.
 	if r.projMgr.HasProjectionTable(entity.TypeSlug()) {
-		if err := r.updateProjection(ctx, entity); err != nil {
+		if err := r.updateProjectionBySlug(ctx, entity, entity.TypeSlug()); err != nil {
 			return err
 		}
 	}
-	return nil
-}
-
-func (r *ResourceRepository) updateProjection(
-	ctx context.Context, entity *entities.Resource,
-) error {
-	tableName := r.projMgr.TableName(entity.TypeSlug())
-	row := map[string]any{
-		"status":      entity.Status(),
-		"sequence_no": entity.GetSequenceNo(),
-		"updated_at":  time.Now(),
-	}
-	ldCtx := r.projMgr.Context(entity.TypeSlug())
-	ExtractFlatColumns(entity.Data(), ldCtx, row)
-	err := r.db.WithContext(ctx).Table(tableName).
-		Where("id = ?", entity.GetID()).Updates(row).Error
-	if err != nil {
-		return fmt.Errorf("failed to update resource in %s: %w", tableName, err)
+	// Dual-projection: also update ancestor tables.
+	for _, ancestorSlug := range r.projMgr.AncestorSlugs(entity.TypeSlug()) {
+		if !r.projMgr.HasProjectionTable(ancestorSlug) {
+			continue
+		}
+		if err := r.updateProjectionBySlug(ctx, entity, ancestorSlug); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -834,20 +892,31 @@ func (r *ResourceRepository) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return fmt.Errorf("failed to delete resource: %w", err)
 	}
-	// Also delete from the projection table if one exists.
+	// Also delete from the projection table and ancestor tables.
 	typeSlug := identity.ExtractResourceTypeSlug(id)
-	if typeSlug != "" && r.projMgr.HasProjectionTable(typeSlug) {
-		if err := r.deleteFromProjection(ctx, id, typeSlug); err != nil {
+	if typeSlug == "" {
+		return nil
+	}
+	if r.projMgr.HasProjectionTable(typeSlug) {
+		if err := r.deleteFromProjectionTable(ctx, id, typeSlug); err != nil {
+			return err
+		}
+	}
+	for _, ancestorSlug := range r.projMgr.AncestorSlugs(typeSlug) {
+		if !r.projMgr.HasProjectionTable(ancestorSlug) {
+			continue
+		}
+		if err := r.deleteFromProjectionTable(ctx, id, ancestorSlug); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (r *ResourceRepository) deleteFromProjection(
-	ctx context.Context, id, typeSlug string,
+func (r *ResourceRepository) deleteFromProjectionTable(
+	ctx context.Context, id, targetSlug string,
 ) error {
-	tableName := r.projMgr.TableName(typeSlug)
+	tableName := r.projMgr.TableName(targetSlug)
 	err := r.db.WithContext(ctx).Table(tableName).
 		Where("id = ?", id).Delete(map[string]any{}).Error
 	if err != nil {

--- a/infrastructure/database/gorm/resource_repository.go
+++ b/infrastructure/database/gorm/resource_repository.go
@@ -31,6 +31,7 @@ import (
 
 	"go.uber.org/fx"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // genericSortableColumns are allowed for sorting in the generic resources table.
@@ -151,36 +152,41 @@ func (r *ResourceRepository) saveToProjection(
 	return nil
 }
 
-// updateProjectionBySlug updates a resource's projection row in the table identified by targetSlug.
-// If the row doesn't exist (e.g., ancestor table created after initial save), falls back to insert.
+// updateProjectionBySlug upserts a resource's projection row in the table identified by targetSlug.
+// Uses INSERT with ON CONFLICT to atomically handle both existing and missing rows.
 func (r *ResourceRepository) updateProjectionBySlug(
 	ctx context.Context, entity *entities.Resource, targetSlug string,
 ) error {
 	tableName := r.projMgr.TableName(targetSlug)
 	row := map[string]any{
+		"id":          entity.GetID(),
+		"type_slug":   entity.TypeSlug(),
 		"status":      entity.Status(),
+		"created_by":  entity.CreatedBy(),
+		"account_id":  entity.AccountID(),
 		"sequence_no": entity.GetSequenceNo(),
+		"created_at":  entity.CreatedAt(),
 		"updated_at":  time.Now(),
 	}
 	ldCtx := r.projMgr.Context(targetSlug)
 	ExtractFlatColumns(entity.Data(), ldCtx, row)
 	r.dropMissingColumns(targetSlug, row)
-	result := r.db.WithContext(ctx).Table(tableName).
-		Where("id = ?", entity.GetID()).Updates(row)
-	if result.Error != nil {
-		return fmt.Errorf("failed to update resource in %s: %w", tableName, result.Error)
+
+	// Build column list for ON CONFLICT UPDATE (all except id).
+	updateCols := make([]string, 0, len(row))
+	for col := range row {
+		if col != "id" {
+			updateCols = append(updateCols, col)
+		}
 	}
-	// RowsAffected==0 can mean row missing OR no-op update (values unchanged).
-	// Check existence before inserting to avoid duplicate PK errors.
-	if result.RowsAffected == 0 {
-		var count int64
-		if err := r.db.WithContext(ctx).Table(tableName).
-			Where("id = ?", entity.GetID()).Count(&count).Error; err != nil {
-			return fmt.Errorf("failed to check existence in %s: %w", tableName, err)
-		}
-		if count == 0 {
-			return r.saveToProjection(ctx, entity, targetSlug)
-		}
+
+	err := r.db.WithContext(ctx).Table(tableName).
+		Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "id"}},
+			DoUpdates: clause.AssignmentColumns(updateCols),
+		}).Create(row).Error
+	if err != nil {
+		return fmt.Errorf("failed to upsert resource in %s: %w", tableName, err)
 	}
 	return nil
 }

--- a/infrastructure/database/gorm/resource_repository.go
+++ b/infrastructure/database/gorm/resource_repository.go
@@ -234,8 +234,10 @@ func (r *ResourceRepository) findAllFromProjection(
 
 	// Join with the resources table to get the JSON-LD data (not stored in projection).
 	tbl := tableName
-	selectCols := fmt.Sprintf("%s.id, %s.type_slug, resources.data, %s.status, %s.sequence_no, %s.created_at",
-		tbl, tbl, tbl, tbl, tbl)
+	selectCols := fmt.Sprintf(
+		"%s.id, %s.type_slug, resources.data, %s.status, %s.sequence_no, %s.created_at, "+
+			"%s.created_by, %s.account_id",
+		tbl, tbl, tbl, tbl, tbl, tbl, tbl)
 	if !standardColumnNames[colName] && colName != "id" {
 		selectCols += fmt.Sprintf(", %s.%s", tbl, colName)
 	}
@@ -506,8 +508,10 @@ func (r *ResourceRepository) findAllFromProjectionWithFilters(
 	}
 
 	tbl := tableName
-	selectCols := fmt.Sprintf("%s.id, %s.type_slug, resources.data, %s.status, %s.sequence_no, %s.created_at",
-		tbl, tbl, tbl, tbl, tbl)
+	selectCols := fmt.Sprintf(
+		"%s.id, %s.type_slug, resources.data, %s.status, %s.sequence_no, %s.created_at, "+
+			"%s.created_by, %s.account_id",
+		tbl, tbl, tbl, tbl, tbl, tbl, tbl)
 	if !standardColumnNames[colName] && colName != "id" {
 		selectCols += fmt.Sprintf(", %s.%s", tbl, colName)
 	}

--- a/infrastructure/database/gorm/resource_repository.go
+++ b/infrastructure/database/gorm/resource_repository.go
@@ -101,6 +101,10 @@ func ProvideResourceRepository(params struct {
 	}, nil
 }
 
+// Save persists a resource to the canonical table and all projection tables.
+// Projection writes are not transactional by design: projections are eventually-consistent
+// read models that can be rebuilt from the event store. A partial failure leaves the
+// canonical resources table correct; projections self-heal on the next event replay.
 func (r *ResourceRepository) Save(
 	ctx context.Context, entity *entities.Resource,
 ) error {
@@ -172,10 +176,11 @@ func (r *ResourceRepository) updateProjectionBySlug(
 	ExtractFlatColumns(entity.Data(), ldCtx, row)
 	r.dropMissingColumns(targetSlug, row)
 
-	// Build column list for ON CONFLICT UPDATE (all except id).
+	// Build column list for ON CONFLICT UPDATE, excluding immutable fields.
+	immutable := map[string]bool{"id": true, "created_at": true, "created_by": true, "account_id": true}
 	updateCols := make([]string, 0, len(row))
 	for col := range row {
-		if col != "id" {
+		if !immutable[col] {
 			updateCols = append(updateCols, col)
 		}
 	}

--- a/infrastructure/database/gorm/resource_repository.go
+++ b/infrastructure/database/gorm/resource_repository.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"weos/domain/entities"
@@ -157,11 +158,13 @@ func applyVisibilityScope(query *gorm.DB, scope *repositories.VisibilityScope, t
 		return query
 	}
 	col := "created_by"
+	idCol := "id"
 	if tablePrefix != "" {
 		col = tablePrefix + "." + col
+		idCol = tablePrefix + "." + idCol
 	}
 	return query.Where(
-		col+" = ? OR id IN (SELECT resource_id FROM resource_permissions WHERE agent_id = ? AND actions LIKE ?)",
+		col+" = ? OR "+idCol+" IN (SELECT resource_id FROM resource_permissions WHERE agent_id = ? AND actions LIKE ?)",
 		scope.AgentID, scope.AgentID, `%"read"%`,
 	)
 }
@@ -309,20 +312,26 @@ func (r *ResourceRepository) findAllFromProjection(
 }
 
 func applyCursorCondition(query *gorm.DB, colName, sortOrder string, cd cursorData) *gorm.DB {
-	if colName == "id" {
+	// colName may be table-qualified (e.g. "products.id") when used in JOIN queries.
+	// Derive idCol from colName to maintain consistent qualification.
+	idCol := "id"
+	if i := strings.LastIndex(colName, "."); i >= 0 {
+		idCol = colName[:i+1] + "id"
+	}
+	if colName == "id" || strings.HasSuffix(colName, ".id") {
 		if sortOrder == "desc" {
-			return query.Where("id < ?", cd.ID)
+			return query.Where(idCol+" < ?", cd.ID)
 		}
-		return query.Where("id > ?", cd.ID)
+		return query.Where(idCol+" > ?", cd.ID)
 	}
 	if sortOrder == "desc" {
 		return query.Where(
-			fmt.Sprintf("(%s < ?) OR (%s = ? AND id < ?)", colName, colName),
+			fmt.Sprintf("(%s < ?) OR (%s = ? AND %s < ?)", colName, colName, idCol),
 			cd.Value, cd.Value, cd.ID,
 		)
 	}
 	return query.Where(
-		fmt.Sprintf("(%s > ?) OR (%s = ? AND id > ?)", colName, colName),
+		fmt.Sprintf("(%s > ?) OR (%s = ? AND %s > ?)", colName, colName, idCol),
 		cd.Value, cd.Value, cd.ID,
 	)
 }

--- a/infrastructure/database/gorm/resource_repository_test.go
+++ b/infrastructure/database/gorm/resource_repository_test.go
@@ -34,12 +34,18 @@ func TestFindAllFlatFromProjection_TypeSlugFiltering(t *testing.T) {
 	}
 
 	// Insert rows with different type_slug values.
-	db.Exec(`INSERT INTO instruments (id, type_slug, status, name, interest_rate)
-		VALUES ('loan-1', 'loan', 'active', 'Home Loan', 3.5)`)
-	db.Exec(`INSERT INTO instruments (id, type_slug, status, name, interest_rate)
-		VALUES ('loan-2', 'loan', 'active', 'Car Loan', 5.0)`)
-	db.Exec(`INSERT INTO instruments (id, type_slug, status, name, min_balance)
-		VALUES ('dep-1', 'deposit', 'active', 'Savings', 100)`)
+	if err := db.Exec(`INSERT INTO instruments (id, type_slug, status, name, interest_rate)
+		VALUES ('loan-1', 'loan', 'active', 'Home Loan', 3.5)`).Error; err != nil {
+		t.Fatalf("insert loan-1 fixture: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO instruments (id, type_slug, status, name, interest_rate)
+		VALUES ('loan-2', 'loan', 'active', 'Car Loan', 5.0)`).Error; err != nil {
+		t.Fatalf("insert loan-2 fixture: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO instruments (id, type_slug, status, name, min_balance)
+		VALUES ('dep-1', 'deposit', 'active', 'Savings', 100)`).Error; err != nil {
+		t.Fatalf("insert dep-1 fixture: %v", err)
+	}
 
 	repo := &ResourceRepository{db: db, projMgr: pm}
 

--- a/infrastructure/database/gorm/resource_repository_test.go
+++ b/infrastructure/database/gorm/resource_repository_test.go
@@ -100,16 +100,9 @@ func TestDualProjection_UpdatePropagates(t *testing.T) {
 		t.Fatalf("Save: %v", err)
 	}
 
-	// Update the resource.
+	// Update the resource with new data.
 	updated := makeTestResource(t, "urn:loan:002", "loan",
 		`{"name":"Updated Car Loan","interestRate":4.5}`)
-	if err := updated.Restore(
-		"urn:loan:002", "loan", "active",
-		json.RawMessage(`{"name":"Updated Car Loan","interestRate":4.5}`),
-		"user-1", "acct-1", time.Now(), 2,
-	); err != nil {
-		t.Fatal(err)
-	}
 	if err := repo.Update(ctx, updated); err != nil {
 		t.Fatalf("Update: %v", err)
 	}

--- a/infrastructure/database/gorm/resource_repository_test.go
+++ b/infrastructure/database/gorm/resource_repository_test.go
@@ -1,0 +1,69 @@
+package gorm
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"weos/domain/repositories"
+)
+
+func TestFindAllFlatFromProjection_TypeSlugFiltering(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	// Create abstract parent with "name" column.
+	parentSchema := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`)
+	abstractCtx := json.RawMessage(`{"@vocab":"https://schema.org/","weos:abstract":true}`)
+	if err := pm.EnsureTable(ctx, "instrument", parentSchema, abstractCtx); err != nil {
+		t.Fatalf("EnsureTable parent: %v", err)
+	}
+
+	// Register two subtypes.
+	loanSchema := json.RawMessage(
+		`{"type":"object","properties":{"name":{"type":"string"},"interestRate":{"type":"number"}}}`)
+	if err := pm.RegisterSubtype(ctx, "loan", "instrument", loanSchema); err != nil {
+		t.Fatalf("RegisterSubtype loan: %v", err)
+	}
+	depositSchema := json.RawMessage(
+		`{"type":"object","properties":{"name":{"type":"string"},"minBalance":{"type":"number"}}}`)
+	if err := pm.RegisterSubtype(ctx, "deposit", "instrument", depositSchema); err != nil {
+		t.Fatalf("RegisterSubtype deposit: %v", err)
+	}
+
+	// Insert rows with different type_slug values.
+	db.Exec(`INSERT INTO instruments (id, type_slug, status, name, interest_rate)
+		VALUES ('loan-1', 'loan', 'active', 'Home Loan', 3.5)`)
+	db.Exec(`INSERT INTO instruments (id, type_slug, status, name, interest_rate)
+		VALUES ('loan-2', 'loan', 'active', 'Car Loan', 5.0)`)
+	db.Exec(`INSERT INTO instruments (id, type_slug, status, name, min_balance)
+		VALUES ('dep-1', 'deposit', 'active', 'Savings', 100)`)
+
+	repo := &ResourceRepository{db: db, projMgr: pm}
+
+	// Query for loans only.
+	loanResult, err := repo.findAllFlatFromProjection(
+		ctx, "loan", nil, "", 20,
+		repositories.SortOptions{}, nil,
+	)
+	if err != nil {
+		t.Fatalf("findAllFlatFromProjection(loan) failed: %v", err)
+	}
+	if len(loanResult.Data) != 2 {
+		t.Fatalf("expected 2 loan rows, got %d", len(loanResult.Data))
+	}
+
+	// Query for deposits only.
+	depositResult, err := repo.findAllFlatFromProjection(
+		ctx, "deposit", nil, "", 20,
+		repositories.SortOptions{}, nil,
+	)
+	if err != nil {
+		t.Fatalf("findAllFlatFromProjection(deposit) failed: %v", err)
+	}
+	if len(depositResult.Data) != 1 {
+		t.Fatalf("expected 1 deposit row, got %d", len(depositResult.Data))
+	}
+}

--- a/infrastructure/database/gorm/resource_repository_test.go
+++ b/infrastructure/database/gorm/resource_repository_test.go
@@ -4,72 +4,190 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
-	"weos/domain/repositories"
+	"weos/domain/entities"
+	"weos/infrastructure/models"
 )
 
-func TestFindAllFlatFromProjection_TypeSlugFiltering(t *testing.T) {
+func setupDualProjectionTest(t *testing.T) (
+	*ResourceRepository, *projectionManager, context.Context,
+) {
+	t.Helper()
+	db := newTestDB(t)
+	if err := db.AutoMigrate(&models.Resource{}); err != nil {
+		t.Fatalf("migrate resources: %v", err)
+	}
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	parentCtx := json.RawMessage(`{"@vocab":"https://schema.org/","weos:abstract":true}`)
+	parentSchema := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`)
+	childCtx := json.RawMessage(
+		`{"@vocab":"https://schema.org/","rdfs:subClassOf":"instrument"}`)
+	childSchema := json.RawMessage(`{"type":"object","properties":{` +
+		`"name":{"type":"string"},"interestRate":{"type":"number"}}}`)
+
+	if err := pm.EnsureTable(ctx, "instrument", parentSchema, parentCtx); err != nil {
+		t.Fatal(err)
+	}
+	if err := pm.EnsureTable(ctx, "loan", childSchema, childCtx); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := &ResourceRepository{db: db, projMgr: pm}
+	return repo, pm, ctx
+}
+
+func makeTestResource(t *testing.T, id, typeSlug, dataJSON string) *entities.Resource {
+	t.Helper()
+	e := &entities.Resource{}
+	if err := e.Restore(
+		id, typeSlug, "active",
+		json.RawMessage(dataJSON),
+		"user-1", "acct-1",
+		time.Now(), 1,
+	); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	return e
+}
+
+func TestDualProjection_SavePopulatesBothTables(t *testing.T) {
+	t.Parallel()
+	repo, _, ctx := setupDualProjectionTest(t)
+
+	entity := makeTestResource(t, "urn:loan:001", "loan",
+		`{"name":"Home Loan","interestRate":3.5}`)
+
+	if err := repo.Save(ctx, entity); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Verify loan exists in its own table.
+	var loanCount int64
+	repo.db.Table("loans").Count(&loanCount)
+	if loanCount != 1 {
+		t.Fatalf("expected 1 row in loans, got %d", loanCount)
+	}
+
+	// Verify loan also projected into ancestor table.
+	var instrCount int64
+	repo.db.Table("instruments").Count(&instrCount)
+	if instrCount != 1 {
+		t.Fatalf("expected 1 row in instruments, got %d", instrCount)
+	}
+
+	// Verify ancestor row has parent-schema columns but NOT child-only columns.
+	var instrRow map[string]any
+	repo.db.Table("instruments").Where("id = ?", "urn:loan:001").Take(&instrRow)
+	if instrRow["name"] != "Home Loan" {
+		t.Fatalf("ancestor name = %v, want 'Home Loan'", instrRow["name"])
+	}
+	// interest_rate column should NOT exist in ancestor table.
+	if repo.db.Migrator().HasColumn("instruments", "interest_rate") {
+		t.Fatal("ancestor table should NOT have child-specific interest_rate column")
+	}
+}
+
+func TestDualProjection_UpdatePropagates(t *testing.T) {
+	t.Parallel()
+	repo, _, ctx := setupDualProjectionTest(t)
+
+	entity := makeTestResource(t, "urn:loan:002", "loan",
+		`{"name":"Car Loan","interestRate":5.0}`)
+	if err := repo.Save(ctx, entity); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Update the resource.
+	updated := makeTestResource(t, "urn:loan:002", "loan",
+		`{"name":"Updated Car Loan","interestRate":4.5}`)
+	if err := updated.Restore(
+		"urn:loan:002", "loan", "active",
+		json.RawMessage(`{"name":"Updated Car Loan","interestRate":4.5}`),
+		"user-1", "acct-1", time.Now(), 2,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Update(ctx, updated); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	// Verify ancestor table has updated name.
+	var instrRow map[string]any
+	repo.db.Table("instruments").Where("id = ?", "urn:loan:002").Take(&instrRow)
+	if instrRow["name"] != "Updated Car Loan" {
+		t.Fatalf("ancestor name = %v, want 'Updated Car Loan'", instrRow["name"])
+	}
+}
+
+func TestDualProjection_DeleteRemovesFromBothTables(t *testing.T) {
+	t.Parallel()
+	repo, _, ctx := setupDualProjectionTest(t)
+
+	entity := makeTestResource(t, "urn:loan:003", "loan",
+		`{"name":"Delete Me","interestRate":2.0}`)
+	if err := repo.Save(ctx, entity); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Verify rows exist in both tables before delete.
+	var loanCount, instrCount int64
+	repo.db.Table("loans").Count(&loanCount)
+	repo.db.Table("instruments").Count(&instrCount)
+	if loanCount != 1 || instrCount != 1 {
+		t.Fatalf("pre-delete: loans=%d instruments=%d, want 1,1", loanCount, instrCount)
+	}
+
+	if err := repo.Delete(ctx, "urn:loan:003"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// Verify rows removed from both tables.
+	repo.db.Table("loans").Count(&loanCount)
+	repo.db.Table("instruments").Count(&instrCount)
+	if loanCount != 0 {
+		t.Fatalf("post-delete: loans=%d, want 0", loanCount)
+	}
+	if instrCount != 0 {
+		t.Fatalf("post-delete: instruments=%d, want 0", instrCount)
+	}
+}
+
+func TestDualProjection_AncestorUsesOwnSchema(t *testing.T) {
 	t.Parallel()
 	db := newTestDB(t)
 	pm := &projectionManager{db: db, logger: &testLogger{}}
 	ctx := context.Background()
 
-	// Create abstract parent with "name" column.
+	parentCtx := json.RawMessage(`{"@vocab":"https://schema.org/","weos:abstract":true}`)
 	parentSchema := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`)
-	abstractCtx := json.RawMessage(`{"@vocab":"https://schema.org/","weos:abstract":true}`)
-	if err := pm.EnsureTable(ctx, "instrument", parentSchema, abstractCtx); err != nil {
-		t.Fatalf("EnsureTable parent: %v", err)
+	childCtx := json.RawMessage(
+		`{"@vocab":"https://schema.org/","rdfs:subClassOf":"instrument"}`)
+	childSchema := json.RawMessage(`{"type":"object","properties":{` +
+		`"name":{"type":"string"},"interestRate":{"type":"number"}}}`)
+
+	if err := pm.EnsureTable(ctx, "instrument", parentSchema, parentCtx); err != nil {
+		t.Fatal(err)
+	}
+	if err := pm.EnsureTable(ctx, "loan", childSchema, childCtx); err != nil {
+		t.Fatal(err)
 	}
 
-	// Register two subtypes.
-	loanSchema := json.RawMessage(
-		`{"type":"object","properties":{"name":{"type":"string"},"interestRate":{"type":"number"}}}`)
-	if err := pm.RegisterSubtype(ctx, "loan", "instrument", loanSchema, nil); err != nil {
-		t.Fatalf("RegisterSubtype loan: %v", err)
+	// Ancestor table: has "name" but NOT "interest_rate".
+	if db.Migrator().HasColumn("instruments", "interest_rate") {
+		t.Fatal("ancestor table should NOT have child-specific column")
 	}
-	depositSchema := json.RawMessage(
-		`{"type":"object","properties":{"name":{"type":"string"},"minBalance":{"type":"number"}}}`)
-	if err := pm.RegisterSubtype(ctx, "deposit", "instrument", depositSchema, nil); err != nil {
-		t.Fatalf("RegisterSubtype deposit: %v", err)
+	if !db.Migrator().HasColumn("instruments", "name") {
+		t.Fatal("ancestor table should have 'name' from its own schema")
 	}
 
-	// Insert rows with different type_slug values.
-	if err := db.Exec(`INSERT INTO instruments (id, type_slug, status, name, interest_rate)
-		VALUES ('loan-1', 'loan', 'active', 'Home Loan', 3.5)`).Error; err != nil {
-		t.Fatalf("insert loan-1 fixture: %v", err)
+	// Child table: has both.
+	if !db.Migrator().HasColumn("loans", "interest_rate") {
+		t.Fatal("child table should have interest_rate")
 	}
-	if err := db.Exec(`INSERT INTO instruments (id, type_slug, status, name, interest_rate)
-		VALUES ('loan-2', 'loan', 'active', 'Car Loan', 5.0)`).Error; err != nil {
-		t.Fatalf("insert loan-2 fixture: %v", err)
-	}
-	if err := db.Exec(`INSERT INTO instruments (id, type_slug, status, name, min_balance)
-		VALUES ('dep-1', 'deposit', 'active', 'Savings', 100)`).Error; err != nil {
-		t.Fatalf("insert dep-1 fixture: %v", err)
-	}
-
-	repo := &ResourceRepository{db: db, projMgr: pm}
-
-	// Query for loans only.
-	loanResult, err := repo.findAllFlatFromProjection(
-		ctx, "loan", nil, "", 20,
-		repositories.SortOptions{}, nil,
-	)
-	if err != nil {
-		t.Fatalf("findAllFlatFromProjection(loan) failed: %v", err)
-	}
-	if len(loanResult.Data) != 2 {
-		t.Fatalf("expected 2 loan rows, got %d", len(loanResult.Data))
-	}
-
-	// Query for deposits only.
-	depositResult, err := repo.findAllFlatFromProjection(
-		ctx, "deposit", nil, "", 20,
-		repositories.SortOptions{}, nil,
-	)
-	if err != nil {
-		t.Fatalf("findAllFlatFromProjection(deposit) failed: %v", err)
-	}
-	if len(depositResult.Data) != 1 {
-		t.Fatalf("expected 1 deposit row, got %d", len(depositResult.Data))
+	if !db.Migrator().HasColumn("loans", "name") {
+		t.Fatal("child table should have name")
 	}
 }

--- a/infrastructure/database/gorm/resource_repository_test.go
+++ b/infrastructure/database/gorm/resource_repository_test.go
@@ -24,12 +24,12 @@ func TestFindAllFlatFromProjection_TypeSlugFiltering(t *testing.T) {
 	// Register two subtypes.
 	loanSchema := json.RawMessage(
 		`{"type":"object","properties":{"name":{"type":"string"},"interestRate":{"type":"number"}}}`)
-	if err := pm.RegisterSubtype(ctx, "loan", "instrument", loanSchema); err != nil {
+	if err := pm.RegisterSubtype(ctx, "loan", "instrument", loanSchema, nil); err != nil {
 		t.Fatalf("RegisterSubtype loan: %v", err)
 	}
 	depositSchema := json.RawMessage(
 		`{"type":"object","properties":{"name":{"type":"string"},"minBalance":{"type":"number"}}}`)
-	if err := pm.RegisterSubtype(ctx, "deposit", "instrument", depositSchema); err != nil {
+	if err := pm.RegisterSubtype(ctx, "deposit", "instrument", depositSchema, nil); err != nil {
 		t.Fatalf("RegisterSubtype deposit: %v", err)
 	}
 

--- a/infrastructure/database/gorm/resource_repository_test.go
+++ b/infrastructure/database/gorm/resource_repository_test.go
@@ -3,6 +3,7 @@ package gorm
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -81,7 +82,7 @@ func TestDualProjection_SavePopulatesBothTables(t *testing.T) {
 	// Verify ancestor row has parent-schema columns but NOT child-only columns.
 	var instrRow map[string]any
 	repo.db.Table("instruments").Where("id = ?", "urn:loan:001").Take(&instrRow)
-	if instrRow["name"] != "Home Loan" {
+	if fmt.Sprint(instrRow["name"]) != "Home Loan" {
 		t.Fatalf("ancestor name = %v, want 'Home Loan'", instrRow["name"])
 	}
 	// interest_rate column should NOT exist in ancestor table.
@@ -110,7 +111,7 @@ func TestDualProjection_UpdatePropagates(t *testing.T) {
 	// Verify ancestor table has updated name.
 	var instrRow map[string]any
 	repo.db.Table("instruments").Where("id = ?", "urn:loan:002").Take(&instrRow)
-	if instrRow["name"] != "Updated Car Loan" {
+	if fmt.Sprint(instrRow["name"]) != "Updated Car Loan" {
 		t.Fatalf("ancestor name = %v, want 'Updated Car Loan'", instrRow["name"])
 	}
 }

--- a/infrastructure/database/gorm/resource_type_repository.go
+++ b/infrastructure/database/gorm/resource_type_repository.go
@@ -17,6 +17,7 @@ package gorm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -75,6 +76,9 @@ func (r *ResourceTypeRepository) FindBySlug(
 	err := r.db.WithContext(ctx).
 		Where("slug = ? AND deleted_at IS NULL", slug).First(&model).Error
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("resource type %q: %w", slug, repositories.ErrNotFound)
+		}
 		return nil, fmt.Errorf("failed to find resource type by slug: %w", err)
 	}
 	return model.ToResourceType()

--- a/pkg/jsonld/context.go
+++ b/pkg/jsonld/context.go
@@ -111,8 +111,8 @@ func IsValueObject(ldContext json.RawMessage) bool {
 }
 
 // IsAbstract checks whether a JSON-LD context declares "weos:abstract": true.
-// Abstract types define shared behaviors for child types (via rdfs:subClassOf)
-// but have no projection table and cannot have instances created directly.
+// Abstract types define shared projection tables for child types (via rdfs:subClassOf).
+// Subtypes share the parent's projection table using type_slug as a discriminator.
 func IsAbstract(ldContext json.RawMessage) bool {
 	if len(ldContext) == 0 {
 		return false

--- a/pkg/jsonld/context.go
+++ b/pkg/jsonld/context.go
@@ -111,8 +111,9 @@ func IsValueObject(ldContext json.RawMessage) bool {
 }
 
 // IsAbstract checks whether a JSON-LD context declares "weos:abstract": true.
-// Abstract types define shared projection tables for child types (via rdfs:subClassOf).
-// Subtypes share the parent's projection table using type_slug as a discriminator.
+// Abstract types serve as base types for child types (via rdfs:subClassOf).
+// Each type gets its own projection table; child resources are dual-projected
+// into both their own table and all ancestor tables.
 func IsAbstract(ldContext json.RawMessage) bool {
 	if len(ldContext) == 0 {
 		return false


### PR DESCRIPTION
## Summary

Every resource type (abstract and concrete) now gets its own projection table.
When a resource is saved/updated/deleted, it is dual-projected into both its
own table and all ancestor tables (via rdfs:subClassOf). The ancestor projection
uses the ancestor's JSON-LD context so only ancestor-relevant columns are populated.

This replaces the earlier shared-table approach where subtypes merged columns
into the parent table with type_slug as a discriminator.

### Key changes:
- **Dual-projection**: Save/Update/Delete project into own table + all ancestor tables
- **AncestorSlugs**: walks rdfs:subClassOf chain with cycle detection
- **dropMissingColumns**: filters child-only columns from ancestor projections using cached column sets
- **Upsert for ancestor updates**: falls back to insert if ancestor row doesn't exist yet
- **Simplified startup**: single-pass EnsureExistingTables (no ordering constraints)
- **PresetRegistry**: deep-copy clone(), restored ecommerce preset, unexported behaviors
- **Domain error**: repositories.ErrNotFound replaces gorm dependency in application layer

## Test plan
- [x] Unit tests for AncestorSlugs (single/multi/circular/no-parent)
- [x] Integration tests for dual-projection Save/Update/Delete through repository
- [x] Column schema isolation (ancestor table has only ancestor columns)
- [x] ensureProjection ensures both child and parent tables
- [x] Preset validation tests updated for ecommerce
- [x] All existing e2e tests pass
- [x] `make test` / `make lint` / `make vet` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)