### PR TITLE
Add fixture data support to preset resource types

### DIFF
--- a/application/builtin_resource_types.go
+++ b/application/builtin_resource_types.go
@@ -41,10 +41,16 @@ func ensureBuiltInResourceTypes(params struct {
 		if err != nil {
 			params.Logger.Error(ctx, "failed to install built-in preset",
 				"preset", preset.Name, "error", err)
+		}
+		if result == nil {
 			continue
 		}
 		for _, slug := range result.Created {
 			params.Logger.Info(ctx, "created built-in resource type", "slug", slug)
+		}
+		for slug, count := range result.Seeded {
+			params.Logger.Info(ctx, "seeded built-in fixture data",
+				"slug", slug, "count", count)
 		}
 	}
 	return nil

--- a/application/builtin_resource_types.go
+++ b/application/builtin_resource_types.go
@@ -23,8 +23,9 @@ import (
 	"go.uber.org/fx"
 )
 
-// ensureBuiltInResourceTypes creates resource types from all presets marked as
-// AutoInstall at startup, if they don't already exist.
+// ensureBuiltInResourceTypes installs all presets marked as AutoInstall at
+// startup, creating resource types and seeding fixture data if they don't
+// already exist.
 func ensureBuiltInResourceTypes(params struct {
 	fx.In
 	Registry *PresetRegistry
@@ -36,17 +37,14 @@ func ensureBuiltInResourceTypes(params struct {
 		if !preset.AutoInstall {
 			continue
 		}
-		for _, bt := range preset.Types {
-			if _, err := params.TypeSvc.GetBySlug(ctx, bt.Slug); err == nil {
-				continue // already exists
-			}
-			cmd := CreateResourceTypeCommand(bt)
-			if _, err := params.TypeSvc.Create(ctx, cmd); err != nil {
-				params.Logger.Error(ctx, "failed to create built-in resource type",
-					"slug", bt.Slug, "error", err)
-			} else {
-				params.Logger.Info(ctx, "created built-in resource type", "slug", bt.Slug)
-			}
+		result, err := params.TypeSvc.InstallPreset(ctx, preset.Name, false)
+		if err != nil {
+			params.Logger.Error(ctx, "failed to install built-in preset",
+				"preset", preset.Name, "error", err)
+			continue
+		}
+		for _, slug := range result.Created {
+			params.Logger.Info(ctx, "created built-in resource type", "slug", slug)
 		}
 	}
 	return nil

--- a/application/builtin_resource_types.go
+++ b/application/builtin_resource_types.go
@@ -49,6 +49,9 @@ func ensureBuiltInResourceTypes(params struct {
 			params.Logger.Info(ctx, "created built-in resource type", "slug", slug)
 		}
 		for slug, count := range result.Seeded {
+			if count <= 0 {
+				continue
+			}
 			params.Logger.Info(ctx, "seeded built-in fixture data",
 				"slug", slug, "count", count)
 		}

--- a/application/install_preset_test.go
+++ b/application/install_preset_test.go
@@ -1,0 +1,348 @@
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"weos/domain/entities"
+	"weos/domain/repositories"
+
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
+)
+
+// --- stubs ---
+
+// installTestTypeRepo is a ResourceTypeRepository backed by an in-memory map.
+type installTestTypeRepo struct {
+	types map[string]*entities.ResourceType
+}
+
+func newInstallTestTypeRepo() *installTestTypeRepo {
+	return &installTestTypeRepo{types: make(map[string]*entities.ResourceType)}
+}
+
+func (r *installTestTypeRepo) FindBySlug(_ context.Context, slug string) (*entities.ResourceType, error) {
+	if rt, ok := r.types[slug]; ok {
+		return rt, nil
+	}
+	return nil, fmt.Errorf("resource type %q: %w", slug, repositories.ErrNotFound)
+}
+
+func (r *installTestTypeRepo) Save(_ context.Context, e *entities.ResourceType) error {
+	r.types[e.Slug()] = e
+	return nil
+}
+
+func (r *installTestTypeRepo) FindByID(_ context.Context, id string) (*entities.ResourceType, error) {
+	for _, rt := range r.types {
+		if rt.GetID() == id {
+			return rt, nil
+		}
+	}
+	return nil, fmt.Errorf("resource type %q: %w", id, repositories.ErrNotFound)
+}
+
+func (r *installTestTypeRepo) FindAll(
+	_ context.Context, _ string, _ int,
+) (repositories.PaginatedResponse[*entities.ResourceType], error) {
+	return repositories.PaginatedResponse[*entities.ResourceType]{}, nil
+}
+
+func (r *installTestTypeRepo) Update(_ context.Context, _ *entities.ResourceType) error { return nil }
+func (r *installTestTypeRepo) Delete(_ context.Context, _ string) error                 { return nil }
+
+// stubEventStore is a minimal in-memory event store for testing.
+type stubEventStore struct{}
+
+func (s *stubEventStore) Append(
+	_ context.Context, _ string, _ int, _ ...domain.EventEnvelope[any],
+) error {
+	return nil
+}
+func (s *stubEventStore) GetEvents(
+	_ context.Context, _ string,
+) ([]domain.EventEnvelope[any], error) {
+	return nil, nil
+}
+func (s *stubEventStore) GetEventsFromVersion(
+	_ context.Context, _ string, _ int,
+) ([]domain.EventEnvelope[any], error) {
+	return nil, nil
+}
+func (s *stubEventStore) GetEventsRange(
+	_ context.Context, _ string, _, _ int,
+) ([]domain.EventEnvelope[any], error) {
+	return nil, nil
+}
+func (s *stubEventStore) GetEventByID(
+	_ context.Context, _ string,
+) (domain.EventEnvelope[any], error) {
+	return domain.EventEnvelope[any]{}, nil
+}
+func (s *stubEventStore) GetEventsByTransactionID(
+	_ context.Context, _ string,
+) ([]domain.EventEnvelope[any], error) {
+	return nil, nil
+}
+func (s *stubEventStore) GetCurrentVersion(_ context.Context, _ string) (int, error) { return 0, nil }
+func (s *stubEventStore) Close() error                                               { return nil }
+
+// fakeResourceSvc records Create calls and can be configured to fail.
+type fakeResourceSvc struct {
+	created  []CreateResourceCommand
+	calls    int    // total Create calls (including failures)
+	failAt   int    // call index at which to fail (-1 = never)
+	failSlug string // only fail for this slug
+}
+
+func newFakeResourceSvc() *fakeResourceSvc {
+	return &fakeResourceSvc{failAt: -1}
+}
+
+func (f *fakeResourceSvc) Create(
+	_ context.Context, cmd CreateResourceCommand,
+) (*entities.Resource, error) {
+	idx := f.calls
+	f.calls++
+	if f.failSlug == cmd.TypeSlug && idx == f.failAt {
+		return nil, errors.New("seed failure")
+	}
+	f.created = append(f.created, cmd)
+	return nil, nil //nolint:nilnil // stub
+}
+
+func (f *fakeResourceSvc) GetByID(context.Context, string) (*entities.Resource, error) {
+	return nil, nil //nolint:nilnil
+}
+func (f *fakeResourceSvc) List(
+	context.Context, string, string, int, repositories.SortOptions,
+) (repositories.PaginatedResponse[*entities.Resource], error) {
+	return repositories.PaginatedResponse[*entities.Resource]{}, nil
+}
+func (f *fakeResourceSvc) ListFlat(
+	context.Context, string, string, int, repositories.SortOptions,
+) (repositories.PaginatedResponse[map[string]any], error) {
+	return repositories.PaginatedResponse[map[string]any]{}, nil
+}
+func (f *fakeResourceSvc) ListByField(
+	context.Context, string, string, string,
+) (repositories.PaginatedResponse[*entities.Resource], error) {
+	return repositories.PaginatedResponse[*entities.Resource]{}, nil
+}
+func (f *fakeResourceSvc) ListWithFilters(
+	context.Context, string, []repositories.FilterCondition, string, int, repositories.SortOptions,
+) (repositories.PaginatedResponse[*entities.Resource], error) {
+	return repositories.PaginatedResponse[*entities.Resource]{}, nil
+}
+func (f *fakeResourceSvc) ListFlatWithFilters(
+	context.Context, string, []repositories.FilterCondition, string, int, repositories.SortOptions,
+) (repositories.PaginatedResponse[map[string]any], error) {
+	return repositories.PaginatedResponse[map[string]any]{}, nil
+}
+func (f *fakeResourceSvc) Update(context.Context, UpdateResourceCommand) (*entities.Resource, error) {
+	return nil, nil //nolint:nilnil
+}
+func (f *fakeResourceSvc) Delete(context.Context, DeleteResourceCommand) error { return nil }
+
+// --- helpers ---
+
+func makeInstallTestService(
+	repo repositories.ResourceTypeRepository,
+	resourceSvc *fakeResourceSvc,
+	registry *PresetRegistry,
+) ResourceTypeService {
+	es := &stubEventStore{}
+	d := domain.NewEventDispatcher()
+	pm := &stubProjMgr{}
+	// Wire up event handlers so created types are projected to the repo.
+	_ = SubscribeResourceTypeHandlers(d, repo, pm, noopLogger{})
+	return &resourceTypeService{
+		repo:        repo,
+		projMgr:     pm,
+		eventStore:  es,
+		dispatcher:  d,
+		registry:    registry,
+		logger:      noopLogger{},
+		resourceSvc: resourceSvc,
+	}
+}
+
+func testPresetWithFixtures() PresetDefinition {
+	return PresetDefinition{
+		Name:        "test-fixtures",
+		Description: "Preset for fixture seeding tests",
+		Types: []PresetResourceType{
+			{
+				Name:        "Measure",
+				Slug:        "measure",
+				Description: "Unit of measure",
+				Context:     json.RawMessage(`{"@vocab":"https://schema.org/"}`),
+				Schema: json.RawMessage(`{
+					"type":"object",
+					"properties":{"name":{"type":"string"},"abbr":{"type":"string"}},
+					"required":["name"]
+				}`),
+				Fixtures: []json.RawMessage{
+					json.RawMessage(`{"name":"Cup","abbr":"cup"}`),
+					json.RawMessage(`{"name":"Tablespoon","abbr":"tbsp"}`),
+					json.RawMessage(`{"name":"Gram","abbr":"g"}`),
+				},
+			},
+			{
+				Name:        "Tag",
+				Slug:        "tag",
+				Description: "Simple tag",
+				Context:     json.RawMessage(`{"@vocab":"https://schema.org/"}`),
+				Schema: json.RawMessage(`{
+					"type":"object",
+					"properties":{"name":{"type":"string"}},
+					"required":["name"]
+				}`),
+			},
+		},
+	}
+}
+
+// --- tests ---
+
+func TestInstallPreset_SeedsFixturesOnCreate(t *testing.T) {
+	t.Parallel()
+	registry := NewPresetRegistry()
+	registry.MustAdd(testPresetWithFixtures())
+	repo := newInstallTestTypeRepo()
+	rSvc := newFakeResourceSvc()
+	svc := makeInstallTestService(repo, rSvc, registry)
+
+	result, err := svc.InstallPreset(context.Background(), "test-fixtures", false)
+	if err != nil {
+		t.Fatalf("InstallPreset failed: %v", err)
+	}
+
+	// Both types should be created.
+	if len(result.Created) != 2 {
+		t.Fatalf("expected 2 created types, got %d: %v", len(result.Created), result.Created)
+	}
+
+	// 3 fixtures should be seeded for "measure", 0 for "tag".
+	if result.Seeded == nil {
+		t.Fatal("expected non-nil Seeded map")
+	}
+	if result.Seeded["measure"] != 3 {
+		t.Fatalf("expected 3 seeded for measure, got %d", result.Seeded["measure"])
+	}
+	if _, ok := result.Seeded["tag"]; ok {
+		t.Fatal("tag has no fixtures, should not appear in Seeded")
+	}
+
+	// Verify the resource service received correct commands.
+	if len(rSvc.created) != 3 {
+		t.Fatalf("expected 3 resource creates, got %d", len(rSvc.created))
+	}
+	for _, cmd := range rSvc.created {
+		if cmd.TypeSlug != "measure" {
+			t.Fatalf("expected TypeSlug 'measure', got %q", cmd.TypeSlug)
+		}
+	}
+}
+
+func TestInstallPreset_SkipsFixturesForExistingTypes(t *testing.T) {
+	t.Parallel()
+	registry := NewPresetRegistry()
+	registry.MustAdd(testPresetWithFixtures())
+	repo := newInstallTestTypeRepo()
+	rSvc := newFakeResourceSvc()
+	svc := makeInstallTestService(repo, rSvc, registry)
+
+	// First install creates types + fixtures.
+	_, err := svc.InstallPreset(context.Background(), "test-fixtures", false)
+	if err != nil {
+		t.Fatalf("first install failed: %v", err)
+	}
+
+	// Second install should skip all types -- no new fixtures.
+	rSvc2 := newFakeResourceSvc()
+	svc2 := makeInstallTestService(repo, rSvc2, registry)
+	result, err := svc2.InstallPreset(context.Background(), "test-fixtures", false)
+	if err != nil {
+		t.Fatalf("second install failed: %v", err)
+	}
+	if len(result.Skipped) != 2 {
+		t.Fatalf("expected 2 skipped, got %d", len(result.Skipped))
+	}
+	if len(rSvc2.created) != 0 {
+		t.Fatalf("expected 0 resource creates on second install, got %d", len(rSvc2.created))
+	}
+}
+
+func TestInstallPreset_FixtureFailureIsNonFatal(t *testing.T) {
+	t.Parallel()
+	registry := NewPresetRegistry()
+	registry.MustAdd(testPresetWithFixtures())
+	repo := newInstallTestTypeRepo()
+	rSvc := newFakeResourceSvc()
+	rSvc.failAt = 1 // fail on second fixture
+	rSvc.failSlug = "measure"
+	svc := makeInstallTestService(repo, rSvc, registry)
+
+	result, err := svc.InstallPreset(context.Background(), "test-fixtures", false)
+	if err != nil {
+		t.Fatalf("InstallPreset should not fail on fixture error, got: %v", err)
+	}
+
+	// Both types should still be created.
+	if len(result.Created) != 2 {
+		t.Fatalf("expected 2 created types, got %d", len(result.Created))
+	}
+
+	// 2 of 3 fixtures should have been seeded (index 0 and 2 succeed, 1 fails).
+	if result.Seeded["measure"] != 2 {
+		t.Fatalf("expected 2 seeded for measure (1 failed), got %d", result.Seeded["measure"])
+	}
+}
+
+func TestInstallPreset_GetBySlugNonNotFoundError(t *testing.T) {
+	t.Parallel()
+	registry := NewPresetRegistry()
+	registry.MustAdd(testPresetWithFixtures())
+
+	// Use a repo that returns a non-not-found error.
+	dbErr := errors.New("database connection refused")
+	repo := &failingTypeRepo{err: dbErr}
+	rSvc := newFakeResourceSvc()
+	svc := makeInstallTestService(repo, rSvc, registry)
+
+	result, err := svc.InstallPreset(context.Background(), "test-fixtures", false)
+	if err == nil {
+		t.Fatal("expected error for non-not-found GetBySlug failure")
+	}
+	if !errors.Is(err, dbErr) {
+		t.Fatalf("expected wrapped database error, got: %v", err)
+	}
+	// Result should be returned (possibly partial) even on error.
+	if result == nil {
+		t.Fatal("expected non-nil result even on error")
+	}
+}
+
+// failingTypeRepo always returns a non-not-found error from FindBySlug.
+type failingTypeRepo struct {
+	err error
+}
+
+func (r *failingTypeRepo) FindBySlug(context.Context, string) (*entities.ResourceType, error) {
+	return nil, r.err
+}
+func (r *failingTypeRepo) Save(context.Context, *entities.ResourceType) error { return nil }
+func (r *failingTypeRepo) FindByID(context.Context, string) (*entities.ResourceType, error) {
+	return nil, r.err
+}
+func (r *failingTypeRepo) FindAll(
+	context.Context, string, int,
+) (repositories.PaginatedResponse[*entities.ResourceType], error) {
+	return repositories.PaginatedResponse[*entities.ResourceType]{}, nil
+}
+func (r *failingTypeRepo) Update(context.Context, *entities.ResourceType) error { return nil }
+func (r *failingTypeRepo) Delete(context.Context, string) error                 { return nil }

--- a/application/install_preset_test.go
+++ b/application/install_preset_test.go
@@ -158,7 +158,9 @@ func makeInstallTestService(
 	d := domain.NewEventDispatcher()
 	pm := &stubProjMgr{}
 	// Wire up event handlers so created types are projected to the repo.
-	_ = SubscribeResourceTypeHandlers(d, repo, pm, noopLogger{})
+	if err := SubscribeResourceTypeHandlers(d, repo, pm, noopLogger{}); err != nil {
+		panic(fmt.Sprintf("SubscribeResourceTypeHandlers failed in test setup: %v", err))
+	}
 	return &resourceTypeService{
 		repo:        repo,
 		projMgr:     pm,

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -86,6 +86,9 @@ func (r *PresetRegistry) Add(def PresetDefinition) error {
 		if pt.Name == "" || pt.Slug == "" {
 			return fmt.Errorf("type at index %d in preset %q: name and slug are required", i, def.Name)
 		}
+		if err := pt.validateFixtures(); err != nil {
+			return fmt.Errorf("preset %q: %w", def.Name, err)
+		}
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -230,6 +233,26 @@ func (r *PresetRegistry) Behaviors() ResourceBehaviorRegistry {
 		}
 	}
 	return behaviors
+}
+
+// validateFixtures checks that fixture data is well-formed at registration time.
+func (pt PresetResourceType) validateFixtures() error {
+	if len(pt.Fixtures) == 0 {
+		return nil
+	}
+	if len(pt.Schema) == 0 {
+		return fmt.Errorf("type %q has fixtures but no schema", pt.Slug)
+	}
+	for i, f := range pt.Fixtures {
+		if !json.Valid(f) {
+			return fmt.Errorf("type %q fixture[%d] is not valid JSON", pt.Slug, i)
+		}
+		var obj map[string]any
+		if err := json.Unmarshal(f, &obj); err != nil || obj == nil {
+			return fmt.Errorf("type %q fixture[%d] must be a JSON object", pt.Slug, i)
+		}
+	}
+	return nil
 }
 
 // NewPresetType is a helper to create a PresetResourceType from raw strings.

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -34,6 +34,7 @@ type PresetResourceType struct {
 	Description string
 	Context     json.RawMessage
 	Schema      json.RawMessage
+	Fixtures    []json.RawMessage // optional seed data created on install
 }
 
 // PresetSidebarConfig holds default sidebar settings applied when a preset is installed.
@@ -56,9 +57,10 @@ type PresetDefinition struct {
 
 // InstallPresetResult reports which types were created, updated, or skipped.
 type InstallPresetResult struct {
-	Created []string `json:"created"`
-	Updated []string `json:"updated,omitempty"`
-	Skipped []string `json:"skipped"`
+	Created []string       `json:"created"`
+	Updated []string       `json:"updated,omitempty"`
+	Skipped []string       `json:"skipped"`
+	Seeded  map[string]int `json:"seeded,omitempty"` // slug -> count of fixtures created
 }
 
 // PresetRegistry holds all registered presets. Preset packages call Add() to register.
@@ -132,6 +134,13 @@ func (d PresetDefinition) clone() PresetDefinition {
 			}
 			if t.Schema != nil {
 				types[i].Schema = append(json.RawMessage(nil), t.Schema...)
+			}
+			if t.Fixtures != nil {
+				fixtures := make([]json.RawMessage, len(t.Fixtures))
+				for j, f := range t.Fixtures {
+					fixtures[j] = append(json.RawMessage(nil), f...)
+				}
+				types[i].Fixtures = fixtures
 			}
 		}
 		d.Types = types

--- a/application/resource_type_presets_test.go
+++ b/application/resource_type_presets_test.go
@@ -181,6 +181,38 @@ func TestPresets_NoReservedSlugCollisions(t *testing.T) {
 	}
 }
 
+func TestPresets_AllFixturesAreValidJSON(t *testing.T) {
+	t.Parallel()
+	for _, d := range testRegistry().List() {
+		for _, pt := range d.Types {
+			for i, fixture := range pt.Fixtures {
+				var v any
+				if err := json.Unmarshal(fixture, &v); err != nil {
+					t.Fatalf("preset %q type %q fixture[%d] is invalid JSON: %v",
+						d.Name, pt.Slug, i, err)
+				}
+				// Fixtures must be JSON objects, not arrays or scalars.
+				if _, ok := v.(map[string]any); !ok {
+					t.Fatalf("preset %q type %q fixture[%d] must be a JSON object, got %T",
+						d.Name, pt.Slug, i, v)
+				}
+			}
+		}
+	}
+}
+
+func TestPresets_FixturesOnlyOnTypesWithSchema(t *testing.T) {
+	t.Parallel()
+	for _, d := range testRegistry().List() {
+		for _, pt := range d.Types {
+			if len(pt.Fixtures) > 0 && len(pt.Schema) == 0 {
+				t.Fatalf("preset %q type %q has fixtures but no schema — "+
+					"fixtures require a schema for validation", d.Name, pt.Slug)
+			}
+		}
+	}
+}
+
 func TestScreenManifest_NilScreens(t *testing.T) {
 	t.Parallel()
 	def := application.PresetDefinition{Name: "test"}

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"weos/domain/entities"
@@ -185,12 +186,13 @@ func (s *resourceTypeService) InstallPreset(
 	result := &InstallPresetResult{}
 	for _, pt := range preset.Types {
 		existing, err := s.GetBySlug(ctx, pt.Slug)
-		if err == nil {
+		switch {
+		case err == nil:
 			if !update {
 				result.Skipped = append(result.Skipped, pt.Slug)
 				continue
 			}
-			_, err := s.Update(ctx, UpdateResourceTypeCommand{
+			_, uErr := s.Update(ctx, UpdateResourceTypeCommand{
 				ID:          existing.GetID(),
 				Name:        pt.Name,
 				Slug:        pt.Slug,
@@ -198,33 +200,34 @@ func (s *resourceTypeService) InstallPreset(
 				Context:     pt.Context,
 				Schema:      pt.Schema,
 			})
-			if err != nil {
-				return nil, fmt.Errorf("failed to update resource type %q: %w", pt.Slug, err)
+			if uErr != nil {
+				return result, fmt.Errorf("failed to update resource type %q: %w", pt.Slug, uErr)
 			}
 			result.Updated = append(result.Updated, pt.Slug)
-			continue
-		}
-		_, err = s.Create(ctx, CreateResourceTypeCommand{
-			Name: pt.Name, Slug: pt.Slug, Description: pt.Description,
-			Context: pt.Context, Schema: pt.Schema,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to create resource type %q: %w", pt.Slug, err)
-		}
-		result.Created = append(result.Created, pt.Slug)
-		if err := s.seedFixtures(ctx, pt, result); err != nil {
-			return nil, err
+		case errors.Is(err, repositories.ErrNotFound):
+			_, cErr := s.Create(ctx, CreateResourceTypeCommand{
+				Name: pt.Name, Slug: pt.Slug, Description: pt.Description,
+				Context: pt.Context, Schema: pt.Schema,
+			})
+			if cErr != nil {
+				return result, fmt.Errorf("failed to create resource type %q: %w", pt.Slug, cErr)
+			}
+			result.Created = append(result.Created, pt.Slug)
+			s.seedFixtures(ctx, pt, result)
+		default:
+			return result, fmt.Errorf("failed to look up resource type %q: %w", pt.Slug, err)
 		}
 	}
 	return result, nil
 }
 
 // seedFixtures creates resources from the preset type's fixture data.
+// Failures are logged but do not prevent the rest of the preset from installing.
 func (s *resourceTypeService) seedFixtures(
 	ctx context.Context, pt PresetResourceType, result *InstallPresetResult,
-) error {
+) {
 	if len(pt.Fixtures) == 0 {
-		return nil
+		return
 	}
 	count := 0
 	for i, fixture := range pt.Fixtures {
@@ -233,14 +236,17 @@ func (s *resourceTypeService) seedFixtures(
 			Data:     fixture,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to seed fixture %d for %q: %w", i, pt.Slug, err)
+			s.logger.Error(ctx, "failed to seed fixture",
+				"slug", pt.Slug, "index", i, "error", err)
+			continue
 		}
 		count++
 	}
-	if result.Seeded == nil {
-		result.Seeded = make(map[string]int)
+	if count > 0 {
+		if result.Seeded == nil {
+			result.Seeded = make(map[string]int)
+		}
+		result.Seeded[pt.Slug] = count
+		s.logger.Info(ctx, "seeded fixture data", "slug", pt.Slug, "count", count)
 	}
-	result.Seeded[pt.Slug] = count
-	s.logger.Info(ctx, "seeded fixture data", "slug", pt.Slug, "count", count)
-	return nil
 }

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -197,6 +197,7 @@ func (s *resourceTypeService) InstallPreset(
 				Name:        pt.Name,
 				Slug:        pt.Slug,
 				Description: pt.Description,
+				Status:      existing.Status(),
 				Context:     pt.Context,
 				Schema:      pt.Schema,
 			})
@@ -222,11 +223,18 @@ func (s *resourceTypeService) InstallPreset(
 }
 
 // seedFixtures creates resources from the preset type's fixture data.
+// Fixtures require a schema on the resource type for validation.
 // Failures are logged but do not prevent the rest of the preset from installing.
+// Built-in fixtures seeded at startup (via ensureBuiltInResourceTypes) use a
+// background context and have no owner — they are intentionally global/public.
 func (s *resourceTypeService) seedFixtures(
 	ctx context.Context, pt PresetResourceType, result *InstallPresetResult,
 ) {
 	if len(pt.Fixtures) == 0 {
+		return
+	}
+	if len(pt.Schema) == 0 {
+		s.logger.Error(ctx, "cannot seed fixtures without a schema", "slug", pt.Slug)
 		return
 	}
 	count := 0

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -2,7 +2,6 @@ package application
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -11,7 +10,6 @@ import (
 
 	esapp "github.com/akeemphilbert/pericarp/pkg/eventsourcing/application"
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
-	"github.com/santhosh-tekuri/jsonschema/v6"
 	"go.uber.org/fx"
 )
 
@@ -239,23 +237,12 @@ func (s *resourceTypeService) seedFixtures(
 		s.logger.Error(ctx, "cannot seed fixtures without a schema", "slug", pt.Slug)
 		return
 	}
-	// Precompile schema once to avoid O(n) recompilation per fixture.
-	compiled, compileErr := compileSchema(pt.Schema)
-	if compileErr != nil {
-		s.logger.Error(ctx, "failed to compile schema for fixture validation",
-			"slug", pt.Slug, "error", compileErr)
-		return
-	}
 	if result.Seeded == nil {
 		result.Seeded = make(map[string]int)
 	}
 	count := 0
 	for i, fixture := range pt.Fixtures {
-		if err := validateWithCompiledSchema(compiled, fixture); err != nil {
-			s.logger.Error(ctx, "fixture failed schema validation",
-				"slug", pt.Slug, "index", i, "error", err)
-			continue
-		}
+		// Schema validation is handled by ResourceService.Create.
 		_, err := s.resourceSvc.Create(ctx, CreateResourceCommand{
 			TypeSlug: pt.Slug,
 			Data:     fixture,
@@ -271,26 +258,4 @@ func (s *resourceTypeService) seedFixtures(
 	if count > 0 {
 		s.logger.Info(ctx, "seeded fixture data", "slug", pt.Slug, "count", count)
 	}
-}
-
-// compileSchema compiles a JSON Schema once for reuse across multiple validations.
-func compileSchema(schema json.RawMessage) (*jsonschema.Schema, error) {
-	var schemaDoc any
-	if err := json.Unmarshal(schema, &schemaDoc); err != nil {
-		return nil, fmt.Errorf("invalid schema JSON: %w", err)
-	}
-	c := jsonschema.NewCompiler()
-	if err := c.AddResource("schema.json", schemaDoc); err != nil {
-		return nil, fmt.Errorf("invalid schema: %w", err)
-	}
-	return c.Compile("schema.json")
-}
-
-// validateWithCompiledSchema validates data against a precompiled JSON Schema.
-func validateWithCompiledSchema(sch *jsonschema.Schema, data json.RawMessage) error {
-	var v any
-	if err := json.Unmarshal(data, &v); err != nil {
-		return fmt.Errorf("invalid JSON data: %w", err)
-	}
-	return sch.Validate(v)
 }

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -47,30 +47,33 @@ type ResourceTypeService interface {
 }
 
 type resourceTypeService struct {
-	repo       repositories.ResourceTypeRepository
-	projMgr    repositories.ProjectionManager
-	eventStore domain.EventStore
-	dispatcher *domain.EventDispatcher
-	registry   *PresetRegistry
-	logger     entities.Logger
+	repo        repositories.ResourceTypeRepository
+	projMgr     repositories.ProjectionManager
+	eventStore  domain.EventStore
+	dispatcher  *domain.EventDispatcher
+	registry    *PresetRegistry
+	logger      entities.Logger
+	resourceSvc ResourceService
 }
 
 func ProvideResourceTypeService(params struct {
 	fx.In
-	Repo       repositories.ResourceTypeRepository
-	ProjMgr    repositories.ProjectionManager
-	EventStore domain.EventStore
-	Dispatcher *domain.EventDispatcher
-	Registry   *PresetRegistry
-	Logger     entities.Logger
+	Repo        repositories.ResourceTypeRepository
+	ProjMgr     repositories.ProjectionManager
+	EventStore  domain.EventStore
+	Dispatcher  *domain.EventDispatcher
+	Registry    *PresetRegistry
+	Logger      entities.Logger
+	ResourceSvc ResourceService
 }) ResourceTypeService {
 	return &resourceTypeService{
-		repo:       params.Repo,
-		projMgr:    params.ProjMgr,
-		eventStore: params.EventStore,
-		dispatcher: params.Dispatcher,
-		registry:   params.Registry,
-		logger:     params.Logger,
+		repo:        params.Repo,
+		projMgr:     params.ProjMgr,
+		eventStore:  params.EventStore,
+		dispatcher:  params.Dispatcher,
+		registry:    params.Registry,
+		logger:      params.Logger,
+		resourceSvc: params.ResourceSvc,
 	}
 }
 
@@ -201,11 +204,43 @@ func (s *resourceTypeService) InstallPreset(
 			result.Updated = append(result.Updated, pt.Slug)
 			continue
 		}
-		_, err = s.Create(ctx, CreateResourceTypeCommand(pt))
+		_, err = s.Create(ctx, CreateResourceTypeCommand{
+			Name: pt.Name, Slug: pt.Slug, Description: pt.Description,
+			Context: pt.Context, Schema: pt.Schema,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create resource type %q: %w", pt.Slug, err)
 		}
 		result.Created = append(result.Created, pt.Slug)
+		if err := s.seedFixtures(ctx, pt, result); err != nil {
+			return nil, err
+		}
 	}
 	return result, nil
+}
+
+// seedFixtures creates resources from the preset type's fixture data.
+func (s *resourceTypeService) seedFixtures(
+	ctx context.Context, pt PresetResourceType, result *InstallPresetResult,
+) error {
+	if len(pt.Fixtures) == 0 {
+		return nil
+	}
+	count := 0
+	for i, fixture := range pt.Fixtures {
+		_, err := s.resourceSvc.Create(ctx, CreateResourceCommand{
+			TypeSlug: pt.Slug,
+			Data:     fixture,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to seed fixture %d for %q: %w", i, pt.Slug, err)
+		}
+		count++
+	}
+	if result.Seeded == nil {
+		result.Seeded = make(map[string]int)
+	}
+	result.Seeded[pt.Slug] = count
+	s.logger.Info(ctx, "seeded fixture data", "slug", pt.Slug, "count", count)
+	return nil
 }

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -237,6 +237,9 @@ func (s *resourceTypeService) seedFixtures(
 		s.logger.Error(ctx, "cannot seed fixtures without a schema", "slug", pt.Slug)
 		return
 	}
+	if result.Seeded == nil {
+		result.Seeded = make(map[string]int)
+	}
 	count := 0
 	for i, fixture := range pt.Fixtures {
 		_, err := s.resourceSvc.Create(ctx, CreateResourceCommand{
@@ -250,11 +253,8 @@ func (s *resourceTypeService) seedFixtures(
 		}
 		count++
 	}
+	result.Seeded[pt.Slug] = count
 	if count > 0 {
-		if result.Seeded == nil {
-			result.Seeded = make(map[string]int)
-		}
-		result.Seeded[pt.Slug] = count
 		s.logger.Info(ctx, "seeded fixture data", "slug", pt.Slug, "count", count)
 	}
 }

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -10,6 +11,7 @@ import (
 
 	esapp "github.com/akeemphilbert/pericarp/pkg/eventsourcing/application"
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
+	"github.com/santhosh-tekuri/jsonschema/v6"
 	"go.uber.org/fx"
 )
 
@@ -237,11 +239,23 @@ func (s *resourceTypeService) seedFixtures(
 		s.logger.Error(ctx, "cannot seed fixtures without a schema", "slug", pt.Slug)
 		return
 	}
+	// Precompile schema once to avoid O(n) recompilation per fixture.
+	compiled, compileErr := compileSchema(pt.Schema)
+	if compileErr != nil {
+		s.logger.Error(ctx, "failed to compile schema for fixture validation",
+			"slug", pt.Slug, "error", compileErr)
+		return
+	}
 	if result.Seeded == nil {
 		result.Seeded = make(map[string]int)
 	}
 	count := 0
 	for i, fixture := range pt.Fixtures {
+		if err := validateWithCompiledSchema(compiled, fixture); err != nil {
+			s.logger.Error(ctx, "fixture failed schema validation",
+				"slug", pt.Slug, "index", i, "error", err)
+			continue
+		}
 		_, err := s.resourceSvc.Create(ctx, CreateResourceCommand{
 			TypeSlug: pt.Slug,
 			Data:     fixture,
@@ -257,4 +271,26 @@ func (s *resourceTypeService) seedFixtures(
 	if count > 0 {
 		s.logger.Info(ctx, "seeded fixture data", "slug", pt.Slug, "count", count)
 	}
+}
+
+// compileSchema compiles a JSON Schema once for reuse across multiple validations.
+func compileSchema(schema json.RawMessage) (*jsonschema.Schema, error) {
+	var schemaDoc any
+	if err := json.Unmarshal(schema, &schemaDoc); err != nil {
+		return nil, fmt.Errorf("invalid schema JSON: %w", err)
+	}
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource("schema.json", schemaDoc); err != nil {
+		return nil, fmt.Errorf("invalid schema: %w", err)
+	}
+	return c.Compile("schema.json")
+}
+
+// validateWithCompiledSchema validates data against a precompiled JSON Schema.
+func validateWithCompiledSchema(sch *jsonschema.Schema, data json.RawMessage) error {
+	var v any
+	if err := json.Unmarshal(data, &v); err != nil {
+		return fmt.Errorf("invalid JSON data: %w", err)
+	}
+	return sch.Validate(v)
 }

--- a/application/testing.go
+++ b/application/testing.go
@@ -64,3 +64,24 @@ func NewResourceServiceForTest(
 		behaviors:  behaviors,
 	}
 }
+
+// NewResourceTypeServiceForTest creates a ResourceTypeService without fx wiring.
+func NewResourceTypeServiceForTest(
+	repo repositories.ResourceTypeRepository,
+	projMgr repositories.ProjectionManager,
+	eventStore domain.EventStore,
+	dispatcher *domain.EventDispatcher,
+	registry *PresetRegistry,
+	logger entities.Logger,
+	resourceSvc ResourceService,
+) ResourceTypeService {
+	return &resourceTypeService{
+		repo:        repo,
+		projMgr:     projMgr,
+		eventStore:  eventStore,
+		dispatcher:  dispatcher,
+		registry:    registry,
+		logger:      logger,
+		resourceSvc: resourceSvc,
+	}
+}

--- a/internal/mcp/resource_type_preset_tools.go
+++ b/internal/mcp/resource_type_preset_tools.go
@@ -26,9 +26,10 @@ type PresetInstallInput struct {
 }
 
 type PresetInstallOutput struct {
-	Created []string `json:"created"`
-	Updated []string `json:"updated,omitempty"`
-	Skipped []string `json:"skipped"`
+	Created []string       `json:"created"`
+	Updated []string       `json:"updated,omitempty"`
+	Skipped []string       `json:"skipped"`
+	Seeded  map[string]int `json:"seeded,omitempty"`
 }
 
 func registerResourceTypePresetTools(server *mcp.Server, svc application.ResourceTypeService) {
@@ -68,6 +69,7 @@ func registerResourceTypePresetTools(server *mcp.Server, svc application.Resourc
 			Created: result.Created,
 			Updated: result.Updated,
 			Skipped: result.Skipped,
+			Seeded:  result.Seeded,
 		}, nil
 	})
 }

--- a/internal/mcp/resource_type_preset_tools.go
+++ b/internal/mcp/resource_type_preset_tools.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 
 	"weos/application"
 
@@ -63,7 +64,18 @@ func registerResourceTypePresetTools(server *mcp.Server, svc application.Resourc
 	) (*mcp.CallToolResult, PresetInstallOutput, error) {
 		result, err := svc.InstallPreset(ctx, input.Name, input.Update)
 		if err != nil {
-			return nil, PresetInstallOutput{}, err
+			if result == nil {
+				return nil, PresetInstallOutput{}, err
+			}
+			return nil, PresetInstallOutput{
+				Created: result.Created,
+				Updated: result.Updated,
+				Skipped: result.Skipped,
+				Seeded:  result.Seeded,
+			}, err
+		}
+		if result == nil {
+			return nil, PresetInstallOutput{}, fmt.Errorf("install preset %q returned nil result", input.Name)
 		}
 		return nil, PresetInstallOutput{
 			Created: result.Created,


### PR DESCRIPTION
## Summary
- Adds `Fixtures []json.RawMessage` field to `PresetResourceType` so presets can bundle seed data
- When `InstallPreset` creates a new resource type, it automatically creates resources from the fixture data
- Fixtures are only seeded for **newly created** types (not on update/skip) for idempotency
- `InstallPresetResult` now includes a `Seeded` map reporting how many fixtures were created per type
- Refactors `ensureBuiltInResourceTypes` to delegate to `InstallPreset`, eliminating duplicated logic

Closes #299

## Test plan
- [x] All existing preset validation tests pass
- [x] New `TestPresets_AllFixturesAreValidJSON` validates fixture JSON
- [x] New `TestPresets_FixturesOnlyOnTypesWithSchema` ensures fixtures require schemas
- [x] Full test suite passes with `-race` flag
- [ ] Manual: define a preset with fixtures, install it, verify resources are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)