### PR TITLE
feat: embed MCP server in HTTP serve command

### DIFF
--- a/api/middleware/static.go
+++ b/api/middleware/static.go
@@ -50,8 +50,8 @@ func Static(cfg StaticConfig) echo.MiddlewareFunc {
 		return func(c echo.Context) error {
 			reqPath := c.Request().URL.Path
 
-			// Skip API and MCP routes - let them pass through to registered handlers
-			if strings.HasPrefix(reqPath, "/api") || strings.HasPrefix(reqPath, "/mcp") {
+			// Skip API routes - let them pass through to registered handlers
+			if strings.HasPrefix(reqPath, "/api") {
 				return next(c)
 			}
 

--- a/api/middleware/static.go
+++ b/api/middleware/static.go
@@ -50,8 +50,8 @@ func Static(cfg StaticConfig) echo.MiddlewareFunc {
 		return func(c echo.Context) error {
 			reqPath := c.Request().URL.Path
 
-			// Skip API routes - let them pass through to registered handlers
-			if strings.HasPrefix(reqPath, "/api") {
+			// Skip API and MCP routes - let them pass through to registered handlers
+			if strings.HasPrefix(reqPath, "/api") || strings.HasPrefix(reqPath, "/mcp") {
 				return next(c)
 			}
 

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -235,20 +235,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	protected.POST("/admin/stop-impersonation", impersonationHandler.Stop)
 	protected.GET("/admin/impersonation-status", impersonationHandler.Status)
 
-	// Permission routes — registered before dynamic catch-all
-	permHandler := handlers.NewResourcePermissionHandler(resourcePermService)
-	protected.POST("/:typeSlug/:id/permissions", permHandler.Grant)
-	protected.GET("/:typeSlug/:id/permissions", permHandler.List)
-	protected.DELETE("/:typeSlug/:id/permissions/:agentId", permHandler.Revoke)
-
-	// Dynamic resource routes — MUST be registered after ALL static routes
-	resourceHandler := handlers.NewResourceHandler(resourceService, resourceTypeService)
-	protected.POST("/:typeSlug", resourceHandler.Create)
-	protected.GET("/:typeSlug", resourceHandler.List)
-	protected.GET("/:typeSlug/:id", resourceHandler.Get)
-	protected.PUT("/:typeSlug/:id", resourceHandler.Update)
-	protected.DELETE("/:typeSlug/:id", resourceHandler.Delete)
-
+	// MCP routes — registered before dynamic catch-all
 	if serveViper.GetBool("enabled") {
 		mcpHandler, mcpErr := mcpserver.NewHTTPHandler(
 			resourceTypeService, resourceService, slog.Default(),
@@ -262,6 +249,20 @@ func runServe(cmd *cobra.Command, args []string) error {
 	} else {
 		logger.Info(context.Background(), "MCP server disabled via configuration")
 	}
+
+	// Permission routes — registered before dynamic catch-all
+	permHandler := handlers.NewResourcePermissionHandler(resourcePermService)
+	protected.POST("/:typeSlug/:id/permissions", permHandler.Grant)
+	protected.GET("/:typeSlug/:id/permissions", permHandler.List)
+	protected.DELETE("/:typeSlug/:id/permissions/:agentId", permHandler.Revoke)
+
+	// Dynamic resource routes — MUST be registered after ALL static routes
+	resourceHandler := handlers.NewResourceHandler(resourceService, resourceTypeService)
+	protected.POST("/:typeSlug", resourceHandler.Create)
+	protected.GET("/:typeSlug", resourceHandler.List)
+	protected.GET("/:typeSlug/:id", resourceHandler.Get)
+	protected.PUT("/:typeSlug/:id", resourceHandler.Update)
+	protected.DELETE("/:typeSlug/:id", resourceHandler.Delete)
 
 	addr := fmt.Sprintf("%s:%d", appCfg.Server.Host, appCfg.Server.Port)
 

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -32,6 +32,7 @@ import (
 	"weos/domain/entities"
 	gormdb "weos/infrastructure/database/gorm"
 	"weos/internal/config"
+	mcpserver "weos/internal/mcp"
 	"weos/web"
 
 	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
@@ -42,8 +43,11 @@ import (
 	"github.com/gorilla/sessions"
 	"github.com/labstack/echo/v4"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"go.uber.org/fx"
 )
+
+var serveViper = viper.New()
 
 var serveCmd = &cobra.Command{
 	Use:   "serve",
@@ -53,6 +57,10 @@ var serveCmd = &cobra.Command{
 }
 
 func init() {
+	serveCmd.Flags().Bool("mcp", true, "enable MCP server over HTTP at /mcp")
+	serveViper.SetEnvPrefix("MCP")
+	serveViper.AutomaticEnv()
+	_ = serveViper.BindPFlag("enabled", serveCmd.Flags().Lookup("mcp"))
 	rootCmd.AddCommand(serveCmd)
 }
 
@@ -237,6 +245,12 @@ func runServe(cmd *cobra.Command, args []string) error {
 	protected.GET("/:typeSlug/:id", resourceHandler.Get)
 	protected.PUT("/:typeSlug/:id", resourceHandler.Update)
 	protected.DELETE("/:typeSlug/:id", resourceHandler.Delete)
+
+	if serveViper.GetBool("enabled") {
+		mcpHandler := mcpserver.NewHTTPHandler(resourceTypeService, resourceService)
+		e.Any("/mcp", echo.WrapHandler(mcpHandler))
+		fmt.Println("MCP server enabled at /mcp")
+	}
 
 	addr := fmt.Sprintf("%s:%d", appCfg.Server.Host, appCfg.Server.Port)
 

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -58,7 +58,7 @@ var serveCmd = &cobra.Command{
 }
 
 func init() {
-	serveCmd.Flags().Bool("mcp", true, "enable MCP server over HTTP at /mcp")
+	serveCmd.Flags().Bool("mcp", true, "enable MCP server over HTTP at /api/mcp")
 	serveViper.SetEnvPrefix("MCP")
 	serveViper.AutomaticEnv()
 	if err := serveViper.BindPFlag("enabled", serveCmd.Flags().Lookup("mcp")); err != nil {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -256,8 +256,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 		if mcpErr != nil {
 			return fmt.Errorf("failed to create MCP handler: %w", mcpErr)
 		}
-		e.Any("/mcp", echo.WrapHandler(mcpHandler))
-		logger.Info(context.Background(), "MCP server enabled", "path", "/mcp")
+		protected.Any("/mcp", echo.WrapHandler(mcpHandler))
+		protected.Any("/mcp/*", echo.WrapHandler(mcpHandler))
+		logger.Info(context.Background(), "MCP server enabled", "path", "/api/mcp")
 	} else {
 		logger.Info(context.Background(), "MCP server disabled via configuration")
 	}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -18,6 +18,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -60,7 +61,9 @@ func init() {
 	serveCmd.Flags().Bool("mcp", true, "enable MCP server over HTTP at /mcp")
 	serveViper.SetEnvPrefix("MCP")
 	serveViper.AutomaticEnv()
-	_ = serveViper.BindPFlag("enabled", serveCmd.Flags().Lookup("mcp"))
+	if err := serveViper.BindPFlag("enabled", serveCmd.Flags().Lookup("mcp")); err != nil {
+		panic(fmt.Sprintf("failed to bind MCP flag: %v", err))
+	}
 	rootCmd.AddCommand(serveCmd)
 }
 
@@ -247,9 +250,16 @@ func runServe(cmd *cobra.Command, args []string) error {
 	protected.DELETE("/:typeSlug/:id", resourceHandler.Delete)
 
 	if serveViper.GetBool("enabled") {
-		mcpHandler := mcpserver.NewHTTPHandler(resourceTypeService, resourceService)
+		mcpHandler, mcpErr := mcpserver.NewHTTPHandler(
+			resourceTypeService, resourceService, slog.Default(),
+		)
+		if mcpErr != nil {
+			return fmt.Errorf("failed to create MCP handler: %w", mcpErr)
+		}
 		e.Any("/mcp", echo.WrapHandler(mcpHandler))
-		fmt.Println("MCP server enabled at /mcp")
+		logger.Info(context.Background(), "MCP server enabled", "path", "/mcp")
+	} else {
+		logger.Info(context.Background(), "MCP server disabled via configuration")
 	}
 
 	addr := fmt.Sprintf("%s:%d", appCfg.Server.Host, appCfg.Server.Port)

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package mcp
+
+import (
+	"net/http"
+
+	"weos/application"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// NewHTTPHandler returns an http.Handler that serves the MCP protocol over
+// Streamable HTTP with all tool groups enabled.
+func NewHTTPHandler(
+	resourceTypeService application.ResourceTypeService,
+	resourceService application.ResourceService,
+) http.Handler {
+	server := NewMCPServer(resourceTypeService, resourceService, nil)
+	return gomcp.NewStreamableHTTPHandler(func(_ *http.Request) *gomcp.Server {
+		return server
+	}, nil)
+}

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -16,7 +16,10 @@
 package mcp
 
 import (
+	"fmt"
+	"log/slog"
 	"net/http"
+	"time"
 
 	"weos/application"
 
@@ -28,9 +31,16 @@ import (
 func NewHTTPHandler(
 	resourceTypeService application.ResourceTypeService,
 	resourceService application.ResourceService,
-) http.Handler {
-	server := NewMCPServer(resourceTypeService, resourceService, nil)
+	logger *slog.Logger,
+) (http.Handler, error) {
+	server, err := NewMCPServer(resourceTypeService, resourceService, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create MCP server: %w", err)
+	}
 	return gomcp.NewStreamableHTTPHandler(func(_ *http.Request) *gomcp.Server {
 		return server
-	}, nil)
+	}, &gomcp.StreamableHTTPOptions{
+		Logger:         logger,
+		SessionTimeout: 30 * time.Minute,
+	}), nil
 }

--- a/internal/mcp/handler_test.go
+++ b/internal/mcp/handler_test.go
@@ -1,0 +1,274 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+
+	"weos/application"
+	"weos/domain/entities"
+	"weos/domain/repositories"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// stubResourceTypeService is a minimal stub satisfying application.ResourceTypeService.
+type stubResourceTypeService struct{}
+
+func (s *stubResourceTypeService) Create(
+	_ context.Context, _ application.CreateResourceTypeCommand,
+) (*entities.ResourceType, error) {
+	return nil, nil
+}
+
+func (s *stubResourceTypeService) GetByID(_ context.Context, _ string) (*entities.ResourceType, error) {
+	return nil, nil
+}
+
+func (s *stubResourceTypeService) GetBySlug(_ context.Context, _ string) (*entities.ResourceType, error) {
+	return nil, nil
+}
+
+func (s *stubResourceTypeService) List(
+	_ context.Context, _ string, _ int,
+) (repositories.PaginatedResponse[*entities.ResourceType], error) {
+	return repositories.PaginatedResponse[*entities.ResourceType]{}, nil
+}
+
+func (s *stubResourceTypeService) Update(
+	_ context.Context, _ application.UpdateResourceTypeCommand,
+) (*entities.ResourceType, error) {
+	return nil, nil
+}
+
+func (s *stubResourceTypeService) Delete(_ context.Context, _ application.DeleteResourceTypeCommand) error {
+	return nil
+}
+
+func (s *stubResourceTypeService) ListPresets() []application.PresetDefinition {
+	return nil
+}
+
+func (s *stubResourceTypeService) InstallPreset(
+	_ context.Context, _ string, _ bool,
+) (*application.InstallPresetResult, error) {
+	return nil, nil
+}
+
+// stubResourceService is a minimal stub satisfying application.ResourceService.
+type stubResourceService struct{}
+
+func (s *stubResourceService) Create(
+	_ context.Context, _ application.CreateResourceCommand,
+) (*entities.Resource, error) {
+	return nil, nil
+}
+
+func (s *stubResourceService) GetByID(_ context.Context, _ string) (*entities.Resource, error) {
+	return nil, nil
+}
+
+func (s *stubResourceService) List(
+	_ context.Context, _, _ string, _ int, _ repositories.SortOptions,
+) (repositories.PaginatedResponse[*entities.Resource], error) {
+	return repositories.PaginatedResponse[*entities.Resource]{}, nil
+}
+
+func (s *stubResourceService) ListFlat(
+	_ context.Context, _, _ string, _ int, _ repositories.SortOptions,
+) (repositories.PaginatedResponse[map[string]any], error) {
+	return repositories.PaginatedResponse[map[string]any]{}, nil
+}
+
+func (s *stubResourceService) ListByField(
+	_ context.Context, _, _, _ string,
+) (repositories.PaginatedResponse[*entities.Resource], error) {
+	return repositories.PaginatedResponse[*entities.Resource]{}, nil
+}
+
+func (s *stubResourceService) ListWithFilters(
+	_ context.Context, _ string, _ []repositories.FilterCondition, _ string, _ int, _ repositories.SortOptions,
+) (repositories.PaginatedResponse[*entities.Resource], error) {
+	return repositories.PaginatedResponse[*entities.Resource]{}, nil
+}
+
+func (s *stubResourceService) ListFlatWithFilters(
+	_ context.Context, _ string, _ []repositories.FilterCondition, _ string, _ int, _ repositories.SortOptions,
+) (repositories.PaginatedResponse[map[string]any], error) {
+	return repositories.PaginatedResponse[map[string]any]{}, nil
+}
+
+func (s *stubResourceService) Update(
+	_ context.Context, _ application.UpdateResourceCommand,
+) (*entities.Resource, error) {
+	return nil, nil
+}
+
+func (s *stubResourceService) Delete(_ context.Context, _ application.DeleteResourceCommand) error {
+	return nil
+}
+
+// toolNames connects to an MCP server via in-memory transport and returns the registered tool names.
+func toolNames(t *testing.T, server *gomcp.Server) []string {
+	t.Helper()
+	serverTransport, clientTransport := gomcp.NewInMemoryTransports()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := server.Connect(ctx, serverTransport, nil)
+		done <- err
+	}()
+
+	client := gomcp.NewClient(&gomcp.Implementation{Name: "test-client", Version: "0.0.1"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+
+	result, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("list tools: %v", err)
+	}
+
+	names := make([]string, len(result.Tools))
+	for i, tool := range result.Tools {
+		names[i] = tool.Name
+	}
+	sort.Strings(names)
+	return names
+}
+
+func TestNewMCPServer_AllServices(t *testing.T) {
+	server, err := NewMCPServer(&stubResourceTypeService{}, &stubResourceService{}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if server == nil {
+		t.Fatal("expected non-nil server")
+	}
+
+	names := toolNames(t, server)
+
+	// All 4 service groups should be registered (22 tools total).
+	expectedPrefixes := []string{"person_", "organization_", "resource_type_", "resource_"}
+	for _, prefix := range expectedPrefixes {
+		found := false
+		for _, name := range names {
+			if strings.HasPrefix(name, prefix) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected at least one tool with prefix %q, got: %v", prefix, names)
+		}
+	}
+
+	if len(names) != 22 {
+		t.Errorf("expected 22 tools, got %d: %v", len(names), names)
+	}
+}
+
+func TestNewMCPServer_Subset(t *testing.T) {
+	server, err := NewMCPServer(&stubResourceTypeService{}, &stubResourceService{}, []string{"person"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	names := toolNames(t, server)
+
+	for _, name := range names {
+		if !strings.HasPrefix(name, "person_") {
+			t.Errorf("unexpected tool %q for person-only config", name)
+		}
+	}
+	if len(names) != 5 {
+		t.Errorf("expected 5 person tools, got %d: %v", len(names), names)
+	}
+}
+
+func TestNewMCPServer_ResourceTypeIncludesPresets(t *testing.T) {
+	server, err := NewMCPServer(
+		&stubResourceTypeService{}, &stubResourceService{}, []string{"resource-type"},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	names := toolNames(t, server)
+
+	hasPreset := false
+	for _, name := range names {
+		if strings.HasPrefix(name, "resource_type_preset_") {
+			hasPreset = true
+			break
+		}
+	}
+	if !hasPreset {
+		t.Errorf("expected resource_type_preset_* tools to be registered with resource-type service, got: %v", names)
+	}
+}
+
+func TestNewMCPServer_NilResourceTypeService(t *testing.T) {
+	_, err := NewMCPServer(nil, &stubResourceService{}, nil)
+	if err == nil {
+		t.Fatal("expected error for nil resourceTypeService")
+	}
+}
+
+func TestNewMCPServer_NilResourceService(t *testing.T) {
+	_, err := NewMCPServer(&stubResourceTypeService{}, nil, nil)
+	if err == nil {
+		t.Fatal("expected error for nil resourceService")
+	}
+}
+
+func TestNewHTTPHandler_ReturnsHandler(t *testing.T) {
+	handler, err := NewHTTPHandler(&stubResourceTypeService{}, &stubResourceService{}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if handler == nil {
+		t.Fatal("expected non-nil handler")
+	}
+}
+
+func TestNewHTTPHandler_AcceptsMCPRequest(t *testing.T) {
+	handler, err := NewHTTPHandler(&stubResourceTypeService{}, &stubResourceService{}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Send a valid MCP initialize JSON-RPC request.
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{` +
+		`"protocolVersion":"2025-06-18",` +
+		`"capabilities":{},` +
+		`"clientInfo":{"name":"test","version":"0.1.0"}}}`
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "weos") {
+		t.Errorf("expected response to contain server name 'weos', got: %s", rec.Body.String())
+	}
+}
+
+func TestNewHTTPHandler_NilServices(t *testing.T) {
+	_, err := NewHTTPHandler(nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error for nil services")
+	}
+}

--- a/internal/mcp/handler_test.go
+++ b/internal/mcp/handler_test.go
@@ -119,10 +119,10 @@ func toolNames(t *testing.T, server *gomcp.Server) []string {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	done := make(chan error, 1)
+	serverErr := make(chan error, 1)
 	go func() {
 		_, err := server.Connect(ctx, serverTransport, nil)
-		done <- err
+		serverErr <- err
 	}()
 
 	client := gomcp.NewClient(&gomcp.Implementation{Name: "test-client", Version: "0.0.1"}, nil)
@@ -141,6 +141,13 @@ func toolNames(t *testing.T, server *gomcp.Server) []string {
 		names[i] = tool.Name
 	}
 	sort.Strings(names)
+
+	// Cancel context and wait for server goroutine to finish.
+	cancel()
+	if sErr := <-serverErr; sErr != nil && sErr != context.Canceled {
+		t.Errorf("server connect error: %v", sErr)
+	}
+
 	return names
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os/signal"
+	"reflect"
 	"strings"
 	"syscall"
 
@@ -91,10 +92,10 @@ func NewMCPServer(
 	resourceService application.ResourceService,
 	enabledServices []string,
 ) (*mcp.Server, error) {
-	if resourceTypeService == nil {
+	if isNilInterface(resourceTypeService) {
 		return nil, fmt.Errorf("resourceTypeService must not be nil")
 	}
-	if resourceService == nil {
+	if isNilInterface(resourceService) {
 		return nil, fmt.Errorf("resourceService must not be nil")
 	}
 
@@ -161,6 +162,15 @@ func Run(enabledServices []string) error {
 	_ = app.Stop(stopCtx)
 
 	return err
+}
+
+// isNilInterface returns true if v is nil or a typed-nil (interface wrapping a nil pointer).
+func isNilInterface(v any) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	return rv.Kind() == reflect.Ptr && rv.IsNil()
 }
 
 func loadConfig() config.Config {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/signal"
 	"reflect"
 	"strings"
@@ -153,7 +154,9 @@ func Run(enabledServices []string) error {
 	defer func() {
 		stopCtx, stopCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
 		defer stopCancel()
-		_ = app.Stop(stopCtx)
+		if stopErr := app.Stop(stopCtx); stopErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to stop application: %v\n", stopErr)
+		}
 	}()
 
 	server, err := NewMCPServer(resourceTypeService, resourceService, enabledServices)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -69,7 +69,7 @@ func ValidateServiceNames(names []string) error {
 	return nil
 }
 
-// resolveEnabled returns a set of enabled services. If the input is empty, all services are enabled.
+// resolveEnabled returns a set of enabled services. If the input is nil or empty, all services are enabled.
 func resolveEnabled(services []string) map[ServiceName]bool {
 	enabled := make(map[ServiceName]bool, len(AllServices))
 	if len(services) == 0 {
@@ -85,12 +85,19 @@ func resolveEnabled(services []string) map[ServiceName]bool {
 }
 
 // NewMCPServer creates a configured MCP server with the specified tool groups registered.
-// If enabledServices is empty, all tool groups are registered.
+// If enabledServices is nil or empty, all tool groups are registered.
 func NewMCPServer(
 	resourceTypeService application.ResourceTypeService,
 	resourceService application.ResourceService,
 	enabledServices []string,
-) *mcp.Server {
+) (*mcp.Server, error) {
+	if resourceTypeService == nil {
+		return nil, fmt.Errorf("resourceTypeService must not be nil")
+	}
+	if resourceService == nil {
+		return nil, fmt.Errorf("resourceService must not be nil")
+	}
+
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "weos",
 		Title:   "WeOS MCP Server",
@@ -113,7 +120,7 @@ func NewMCPServer(
 		registerResourceTools(server, resourceService)
 	}
 
-	return server
+	return server, nil
 }
 
 // Run starts the MCP server on stdio, registering only the tool groups listed in enabledServices.
@@ -138,12 +145,15 @@ func Run(enabledServices []string) error {
 		return fmt.Errorf("failed to start application: %w", err)
 	}
 
-	server := NewMCPServer(resourceTypeService, resourceService, enabledServices)
+	server, err := NewMCPServer(resourceTypeService, resourceService, enabledServices)
+	if err != nil {
+		return fmt.Errorf("failed to create MCP server: %w", err)
+	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	err := server.Run(ctx, &mcp.StdioTransport{})
+	err = server.Run(ctx, &mcp.StdioTransport{})
 
 	stopCtx, stopCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
 	defer stopCancel()

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -124,7 +124,7 @@ func NewMCPServer(
 }
 
 // Run starts the MCP server on stdio, registering only the tool groups listed in enabledServices.
-// If enabledServices is empty, all tool groups are registered.
+// If enabledServices is nil or empty, all tool groups are registered.
 func Run(enabledServices []string) error {
 	cfg := loadConfig()
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -84,28 +84,13 @@ func resolveEnabled(services []string) map[ServiceName]bool {
 	return enabled
 }
 
-// Run starts the MCP server, registering only the tool groups listed in enabledServices.
+// NewMCPServer creates a configured MCP server with the specified tool groups registered.
 // If enabledServices is empty, all tool groups are registered.
-func Run(enabledServices []string) error {
-	cfg := loadConfig()
-
-	var resourceTypeService application.ResourceTypeService
-	var resourceService application.ResourceService
-
-	app := fx.New(
-		fx.NopLogger,
-		application.Module(cfg, presets.NewDefaultRegistry()),
-		fx.Populate(&resourceTypeService),
-		fx.Populate(&resourceService),
-	)
-
-	startCtx, startCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
-	defer startCancel()
-
-	if err := app.Start(startCtx); err != nil {
-		return fmt.Errorf("failed to start application: %w", err)
-	}
-
+func NewMCPServer(
+	resourceTypeService application.ResourceTypeService,
+	resourceService application.ResourceService,
+	enabledServices []string,
+) *mcp.Server {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "weos",
 		Title:   "WeOS MCP Server",
@@ -127,6 +112,33 @@ func Run(enabledServices []string) error {
 	if enabled[ServiceResource] {
 		registerResourceTools(server, resourceService)
 	}
+
+	return server
+}
+
+// Run starts the MCP server on stdio, registering only the tool groups listed in enabledServices.
+// If enabledServices is empty, all tool groups are registered.
+func Run(enabledServices []string) error {
+	cfg := loadConfig()
+
+	var resourceTypeService application.ResourceTypeService
+	var resourceService application.ResourceService
+
+	app := fx.New(
+		fx.NopLogger,
+		application.Module(cfg, presets.NewDefaultRegistry()),
+		fx.Populate(&resourceTypeService),
+		fx.Populate(&resourceService),
+	)
+
+	startCtx, startCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+	defer startCancel()
+
+	if err := app.Start(startCtx); err != nil {
+		return fmt.Errorf("failed to start application: %w", err)
+	}
+
+	server := NewMCPServer(resourceTypeService, resourceService, enabledServices)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -98,6 +98,11 @@ func NewMCPServer(
 	if isNilInterface(resourceService) {
 		return nil, fmt.Errorf("resourceService must not be nil")
 	}
+	if len(enabledServices) > 0 {
+		if err := ValidateServiceNames(enabledServices); err != nil {
+			return nil, err
+		}
+	}
 
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "weos",

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -145,6 +145,11 @@ func Run(enabledServices []string) error {
 	if err := app.Start(startCtx); err != nil {
 		return fmt.Errorf("failed to start application: %w", err)
 	}
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		defer stopCancel()
+		_ = app.Stop(stopCtx)
+	}()
 
 	server, err := NewMCPServer(resourceTypeService, resourceService, enabledServices)
 	if err != nil {
@@ -154,14 +159,7 @@ func Run(enabledServices []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	err = server.Run(ctx, &mcp.StdioTransport{})
-
-	stopCtx, stopCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
-	defer stopCancel()
-
-	_ = app.Stop(stopCtx)
-
-	return err
+	return server.Run(ctx, &mcp.StdioTransport{})
 }
 
 // isNilInterface returns true if v is nil or a typed-nil (interface wrapping a nil pointer).


### PR DESCRIPTION
## Summary
- Adds `--mcp` flag (default `true`) to `weos serve` that mounts the MCP protocol at `/api/mcp` using Streamable HTTP transport
- Extracts `NewMCPServer()` for reuse across stdio and HTTP transports
- Users can now run REST API, web app, and MCP server from a single `weos serve` command
- MCP endpoint is under the protected API group, inheriting auth/authorization middleware
- `weos mcp` (stdio) remains unchanged for direct LLM piping
- Disable with `--mcp=false` or `MCP_ENABLED=false`

Closes #296

## Test plan
- [ ] `weos serve` starts with MCP enabled at `/api/mcp` by default
- [ ] `weos serve --mcp=false` starts without MCP endpoint
- [ ] `weos mcp` still works on stdio
- [ ] POST MCP initialize request to `http://localhost:8080/api/mcp` returns valid response
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)