### PR TITLE
Add per-account behavior configuration for resource types

### DIFF
--- a/api/handlers/resource_type_preset_handler.go
+++ b/api/handlers/resource_type_preset_handler.go
@@ -65,3 +65,33 @@ func (h *ResourceTypePresetHandler) Install(c echo.Context) error {
 	}
 	return c.JSON(http.StatusOK, result)
 }
+
+func (h *ResourceTypePresetHandler) ListBehaviors(c echo.Context) error {
+	typeSlug := c.Param("slug")
+	behaviors, err := h.service.ListBehaviors(c.Request().Context(), typeSlug)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError,
+			map[string]string{"error": "failed to list behaviors"})
+	}
+	return c.JSON(http.StatusOK, map[string]any{"data": behaviors})
+}
+
+func (h *ResourceTypePresetHandler) SetBehaviors(c echo.Context) error {
+	typeSlug := c.Param("slug")
+	var body struct {
+		Slugs *[]string `json:"slugs"`
+	}
+	if err := c.Bind(&body); err != nil {
+		return c.JSON(http.StatusBadRequest,
+			map[string]string{"error": "invalid request body"})
+	}
+	if body.Slugs == nil {
+		return c.JSON(http.StatusBadRequest,
+			map[string]string{"error": "slugs field is required"})
+	}
+	if err := h.service.SetBehaviors(c.Request().Context(), typeSlug, *body.Slugs); err != nil {
+		return c.JSON(http.StatusBadRequest,
+			map[string]string{"error": err.Error()})
+	}
+	return c.JSON(http.StatusOK, map[string]bool{"success": true})
+}

--- a/api/handlers/resource_type_preset_handler.go
+++ b/api/handlers/resource_type_preset_handler.go
@@ -16,9 +16,11 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 
 	"weos/application"
+	"weos/domain/repositories"
 
 	"github.com/labstack/echo/v4"
 )
@@ -67,9 +69,13 @@ func (h *ResourceTypePresetHandler) Install(c echo.Context) error {
 }
 
 func (h *ResourceTypePresetHandler) ListBehaviors(c echo.Context) error {
-	typeSlug := c.Param("slug")
+	typeSlug := c.Param("typeSlug")
 	behaviors, err := h.service.ListBehaviors(c.Request().Context(), typeSlug)
 	if err != nil {
+		if errors.Is(err, repositories.ErrNotFound) {
+			return c.JSON(http.StatusNotFound,
+				map[string]string{"error": err.Error()})
+		}
 		return c.JSON(http.StatusInternalServerError,
 			map[string]string{"error": "failed to list behaviors"})
 	}
@@ -77,7 +83,7 @@ func (h *ResourceTypePresetHandler) ListBehaviors(c echo.Context) error {
 }
 
 func (h *ResourceTypePresetHandler) SetBehaviors(c echo.Context) error {
-	typeSlug := c.Param("slug")
+	typeSlug := c.Param("typeSlug")
 	var body struct {
 		Slugs *[]string `json:"slugs"`
 	}
@@ -89,9 +95,22 @@ func (h *ResourceTypePresetHandler) SetBehaviors(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest,
 			map[string]string{"error": "slugs field is required"})
 	}
-	if err := h.service.SetBehaviors(c.Request().Context(), typeSlug, *body.Slugs); err != nil {
-		return c.JSON(http.StatusBadRequest,
-			map[string]string{"error": err.Error()})
+	ctx := c.Request().Context()
+	if err := h.service.SetBehaviors(ctx, typeSlug, *body.Slugs); err != nil {
+		if errors.Is(err, application.ErrForbidden) {
+			return c.JSON(http.StatusForbidden,
+				map[string]string{"error": err.Error()})
+		}
+		if errors.Is(err, repositories.ErrNotFound) {
+			return c.JSON(http.StatusNotFound,
+				map[string]string{"error": err.Error()})
+		}
+		if errors.Is(err, application.ErrValidation) {
+			return c.JSON(http.StatusBadRequest,
+				map[string]string{"error": err.Error()})
+		}
+		return c.JSON(http.StatusInternalServerError,
+			map[string]string{"error": "failed to set behaviors"})
 	}
 	return c.JSON(http.StatusOK, map[string]bool{"success": true})
 }

--- a/application/module.go
+++ b/application/module.go
@@ -90,8 +90,10 @@ func Module(cfg config.Config, registry *PresetRegistry) fx.Option {
 		fx.Provide(ProvideAuthenticationService),
 		fx.Provide(ProvideSessionManager),
 
-		// Resource behavior registry (must come before ProvideResourceService)
+		// Resource behavior registries (must come before ProvideResourceService)
 		fx.Provide(ProvideResourceBehaviorRegistry),
+		fx.Provide(ProvideBehaviorMetaRegistry),
+		fx.Provide(gorm.ProvideBehaviorSettingsRepository),
 
 		// Service providers
 		fx.Provide(ProvideResourceTypeService),

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -46,13 +46,14 @@ type PresetSidebarConfig struct {
 // PresetDefinition defines a named preset package that bundles resource types,
 // behaviors, screen components, and sidebar configuration.
 type PresetDefinition struct {
-	Name        string
-	Description string
-	Types       []PresetResourceType
-	Behaviors   map[string]entities.ResourceBehavior // slug -> behavior
-	Screens     fs.FS                                // optional embedded screen components
-	Sidebar     *PresetSidebarConfig                 // optional sidebar defaults
-	AutoInstall bool                                 // if true, types are auto-created at startup
+	Name         string
+	Description  string
+	Types        []PresetResourceType
+	Behaviors    map[string]entities.ResourceBehavior // slug -> behavior implementation
+	BehaviorMeta map[string]entities.BehaviorMeta     // slug -> metadata for UI/config
+	Screens      fs.FS                                // optional embedded screen components
+	Sidebar      *PresetSidebarConfig                 // optional sidebar defaults
+	AutoInstall  bool                                 // if true, types are auto-created at startup
 }
 
 // InstallPresetResult reports which types were created, updated, or skipped.
@@ -155,6 +156,13 @@ func (d PresetDefinition) clone() PresetDefinition {
 		}
 		d.Behaviors = behaviors
 	}
+	if d.BehaviorMeta != nil {
+		meta := make(map[string]entities.BehaviorMeta, len(d.BehaviorMeta))
+		for k, v := range d.BehaviorMeta {
+			meta[k] = v
+		}
+		d.BehaviorMeta = meta
+	}
 	if d.Sidebar != nil {
 		s := *d.Sidebar
 		if s.HiddenSlugs != nil {
@@ -253,6 +261,26 @@ func (pt PresetResourceType) validateFixtures() error {
 		}
 	}
 	return nil
+}
+
+// BehaviorsMeta returns a merged BehaviorMetaRegistry from all registered presets.
+// Same merge semantics as Behaviors(): alphabetical order, last wins.
+func (r *PresetRegistry) BehaviorsMeta() BehaviorMetaRegistry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.presets))
+	for name := range r.presets {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	meta := make(BehaviorMetaRegistry)
+	for _, name := range names {
+		for slug, m := range r.presets[name].BehaviorMeta {
+			meta[slug] = m
+		}
+	}
+	return meta
 }
 
 // NewPresetType is a helper to create a PresetResourceType from raw strings.

--- a/application/presets/core/preset.go
+++ b/application/presets/core/preset.go
@@ -53,6 +53,22 @@ func Register(registry *application.PresetRegistry) {
 			"person":       &personBehavior{},
 			"organization": &organizationBehavior{},
 		},
+		BehaviorMeta: map[string]entities.BehaviorMeta{
+			"person": {
+				Slug:        "person",
+				DisplayName: "Computed Name",
+				Description: "Auto-computes full name from givenName + familyName",
+				Default:     true,
+				Manageable:  false,
+			},
+			"organization": {
+				Slug:        "organization",
+				DisplayName: "Organization Defaults",
+				Description: "Placeholder for organization-specific logic",
+				Default:     true,
+				Manageable:  false,
+			},
+		},
 		AutoInstall: true,
 	})
 }

--- a/application/resource_behaviors.go
+++ b/application/resource_behaviors.go
@@ -28,3 +28,12 @@ type ResourceBehaviorRegistry map[string]entities.ResourceBehavior
 func ProvideResourceBehaviorRegistry(registry *PresetRegistry) ResourceBehaviorRegistry {
 	return registry.Behaviors()
 }
+
+// BehaviorMetaRegistry maps resource type slugs to their behavior metadata.
+// Used by services to expose available behaviors and enforce manageability.
+type BehaviorMetaRegistry map[string]entities.BehaviorMeta
+
+// ProvideBehaviorMetaRegistry builds the metadata registry from all presets.
+func ProvideBehaviorMetaRegistry(registry *PresetRegistry) BehaviorMetaRegistry {
+	return registry.BehaviorsMeta()
+}

--- a/application/resource_behaviors_test.go
+++ b/application/resource_behaviors_test.go
@@ -327,7 +327,7 @@ func TestBehaviorFor_AccountOverrideDisablesBehavior(t *testing.T) {
 		typeRepo:         &stubTypeRepo{types: map[string]*entities.ResourceType{"person": rt}},
 		logger:           noopLogger{},
 		behaviors:        ResourceBehaviorRegistry{"person": &trackBehavior{label: "person", calls: &calls}},
-		behaviorMeta:     BehaviorMetaRegistry{"person": entities.BehaviorMeta{Slug: "person", Default: true}},
+		behaviorMeta:     BehaviorMetaRegistry{"person": entities.BehaviorMeta{Slug: "person", Default: true, Manageable: true}},
 		behaviorSettings: settings,
 	}
 
@@ -350,7 +350,7 @@ func TestBehaviorFor_NoAccountOverrideUsesPresetDefaults(t *testing.T) {
 		typeRepo:         &stubTypeRepo{types: map[string]*entities.ResourceType{"person": rt}},
 		logger:           noopLogger{},
 		behaviors:        ResourceBehaviorRegistry{"person": &trackBehavior{label: "person", calls: &calls}},
-		behaviorMeta:     BehaviorMetaRegistry{"person": entities.BehaviorMeta{Slug: "person", Default: true}},
+		behaviorMeta:     BehaviorMetaRegistry{"person": entities.BehaviorMeta{Slug: "person", Default: true, Manageable: true}},
 		behaviorSettings: settings,
 	}
 
@@ -394,7 +394,7 @@ func TestBehaviorFor_SettingsErrorFallsBackToDefaults(t *testing.T) {
 		typeRepo:         &stubTypeRepo{types: map[string]*entities.ResourceType{"person": rt}},
 		logger:           noopLogger{},
 		behaviors:        ResourceBehaviorRegistry{"person": &trackBehavior{label: "person", calls: &calls}},
-		behaviorMeta:     BehaviorMetaRegistry{"person": entities.BehaviorMeta{Slug: "person", Default: true}},
+		behaviorMeta:     BehaviorMetaRegistry{"person": entities.BehaviorMeta{Slug: "person", Default: true, Manageable: true}},
 		behaviorSettings: settings,
 	}
 
@@ -416,7 +416,7 @@ func TestBehaviorFor_NilSettingsRepo(t *testing.T) {
 		typeRepo:     &stubTypeRepo{types: map[string]*entities.ResourceType{"person": rt}},
 		logger:       noopLogger{},
 		behaviors:    ResourceBehaviorRegistry{"person": &trackBehavior{label: "person", calls: &calls}},
-		behaviorMeta: BehaviorMetaRegistry{"person": entities.BehaviorMeta{Slug: "person", Default: true}},
+		behaviorMeta: BehaviorMetaRegistry{"person": entities.BehaviorMeta{Slug: "person", Default: true, Manageable: true}},
 		// behaviorSettings intentionally nil
 	}
 
@@ -455,8 +455,8 @@ func TestBehaviorFor_InheritanceWithAccountOverride(t *testing.T) {
 			"commitment": &trackBehavior{label: "commitment", calls: &calls},
 		},
 		behaviorMeta: BehaviorMetaRegistry{
-			"invoice":    entities.BehaviorMeta{Slug: "invoice", Default: true},
-			"commitment": entities.BehaviorMeta{Slug: "commitment", Default: true},
+			"invoice":    entities.BehaviorMeta{Slug: "invoice", Default: true, Manageable: true},
+			"commitment": entities.BehaviorMeta{Slug: "commitment", Default: true, Manageable: true},
 		},
 		behaviorSettings: settings,
 	}
@@ -468,5 +468,32 @@ func TestBehaviorFor_InheritanceWithAccountOverride(t *testing.T) {
 	// Only invoice should fire; commitment is excluded from override list
 	if len(calls) != 1 || calls[0] != "invoice.BeforeCreate" {
 		t.Errorf("expected [invoice.BeforeCreate], got %v", calls)
+	}
+}
+
+func TestBehaviorFor_NonManageableNotAffectedByOverride(t *testing.T) {
+	var calls []string
+	rt := makeTestRT("person", json.RawMessage(`{"@vocab":"https://schema.org/"}`))
+
+	settings := &stubBehaviorSettings{
+		data: map[string][]string{
+			"acct1|person": {},
+		},
+	}
+
+	svc := &resourceService{
+		typeRepo:         &stubTypeRepo{types: map[string]*entities.ResourceType{"person": rt}},
+		logger:           noopLogger{},
+		behaviors:        ResourceBehaviorRegistry{"person": &trackBehavior{label: "person", calls: &calls}},
+		behaviorMeta:     BehaviorMetaRegistry{"person": entities.BehaviorMeta{Slug: "person", Default: true, Manageable: false}},
+		behaviorSettings: settings,
+	}
+
+	ctx := withAccount(context.Background(), "agent1", "acct1")
+	behavior := svc.behaviorFor(ctx, rt)
+	_, _ = behavior.BeforeCreate(ctx, json.RawMessage(`{"name":"test"}`), rt)
+
+	if len(calls) != 1 || calls[0] != "person.BeforeCreate" {
+		t.Errorf("expected [person.BeforeCreate] (non-manageable, ignores override), got %v", calls)
 	}
 }

--- a/application/resource_behaviors_test.go
+++ b/application/resource_behaviors_test.go
@@ -9,6 +9,8 @@ import (
 	"weos/domain/entities"
 	"weos/domain/repositories"
 	"weos/pkg/jsonld"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
 )
 
 // stubTypeRepo implements ResourceTypeRepository for testing behavior hierarchy.
@@ -265,5 +267,206 @@ func TestSubClassOf_UsedByBehaviorFor(t *testing.T) {
 	parent := jsonld.SubClassOf(ctx)
 	if parent != "commitment" {
 		t.Errorf("SubClassOf = %q, want %q", parent, "commitment")
+	}
+}
+
+// --- Stub BehaviorSettingsRepository for tests ---
+
+type stubBehaviorSettings struct {
+	data map[string][]string // key = accountID+"|"+typeSlug
+	err  error
+}
+
+func (s *stubBehaviorSettings) GetByAccountAndType(
+	_ context.Context, accountID, typeSlug string,
+) ([]string, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	slugs, ok := s.data[accountID+"|"+typeSlug]
+	if !ok {
+		return nil, nil
+	}
+	return slugs, nil
+}
+
+func (s *stubBehaviorSettings) SaveByAccountAndType(
+	_ context.Context, accountID, typeSlug string, slugs []string,
+) error {
+	if s.err != nil {
+		return s.err
+	}
+	if s.data == nil {
+		s.data = make(map[string][]string)
+	}
+	s.data[accountID+"|"+typeSlug] = slugs
+	return nil
+}
+
+func withAccount(ctx context.Context, agentID, accountID string) context.Context {
+	return auth.ContextWithAgent(ctx, &auth.Identity{
+		AgentID:         agentID,
+		AccountIDs:      []string{accountID},
+		ActiveAccountID: accountID,
+	})
+}
+
+// --- Account-scoped behavior filtering tests ---
+
+func TestBehaviorFor_AccountOverrideDisablesBehavior(t *testing.T) {
+	var calls []string
+	rt := makeTestRT("person", json.RawMessage(`{"@vocab":"https://schema.org/"}`))
+
+	settings := &stubBehaviorSettings{
+		data: map[string][]string{
+			"acct1|person": {}, // empty list = all disabled
+		},
+	}
+
+	svc := &resourceService{
+		typeRepo:         &stubTypeRepo{types: map[string]*entities.ResourceType{"person": rt}},
+		logger:           noopLogger{},
+		behaviors:        ResourceBehaviorRegistry{"person": &trackBehavior{label: "person", calls: &calls}},
+		behaviorMeta:     BehaviorMetaRegistry{"person": entities.BehaviorMeta{Slug: "person", Default: true}},
+		behaviorSettings: settings,
+	}
+
+	ctx := withAccount(context.Background(), "agent1", "acct1")
+	behavior := svc.behaviorFor(ctx, rt)
+	_, _ = behavior.BeforeCreate(ctx, json.RawMessage(`{"name":"test"}`), rt)
+
+	if len(calls) != 0 {
+		t.Errorf("expected no calls (behavior disabled by account), got %v", calls)
+	}
+}
+
+func TestBehaviorFor_NoAccountOverrideUsesPresetDefaults(t *testing.T) {
+	var calls []string
+	rt := makeTestRT("person", json.RawMessage(`{"@vocab":"https://schema.org/"}`))
+
+	settings := &stubBehaviorSettings{} // no overrides stored
+
+	svc := &resourceService{
+		typeRepo:         &stubTypeRepo{types: map[string]*entities.ResourceType{"person": rt}},
+		logger:           noopLogger{},
+		behaviors:        ResourceBehaviorRegistry{"person": &trackBehavior{label: "person", calls: &calls}},
+		behaviorMeta:     BehaviorMetaRegistry{"person": entities.BehaviorMeta{Slug: "person", Default: true}},
+		behaviorSettings: settings,
+	}
+
+	ctx := withAccount(context.Background(), "agent1", "acct1")
+	behavior := svc.behaviorFor(ctx, rt)
+	_, _ = behavior.BeforeCreate(ctx, json.RawMessage(`{"name":"test"}`), rt)
+
+	if len(calls) != 1 || calls[0] != "person.BeforeCreate" {
+		t.Errorf("expected [person.BeforeCreate] (default enabled), got %v", calls)
+	}
+}
+
+func TestBehaviorFor_PresetDefaultFalseDisablesBehavior(t *testing.T) {
+	var calls []string
+	rt := makeTestRT("person", json.RawMessage(`{"@vocab":"https://schema.org/"}`))
+
+	svc := &resourceService{
+		typeRepo:         &stubTypeRepo{types: map[string]*entities.ResourceType{"person": rt}},
+		logger:           noopLogger{},
+		behaviors:        ResourceBehaviorRegistry{"person": &trackBehavior{label: "person", calls: &calls}},
+		behaviorMeta:     BehaviorMetaRegistry{"person": entities.BehaviorMeta{Slug: "person", Default: false}},
+		behaviorSettings: &stubBehaviorSettings{},
+	}
+
+	ctx := withAccount(context.Background(), "agent1", "acct1")
+	behavior := svc.behaviorFor(ctx, rt)
+	_, _ = behavior.BeforeCreate(ctx, json.RawMessage(`{"name":"test"}`), rt)
+
+	if len(calls) != 0 {
+		t.Errorf("expected no calls (default=false, no override), got %v", calls)
+	}
+}
+
+func TestBehaviorFor_SettingsErrorFallsBackToDefaults(t *testing.T) {
+	var calls []string
+	rt := makeTestRT("person", json.RawMessage(`{"@vocab":"https://schema.org/"}`))
+
+	settings := &stubBehaviorSettings{err: errors.New("db down")}
+
+	svc := &resourceService{
+		typeRepo:         &stubTypeRepo{types: map[string]*entities.ResourceType{"person": rt}},
+		logger:           noopLogger{},
+		behaviors:        ResourceBehaviorRegistry{"person": &trackBehavior{label: "person", calls: &calls}},
+		behaviorMeta:     BehaviorMetaRegistry{"person": entities.BehaviorMeta{Slug: "person", Default: true}},
+		behaviorSettings: settings,
+	}
+
+	ctx := withAccount(context.Background(), "agent1", "acct1")
+	behavior := svc.behaviorFor(ctx, rt)
+	_, _ = behavior.BeforeCreate(ctx, json.RawMessage(`{"name":"test"}`), rt)
+
+	// Should fall back to defaults (Default: true), so behavior fires
+	if len(calls) != 1 || calls[0] != "person.BeforeCreate" {
+		t.Errorf("expected [person.BeforeCreate] (fallback to defaults), got %v", calls)
+	}
+}
+
+func TestBehaviorFor_NilSettingsRepo(t *testing.T) {
+	var calls []string
+	rt := makeTestRT("person", json.RawMessage(`{"@vocab":"https://schema.org/"}`))
+
+	svc := &resourceService{
+		typeRepo:     &stubTypeRepo{types: map[string]*entities.ResourceType{"person": rt}},
+		logger:       noopLogger{},
+		behaviors:    ResourceBehaviorRegistry{"person": &trackBehavior{label: "person", calls: &calls}},
+		behaviorMeta: BehaviorMetaRegistry{"person": entities.BehaviorMeta{Slug: "person", Default: true}},
+		// behaviorSettings intentionally nil
+	}
+
+	ctx := withAccount(context.Background(), "agent1", "acct1")
+	// Should not panic — nil guard in resolveEnabledBehaviors
+	behavior := svc.behaviorFor(ctx, rt)
+	_, _ = behavior.BeforeCreate(ctx, json.RawMessage(`{"name":"test"}`), rt)
+
+	if len(calls) != 1 || calls[0] != "person.BeforeCreate" {
+		t.Errorf("expected [person.BeforeCreate] (nil settings repo), got %v", calls)
+	}
+}
+
+func TestBehaviorFor_InheritanceWithAccountOverride(t *testing.T) {
+	var calls []string
+	commitmentRT := makeTestRT("commitment", vfContext(""))
+	invoiceRT := makeTestRT("invoice", vfContext(subClassOf("commitment")))
+
+	repo := &stubTypeRepo{types: map[string]*entities.ResourceType{
+		"invoice":    invoiceRT,
+		"commitment": commitmentRT,
+	}}
+
+	// Account override enables invoice but not commitment
+	settings := &stubBehaviorSettings{
+		data: map[string][]string{
+			"acct1|invoice": {"invoice"}, // only invoice enabled
+		},
+	}
+
+	svc := &resourceService{
+		typeRepo: repo,
+		logger:   noopLogger{},
+		behaviors: ResourceBehaviorRegistry{
+			"invoice":    &trackBehavior{label: "invoice", calls: &calls},
+			"commitment": &trackBehavior{label: "commitment", calls: &calls},
+		},
+		behaviorMeta: BehaviorMetaRegistry{
+			"invoice":    entities.BehaviorMeta{Slug: "invoice", Default: true},
+			"commitment": entities.BehaviorMeta{Slug: "commitment", Default: true},
+		},
+		behaviorSettings: settings,
+	}
+
+	ctx := withAccount(context.Background(), "agent1", "acct1")
+	behavior := svc.behaviorFor(ctx, invoiceRT)
+	_, _ = behavior.BeforeCreate(ctx, json.RawMessage(`{"name":"test"}`), invoiceRT)
+
+	// Only invoice should fire; commitment is excluded from override list
+	if len(calls) != 1 || calls[0] != "invoice.BeforeCreate" {
+		t.Errorf("expected [invoice.BeforeCreate], got %v", calls)
 	}
 }

--- a/application/resource_service.go
+++ b/application/resource_service.go
@@ -125,16 +125,17 @@ func (s *resourceService) resolveEnabledBehaviors(ctx context.Context, typeSlug 
 }
 
 // isBehaviorEnabled checks whether a behavior slug should be active.
-// When enabledSet is nil (no account override), falls back to preset defaults.
+// Account overrides only apply to manageable behaviors.
+// Non-manageable behaviors always use preset defaults.
 // When no metadata exists for the slug, the behavior fires (backward compat).
 func (s *resourceService) isBehaviorEnabled(slug string, enabledSet map[string]bool) bool {
-	if enabledSet != nil {
-		return enabledSet[slug]
-	}
-	// No account override — use preset default.
 	meta, ok := s.behaviorMeta[slug]
 	if !ok {
 		return true // no metadata — legacy behavior, always fire
+	}
+
+	if enabledSet != nil && meta.Manageable {
+		return enabledSet[slug]
 	}
 	return meta.Default
 }

--- a/application/resource_service.go
+++ b/application/resource_service.go
@@ -38,15 +38,17 @@ type ResourceService interface {
 }
 
 type resourceService struct {
-	repo        repositories.ResourceRepository
-	typeRepo    repositories.ResourceTypeRepository
-	tripleRepo  repositories.TripleRepository
-	permRepo    repositories.ResourcePermissionRepository
-	accountRepo authrepos.AccountRepository
-	eventStore  domain.EventStore
-	dispatcher  *domain.EventDispatcher
-	logger      entities.Logger
-	behaviors   ResourceBehaviorRegistry
+	repo             repositories.ResourceRepository
+	typeRepo         repositories.ResourceTypeRepository
+	tripleRepo       repositories.TripleRepository
+	permRepo         repositories.ResourcePermissionRepository
+	accountRepo      authrepos.AccountRepository
+	eventStore       domain.EventStore
+	dispatcher       *domain.EventDispatcher
+	logger           entities.Logger
+	behaviors        ResourceBehaviorRegistry
+	behaviorMeta     BehaviorMetaRegistry
+	behaviorSettings repositories.BehaviorSettingsRepository
 }
 
 func (s *resourceService) behaviorFor(ctx context.Context, rt *entities.ResourceType) entities.ResourceBehavior {
@@ -54,13 +56,17 @@ func (s *resourceService) behaviorFor(ctx context.Context, rt *entities.Resource
 		return entities.DefaultBehavior{}
 	}
 
+	enabledSet := s.resolveEnabledBehaviors(ctx, rt.Slug())
+
 	var chain []entities.ResourceBehavior
 	visited := map[string]bool{rt.Slug(): true}
 	current := rt
 
 	for current != nil {
 		if b, ok := s.behaviors[current.Slug()]; ok {
-			chain = append(chain, b)
+			if s.isBehaviorEnabled(current.Slug(), enabledSet) {
+				chain = append(chain, b)
+			}
 		}
 		parentSlug := jsonld.SubClassOf(current.Context())
 		if parentSlug == "" || visited[parentSlug] {
@@ -86,28 +92,79 @@ func (s *resourceService) behaviorFor(ctx context.Context, rt *entities.Resource
 	}
 }
 
+// resolveEnabledBehaviors returns the set of enabled behavior slugs for the
+// given resource type in the caller's account context. Returns nil when no
+// account override exists (use preset defaults).
+func (s *resourceService) resolveEnabledBehaviors(ctx context.Context, typeSlug string) map[string]bool {
+	accountID := ""
+	if ident := auth.AgentFromCtx(ctx); ident != nil {
+		accountID = ident.ActiveAccountID
+	}
+	if accountID == "" {
+		return nil // no account context — use defaults
+	}
+	if s.behaviorSettings == nil {
+		return nil // no settings repo configured — use defaults
+	}
+
+	slugs, err := s.behaviorSettings.GetByAccountAndType(ctx, accountID, typeSlug)
+	if err != nil {
+		s.logger.Error(ctx, "failed to load behavior settings, using defaults",
+			"account", accountID, "type", typeSlug, "error", err)
+		return nil
+	}
+	if slugs == nil {
+		return nil // no override — use defaults
+	}
+
+	set := make(map[string]bool, len(slugs))
+	for _, slug := range slugs {
+		set[slug] = true
+	}
+	return set
+}
+
+// isBehaviorEnabled checks whether a behavior slug should be active.
+// When enabledSet is nil (no account override), falls back to preset defaults.
+// When no metadata exists for the slug, the behavior fires (backward compat).
+func (s *resourceService) isBehaviorEnabled(slug string, enabledSet map[string]bool) bool {
+	if enabledSet != nil {
+		return enabledSet[slug]
+	}
+	// No account override — use preset default.
+	meta, ok := s.behaviorMeta[slug]
+	if !ok {
+		return true // no metadata — legacy behavior, always fire
+	}
+	return meta.Default
+}
+
 func ProvideResourceService(params struct {
 	fx.In
-	Repo        repositories.ResourceRepository
-	TypeRepo    repositories.ResourceTypeRepository
-	TripleRepo  repositories.TripleRepository
-	PermRepo    repositories.ResourcePermissionRepository
-	AccountRepo authrepos.AccountRepository
-	EventStore  domain.EventStore
-	Dispatcher  *domain.EventDispatcher
-	Logger      entities.Logger
-	Behaviors   ResourceBehaviorRegistry
+	Repo             repositories.ResourceRepository
+	TypeRepo         repositories.ResourceTypeRepository
+	TripleRepo       repositories.TripleRepository
+	PermRepo         repositories.ResourcePermissionRepository
+	AccountRepo      authrepos.AccountRepository
+	EventStore       domain.EventStore
+	Dispatcher       *domain.EventDispatcher
+	Logger           entities.Logger
+	Behaviors        ResourceBehaviorRegistry
+	BehaviorMeta     BehaviorMetaRegistry
+	BehaviorSettings repositories.BehaviorSettingsRepository
 }) ResourceService {
 	return &resourceService{
-		repo:        params.Repo,
-		typeRepo:    params.TypeRepo,
-		tripleRepo:  params.TripleRepo,
-		permRepo:    params.PermRepo,
-		accountRepo: params.AccountRepo,
-		eventStore:  params.EventStore,
-		dispatcher:  params.Dispatcher,
-		logger:      params.Logger,
-		behaviors:   params.Behaviors,
+		repo:             params.Repo,
+		typeRepo:         params.TypeRepo,
+		tripleRepo:       params.TripleRepo,
+		permRepo:         params.PermRepo,
+		accountRepo:      params.AccountRepo,
+		eventStore:       params.EventStore,
+		dispatcher:       params.Dispatcher,
+		logger:           params.Logger,
+		behaviors:        params.Behaviors,
+		behaviorMeta:     params.BehaviorMeta,
+		behaviorSettings: params.BehaviorSettings,
 	}
 }
 

--- a/application/resource_type_presets_test.go
+++ b/application/resource_type_presets_test.go
@@ -23,6 +23,7 @@ import (
 
 	"weos/application"
 	"weos/application/presets"
+	"weos/domain/entities"
 )
 
 func testRegistry() *application.PresetRegistry {
@@ -370,5 +371,69 @@ func TestScreenManifest_WithSubFS(t *testing.T) {
 	}
 	if len(manifest["widget"]) != 1 {
 		t.Fatalf("expected 1 widget screen, got %v", manifest)
+	}
+}
+
+func TestPresets_CoreHasBehaviorMeta(t *testing.T) {
+	t.Parallel()
+	d, ok := testRegistry().Get("core")
+	if !ok {
+		t.Fatal("expected to find 'core' preset")
+	}
+	if d.BehaviorMeta == nil {
+		t.Fatal("core preset should have BehaviorMeta")
+	}
+	pm, ok := d.BehaviorMeta["person"]
+	if !ok {
+		t.Fatal("core preset should have 'person' behavior metadata")
+	}
+	if pm.Slug != "person" {
+		t.Fatalf("expected slug 'person', got %q", pm.Slug)
+	}
+	if pm.DisplayName == "" {
+		t.Fatal("person behavior meta should have a display name")
+	}
+	if !pm.Default {
+		t.Fatal("person behavior should be default-enabled")
+	}
+	if pm.Manageable {
+		t.Fatal("person behavior should not be user-manageable")
+	}
+}
+
+func TestPresets_BehaviorsMetaRegistry(t *testing.T) {
+	t.Parallel()
+	meta := testRegistry().BehaviorsMeta()
+	if _, ok := meta["person"]; !ok {
+		t.Fatal("merged behavior meta should include 'person'")
+	}
+	if _, ok := meta["organization"]; !ok {
+		t.Fatal("merged behavior meta should include 'organization'")
+	}
+}
+
+func TestPresets_BehaviorMetaClone(t *testing.T) {
+	t.Parallel()
+	d, ok := testRegistry().Get("core")
+	if !ok {
+		t.Fatal("expected to find 'core' preset")
+	}
+	// Mutating the clone should not affect the registry.
+	d.BehaviorMeta["person"] = entities.BehaviorMeta{Slug: "mutated"}
+	d2, _ := testRegistry().Get("core")
+	if d2.BehaviorMeta["person"].Slug == "mutated" {
+		t.Fatal("clone mutation leaked into registry")
+	}
+}
+
+func TestPresets_BehaviorMetaKeysMatchBehaviors(t *testing.T) {
+	t.Parallel()
+	for _, d := range testRegistry().List() {
+		for slug := range d.BehaviorMeta {
+			if _, ok := d.Behaviors[slug]; !ok {
+				t.Fatalf("preset %q has BehaviorMeta for %q but no matching Behaviors entry",
+					d.Name, slug)
+			}
+		}
 	}
 }

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -423,6 +423,9 @@ func (s *resourceTypeService) requireAdmin(ctx context.Context) error {
 	if ident.ActiveAccountID == "" {
 		return fmt.Errorf("account context required: %w", ErrForbidden)
 	}
+	if s.accountRepo == nil {
+		return fmt.Errorf("authorization not configured: %w", ErrForbidden)
+	}
 	role, err := s.accountRepo.FindMemberRole(
 		ctx, ident.ActiveAccountID, ident.AgentID)
 	if err != nil {

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -300,7 +300,10 @@ func (s *resourceTypeService) ListBehaviors(
 	// Verify the resource type exists.
 	rt, err := s.repo.FindBySlug(ctx, typeSlug)
 	if err != nil {
-		return nil, fmt.Errorf("resource type %q not found: %w", typeSlug, err)
+		if errors.Is(err, repositories.ErrNotFound) {
+			return nil, fmt.Errorf("resource type %q not found: %w", typeSlug, err)
+		}
+		return nil, fmt.Errorf("failed to load resource type %q: %w", typeSlug, err)
 	}
 
 	// Load account-level overrides (nil means use preset defaults).
@@ -326,7 +329,7 @@ func (s *resourceTypeService) ListBehaviors(
 		slug := current.Slug()
 		if meta, ok := s.behaviorMeta[slug]; ok {
 			enabled := meta.Default
-			if overrides != nil {
+			if meta.Manageable && overrides != nil {
 				enabled = slugInList(slug, overrides)
 			}
 			infos = append(infos, BehaviorInfo{
@@ -349,7 +352,13 @@ func (s *resourceTypeService) ListBehaviors(
 		visited[parentSlug] = true
 		parentRT, lookupErr := s.repo.FindBySlug(ctx, parentSlug)
 		if lookupErr != nil {
-			break
+			if errors.Is(lookupErr, repositories.ErrNotFound) {
+				break
+			}
+			return nil, fmt.Errorf(
+				"failed to load parent resource type %q for %q: %w",
+				parentSlug, current.Slug(), lookupErr,
+			)
 		}
 		current = parentRT
 	}

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -408,7 +408,7 @@ func (s *resourceTypeService) SetBehaviors(
 		accountID = ident.ActiveAccountID
 	}
 	if accountID == "" {
-		return fmt.Errorf("account context required to set behaviors")
+		return fmt.Errorf("account context required to set behaviors: %w", ErrForbidden)
 	}
 
 	return s.behaviorSettings.SaveByAccountAndType(
@@ -418,7 +418,7 @@ func (s *resourceTypeService) SetBehaviors(
 func (s *resourceTypeService) requireAdmin(ctx context.Context) error {
 	ident := auth.AgentFromCtx(ctx)
 	if ident == nil {
-		return nil
+		return fmt.Errorf("authentication required: %w", ErrForbidden)
 	}
 	if ident.ActiveAccountID == "" {
 		return fmt.Errorf("account context required: %w", ErrForbidden)

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -10,10 +10,18 @@ import (
 	"weos/pkg/jsonld"
 
 	"github.com/akeemphilbert/pericarp/pkg/auth"
+	authentities "github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
 	esapp "github.com/akeemphilbert/pericarp/pkg/eventsourcing/application"
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
 	"go.uber.org/fx"
 )
+
+// ErrValidation is returned for client-side validation failures (bad input).
+var ErrValidation = errors.New("validation error")
+
+// ErrForbidden is returned when the caller lacks required permissions.
+var ErrForbidden = errors.New("forbidden")
 
 var reservedSlugs = map[string]bool{
 	"persons":        true,
@@ -62,14 +70,13 @@ type ResourceTypeService interface {
 }
 
 type resourceTypeService struct {
-<<<<<<< HEAD
-	repo        repositories.ResourceTypeRepository
-	projMgr     repositories.ProjectionManager
-	eventStore  domain.EventStore
-	dispatcher  *domain.EventDispatcher
-	registry    *PresetRegistry
-	logger      entities.Logger
-	resourceSvc  ResourceService
+	repo             repositories.ResourceTypeRepository
+	projMgr          repositories.ProjectionManager
+	eventStore       domain.EventStore
+	dispatcher       *domain.EventDispatcher
+	registry         *PresetRegistry
+	logger           entities.Logger
+	resourceSvc      ResourceService
 	behaviors        ResourceBehaviorRegistry
 	behaviorMeta     BehaviorMetaRegistry
 	behaviorSettings repositories.BehaviorSettingsRepository
@@ -249,7 +256,6 @@ func (s *resourceTypeService) InstallPreset(
 	return result, nil
 }
 
-<<<<<<< HEAD
 // seedFixtures creates resources from the preset type's fixture data.
 // Fixtures require a schema on the resource type for validation.
 // Failures are logged but do not prevent the rest of the preset from installing.

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -395,7 +395,8 @@ func (s *resourceTypeService) SetBehaviors(
 		}
 		meta, ok := s.behaviorMeta[slug]
 		if !ok {
-			return fmt.Errorf("unknown behavior %q: %w", slug, ErrValidation)
+			return fmt.Errorf(
+				"behavior %q is not user-manageable: %w", slug, ErrValidation)
 		}
 		if !meta.Manageable {
 			return fmt.Errorf(

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -7,7 +7,9 @@ import (
 
 	"weos/domain/entities"
 	"weos/domain/repositories"
+	"weos/pkg/jsonld"
 
+	"github.com/akeemphilbert/pericarp/pkg/auth"
 	esapp "github.com/akeemphilbert/pericarp/pkg/eventsourcing/application"
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
 	"go.uber.org/fx"
@@ -35,6 +37,16 @@ func ReservedResourceTypeSlugs() map[string]bool {
 	return cp
 }
 
+// BehaviorInfo describes a behavior's state for a resource type within
+// the caller's account context.
+type BehaviorInfo struct {
+	Slug        string `json:"slug"`
+	DisplayName string `json:"displayName"`
+	Description string `json:"description"`
+	Enabled     bool   `json:"enabled"`
+	Manageable  bool   `json:"manageable"`
+}
+
 type ResourceTypeService interface {
 	Create(ctx context.Context, cmd CreateResourceTypeCommand) (*entities.ResourceType, error)
 	GetByID(ctx context.Context, id string) (*entities.ResourceType, error)
@@ -45,36 +57,51 @@ type ResourceTypeService interface {
 	Delete(ctx context.Context, cmd DeleteResourceTypeCommand) error
 	ListPresets() []PresetDefinition
 	InstallPreset(ctx context.Context, presetName string, update bool) (*InstallPresetResult, error)
+	ListBehaviors(ctx context.Context, typeSlug string) ([]BehaviorInfo, error)
+	SetBehaviors(ctx context.Context, typeSlug string, slugs []string) error
 }
 
 type resourceTypeService struct {
+<<<<<<< HEAD
 	repo        repositories.ResourceTypeRepository
 	projMgr     repositories.ProjectionManager
 	eventStore  domain.EventStore
 	dispatcher  *domain.EventDispatcher
 	registry    *PresetRegistry
 	logger      entities.Logger
-	resourceSvc ResourceService
+	resourceSvc  ResourceService
+	behaviors        ResourceBehaviorRegistry
+	behaviorMeta     BehaviorMetaRegistry
+	behaviorSettings repositories.BehaviorSettingsRepository
+	accountRepo      authrepos.AccountRepository
 }
 
 func ProvideResourceTypeService(params struct {
 	fx.In
-	Repo        repositories.ResourceTypeRepository
-	ProjMgr     repositories.ProjectionManager
-	EventStore  domain.EventStore
-	Dispatcher  *domain.EventDispatcher
-	Registry    *PresetRegistry
-	Logger      entities.Logger
-	ResourceSvc ResourceService
+	Repo             repositories.ResourceTypeRepository
+	ProjMgr          repositories.ProjectionManager
+	EventStore       domain.EventStore
+	Dispatcher       *domain.EventDispatcher
+	Registry         *PresetRegistry
+	Logger           entities.Logger
+	ResourceSvc      ResourceService
+	Behaviors        ResourceBehaviorRegistry
+	BehaviorMeta     BehaviorMetaRegistry
+	BehaviorSettings repositories.BehaviorSettingsRepository
+	AccountRepo      authrepos.AccountRepository
 }) ResourceTypeService {
 	return &resourceTypeService{
-		repo:        params.Repo,
-		projMgr:     params.ProjMgr,
-		eventStore:  params.EventStore,
-		dispatcher:  params.Dispatcher,
-		registry:    params.Registry,
-		logger:      params.Logger,
-		resourceSvc: params.ResourceSvc,
+		repo:             params.Repo,
+		projMgr:          params.ProjMgr,
+		eventStore:       params.EventStore,
+		dispatcher:       params.Dispatcher,
+		registry:         params.Registry,
+		logger:           params.Logger,
+		resourceSvc:      params.ResourceSvc,
+		behaviors:        params.Behaviors,
+		behaviorMeta:     params.BehaviorMeta,
+		behaviorSettings: params.BehaviorSettings,
+		accountRepo:      params.AccountRepo,
 	}
 }
 
@@ -222,6 +249,7 @@ func (s *resourceTypeService) InstallPreset(
 	return result, nil
 }
 
+<<<<<<< HEAD
 // seedFixtures creates resources from the preset type's fixture data.
 // Fixtures require a schema on the resource type for validation.
 // Failures are logged but do not prevent the rest of the preset from installing.
@@ -258,4 +286,200 @@ func (s *resourceTypeService) seedFixtures(
 	if count > 0 {
 		s.logger.Info(ctx, "seeded fixture data", "slug", pt.Slug, "count", count)
 	}
+}
+
+func (s *resourceTypeService) ListBehaviors(
+	ctx context.Context, typeSlug string,
+) ([]BehaviorInfo, error) {
+	// Verify the resource type exists.
+	rt, err := s.repo.FindBySlug(ctx, typeSlug)
+	if err != nil {
+		return nil, fmt.Errorf("resource type %q not found: %w", typeSlug, err)
+	}
+
+	// Load account-level overrides (nil means use preset defaults).
+	var overrides []string
+	accountID := ""
+	if ident := auth.AgentFromCtx(ctx); ident != nil {
+		accountID = ident.ActiveAccountID
+	}
+	if accountID != "" && s.behaviorSettings != nil {
+		overrides, err = s.behaviorSettings.GetByAccountAndType(
+			ctx, accountID, typeSlug)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load behavior settings: %w", err)
+		}
+	}
+
+	// Walk the inheritance chain to collect all behaviors that apply.
+	var infos []BehaviorInfo
+	visited := map[string]bool{rt.Slug(): true}
+	current := rt
+
+	for current != nil {
+		slug := current.Slug()
+		if meta, ok := s.behaviorMeta[slug]; ok {
+			enabled := meta.Default
+			if overrides != nil {
+				enabled = slugInList(slug, overrides)
+			}
+			infos = append(infos, BehaviorInfo{
+				Slug:        slug,
+				DisplayName: meta.DisplayName,
+				Description: meta.Description,
+				Enabled:     enabled,
+				Manageable:  meta.Manageable,
+			})
+		} else if _, hasBehavior := s.behaviors[slug]; hasBehavior {
+			infos = append(infos, BehaviorInfo{
+				Slug:    slug,
+				Enabled: true,
+			})
+		}
+		parentSlug := jsonld.SubClassOf(current.Context())
+		if parentSlug == "" || visited[parentSlug] {
+			break
+		}
+		visited[parentSlug] = true
+		parentRT, lookupErr := s.repo.FindBySlug(ctx, parentSlug)
+		if lookupErr != nil {
+			break
+		}
+		current = parentRT
+	}
+
+	return infos, nil
+}
+
+func (s *resourceTypeService) SetBehaviors(
+	ctx context.Context, typeSlug string, slugs []string,
+) error {
+	if err := s.requireAdmin(ctx); err != nil {
+		return err
+	}
+
+	if s.behaviorSettings == nil {
+		return fmt.Errorf("behavior settings not available")
+	}
+
+	applicable, err := s.applicableBehaviorSlugs(ctx, typeSlug)
+	if err != nil {
+		return err
+	}
+
+	if slugs == nil {
+		slugs = []string{}
+	}
+	slugs = dedup(slugs)
+
+	for _, slug := range slugs {
+		if !applicable[slug] {
+			return fmt.Errorf(
+				"behavior %q does not apply to type %q: %w",
+				slug, typeSlug, ErrValidation)
+		}
+		meta, ok := s.behaviorMeta[slug]
+		if !ok {
+			return fmt.Errorf("unknown behavior %q: %w", slug, ErrValidation)
+		}
+		if !meta.Manageable {
+			return fmt.Errorf(
+				"behavior %q is not user-manageable: %w", slug, ErrValidation)
+		}
+	}
+
+	accountID := ""
+	if ident := auth.AgentFromCtx(ctx); ident != nil {
+		accountID = ident.ActiveAccountID
+	}
+	if accountID == "" {
+		return fmt.Errorf("account context required to set behaviors")
+	}
+
+	return s.behaviorSettings.SaveByAccountAndType(
+		ctx, accountID, typeSlug, slugs)
+}
+
+func (s *resourceTypeService) requireAdmin(ctx context.Context) error {
+	ident := auth.AgentFromCtx(ctx)
+	if ident == nil {
+		return nil
+	}
+	if ident.ActiveAccountID == "" {
+		return fmt.Errorf("account context required: %w", ErrForbidden)
+	}
+	role, err := s.accountRepo.FindMemberRole(
+		ctx, ident.ActiveAccountID, ident.AgentID)
+	if err != nil {
+		return fmt.Errorf("failed to check admin status: %w", err)
+	}
+	if role != authentities.RoleAdmin && role != authentities.RoleOwner {
+		return fmt.Errorf("admin role required: %w", ErrForbidden)
+	}
+	return nil
+}
+
+func (s *resourceTypeService) applicableBehaviorSlugs(
+	ctx context.Context, typeSlug string,
+) (map[string]bool, error) {
+	rt, err := s.repo.FindBySlug(ctx, typeSlug)
+	if err != nil {
+		if errors.Is(err, repositories.ErrNotFound) {
+			return nil, fmt.Errorf(
+				"resource type %q not found: %w", typeSlug, err)
+		}
+		return nil, fmt.Errorf(
+			"failed to look up resource type %q: %w", typeSlug, err)
+	}
+
+	allowed := make(map[string]bool)
+	visited := map[string]bool{rt.Slug(): true}
+	current := rt
+
+	for current != nil {
+		slug := current.Slug()
+		if _, ok := s.behaviorMeta[slug]; ok {
+			allowed[slug] = true
+		} else if _, ok := s.behaviors[slug]; ok {
+			allowed[slug] = true
+		}
+		parentSlug := jsonld.SubClassOf(current.Context())
+		if parentSlug == "" || visited[parentSlug] {
+			break
+		}
+		visited[parentSlug] = true
+		parentRT, lookupErr := s.repo.FindBySlug(ctx, parentSlug)
+		if lookupErr != nil {
+			if errors.Is(lookupErr, repositories.ErrNotFound) {
+				break
+			}
+			return nil, fmt.Errorf(
+				"failed to look up parent type %q for %q: %w",
+				parentSlug, typeSlug, lookupErr)
+		}
+		current = parentRT
+	}
+
+	return allowed, nil
+}
+
+func slugInList(slug string, list []string) bool {
+	for _, s := range list {
+		if s == slug {
+			return true
+		}
+	}
+	return false
+}
+
+func dedup(slugs []string) []string {
+	seen := make(map[string]bool, len(slugs))
+	out := make([]string, 0, len(slugs))
+	for _, s := range slugs {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	return out
 }

--- a/application/testing.go
+++ b/application/testing.go
@@ -55,13 +55,46 @@ func NewResourceServiceForTest(
 		behaviors = make(ResourceBehaviorRegistry)
 	}
 	return &resourceService{
-		repo:       repo,
-		typeRepo:   typeRepo,
-		tripleRepo: tripleRepo,
-		eventStore: eventStore,
-		dispatcher: dispatcher,
-		logger:     logger,
-		behaviors:  behaviors,
+		repo:         repo,
+		typeRepo:     typeRepo,
+		tripleRepo:   tripleRepo,
+		eventStore:   eventStore,
+		dispatcher:   dispatcher,
+		logger:       logger,
+		behaviors:    behaviors,
+		behaviorMeta: make(BehaviorMetaRegistry),
+	}
+}
+
+// NewResourceServiceForTestWithSettings creates a ResourceService with
+// behavior settings support for tests that need account-scoped behavior config.
+func NewResourceServiceForTestWithSettings(
+	repo repositories.ResourceRepository,
+	typeRepo repositories.ResourceTypeRepository,
+	tripleRepo repositories.TripleRepository,
+	eventStore domain.EventStore,
+	dispatcher *domain.EventDispatcher,
+	logger entities.Logger,
+	behaviors ResourceBehaviorRegistry,
+	behaviorMeta BehaviorMetaRegistry,
+	behaviorSettings repositories.BehaviorSettingsRepository,
+) ResourceService {
+	if behaviors == nil {
+		behaviors = make(ResourceBehaviorRegistry)
+	}
+	if behaviorMeta == nil {
+		behaviorMeta = make(BehaviorMetaRegistry)
+	}
+	return &resourceService{
+		repo:             repo,
+		typeRepo:         typeRepo,
+		tripleRepo:       tripleRepo,
+		eventStore:       eventStore,
+		dispatcher:       dispatcher,
+		logger:           logger,
+		behaviors:        behaviors,
+		behaviorMeta:     behaviorMeta,
+		behaviorSettings: behaviorSettings,
 	}
 }
 

--- a/domain/entities/resource_behavior.go
+++ b/domain/entities/resource_behavior.go
@@ -5,6 +5,18 @@ import (
 	"encoding/json"
 )
 
+// BehaviorMeta describes a behavior for display and configuration purposes.
+// Presets declare metadata alongside their ResourceBehavior implementations
+// so that APIs can expose which behaviors exist, their defaults, and whether
+// users can toggle them per account.
+type BehaviorMeta struct {
+	Slug        string // matches the key in PresetDefinition.Behaviors
+	DisplayName string // human-readable name shown in UI
+	Description string // short explanation of what this behavior does
+	Default     bool   // enabled when no account-level override exists
+	Manageable  bool   // if true, account admins can toggle on/off
+}
+
 // ResourceBehavior allows concrete types to specialize business logic for
 // specific resource type slugs. If no behavior is registered for a slug,
 // DefaultBehavior (a no-op) is used — mirroring the frontend pattern where

--- a/domain/repositories/behavior_settings_repository.go
+++ b/domain/repositories/behavior_settings_repository.go
@@ -1,0 +1,31 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package repositories
+
+import "context"
+
+// BehaviorSettingsRepository persists per-account behavior configuration
+// for resource types. A nil slice from GetByAccountAndType signals that
+// no account-level override exists (use preset defaults).
+type BehaviorSettingsRepository interface {
+	// GetByAccountAndType returns the enabled behavior slugs for a resource
+	// type within an account. Returns (nil, nil) when no override exists.
+	GetByAccountAndType(ctx context.Context, accountID, typeSlug string) ([]string, error)
+
+	// SaveByAccountAndType upserts the enabled behavior slugs for a resource
+	// type within an account.
+	SaveByAccountAndType(ctx context.Context, accountID, typeSlug string, enabledSlugs []string) error
+}

--- a/infrastructure/database/gorm/behavior_settings_repository.go
+++ b/infrastructure/database/gorm/behavior_settings_repository.go
@@ -49,13 +49,12 @@ func (r *BehaviorSettingsRepository) GetByAccountAndType(
 		return nil, err
 	}
 	var slugs []string
-	if row.EnabledBehaviors != "" {
-		if err := json.Unmarshal([]byte(row.EnabledBehaviors), &slugs); err != nil {
-			return nil, fmt.Errorf(
-				"corrupt behavior settings for account %q type %q: %w",
-				accountID, typeSlug, err)
-		}
+	if err := json.Unmarshal([]byte(row.EnabledBehaviors), &slugs); err != nil {
+		return nil, fmt.Errorf(
+			"corrupt behavior settings for account %q type %q: %w",
+			accountID, typeSlug, err)
 	}
+	// Row exists — return the parsed list (may be empty, meaning all disabled).
 	return slugs, nil
 }
 

--- a/infrastructure/database/gorm/behavior_settings_repository.go
+++ b/infrastructure/database/gorm/behavior_settings_repository.go
@@ -1,0 +1,89 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package gorm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"weos/domain/repositories"
+	"weos/infrastructure/models"
+
+	"gorm.io/gorm"
+)
+
+type BehaviorSettingsRepository struct {
+	db *gorm.DB
+}
+
+func ProvideBehaviorSettingsRepository(db *gorm.DB) repositories.BehaviorSettingsRepository {
+	return &BehaviorSettingsRepository{db: db}
+}
+
+func (r *BehaviorSettingsRepository) GetByAccountAndType(
+	ctx context.Context, accountID, typeSlug string,
+) ([]string, error) {
+	var row models.BehaviorSettings
+	err := r.db.WithContext(ctx).
+		Where("account_id = ? AND type_slug = ?", accountID, typeSlug).
+		First(&row).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil // no override — caller should use preset defaults
+	}
+	if err != nil {
+		return nil, err
+	}
+	var slugs []string
+	if row.EnabledBehaviors != "" {
+		if err := json.Unmarshal([]byte(row.EnabledBehaviors), &slugs); err != nil {
+			return nil, fmt.Errorf(
+				"corrupt behavior settings for account %q type %q: %w",
+				accountID, typeSlug, err)
+		}
+	}
+	return slugs, nil
+}
+
+func (r *BehaviorSettingsRepository) SaveByAccountAndType(
+	ctx context.Context, accountID, typeSlug string, enabledSlugs []string,
+) error {
+	data, err := json.Marshal(enabledSlugs)
+	if err != nil {
+		return err
+	}
+
+	var existing models.BehaviorSettings
+	err = r.db.WithContext(ctx).
+		Where("account_id = ? AND type_slug = ?", accountID, typeSlug).
+		First(&existing).Error
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
+
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		row := models.BehaviorSettings{
+			AccountID:        accountID,
+			TypeSlug:         typeSlug,
+			EnabledBehaviors: string(data),
+		}
+		return r.db.WithContext(ctx).Create(&row).Error
+	}
+
+	existing.EnabledBehaviors = string(data)
+	return r.db.WithContext(ctx).Save(&existing).Error
+}

--- a/infrastructure/database/gorm/behavior_settings_repository.go
+++ b/infrastructure/database/gorm/behavior_settings_repository.go
@@ -25,6 +25,7 @@ import (
 	"weos/infrastructure/models"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type BehaviorSettingsRepository struct {
@@ -61,28 +62,21 @@ func (r *BehaviorSettingsRepository) GetByAccountAndType(
 func (r *BehaviorSettingsRepository) SaveByAccountAndType(
 	ctx context.Context, accountID, typeSlug string, enabledSlugs []string,
 ) error {
+	if enabledSlugs == nil {
+		enabledSlugs = []string{}
+	}
 	data, err := json.Marshal(enabledSlugs)
 	if err != nil {
 		return err
 	}
 
-	var existing models.BehaviorSettings
-	err = r.db.WithContext(ctx).
-		Where("account_id = ? AND type_slug = ?", accountID, typeSlug).
-		First(&existing).Error
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		return err
+	row := models.BehaviorSettings{
+		AccountID:        accountID,
+		TypeSlug:         typeSlug,
+		EnabledBehaviors: string(data),
 	}
-
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		row := models.BehaviorSettings{
-			AccountID:        accountID,
-			TypeSlug:         typeSlug,
-			EnabledBehaviors: string(data),
-		}
-		return r.db.WithContext(ctx).Create(&row).Error
-	}
-
-	existing.EnabledBehaviors = string(data)
-	return r.db.WithContext(ctx).Save(&existing).Error
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "account_id"}, {Name: "type_slug"}},
+		DoUpdates: clause.AssignmentColumns([]string{"enabled_behaviors", "updated_at"}),
+	}).Create(&row).Error
 }

--- a/infrastructure/database/gorm/provider.go
+++ b/infrastructure/database/gorm/provider.go
@@ -80,6 +80,7 @@ func ProvideGormDB(params struct {
 		&weosmodels.RoleResourceAccess{},
 		&weosmodels.Triple{},
 		&weosmodels.ResourcePermission{},
+		&weosmodels.BehaviorSettings{},
 	}
 	if err := db.AutoMigrate(models...); err != nil {
 		return GormDBResult{}, fmt.Errorf("failed to run auto migrate: %w", err)

--- a/infrastructure/models/behavior_settings.go
+++ b/infrastructure/models/behavior_settings.go
@@ -23,7 +23,7 @@ type BehaviorSettings struct {
 	ID               uint   `gorm:"primaryKey;autoIncrement"`
 	AccountID        string `gorm:"type:varchar(255);not null;uniqueIndex:idx_behavior_acct_type"`
 	TypeSlug         string `gorm:"type:varchar(255);not null;uniqueIndex:idx_behavior_acct_type"`
-	EnabledBehaviors string `gorm:"type:text"` // JSON array of behavior slugs
+	EnabledBehaviors string `gorm:"type:text;not null;default:'[]'"` // JSON array of behavior slugs
 	CreatedAt        time.Time
 	UpdatedAt        time.Time
 }

--- a/infrastructure/models/behavior_settings.go
+++ b/infrastructure/models/behavior_settings.go
@@ -1,0 +1,33 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package models
+
+import "time"
+
+// BehaviorSettings stores which behaviors are enabled for a resource type
+// within a specific account. When no row exists, the preset defaults apply.
+type BehaviorSettings struct {
+	ID               uint   `gorm:"primaryKey;autoIncrement"`
+	AccountID        string `gorm:"type:varchar(255);not null;uniqueIndex:idx_behavior_acct_type"`
+	TypeSlug         string `gorm:"type:varchar(255);not null;uniqueIndex:idx_behavior_acct_type"`
+	EnabledBehaviors string `gorm:"type:text"` // JSON array of behavior slugs
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+}
+
+func (BehaviorSettings) TableName() string {
+	return "behavior_settings"
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -201,8 +201,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 	presetHandler := handlers.NewResourceTypePresetHandler(resourceTypeService)
 	protected.GET("/resource-types/presets", presetHandler.List)
 	protected.POST("/resource-types/presets/:name", presetHandler.Install)
-	protected.GET("/resource-types/:slug/behaviors", presetHandler.ListBehaviors)
-	protected.PUT("/resource-types/:slug/behaviors", presetHandler.SetBehaviors)
+	protected.GET("/resource-types/:typeSlug/behaviors", presetHandler.ListBehaviors)
+	protected.PUT("/resource-types/:typeSlug/behaviors", presetHandler.SetBehaviors)
 
 	screenHandler := handlers.NewPresetScreenHandler(registry)
 	protected.GET("/resource-types/presets/:name/screens/*", screenHandler.Serve)

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -201,6 +201,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 	presetHandler := handlers.NewResourceTypePresetHandler(resourceTypeService)
 	protected.GET("/resource-types/presets", presetHandler.List)
 	protected.POST("/resource-types/presets/:name", presetHandler.Install)
+	protected.GET("/resource-types/:slug/behaviors", presetHandler.ListBehaviors)
+	protected.PUT("/resource-types/:slug/behaviors", presetHandler.SetBehaviors)
 
 	screenHandler := handlers.NewPresetScreenHandler(registry)
 	protected.GET("/resource-types/presets/:name/screens/*", screenHandler.Serve)

--- a/internal/mcp/handler_test.go
+++ b/internal/mcp/handler_test.go
@@ -172,7 +172,7 @@ func TestNewMCPServer_AllServices(t *testing.T) {
 
 	names := toolNames(t, server)
 
-	// All 4 service groups should be registered (22 tools total).
+	// All 4 service groups should be registered (24 tools total).
 	expectedPrefixes := []string{"person_", "organization_", "resource_type_", "resource_"}
 	for _, prefix := range expectedPrefixes {
 		found := false

--- a/internal/mcp/handler_test.go
+++ b/internal/mcp/handler_test.go
@@ -58,6 +58,16 @@ func (s *stubResourceTypeService) InstallPreset(
 	return nil, nil
 }
 
+func (s *stubResourceTypeService) ListBehaviors(
+	_ context.Context, _ string,
+) ([]application.BehaviorInfo, error) {
+	return nil, nil
+}
+
+func (s *stubResourceTypeService) SetBehaviors(_ context.Context, _ string, _ []string) error {
+	return nil
+}
+
 // stubResourceService is a minimal stub satisfying application.ResourceService.
 type stubResourceService struct{}
 
@@ -177,8 +187,8 @@ func TestNewMCPServer_AllServices(t *testing.T) {
 		}
 	}
 
-	if len(names) != 22 {
-		t.Errorf("expected 22 tools, got %d: %v", len(names), names)
+	if len(names) != 24 {
+		t.Errorf("expected 24 tools, got %d: %v", len(names), names)
 	}
 }
 

--- a/internal/mcp/resource_type_preset_tools.go
+++ b/internal/mcp/resource_type_preset_tools.go
@@ -113,7 +113,7 @@ func registerResourceTypePresetTools(server *mcp.Server, svc application.Resourc
 }
 
 type BehaviorListInput struct {
-	TypeSlug string `json:"typeSlug" jsonschema:"resource type slug to list behaviors for"`
+	TypeSlug string `json:"type_slug" jsonschema:"resource type slug to list behaviors for"`
 }
 
 type BehaviorListOutput struct {
@@ -121,7 +121,7 @@ type BehaviorListOutput struct {
 }
 
 type BehaviorSetInput struct {
-	TypeSlug string   `json:"typeSlug" jsonschema:"resource type slug"`
+	TypeSlug string   `json:"type_slug" jsonschema:"resource type slug"`
 	Slugs    []string `json:"slugs" jsonschema:"behavior slugs to enable"`
 }
 

--- a/internal/mcp/resource_type_preset_tools.go
+++ b/internal/mcp/resource_type_preset_tools.go
@@ -16,9 +16,18 @@ type PresetListOutput struct {
 }
 
 type PresetSummary struct {
-	Name        string   `json:"name"`
-	Description string   `json:"description"`
-	Types       []string `json:"types"`
+	Name        string               `json:"name"`
+	Description string               `json:"description"`
+	Types       []string             `json:"types"`
+	Behaviors   []PresetBehaviorMeta `json:"behaviors,omitempty"`
+}
+
+type PresetBehaviorMeta struct {
+	Slug        string `json:"slug"`
+	DisplayName string `json:"displayName"`
+	Description string `json:"description"`
+	Default     bool   `json:"default"`
+	Manageable  bool   `json:"manageable"`
 }
 
 type PresetInstallInput struct {
@@ -47,10 +56,21 @@ func registerResourceTypePresetTools(server *mcp.Server, svc application.Resourc
 			for i, t := range d.Types {
 				slugs[i] = t.Slug
 			}
+			var behaviors []PresetBehaviorMeta
+			for _, m := range d.BehaviorMeta {
+				behaviors = append(behaviors, PresetBehaviorMeta{
+					Slug:        m.Slug,
+					DisplayName: m.DisplayName,
+					Description: m.Description,
+					Default:     m.Default,
+					Manageable:  m.Manageable,
+				})
+			}
 			out.Presets = append(out.Presets, PresetSummary{
 				Name:        d.Name,
 				Description: d.Description,
 				Types:       slugs,
+				Behaviors:   behaviors,
 			})
 		}
 		return nil, out, nil
@@ -83,5 +103,51 @@ func registerResourceTypePresetTools(server *mcp.Server, svc application.Resourc
 			Skipped: result.Skipped,
 			Seeded:  result.Seeded,
 		}, nil
+	})
+
+	registerBehaviorTools(server, svc)
+}
+
+type BehaviorListInput struct {
+	TypeSlug string `json:"typeSlug" jsonschema:"resource type slug to list behaviors for"`
+}
+
+type BehaviorListOutput struct {
+	Behaviors []application.BehaviorInfo `json:"behaviors"`
+}
+
+type BehaviorSetInput struct {
+	TypeSlug string   `json:"typeSlug" jsonschema:"resource type slug"`
+	Slugs    []string `json:"slugs" jsonschema:"behavior slugs to enable"`
+}
+
+type BehaviorSetOutput struct {
+	Success bool `json:"success"`
+}
+
+func registerBehaviorTools(server *mcp.Server, svc application.ResourceTypeService) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "resource_type_behavior_list",
+		Description: "List available behaviors for a resource type with their enabled state in the current account.",
+	}, func(
+		ctx context.Context, _ *mcp.CallToolRequest, input BehaviorListInput,
+	) (*mcp.CallToolResult, BehaviorListOutput, error) {
+		behaviors, err := svc.ListBehaviors(ctx, input.TypeSlug)
+		if err != nil {
+			return nil, BehaviorListOutput{}, err
+		}
+		return nil, BehaviorListOutput{Behaviors: behaviors}, nil
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "resource_type_behavior_set",
+		Description: "Set which manageable behaviors are enabled for a resource type in the current account.",
+	}, func(
+		ctx context.Context, _ *mcp.CallToolRequest, input BehaviorSetInput,
+	) (*mcp.CallToolResult, BehaviorSetOutput, error) {
+		if err := svc.SetBehaviors(ctx, input.TypeSlug, input.Slugs); err != nil {
+			return nil, BehaviorSetOutput{}, err
+		}
+		return nil, BehaviorSetOutput{Success: true}, nil
 	})
 }

--- a/internal/mcp/resource_type_preset_tools.go
+++ b/internal/mcp/resource_type_preset_tools.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"weos/application"
 
@@ -66,6 +67,9 @@ func registerResourceTypePresetTools(server *mcp.Server, svc application.Resourc
 					Manageable:  m.Manageable,
 				})
 			}
+			sort.Slice(behaviors, func(i, j int) bool {
+				return behaviors[i].Slug < behaviors[j].Slug
+			})
 			out.Presets = append(out.Presets, PresetSummary{
 				Name:        d.Name,
 				Description: d.Description,
@@ -145,7 +149,11 @@ func registerBehaviorTools(server *mcp.Server, svc application.ResourceTypeServi
 	}, func(
 		ctx context.Context, _ *mcp.CallToolRequest, input BehaviorSetInput,
 	) (*mcp.CallToolResult, BehaviorSetOutput, error) {
-		if err := svc.SetBehaviors(ctx, input.TypeSlug, input.Slugs); err != nil {
+		slugs := input.Slugs
+		if slugs == nil {
+			slugs = []string{}
+		}
+		if err := svc.SetBehaviors(ctx, input.TypeSlug, slugs); err != nil {
 			return nil, BehaviorSetOutput{}, err
 		}
 		return nil, BehaviorSetOutput{Success: true}, nil


### PR DESCRIPTION
- [x] Fix `requireAdmin` to return `ErrForbidden`-wrapped error when no identity exists in context
- [x] Fix `SetBehaviors` "account context required" error to wrap with `ErrForbidden`
- [x] Use `json:"type_slug"` (snake_case) in `BehaviorListInput` and `BehaviorSetInput` for consistency with other MCP tool inputs
- [x] Improve error message when a behavior slug exists in the inheritance chain but has no metadata: now says "not user-manageable" instead of "unknown behavior"
- [x] All existing behavior and MCP tests pass