### PR TITLE
feat: consume preset Screens FS — serve and load screen modules

### DIFF
--- a/api/handlers/preset_screen_handler.go
+++ b/api/handlers/preset_screen_handler.go
@@ -63,6 +63,9 @@ func (h *PresetScreenHandler) Serve(c echo.Context) error {
 	if !fs.ValidPath(filePath) {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid path"})
 	}
+	if strings.Count(filePath, "/") != 1 {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid screen path"})
+	}
 
 	f, err := preset.Screens.Open(filePath)
 	if err != nil {

--- a/api/handlers/preset_screen_handler.go
+++ b/api/handlers/preset_screen_handler.go
@@ -39,9 +39,10 @@ func NewPresetScreenHandler(registry *application.PresetRegistry) *PresetScreenH
 	return &PresetScreenHandler{registry: registry}
 }
 
-// Serve handles GET /api/resource-types/presets/:name/screens/*filepath.
+// Serve handles GET /api/resource-types/presets/:name/screens/*.
 // It looks up the preset, opens the requested file from its Screens FS,
-// and serves it with appropriate headers. Only .mjs files are served.
+// and serves it with appropriate headers. Only .mjs files at exactly one
+// directory level (<typeSlug>/<ScreenName>.mjs) are served.
 func (h *PresetScreenHandler) Serve(c echo.Context) error {
 	name := c.Param("name")
 	preset, ok := h.registry.Get(name)

--- a/api/handlers/preset_screen_handler.go
+++ b/api/handlers/preset_screen_handler.go
@@ -60,6 +60,9 @@ func (h *PresetScreenHandler) Serve(c echo.Context) error {
 	if !strings.HasSuffix(filePath, ".mjs") {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "only .mjs files are served"})
 	}
+	if !fs.ValidPath(filePath) {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid path"})
+	}
 
 	f, err := preset.Screens.Open(filePath)
 	if err != nil {
@@ -69,10 +72,10 @@ func (h *PresetScreenHandler) Serve(c echo.Context) error {
 		c.Logger().Errorf("preset screen handler: open %s/%s: %v", name, filePath, err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	c.Response().Header().Set("Content-Type", "application/javascript; charset=utf-8")
-	c.Response().Header().Set("Cache-Control", "public, max-age=3600")
+	c.Response().Header().Set("Cache-Control", "private, max-age=3600")
 	c.Response().WriteHeader(http.StatusOK)
 	if _, copyErr := io.Copy(c.Response(), f); copyErr != nil {
 		c.Logger().Errorf("preset screen handler: io.Copy %s/%s: %v", name, filePath, copyErr)

--- a/api/handlers/preset_screen_handler.go
+++ b/api/handlers/preset_screen_handler.go
@@ -1,0 +1,81 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package handlers
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"net/http"
+	"strings"
+
+	"weos/application"
+
+	"github.com/labstack/echo/v4"
+)
+
+// PresetScreenHandler serves compiled screen modules (.mjs) from preset
+// Screens filesystems.
+type PresetScreenHandler struct {
+	registry *application.PresetRegistry
+}
+
+// NewPresetScreenHandler creates a handler that serves screen files from the
+// preset registry.
+func NewPresetScreenHandler(registry *application.PresetRegistry) *PresetScreenHandler {
+	return &PresetScreenHandler{registry: registry}
+}
+
+// Serve handles GET /api/resource-types/presets/:name/screens/*filepath.
+// It looks up the preset, opens the requested file from its Screens FS,
+// and serves it with appropriate headers. Only .mjs files are served.
+func (h *PresetScreenHandler) Serve(c echo.Context) error {
+	name := c.Param("name")
+	preset, ok := h.registry.Get(name)
+	if !ok {
+		return c.JSON(http.StatusNotFound, map[string]string{"error": "preset not found"})
+	}
+	if preset.Screens == nil {
+		return c.JSON(http.StatusNotFound, map[string]string{"error": "preset has no screens"})
+	}
+
+	filePath := c.Param("*")
+	filePath = strings.TrimPrefix(filePath, "/")
+	if filePath == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "file path required"})
+	}
+	if !strings.HasSuffix(filePath, ".mjs") {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "only .mjs files are served"})
+	}
+
+	f, err := preset.Screens.Open(filePath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, fs.ErrInvalid) {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "screen file not found"})
+		}
+		c.Logger().Errorf("preset screen handler: open %s/%s: %v", name, filePath, err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+	}
+	defer f.Close()
+
+	c.Response().Header().Set("Content-Type", "application/javascript; charset=utf-8")
+	c.Response().Header().Set("Cache-Control", "public, max-age=3600")
+	c.Response().WriteHeader(http.StatusOK)
+	if _, copyErr := io.Copy(c.Response(), f); copyErr != nil {
+		c.Logger().Errorf("preset screen handler: io.Copy %s/%s: %v", name, filePath, copyErr)
+	}
+	return nil
+}

--- a/api/handlers/preset_screen_handler_test.go
+++ b/api/handlers/preset_screen_handler_test.go
@@ -176,6 +176,25 @@ func TestPresetScreenHandler_Serve_NonMjsRejected(t *testing.T) {
 	}
 }
 
+func TestPresetScreenHandler_Serve_NestedPathRejected(t *testing.T) {
+	t.Parallel()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/resource-types/presets/tasks/screens/task/sub/deep.mjs", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("name", "*")
+	c.SetParamValues("tasks", "/task/sub/deep.mjs")
+
+	h := handlers.NewPresetScreenHandler(screenRegistry())
+	err := h.Serve(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for nested path, got %d", rec.Code)
+	}
+}
+
 func TestPresetScreenHandler_Serve_EmptyPath(t *testing.T) {
 	t.Parallel()
 	e := echo.New()

--- a/api/handlers/preset_screen_handler_test.go
+++ b/api/handlers/preset_screen_handler_test.go
@@ -1,0 +1,196 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+
+	"weos/api/handlers"
+	"weos/application"
+
+	"github.com/labstack/echo/v4"
+)
+
+func screenRegistry() *application.PresetRegistry {
+	r := application.NewPresetRegistry()
+	r.MustAdd(application.PresetDefinition{
+		Name: "tasks",
+		Types: []application.PresetResourceType{
+			{Name: "Task", Slug: "task"},
+		},
+		Screens: fstest.MapFS{
+			"task/Checklist.mjs": {Data: []byte(`export const meta={name:"Checklist",label:"Checklist"};export default {}`)},
+		},
+	})
+	r.MustAdd(application.PresetDefinition{
+		Name: "core",
+		Types: []application.PresetResourceType{
+			{Name: "Person", Slug: "person"},
+		},
+		// No Screens
+	})
+	return r
+}
+
+func TestPresetScreenHandler_Serve_Success(t *testing.T) {
+	t.Parallel()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/resource-types/presets/tasks/screens/task/Checklist.mjs", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("name", "*")
+	c.SetParamValues("tasks", "/task/Checklist.mjs")
+
+	h := handlers.NewPresetScreenHandler(screenRegistry())
+	err := h.Serve(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	ct := rec.Header().Get("Content-Type")
+	if ct != "application/javascript; charset=utf-8" {
+		t.Fatalf("expected application/javascript content type, got %q", ct)
+	}
+	cc := rec.Header().Get("Cache-Control")
+	if cc != "public, max-age=3600" {
+		t.Fatalf("expected public cache control, got %q", cc)
+	}
+	body := rec.Body.String()
+	expected := `export const meta={name:"Checklist",label:"Checklist"};export default {}`
+	if body != expected {
+		t.Fatalf("expected body %q, got %q", expected, body)
+	}
+}
+
+func TestPresetScreenHandler_Serve_PresetNotFound(t *testing.T) {
+	t.Parallel()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/resource-types/presets/nonexistent/screens/foo.mjs", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("name", "*")
+	c.SetParamValues("nonexistent", "/foo.mjs")
+
+	h := handlers.NewPresetScreenHandler(screenRegistry())
+	err := h.Serve(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestPresetScreenHandler_Serve_NoScreens(t *testing.T) {
+	t.Parallel()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/resource-types/presets/core/screens/person/List.mjs", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("name", "*")
+	c.SetParamValues("core", "/person/List.mjs")
+
+	h := handlers.NewPresetScreenHandler(screenRegistry())
+	err := h.Serve(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestPresetScreenHandler_Serve_FileNotFound(t *testing.T) {
+	t.Parallel()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/resource-types/presets/tasks/screens/task/Missing.mjs", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("name", "*")
+	c.SetParamValues("tasks", "/task/Missing.mjs")
+
+	h := handlers.NewPresetScreenHandler(screenRegistry())
+	err := h.Serve(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestPresetScreenHandler_Serve_PathTraversal(t *testing.T) {
+	t.Parallel()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/resource-types/presets/tasks/screens/../../etc/passwd", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("name", "*")
+	c.SetParamValues("tasks", "/../../etc/passwd")
+
+	h := handlers.NewPresetScreenHandler(screenRegistry())
+	err := h.Serve(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Path traversal rejected: either by .mjs suffix check (400) or fs.FS contract (404).
+	if rec.Code != http.StatusNotFound && rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 404 or 400 for path traversal, got %d", rec.Code)
+	}
+}
+
+func TestPresetScreenHandler_Serve_NonMjsRejected(t *testing.T) {
+	t.Parallel()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/resource-types/presets/tasks/screens/task/config.json", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("name", "*")
+	c.SetParamValues("tasks", "/task/config.json")
+
+	h := handlers.NewPresetScreenHandler(screenRegistry())
+	err := h.Serve(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for non-.mjs file, got %d", rec.Code)
+	}
+}
+
+func TestPresetScreenHandler_Serve_EmptyPath(t *testing.T) {
+	t.Parallel()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/resource-types/presets/tasks/screens/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("name", "*")
+	c.SetParamValues("tasks", "")
+
+	h := handlers.NewPresetScreenHandler(screenRegistry())
+	err := h.Serve(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}

--- a/api/handlers/preset_screen_handler_test.go
+++ b/api/handlers/preset_screen_handler_test.go
@@ -70,8 +70,8 @@ func TestPresetScreenHandler_Serve_Success(t *testing.T) {
 		t.Fatalf("expected application/javascript content type, got %q", ct)
 	}
 	cc := rec.Header().Get("Cache-Control")
-	if cc != "public, max-age=3600" {
-		t.Fatalf("expected public cache control, got %q", cc)
+	if cc != "private, max-age=3600" {
+		t.Fatalf("expected private cache control, got %q", cc)
 	}
 	body := rec.Body.String()
 	expected := `export const meta={name:"Checklist",label:"Checklist"};export default {}`

--- a/api/handlers/resource_type_preset_handler.go
+++ b/api/handlers/resource_type_preset_handler.go
@@ -32,9 +32,10 @@ func NewResourceTypePresetHandler(service application.ResourceTypeService) *Reso
 }
 
 type presetResponse struct {
-	Name        string   `json:"name"`
-	Description string   `json:"description"`
-	Types       []string `json:"types"`
+	Name        string              `json:"name"`
+	Description string              `json:"description"`
+	Types       []string            `json:"types"`
+	Screens     map[string][]string `json:"screens,omitempty"`
 }
 
 func (h *ResourceTypePresetHandler) List(c echo.Context) error {
@@ -49,6 +50,7 @@ func (h *ResourceTypePresetHandler) List(c echo.Context) error {
 			Name:        d.Name,
 			Description: d.Description,
 			Types:       slugs,
+			Screens:     d.ScreenManifest(),
 		})
 	}
 	return c.JSON(http.StatusOK, map[string]any{"data": out})

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -171,7 +171,11 @@ func (d PresetDefinition) ScreenManifest() map[string][]string {
 		return nil
 	}
 	manifest := make(map[string][]string)
-	_ = fs.WalkDir(d.Screens, ".", func(p string, entry fs.DirEntry, err error) error {
+	// WalkDir error is intentionally not propagated: the Screens FS is an
+	// embedded filesystem whose contents are guaranteed at compile time.
+	// If WalkDir fails (e.g., root unreadable), manifest stays empty and
+	// the method returns nil — the same result as "no screens".
+	_ = fs.WalkDir(d.Screens, ".", func(p string, entry fs.DirEntry, err error) error { //nolint:errcheck
 		if err != nil || entry.IsDir() {
 			return nil //nolint:nilerr // skip unreadable entries
 		}

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -19,7 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"path"
 	"sort"
+	"strings"
 	"sync"
 
 	"weos/domain/entities"
@@ -158,6 +160,35 @@ func (d PresetDefinition) clone() PresetDefinition {
 		d.Sidebar = &s
 	}
 	return d
+}
+
+// ScreenManifest walks the Screens FS and returns a map of typeSlug to screen
+// filenames. Returns nil if Screens is nil or contains no .mjs files.
+// The expected directory structure is <typeSlug>/<ScreenName>.mjs.
+func (d PresetDefinition) ScreenManifest() map[string][]string {
+	if d.Screens == nil {
+		return nil
+	}
+	manifest := make(map[string][]string)
+	_ = fs.WalkDir(d.Screens, ".", func(p string, entry fs.DirEntry, err error) error {
+		if err != nil || entry.IsDir() {
+			return nil //nolint:nilerr // skip unreadable entries
+		}
+		if !strings.HasSuffix(p, ".mjs") {
+			return nil
+		}
+		dir := path.Dir(p)
+		if dir == "." {
+			return nil // files must be under a type-slug directory
+		}
+		slug := dir
+		manifest[slug] = append(manifest[slug], path.Base(p))
+		return nil
+	})
+	if len(manifest) == 0 {
+		return nil
+	}
+	return manifest
 }
 
 // Behaviors returns a merged ResourceBehaviorRegistry from all registered presets.

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -164,7 +164,8 @@ func (d PresetDefinition) clone() PresetDefinition {
 
 // ScreenManifest walks the Screens FS and returns a map of typeSlug to screen
 // filenames. Returns nil if Screens is nil or contains no .mjs files.
-// The expected directory structure is <typeSlug>/<ScreenName>.mjs.
+// Only files at exactly one level of nesting (<typeSlug>/<ScreenName>.mjs) are
+// included; deeper paths are ignored.
 func (d PresetDefinition) ScreenManifest() map[string][]string {
 	if d.Screens == nil {
 		return nil
@@ -181,12 +182,17 @@ func (d PresetDefinition) ScreenManifest() map[string][]string {
 		if dir == "." {
 			return nil // files must be under a type-slug directory
 		}
-		slug := dir
-		manifest[slug] = append(manifest[slug], path.Base(p))
+		if strings.Contains(dir, "/") {
+			return nil // ignore nested paths; only <typeSlug>/<ScreenName>.mjs is supported
+		}
+		manifest[dir] = append(manifest[dir], path.Base(p))
 		return nil
 	})
 	if len(manifest) == 0 {
 		return nil
+	}
+	for slug := range manifest {
+		sort.Strings(manifest[slug])
 	}
 	return manifest
 }

--- a/application/presets/tasks/preset.go
+++ b/application/presets/tasks/preset.go
@@ -1,13 +1,26 @@
 // Package tasks provides resource types for task and project management.
 package tasks
 
-import "weos/application"
+import (
+	"embed"
+	"io/fs"
+
+	"weos/application"
+)
+
+//go:embed screens/dist/*
+var screensRaw embed.FS
 
 // Register adds the tasks preset to the registry.
 func Register(registry *application.PresetRegistry) {
+	screensFS, err := fs.Sub(screensRaw, "screens/dist")
+	if err != nil {
+		panic("tasks preset: invalid screens directory: " + err.Error())
+	}
 	registry.MustAdd(application.PresetDefinition{
 		Name:        "tasks",
 		Description: "Task management types: projects and tasks with status, priority, and due dates",
+		Screens:     screensFS,
 		Types: []application.PresetResourceType{
 			application.NewPresetType("Project", "project",
 				"A project that groups related tasks",

--- a/application/presets/tasks/screens/dist/task/Checklist.mjs
+++ b/application/presets/tasks/screens/dist/task/Checklist.mjs
@@ -17,6 +17,7 @@ export default {
       loading: true,
       hasMore: false,
       cursor: '',
+      error: null,
     }
   },
   computed: {
@@ -37,22 +38,37 @@ export default {
         const res = await fetch(
           `/api/${this.typeSlug}?cursor=${this.cursor}&limit=50`
         )
+        if (!res.ok) {
+          this.error = `Failed to load tasks (HTTP ${res.status})`
+          return
+        }
         const json = await res.json()
         this.items = [...this.items, ...(json.data || [])]
         this.hasMore = json.has_more || false
         this.cursor = json.cursor || ''
+      } catch (err) {
+        console.error('[Checklist] load failed:', err)
+        this.error = 'Failed to load tasks'
       } finally {
         this.loading = false
       }
     },
     async toggleStatus(item) {
-      const newStatus = item.status === 'done' ? 'todo' : 'done'
-      await fetch(`/api/${this.typeSlug}/${item.id}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...item, status: newStatus }),
-      })
+      const oldStatus = item.status
+      const newStatus = oldStatus === 'done' ? 'todo' : 'done'
       item.status = newStatus
+      try {
+        const res = await fetch(`/api/${this.typeSlug}/${item.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...item, status: newStatus }),
+        })
+        if (!res.ok) {
+          item.status = oldStatus
+        }
+      } catch {
+        item.status = oldStatus
+      }
     },
     priorityColor(priority) {
       const colors = { high: '#ff4d4f', medium: '#faad14', low: '#52c41a' }
@@ -63,6 +79,9 @@ export default {
     <div style="max-width: 720px;">
       <div v-if="loading && !items.length" style="text-align: center; padding: 48px">
         Loading...
+      </div>
+      <div v-else-if="error" style="text-align: center; padding: 48px; color: #ff4d4f">
+        {{ error }}
       </div>
       <template v-else>
         <div v-if="todoItems.length" style="margin-bottom: 24px">

--- a/application/presets/tasks/screens/dist/task/Checklist.mjs
+++ b/application/presets/tasks/screens/dist/task/Checklist.mjs
@@ -1,0 +1,101 @@
+// Checklist screen — a task-oriented view showing tasks with status checkboxes.
+// This is a self-describing ES module: exports meta for discovery and a Vue
+// component as the default export.
+
+export const meta = {
+  name: 'Checklist',
+  label: 'Checklist',
+  icon: 'check-square-outlined',
+}
+
+export default {
+  props: ['typeSlug'],
+  emits: ['navigate'],
+  data() {
+    return {
+      items: [],
+      loading: true,
+      hasMore: false,
+      cursor: '',
+    }
+  },
+  computed: {
+    todoItems() {
+      return this.items.filter(i => i.status !== 'done')
+    },
+    doneItems() {
+      return this.items.filter(i => i.status === 'done')
+    },
+  },
+  async mounted() {
+    await this.load()
+  },
+  methods: {
+    async load() {
+      this.loading = true
+      try {
+        const res = await fetch(
+          `/api/${this.typeSlug}?cursor=${this.cursor}&limit=50`
+        )
+        const json = await res.json()
+        this.items = [...this.items, ...(json.data || [])]
+        this.hasMore = json.has_more || false
+        this.cursor = json.cursor || ''
+      } finally {
+        this.loading = false
+      }
+    },
+    async toggleStatus(item) {
+      const newStatus = item.status === 'done' ? 'todo' : 'done'
+      await fetch(`/api/${this.typeSlug}/${item.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...item, status: newStatus }),
+      })
+      item.status = newStatus
+    },
+    priorityColor(priority) {
+      const colors = { high: '#ff4d4f', medium: '#faad14', low: '#52c41a' }
+      return colors[priority] || '#d9d9d9'
+    },
+  },
+  template: `
+    <div style="max-width: 720px;">
+      <div v-if="loading && !items.length" style="text-align: center; padding: 48px">
+        Loading...
+      </div>
+      <template v-else>
+        <div v-if="todoItems.length" style="margin-bottom: 24px">
+          <h3 style="margin-bottom: 12px; color: #595959">To Do</h3>
+          <div v-for="item in todoItems" :key="item.id"
+               style="display: flex; align-items: center; padding: 8px 12px; border: 1px solid #f0f0f0; border-radius: 6px; margin-bottom: 8px; cursor: pointer"
+               @click="toggleStatus(item)">
+            <span style="width: 20px; height: 20px; border: 2px solid #d9d9d9; border-radius: 4px; margin-right: 12px; flex-shrink: 0"></span>
+            <span style="flex: 1">{{ item.name || item.id }}</span>
+            <span v-if="item.priority"
+                  :style="{ fontSize: '12px', padding: '2px 8px', borderRadius: '4px', backgroundColor: priorityColor(item.priority), color: '#fff' }">
+              {{ item.priority }}
+            </span>
+          </div>
+        </div>
+        <div v-if="doneItems.length">
+          <h3 style="margin-bottom: 12px; color: #8c8c8c">Done</h3>
+          <div v-for="item in doneItems" :key="item.id"
+               style="display: flex; align-items: center; padding: 8px 12px; border: 1px solid #f0f0f0; border-radius: 6px; margin-bottom: 8px; opacity: 0.6; cursor: pointer"
+               @click="toggleStatus(item)">
+            <span style="width: 20px; height: 20px; border: 2px solid #52c41a; border-radius: 4px; margin-right: 12px; flex-shrink: 0; background: #52c41a; display: flex; align-items: center; justify-content: center; color: #fff; font-size: 12px">&#10003;</span>
+            <span style="flex: 1; text-decoration: line-through">{{ item.name || item.id }}</span>
+          </div>
+        </div>
+        <div v-if="!items.length" style="text-align: center; padding: 48px; color: #8c8c8c">
+          No tasks yet
+        </div>
+        <div v-if="hasMore" style="text-align: center; margin-top: 16px">
+          <button @click="load" style="padding: 6px 16px; border: 1px solid #d9d9d9; border-radius: 4px; background: #fff; cursor: pointer">
+            Load More
+          </button>
+        </div>
+      </template>
+    </div>
+  `,
+}

--- a/application/resource_type_presets_test.go
+++ b/application/resource_type_presets_test.go
@@ -17,7 +17,9 @@ package application_test
 
 import (
 	"encoding/json"
+	"io/fs"
 	"testing"
+	"testing/fstest"
 
 	"weos/application"
 	"weos/application/presets"
@@ -176,5 +178,148 @@ func TestPresets_NoReservedSlugCollisions(t *testing.T) {
 				t.Fatalf("preset %q type slug %q collides with reserved API route", d.Name, pt.Slug)
 			}
 		}
+	}
+}
+
+func TestScreenManifest_NilScreens(t *testing.T) {
+	t.Parallel()
+	def := application.PresetDefinition{Name: "test"}
+	manifest := def.ScreenManifest()
+	if manifest != nil {
+		t.Fatalf("expected nil manifest for nil Screens, got %v", manifest)
+	}
+}
+
+func TestScreenManifest_EmptyFS(t *testing.T) {
+	t.Parallel()
+	emptyFS := fstest.MapFS{}
+	def := application.PresetDefinition{Name: "test", Screens: emptyFS}
+	manifest := def.ScreenManifest()
+	if manifest != nil {
+		t.Fatalf("expected nil manifest for empty FS, got %v", manifest)
+	}
+}
+
+func TestScreenManifest_MultipleTypeSlugs(t *testing.T) {
+	t.Parallel()
+	// FS is expected to be rooted at the type-slug level (preset uses fs.Sub).
+	testFS := fstest.MapFS{
+		"task/Checklist.mjs":    {Data: []byte("export default {}")},
+		"task/KanbanBoard.mjs":  {Data: []byte("export default {}")},
+		"project/Timeline.mjs":  {Data: []byte("export default {}")},
+		"project/readme.txt":    {Data: []byte("not a screen")},
+	}
+	def := application.PresetDefinition{Name: "test", Screens: testFS}
+	manifest := def.ScreenManifest()
+
+	if len(manifest) != 2 {
+		t.Fatalf("expected 2 type slugs, got %d: %v", len(manifest), manifest)
+	}
+	taskFiles := manifest["task"]
+	if len(taskFiles) != 2 {
+		t.Fatalf("expected 2 task screens, got %d", len(taskFiles))
+	}
+	projectFiles := manifest["project"]
+	if len(projectFiles) != 1 {
+		t.Fatalf("expected 1 project screen, got %d", len(projectFiles))
+	}
+	if projectFiles[0] != "Timeline.mjs" {
+		t.Fatalf("expected Timeline.mjs, got %s", projectFiles[0])
+	}
+}
+
+func TestScreenManifest_RootLevelFilesIgnored(t *testing.T) {
+	t.Parallel()
+	testFS := fstest.MapFS{
+		"orphan.mjs": {Data: []byte("export default {}")},
+	}
+	def := application.PresetDefinition{Name: "test", Screens: testFS}
+	manifest := def.ScreenManifest()
+	if manifest != nil {
+		t.Fatalf("expected nil manifest for root-level files only, got %v", manifest)
+	}
+}
+
+func TestPresets_TasksHasScreens(t *testing.T) {
+	t.Parallel()
+	d, ok := testRegistry().Get("tasks")
+	if !ok {
+		t.Fatal("expected to find 'tasks' preset")
+	}
+	if d.Screens == nil {
+		t.Fatal("tasks preset should have Screens FS")
+	}
+	manifest := d.ScreenManifest()
+	if manifest == nil {
+		t.Fatal("tasks preset should have non-nil screen manifest")
+	}
+	taskScreens, ok := manifest["task"]
+	if !ok {
+		t.Fatal("expected task screens in manifest")
+	}
+	found := false
+	for _, f := range taskScreens {
+		if f == "Checklist.mjs" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected Checklist.mjs in task screens, got %v", taskScreens)
+	}
+
+	// Verify the file is actually readable from the FS (rooted at screens/dist/).
+	f, err := d.Screens.Open("task/Checklist.mjs")
+	if err != nil {
+		t.Fatalf("failed to open Checklist.mjs from Screens FS: %v", err)
+	}
+	_ = f.Close()
+}
+
+func TestPresets_PresetsWithoutScreensHaveNilManifest(t *testing.T) {
+	t.Parallel()
+	for _, d := range testRegistry().List() {
+		if d.Name == "tasks" {
+			continue // tasks has screens
+		}
+		manifest := d.ScreenManifest()
+		if manifest != nil {
+			t.Fatalf("preset %q should have nil screen manifest, got %v", d.Name, manifest)
+		}
+	}
+}
+
+func TestScreenManifest_NonMjsFilesIgnored(t *testing.T) {
+	t.Parallel()
+	testFS := fstest.MapFS{
+		"task/List.mjs":      {Data: []byte("export default {}")},
+		"task/styles.css":    {Data: []byte(".foo{}")},
+		"task/README.md":     {Data: []byte("readme")},
+	}
+	def := application.PresetDefinition{Name: "test", Screens: testFS}
+	manifest := def.ScreenManifest()
+	if len(manifest["task"]) != 1 {
+		t.Fatalf("expected 1 .mjs file, got %d: %v", len(manifest["task"]), manifest["task"])
+	}
+}
+
+// Ensure the ScreenManifest method works with fs.Sub (simulating how presets
+// strip the screens/dist/ prefix before storing the FS).
+func TestScreenManifest_WithSubFS(t *testing.T) {
+	t.Parallel()
+	base := fstest.MapFS{
+		"screens/dist/widget/Dashboard.mjs": {Data: []byte("export default {}")},
+	}
+	sub, err := fs.Sub(base, "screens/dist")
+	if err != nil {
+		t.Fatal(err)
+	}
+	def := application.PresetDefinition{Name: "test", Screens: sub}
+	manifest := def.ScreenManifest()
+	if manifest == nil {
+		t.Fatal("expected non-nil manifest")
+	}
+	if len(manifest["widget"]) != 1 {
+		t.Fatalf("expected 1 widget screen, got %v", manifest)
 	}
 }

--- a/application/resource_type_presets_test.go
+++ b/application/resource_type_presets_test.go
@@ -204,10 +204,10 @@ func TestScreenManifest_MultipleTypeSlugs(t *testing.T) {
 	t.Parallel()
 	// FS is expected to be rooted at the type-slug level (preset uses fs.Sub).
 	testFS := fstest.MapFS{
-		"task/Checklist.mjs":    {Data: []byte("export default {}")},
-		"task/KanbanBoard.mjs":  {Data: []byte("export default {}")},
-		"project/Timeline.mjs":  {Data: []byte("export default {}")},
-		"project/readme.txt":    {Data: []byte("not a screen")},
+		"task/Checklist.mjs":   {Data: []byte("export default {}")},
+		"task/KanbanBoard.mjs": {Data: []byte("export default {}")},
+		"project/Timeline.mjs": {Data: []byte("export default {}")},
+		"project/readme.txt":   {Data: []byte("not a screen")},
 	}
 	def := application.PresetDefinition{Name: "test", Screens: testFS}
 	manifest := def.ScreenManifest()
@@ -289,12 +289,29 @@ func TestPresets_PresetsWithoutScreensHaveNilManifest(t *testing.T) {
 	}
 }
 
+func TestScreenManifest_NestedPathsIgnored(t *testing.T) {
+	t.Parallel()
+	testFS := fstest.MapFS{
+		"task/List.mjs":       {Data: []byte("export default {}")},
+		"task/sub/Nested.mjs": {Data: []byte("export default {}")},
+		"task/a/b/c/Deep.mjs": {Data: []byte("export default {}")},
+	}
+	def := application.PresetDefinition{Name: "test", Screens: testFS}
+	manifest := def.ScreenManifest()
+	if len(manifest["task"]) != 1 {
+		t.Fatalf("expected 1 screen (nested ignored), got %d: %v", len(manifest["task"]), manifest["task"])
+	}
+	if manifest["task"][0] != "List.mjs" {
+		t.Fatalf("expected List.mjs, got %s", manifest["task"][0])
+	}
+}
+
 func TestScreenManifest_NonMjsFilesIgnored(t *testing.T) {
 	t.Parallel()
 	testFS := fstest.MapFS{
-		"task/List.mjs":      {Data: []byte("export default {}")},
-		"task/styles.css":    {Data: []byte(".foo{}")},
-		"task/README.md":     {Data: []byte("readme")},
+		"task/List.mjs":   {Data: []byte("export default {}")},
+		"task/styles.css": {Data: []byte(".foo{}")},
+		"task/README.md":  {Data: []byte("readme")},
 	}
 	def := application.PresetDefinition{Name: "test", Screens: testFS}
 	manifest := def.ScreenManifest()

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -74,9 +74,11 @@ func runServe(cmd *cobra.Command, args []string) error {
 	var roleAccessRepo *gormdb.RoleResourceAccessRepository
 	var authzChecker *authcasbin.CasbinAuthorizationChecker
 
+	registry := presets.NewDefaultRegistry()
+
 	app := fx.New(
 		fx.NopLogger,
-		application.Module(appCfg, presets.NewDefaultRegistry()),
+		application.Module(appCfg, registry),
 		fx.Populate(&resourceTypeService),
 		fx.Populate(&resourceService),
 		fx.Populate(&resourcePermService),
@@ -188,6 +190,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 	presetHandler := handlers.NewResourceTypePresetHandler(resourceTypeService)
 	protected.GET("/resource-types/presets", presetHandler.List)
 	protected.POST("/resource-types/presets/:name", presetHandler.Install)
+
+	screenHandler := handlers.NewPresetScreenHandler(registry)
+	protected.GET("/resource-types/presets/:name/screens/*", screenHandler.Serve)
 
 	sidebarSettingsHandler := handlers.NewSidebarSettingsHandler(sidebarSettingsRepo, accountRepo, logger)
 	protected.GET("/settings/sidebar", sidebarSettingsHandler.Get)

--- a/tests/browser/tests/project-tasks-checklist.spec.ts
+++ b/tests/browser/tests/project-tasks-checklist.spec.ts
@@ -45,7 +45,7 @@ test.describe("Project Detail — Task Checklist", () => {
     await input.fill("New checklist task");
     await input.press("Enter");
 
-    await expect(page.getByText("New checklist task")).toBeVisible();
+    await expect(checklist.getByText("New checklist task").first()).toBeVisible();
     await expect(checklist.locator(".ant-list-item")).toHaveCount(
       countBefore + 1
     );

--- a/web/admin/components/organisms/ResourceForm.vue
+++ b/web/admin/components/organisms/ResourceForm.vue
@@ -21,11 +21,11 @@
     layout="vertical"
     @finish="handleSubmit"
   >
-    <template v-for="(groupFields, groupName) in groupedFields" :key="groupName ?? '__ungrouped'">
-      <a-divider v-if="groupName" orientation="left">{{ groupName }}</a-divider>
+    <template v-for="group in groupedFields" :key="group.name ?? '__ungrouped'">
+      <a-divider v-if="group.name" orientation="left">{{ group.name }}</a-divider>
 
       <a-form-item
-        v-for="field in groupFields"
+        v-for="field in group.fields"
         :key="field.key"
         :label="field.label"
         :name="field.key"
@@ -120,11 +120,12 @@ const groupedFields = computed(() => {
     if (!groups.has(key)) groups.set(key, [])
     groups.get(key)!.push(field)
   }
-  // Ungrouped fields first, then named groups in encounter order
-  const result = new Map<string | undefined, FieldDescriptor[]>()
-  if (groups.has(undefined)) result.set(undefined, groups.get(undefined)!)
+  // Ungrouped fields first, then named groups in encounter order.
+  // Return an array (not a Map) to avoid Vue 3.5 reactive Map v-for issues.
+  const result: { name: string | undefined; fields: FieldDescriptor[] }[] = []
+  if (groups.has(undefined)) result.push({ name: undefined, fields: groups.get(undefined)! })
   for (const [key, val] of groups) {
-    if (key !== undefined) result.set(key, val)
+    if (key !== undefined) result.push({ name: key, fields: val })
   }
   return result
 })

--- a/web/admin/composables/usePresetScreens.ts
+++ b/web/admin/composables/usePresetScreens.ts
@@ -83,7 +83,7 @@ export function usePresetScreens() {
 
     let blobUrl: string | null = null
     try {
-      const url = `/api/resource-types/presets/${entry.preset}/screens/${typeSlug}/${fileName}`
+      const url = `/api/resource-types/presets/${encodeURIComponent(entry.preset)}/screens/${encodeURIComponent(typeSlug)}/${encodeURIComponent(fileName)}`
       const text = await $fetch<string>(url, { responseType: 'text' }).catch((err: any) => {
         console.warn(`[usePresetScreens] loadScreen failed for ${url}:`, err?.statusCode || err)
         return null

--- a/web/admin/composables/usePresetScreens.ts
+++ b/web/admin/composables/usePresetScreens.ts
@@ -84,13 +84,11 @@ export function usePresetScreens() {
     let blobUrl: string | null = null
     try {
       const url = `/api/resource-types/presets/${entry.preset}/screens/${typeSlug}/${fileName}`
-      const response = await fetch(url)
-      if (!response.ok) {
-        console.warn(`[usePresetScreens] loadScreen HTTP ${response.status} for ${url}`)
+      const text = await $fetch<string>(url, { responseType: 'text' }).catch((err: any) => {
+        console.warn(`[usePresetScreens] loadScreen failed for ${url}:`, err?.statusCode || err)
         return null
-      }
-
-      const text = await response.text()
+      })
+      if (!text) return null
       const blob = new Blob([text], { type: 'text/javascript' })
       blobUrl = URL.createObjectURL(blob)
 

--- a/web/admin/composables/usePresetScreens.ts
+++ b/web/admin/composables/usePresetScreens.ts
@@ -22,6 +22,7 @@ export interface ScreenMeta {
 }
 
 export interface LoadedScreen {
+  fileName: string
   component: Component
   meta: ScreenMeta
 }
@@ -80,6 +81,7 @@ export function usePresetScreens() {
     const entry = manifest.value[typeSlug]
     if (!entry) return null
 
+    let blobUrl: string | null = null
     try {
       const url = `/api/resource-types/presets/${entry.preset}/screens/${typeSlug}/${fileName}`
       const response = await fetch(url)
@@ -90,18 +92,21 @@ export function usePresetScreens() {
 
       const text = await response.text()
       const blob = new Blob([text], { type: 'text/javascript' })
-      const blobUrl = URL.createObjectURL(blob)
+      blobUrl = URL.createObjectURL(blob)
 
       const mod = await import(/* @vite-ignore */ blobUrl)
       // Defer revocation to avoid racing with lazy module evaluation.
-      setTimeout(() => URL.revokeObjectURL(blobUrl), 5000)
+      setTimeout(() => URL.revokeObjectURL(blobUrl!), 5000)
+      const baseName = fileName.replace('.mjs', '')
       const screen: LoadedScreen = {
+        fileName,
         component: mod.default,
-        meta: mod.meta || { name: fileName.replace('.mjs', ''), label: fileName.replace('.mjs', '') },
+        meta: mod.meta || { name: baseName, label: baseName },
       }
       loadedScreens.value[cacheKey] = screen
       return screen
     } catch (err) {
+      if (blobUrl) URL.revokeObjectURL(blobUrl)
       console.error(`[usePresetScreens] loadScreen failed for ${typeSlug}/${fileName}:`, err)
       return null
     }

--- a/web/admin/composables/usePresetScreens.ts
+++ b/web/admin/composables/usePresetScreens.ts
@@ -1,0 +1,128 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { Component } from 'vue'
+
+export interface ScreenMeta {
+  name: string
+  label: string
+  icon?: string
+}
+
+export interface LoadedScreen {
+  component: Component
+  meta: ScreenMeta
+}
+
+interface PresetListEntry {
+  name: string
+  description: string
+  types: string[]
+  screens?: Record<string, string[]>
+}
+
+interface SlugMapping {
+  preset: string
+  files: string[]
+}
+
+export function usePresetScreens() {
+  const manifest = useState<Record<string, SlugMapping>>('presetScreenManifest', () => ({}))
+  const manifestLoaded = useState<boolean>('presetScreenManifestLoaded', () => false)
+  const loadedScreens = useState<Record<string, LoadedScreen>>('presetLoadedScreens', () => ({}))
+
+  async function fetchManifest() {
+    if (manifestLoaded.value) return
+    try {
+      const res = await $fetch<{ data: PresetListEntry[] }>('/api/resource-types/presets')
+      const mapping: Record<string, SlugMapping> = {}
+      for (const preset of res.data) {
+        if (!preset.screens) continue
+        for (const [slug, files] of Object.entries(preset.screens)) {
+          // Last preset wins if multiple presets provide screens for the same slug.
+          mapping[slug] = { preset: preset.name, files }
+        }
+      }
+      manifest.value = mapping
+      manifestLoaded.value = true
+    } catch (err) {
+      console.error('[usePresetScreens] fetchManifest failed:', err)
+    }
+  }
+
+  function hasScreens(typeSlug: string): boolean {
+    const entry = manifest.value[typeSlug]
+    return !!entry && entry.files.length > 0
+  }
+
+  function getAvailableScreens(typeSlug: string): { preset: string; file: string }[] {
+    const entry = manifest.value[typeSlug]
+    if (!entry) return []
+    return entry.files.map(file => ({ preset: entry.preset, file }))
+  }
+
+  async function loadScreen(typeSlug: string, fileName: string): Promise<LoadedScreen | null> {
+    const cacheKey = `${typeSlug}/${fileName}`
+    if (loadedScreens.value[cacheKey]) return loadedScreens.value[cacheKey]
+
+    const entry = manifest.value[typeSlug]
+    if (!entry) return null
+
+    try {
+      const url = `/api/resource-types/presets/${entry.preset}/screens/${typeSlug}/${fileName}`
+      const response = await fetch(url)
+      if (!response.ok) {
+        console.warn(`[usePresetScreens] loadScreen HTTP ${response.status} for ${url}`)
+        return null
+      }
+
+      const text = await response.text()
+      const blob = new Blob([text], { type: 'text/javascript' })
+      const blobUrl = URL.createObjectURL(blob)
+
+      const mod = await import(/* @vite-ignore */ blobUrl)
+      // Defer revocation to avoid racing with lazy module evaluation.
+      setTimeout(() => URL.revokeObjectURL(blobUrl), 5000)
+      const screen: LoadedScreen = {
+        component: mod.default,
+        meta: mod.meta || { name: fileName.replace('.mjs', ''), label: fileName.replace('.mjs', '') },
+      }
+      loadedScreens.value[cacheKey] = screen
+      return screen
+    } catch (err) {
+      console.error(`[usePresetScreens] loadScreen failed for ${typeSlug}/${fileName}:`, err)
+      return null
+    }
+  }
+
+  async function loadAllScreens(typeSlug: string): Promise<LoadedScreen[]> {
+    const available = getAvailableScreens(typeSlug)
+    const results: LoadedScreen[] = []
+    for (const { file } of available) {
+      const screen = await loadScreen(typeSlug, file)
+      if (screen) results.push(screen)
+    }
+    return results
+  }
+
+  return {
+    fetchManifest,
+    hasScreens,
+    getAvailableScreens,
+    loadScreen,
+    loadAllScreens,
+    manifestLoaded,
+  }
+}

--- a/web/admin/composables/usePresetScreens.ts
+++ b/web/admin/composables/usePresetScreens.ts
@@ -44,8 +44,8 @@ export function usePresetScreens() {
   const manifestLoaded = useState<boolean>('presetScreenManifestLoaded', () => false)
   const loadedScreens = useState<Record<string, LoadedScreen>>('presetLoadedScreens', () => ({}))
 
-  async function fetchManifest() {
-    if (manifestLoaded.value) return
+  async function fetchManifest(): Promise<boolean> {
+    if (manifestLoaded.value) return true
     try {
       const res = await $fetch<{ data: PresetListEntry[] }>('/api/resource-types/presets')
       const mapping: Record<string, SlugMapping> = {}
@@ -58,8 +58,10 @@ export function usePresetScreens() {
       }
       manifest.value = mapping
       manifestLoaded.value = true
+      return true
     } catch (err) {
       console.error('[usePresetScreens] fetchManifest failed:', err)
+      return false
     }
   }
 

--- a/web/admin/pages/resources/[typeSlug]/index.vue
+++ b/web/admin/pages/resources/[typeSlug]/index.vue
@@ -19,9 +19,23 @@
   <div>
     <div class="page-header">
       <h2>{{ resourceType?.name || typeSlug }}</h2>
-      <NuxtLink :to="`/resources/${typeSlug}/create`">
-        <a-button type="primary">Create {{ resourceType?.name || typeSlug }}</a-button>
-      </NuxtLink>
+      <a-space>
+        <a-dropdown v-if="screens.length">
+          <a-button>Views</a-button>
+          <template #overlay>
+            <a-menu>
+              <a-menu-item v-for="s in screens" :key="s.meta.name">
+                <NuxtLink :to="`/resources/${typeSlug}/screens/${s.meta.name}`">
+                  {{ s.meta.label }}
+                </NuxtLink>
+              </a-menu-item>
+            </a-menu>
+          </template>
+        </a-dropdown>
+        <NuxtLink :to="`/resources/${typeSlug}/create`">
+          <a-button type="primary">Create {{ resourceType?.name || typeSlug }}</a-button>
+        </NuxtLink>
+      </a-space>
     </div>
     <div v-if="referenceFilters.length" style="margin-bottom: 16px; display: flex; gap: 12px; flex-wrap: wrap">
       <div v-for="rf in referenceFilters" :key="rf.field" style="min-width: 200px">
@@ -60,11 +74,13 @@ const typeSlug = route.params.typeSlug as string
 const { getBySlug, fetchResourceTypes, loaded } = useResourceTypeStore()
 const { list, remove } = useResourceApi(typeSlug)
 const { schemaToColumns } = useSchemaUtils()
+const { fetchManifest, loadAllScreens } = usePresetScreens()
 
 const items = ref<any[]>([])
 const loading = ref(false)
 const hasMore = ref(false)
 const cursor = ref('')
+const screens = ref<{ component: any; meta: { name: string; label: string; icon?: string } }[]>([])
 
 const resourceType = computed(() => getBySlug(typeSlug))
 
@@ -160,5 +176,7 @@ onMounted(async () => {
   if (!loaded.value) await fetchResourceTypes()
   await initReferenceFilters()
   await load()
+  await fetchManifest()
+  screens.value = await loadAllScreens(typeSlug)
 })
 </script>

--- a/web/admin/pages/resources/[typeSlug]/index.vue
+++ b/web/admin/pages/resources/[typeSlug]/index.vue
@@ -176,10 +176,12 @@ onMounted(async () => {
   if (!loaded.value) await fetchResourceTypes()
   await initReferenceFilters()
   await load()
-  await fetchManifest()
-  screens.value = getAvailableScreens(typeSlug).map(s => ({
-    file: s.file,
-    label: s.file.replace('.mjs', ''),
-  }))
+  const manifestOk = await fetchManifest()
+  if (manifestOk) {
+    screens.value = getAvailableScreens(typeSlug).map(s => ({
+      file: s.file,
+      label: s.file.replace('.mjs', ''),
+    }))
+  }
 })
 </script>

--- a/web/admin/pages/resources/[typeSlug]/index.vue
+++ b/web/admin/pages/resources/[typeSlug]/index.vue
@@ -24,9 +24,9 @@
           <a-button>Views</a-button>
           <template #overlay>
             <a-menu>
-              <a-menu-item v-for="s in screens" :key="s.meta.name">
-                <NuxtLink :to="`/resources/${typeSlug}/screens/${s.meta.name}`">
-                  {{ s.meta.label }}
+              <a-menu-item v-for="s in screens" :key="s.file">
+                <NuxtLink :to="`/resources/${typeSlug}/screens/${s.file.replace('.mjs', '')}`">
+                  {{ s.label }}
                 </NuxtLink>
               </a-menu-item>
             </a-menu>
@@ -74,13 +74,13 @@ const typeSlug = route.params.typeSlug as string
 const { getBySlug, fetchResourceTypes, loaded } = useResourceTypeStore()
 const { list, remove } = useResourceApi(typeSlug)
 const { schemaToColumns } = useSchemaUtils()
-const { fetchManifest, loadAllScreens } = usePresetScreens()
+const { fetchManifest, getAvailableScreens } = usePresetScreens()
 
 const items = ref<any[]>([])
 const loading = ref(false)
 const hasMore = ref(false)
 const cursor = ref('')
-const screens = ref<{ component: any; meta: { name: string; label: string; icon?: string } }[]>([])
+const screens = ref<{ file: string; label: string }[]>([])
 
 const resourceType = computed(() => getBySlug(typeSlug))
 
@@ -177,6 +177,9 @@ onMounted(async () => {
   await initReferenceFilters()
   await load()
   await fetchManifest()
-  screens.value = await loadAllScreens(typeSlug)
+  screens.value = getAvailableScreens(typeSlug).map(s => ({
+    file: s.file,
+    label: s.file.replace('.mjs', ''),
+  }))
 })
 </script>

--- a/web/admin/pages/resources/[typeSlug]/screens/[screenName].vue
+++ b/web/admin/pages/resources/[typeSlug]/screens/[screenName].vue
@@ -1,0 +1,83 @@
+<!--
+  Copyright (C) 2026 Wepala, LLC
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<template>
+  <div>
+    <a-page-header
+      :title="screenTitle"
+      @back="router.back()"
+    />
+    <a-spin v-if="loading" />
+    <a-result
+      v-else-if="error"
+      status="error"
+      :title="error"
+      sub-title="The requested screen could not be loaded."
+    >
+      <template #extra>
+        <NuxtLink :to="`/resources/${typeSlug}`">
+          <a-button type="primary">Back to List</a-button>
+        </NuxtLink>
+      </template>
+    </a-result>
+    <component
+      v-else-if="screen"
+      :is="screen.component"
+      :type-slug="typeSlug"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+const route = useRoute()
+const router = useRouter()
+const typeSlug = route.params.typeSlug as string
+const screenName = route.params.screenName as string
+
+const { fetchManifest, loadScreen } = usePresetScreens()
+const { getBySlug, fetchResourceTypes, loaded } = useResourceTypeStore()
+
+const screen = ref<{ component: any; meta: { name: string; label: string; icon?: string } } | null>(null)
+const loading = ref(true)
+const error = ref<string | null>(null)
+
+const resourceType = computed(() => getBySlug(typeSlug))
+const screenTitle = computed(() => {
+  const typeName = resourceType.value?.name || typeSlug
+  const label = screen.value?.meta?.label || screenName
+  return `${typeName} — ${label}`
+})
+
+onMounted(async () => {
+  if (!loaded.value) await fetchResourceTypes()
+  await fetchManifest()
+  try {
+    const fileName = screenName.endsWith('.mjs') ? screenName : `${screenName}.mjs`
+    const result = await loadScreen(typeSlug, fileName)
+    if (!result) {
+      error.value = 'Screen not found'
+    } else {
+      screen.value = result
+    }
+  } catch (err) {
+    console.error(`[screenPage] loadScreen failed for ${typeSlug}/${screenName}:`, err)
+    error.value = 'Failed to load screen'
+  } finally {
+    loading.value = false
+  }
+})
+</script>

--- a/web/admin/pages/resources/[typeSlug]/screens/[screenName].vue
+++ b/web/admin/pages/resources/[typeSlug]/screens/[screenName].vue
@@ -51,7 +51,7 @@ const screenName = route.params.screenName as string
 const { fetchManifest, loadScreen } = usePresetScreens()
 const { getBySlug, fetchResourceTypes, loaded } = useResourceTypeStore()
 
-const screen = ref<{ component: any; meta: { name: string; label: string; icon?: string } } | null>(null)
+const screen = ref<{ fileName: string; component: any; meta: { name: string; label: string; icon?: string } } | null>(null)
 const loading = ref(true)
 const error = ref<string | null>(null)
 

--- a/web/admin/pages/resources/[typeSlug]/screens/[screenName].vue
+++ b/web/admin/pages/resources/[typeSlug]/screens/[screenName].vue
@@ -64,7 +64,12 @@ const screenTitle = computed(() => {
 
 onMounted(async () => {
   if (!loaded.value) await fetchResourceTypes()
-  await fetchManifest()
+  const manifestOk = await fetchManifest()
+  if (!manifestOk) {
+    error.value = 'Unable to load screen manifest'
+    loading.value = false
+    return
+  }
   try {
     const fileName = screenName.endsWith('.mjs') ? screenName : `${screenName}.mjs`
     const result = await loadScreen(typeSlug, fileName)


### PR DESCRIPTION
## Summary

Closes #292

- **Backend**: Added `ScreenManifest()` to `PresetDefinition` that walks the `Screens` FS and returns `typeSlug -> []filename`. New `PresetScreenHandler` serves `.mjs` files from preset `Screens` FS at `GET /api/resource-types/presets/:name/screens/*`. Preset list API response now includes screen manifest. Tasks preset embeds a Checklist screen as proof of concept.
- **Frontend**: New `usePresetScreens` composable discovers and loads screen modules via blob URL dynamic import. New `[screenName].vue` page renders screens at `/resources/:typeSlug/screens/:screenName`. Resource list page shows a "Views" dropdown when custom screens are available.

### Screen module convention

Each `.mjs` is a self-describing module with minimal metadata:

```js
export const meta = {
  name: 'Checklist',
  label: 'Checklist',
  icon: 'check-square-outlined',
}
export default {
  props: ['typeSlug'],
  template: `<div>...</div>`,
}
```

Screens are free-form additional views — no rigid slot system. Presets can add any number of screens for any of their resource types.

## Test plan

- [x] `ScreenManifest()` unit tests: nil FS, empty FS, multiple slugs, non-.mjs filtering, fs.Sub compatibility
- [x] `PresetScreenHandler` tests: success with content verification, preset not found, no screens, file not found, empty path, path traversal rejection, non-.mjs rejection
- [x] Tasks preset integration test: embedded Checklist.mjs readable from FS
- [x] All existing tests still pass (`go test ./...`)
- [ ] Manual: install tasks preset, verify "Views" dropdown appears on tasks list page
- [ ] Manual: click "Checklist" view, verify screen renders at `/resources/task/screens/Checklist`

🤖 Generated with [Claude Code](https://claude.com/claude-code)