### PR TITLE
Add standard message envelope to API responses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,22 @@ logger.Info(ctx, "user created", "userID", user.ID, "email", email)
 1. Create handler in `api/handlers/`
 2. Inject service via constructor
 3. Register routes under `/api` group in `internal/cli/serve.go`
+4. Use the response envelope helpers for all JSON responses (see below)
+
+### API Response Envelope
+
+All API responses (except `/health` and static files) use a standard envelope:
+
+**Success:** `respond(c, status, data)` → `{"data": <data>, "messages": [...]}`
+**Paginated:** `respondPaginated(c, status, data, cursor, hasMore)` → `{"data": [...], "cursor": "...", "has_more": bool}`
+**Error:** `respondError(c, status, msg)` → `{"error": "msg", "messages": [{"type":"error","text":"msg"}]}`
+**Raw JSON:** `respondRaw(c, status, rawBytes)` — for pre-serialized JSON (e.g., JSON-LD)
+
+The `messages` key is omitted when empty. Services can surface non-fatal messages via context helpers:
+```go
+entities.AddMessage(ctx, entities.Message{Type: "warning", Text: "schema missing"})
+```
+Messages are accumulated per-request by the `Messages()` middleware and automatically included in responses.
 
 ### Adding a New CLI Command
 1. Create command file in `internal/cli/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,10 +234,10 @@ All API responses (except `/health` and static files) use a standard envelope:
 
 **Success:** `respond(c, status, data)` → `{"data": <data>, "messages": [...]}`
 **Paginated:** `respondPaginated(c, status, data, cursor, hasMore)` → `{"data": [...], "cursor": "...", "has_more": bool}`
-**Error:** `respondError(c, status, msg)` → `{"error": "msg", "messages": [{"type":"error","text":"msg"}]}`
+**Error:** `respondError(c, status, msg)` → `{"error": "msg"}`
 **Raw JSON:** `respondRaw(c, status, rawBytes)` — for pre-serialized JSON (e.g., JSON-LD)
 
-The `messages` key is omitted when empty. Services can surface non-fatal messages via context helpers:
+The `messages` key is omitted when empty. `respondError` does not add the error itself to `messages`; that array only contains messages accumulated via context helpers. Services can surface non-fatal messages via context helpers:
 ```go
 entities.AddMessage(ctx, entities.Message{Type: "warning", Text: "schema missing"})
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,7 +233,7 @@ logger.Info(ctx, "user created", "userID", user.ID, "email", email)
 All API responses (except `/health` and static files) use a standard envelope:
 
 **Success:** `respond(c, status, data)` → `{"data": <data>, "messages": [...]}`
-**Paginated:** `respondPaginated(c, status, data, cursor, hasMore)` → `{"data": [...], "cursor": "...", "has_more": bool}`
+**Paginated:** `respondPaginated(c, status, data, cursor, hasMore)` → `{"data": [...], "cursor": "...", "has_more": bool, "messages": [...]}`
 **Error:** `respondError(c, status, msg)` → `{"error": "msg"}`
 **Raw JSON:** `respondRaw(c, status, rawBytes)` — for pre-serialized JSON (e.g., JSON-LD)
 

--- a/api/handlers/dev_auth_handler.go
+++ b/api/handlers/dev_auth_handler.go
@@ -34,11 +34,11 @@ func DevMe(
 			}
 			creds, err := credRepo.FindByEmail(ctx, email)
 			if err != nil || len(creds) == 0 {
-				return c.JSON(http.StatusUnauthorized, map[string]string{"error": "dev user not found"})
+				return respondError(c, http.StatusUnauthorized, "dev user not found")
 			}
 			agent, err := agentRepo.FindByID(ctx, creds[0].AgentID())
 			if err != nil {
-				return c.JSON(http.StatusUnauthorized, map[string]string{"error": "agent not found"})
+				return respondError(c, http.StatusUnauthorized, "agent not found")
 			}
 			accountID := ""
 			accounts, _ := accountRepo.FindByMember(ctx, agent.GetID())
@@ -49,7 +49,7 @@ func DevMe(
 			if accountID != "" {
 				role, _ = accountRepo.FindMemberRole(ctx, accountID, agent.GetID())
 			}
-			return c.JSON(http.StatusOK, map[string]any{
+			return respond(c, http.StatusOK, map[string]any{
 				"id":    agent.GetID(),
 				"name":  agent.Name(),
 				"email": email,
@@ -60,7 +60,7 @@ func DevMe(
 		// Identity already in context (from SoftAuth)
 		agent, err := agentRepo.FindByID(ctx, identity.AgentID)
 		if err != nil {
-			return c.JSON(http.StatusUnauthorized, map[string]string{"error": "agent not found"})
+			return respondError(c, http.StatusUnauthorized, "agent not found")
 		}
 		role := ""
 		if identity.ActiveAccountID != "" {
@@ -71,7 +71,7 @@ func DevMe(
 		if len(creds) > 0 {
 			email = creds[0].Email()
 		}
-		return c.JSON(http.StatusOK, map[string]any{
+		return respond(c, http.StatusOK, map[string]any{
 			"id":    agent.GetID(),
 			"name":  agent.Name(),
 			"email": email,

--- a/api/handlers/export_test.go
+++ b/api/handlers/export_test.go
@@ -1,0 +1,31 @@
+package handlers
+
+import (
+	"encoding/json"
+
+	"github.com/labstack/echo/v4"
+)
+
+// Test exports for package-private response helpers.
+
+func ExportRespond(c echo.Context, status int, data any) error {
+	return respond(c, status, data)
+}
+
+func ExportRespondRaw(c echo.Context, status int, raw json.RawMessage) error {
+	return respondRaw(c, status, raw)
+}
+
+func ExportRespondPaginated(
+	c echo.Context, status int, data any, cursor string, hasMore bool,
+) error {
+	return respondPaginated(c, status, data, cursor, hasMore)
+}
+
+func ExportRespondError(c echo.Context, status int, msg string) error {
+	return respondError(c, status, msg)
+}
+
+func ExportRespondForbidden(c echo.Context) error {
+	return respondForbidden(c)
+}

--- a/api/handlers/impersonation_handler.go
+++ b/api/handlers/impersonation_handler.go
@@ -65,16 +65,16 @@ type startImpersonationRequest struct {
 func (h *ImpersonationHandler) Start(c echo.Context) error {
 	var req startImpersonationRequest
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request"})
+		return respondError(c, http.StatusBadRequest, "invalid request")
 	}
 	if req.AgentID == "" {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "agent_id is required"})
+		return respondError(c, http.StatusBadRequest, "agent_id is required")
 	}
 
 	ctx := c.Request().Context()
 	identity := auth.AgentFromCtx(ctx)
 	if identity == nil {
-		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "not authenticated"})
+		return respondError(c, http.StatusUnauthorized, "not authenticated")
 	}
 
 	// The impersonation middleware may have already swapped the identity.
@@ -91,7 +91,7 @@ func (h *ImpersonationHandler) Start(c echo.Context) error {
 	isAdmin, adminErr := apimw.IsAdmin(ctx, h.accountRepo)
 	if adminErr != nil {
 		h.logger.Error(ctx, "failed to check admin status", "error", adminErr)
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "authorization check failed"})
+		return respondError(c, http.StatusInternalServerError, "authorization check failed")
 	}
 	if !isAdmin {
 		// Re-check with the real admin identity if impersonation is active.
@@ -105,26 +105,26 @@ func (h *ImpersonationHandler) Start(c echo.Context) error {
 			isAdmin, adminErr = apimw.IsAdmin(adminCtx, h.accountRepo)
 			if adminErr != nil {
 				h.logger.Error(ctx, "failed to re-check admin status", "error", adminErr)
-				return c.JSON(http.StatusInternalServerError, map[string]string{"error": "authorization check failed"})
+				return respondError(c, http.StatusInternalServerError, "authorization check failed")
 			}
 			if !isAdmin {
-				return c.JSON(http.StatusForbidden, map[string]string{"error": "admin role required"})
+				return respondError(c, http.StatusForbidden, "admin role required")
 			}
 		} else {
-			return c.JSON(http.StatusForbidden, map[string]string{"error": "admin role required"})
+			return respondError(c, http.StatusForbidden, "admin role required")
 		}
 	}
 
 	if req.AgentID == adminAgentID {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "cannot impersonate yourself"})
+		return respondError(c, http.StatusBadRequest, "cannot impersonate yourself")
 	}
 
 	target, err := h.agentRepo.FindByID(ctx, req.AgentID)
 	if err != nil || target == nil {
-		return c.JSON(http.StatusNotFound, map[string]string{"error": "user not found"})
+		return respondError(c, http.StatusNotFound, "user not found")
 	}
 	if target.Status() != "active" {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "can only impersonate active users"})
+		return respondError(c, http.StatusBadRequest, "can only impersonate active users")
 	}
 
 	sess.Options = &sessions.Options{
@@ -139,7 +139,7 @@ func (h *ImpersonationHandler) Start(c echo.Context) error {
 	sess.Values[apimw.KeyRealAccountID] = identity.ActiveAccountID
 
 	if err := sess.Save(c.Request(), c.Response()); err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to create impersonation session"})
+		return respondError(c, http.StatusInternalServerError, "failed to create impersonation session")
 	}
 
 	h.logger.Info(ctx, "impersonation started",
@@ -149,7 +149,7 @@ func (h *ImpersonationHandler) Start(c echo.Context) error {
 	)
 
 	name, email := h.resolveAgentInfo(ctx, req.AgentID)
-	return c.JSON(http.StatusOK, map[string]any{
+	return respond(c, http.StatusOK, map[string]any{
 		"impersonating": map[string]string{
 			"id":    req.AgentID,
 			"name":  name,
@@ -162,7 +162,7 @@ func (h *ImpersonationHandler) Start(c echo.Context) error {
 func (h *ImpersonationHandler) Stop(c echo.Context) error {
 	sess, err := h.store.Get(c.Request(), apimw.ImpersonationSessionName)
 	if err != nil {
-		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
+		return respond(c, http.StatusOK, map[string]string{"status": "ok"})
 	}
 
 	realAgentID, _ := sess.Values[apimw.KeyRealAgentID].(string)
@@ -179,7 +179,7 @@ func (h *ImpersonationHandler) Stop(c echo.Context) error {
 		delete(sess.Values, key)
 	}
 	if err := sess.Save(c.Request(), c.Response()); err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to clear impersonation session"})
+		return respondError(c, http.StatusInternalServerError, "failed to clear impersonation session")
 	}
 
 	if realAgentID != "" {
@@ -190,23 +190,23 @@ func (h *ImpersonationHandler) Stop(c echo.Context) error {
 		)
 	}
 
-	return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
+	return respond(c, http.StatusOK, map[string]string{"status": "ok"})
 }
 
 // Status returns the current impersonation state.
 func (h *ImpersonationHandler) Status(c echo.Context) error {
 	sess, err := h.store.Get(c.Request(), apimw.ImpersonationSessionName)
 	if err != nil {
-		return c.JSON(http.StatusOK, map[string]any{"active": false})
+		return respond(c, http.StatusOK, map[string]any{"active": false})
 	}
 
 	impersonatedAgentID, ok := sess.Values[apimw.KeyImpersonatedAgentID].(string)
 	if !ok || impersonatedAgentID == "" {
-		return c.JSON(http.StatusOK, map[string]any{"active": false})
+		return respond(c, http.StatusOK, map[string]any{"active": false})
 	}
 
 	name, email := h.resolveAgentInfo(c.Request().Context(), impersonatedAgentID)
-	return c.JSON(http.StatusOK, map[string]any{
+	return respond(c, http.StatusOK, map[string]any{
 		"active": true,
 		"user": map[string]string{
 			"id":    impersonatedAgentID,
@@ -244,7 +244,7 @@ func (h *ImpersonationHandler) Me(authHandlers *authhttp.AuthHandlers) echo.Hand
 			if accountID != "" {
 				role, _ = h.accountRepo.FindMemberRole(ctx, accountID, agentID)
 			}
-			return c.JSON(http.StatusOK, map[string]any{
+			return respond(c, http.StatusOK, map[string]any{
 				"id":    agentID,
 				"name":  name,
 				"email": email,
@@ -262,7 +262,7 @@ func (h *ImpersonationHandler) Me(authHandlers *authhttp.AuthHandlers) echo.Hand
 			role, _ = h.accountRepo.FindMemberRole(ctx, accounts[0].GetID(), impersonatedAgentID)
 		}
 
-		return c.JSON(http.StatusOK, map[string]any{
+		return respond(c, http.StatusOK, map[string]any{
 			"id":            impersonatedAgentID,
 			"name":          name,
 			"email":         email,

--- a/api/handlers/organization_handler.go
+++ b/api/handlers/organization_handler.go
@@ -49,8 +49,7 @@ type OrganizationResponse struct {
 func (h *OrganizationHandler) Create(c echo.Context) error {
 	var req CreateOrganizationRequest
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest,
-			map[string]string{"error": "invalid request body"})
+		return respondError(c, http.StatusBadRequest, "invalid request body")
 	}
 	data, _ := json.Marshal(map[string]any{
 		"name": req.Name,
@@ -61,19 +60,17 @@ func (h *OrganizationHandler) Create(c echo.Context) error {
 		application.CreateResourceCommand{TypeSlug: "organization", Data: data},
 	)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError,
-			map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
-	return c.JSON(http.StatusCreated, toOrganizationResponse(entity))
+	return respond(c, http.StatusCreated, toOrganizationResponse(entity))
 }
 
 func (h *OrganizationHandler) Get(c echo.Context) error {
 	entity, err := h.resourceService.GetByID(c.Request().Context(), c.Param("id"))
 	if err != nil {
-		return c.JSON(http.StatusNotFound,
-			map[string]string{"error": "organization not found"})
+		return respondError(c, http.StatusNotFound, "organization not found")
 	}
-	return c.JSON(http.StatusOK, toOrganizationResponse(entity))
+	return respond(c, http.StatusOK, toOrganizationResponse(entity))
 }
 
 func (h *OrganizationHandler) List(c echo.Context) error {
@@ -86,25 +83,19 @@ func (h *OrganizationHandler) List(c echo.Context) error {
 		c.Request().Context(), "organization", cursor, limit, repositories.SortOptions{},
 	)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError,
-			map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
 	items := make([]OrganizationResponse, 0, len(result.Data))
 	for _, e := range result.Data {
 		items = append(items, toOrganizationResponse(e))
 	}
-	return c.JSON(http.StatusOK, map[string]interface{}{
-		"data":     items,
-		"cursor":   result.Cursor,
-		"has_more": result.HasMore,
-	})
+	return respondPaginated(c, http.StatusOK, items, result.Cursor, result.HasMore)
 }
 
 func (h *OrganizationHandler) Update(c echo.Context) error {
 	var req UpdateOrganizationRequest
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest,
-			map[string]string{"error": "invalid request body"})
+		return respondError(c, http.StatusBadRequest, "invalid request body")
 	}
 	data, _ := json.Marshal(map[string]any{
 		"name":        req.Name,
@@ -118,17 +109,15 @@ func (h *OrganizationHandler) Update(c echo.Context) error {
 		application.UpdateResourceCommand{ID: c.Param("id"), Data: data},
 	)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError,
-			map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
-	return c.JSON(http.StatusOK, toOrganizationResponse(entity))
+	return respond(c, http.StatusOK, toOrganizationResponse(entity))
 }
 
 func (h *OrganizationHandler) Delete(c echo.Context) error {
 	cmd := application.DeleteResourceCommand{ID: c.Param("id")}
 	if err := h.resourceService.Delete(c.Request().Context(), cmd); err != nil {
-		return c.JSON(http.StatusInternalServerError,
-			map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -136,8 +125,7 @@ func (h *OrganizationHandler) Delete(c echo.Context) error {
 func (h *OrganizationHandler) Members(c echo.Context) error {
 	orgID := c.Param("id")
 	if _, err := h.resourceService.GetByID(c.Request().Context(), orgID); err != nil {
-		return c.JSON(http.StatusNotFound,
-			map[string]string{"error": "organization not found"})
+		return respondError(c, http.StatusNotFound, "organization not found")
 	}
 
 	cursor := c.QueryParam("cursor")
@@ -152,18 +140,13 @@ func (h *OrganizationHandler) Members(c echo.Context) error {
 		c.Request().Context(), "person", filters, cursor, limit, repositories.SortOptions{},
 	)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError,
-			map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
 	items := make([]PersonResponse, 0, len(result.Data))
 	for _, e := range result.Data {
 		items = append(items, toPersonResponse(e))
 	}
-	return c.JSON(http.StatusOK, map[string]interface{}{
-		"data":     items,
-		"cursor":   result.Cursor,
-		"has_more": result.HasMore,
-	})
+	return respondPaginated(c, http.StatusOK, items, result.Cursor, result.HasMore)
 }
 
 func toOrganizationResponse(r *entities.Resource) OrganizationResponse {

--- a/api/handlers/person_handler.go
+++ b/api/handlers/person_handler.go
@@ -49,8 +49,7 @@ type PersonResponse struct {
 func (h *PersonHandler) Create(c echo.Context) error {
 	var req CreatePersonRequest
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest,
-			map[string]string{"error": "invalid request body"})
+		return respondError(c, http.StatusBadRequest, "invalid request body")
 	}
 	data, _ := json.Marshal(map[string]any{
 		"givenName":  req.GivenName,
@@ -62,19 +61,17 @@ func (h *PersonHandler) Create(c echo.Context) error {
 		application.CreateResourceCommand{TypeSlug: "person", Data: data},
 	)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError,
-			map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
-	return c.JSON(http.StatusCreated, toPersonResponse(entity))
+	return respond(c, http.StatusCreated, toPersonResponse(entity))
 }
 
 func (h *PersonHandler) Get(c echo.Context) error {
 	entity, err := h.resourceService.GetByID(c.Request().Context(), c.Param("id"))
 	if err != nil {
-		return c.JSON(http.StatusNotFound,
-			map[string]string{"error": "person not found"})
+		return respondError(c, http.StatusNotFound, "person not found")
 	}
-	return c.JSON(http.StatusOK, toPersonResponse(entity))
+	return respond(c, http.StatusOK, toPersonResponse(entity))
 }
 
 func (h *PersonHandler) List(c echo.Context) error {
@@ -87,25 +84,19 @@ func (h *PersonHandler) List(c echo.Context) error {
 		c.Request().Context(), "person", cursor, limit, repositories.SortOptions{},
 	)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError,
-			map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
 	items := make([]PersonResponse, 0, len(result.Data))
 	for _, e := range result.Data {
 		items = append(items, toPersonResponse(e))
 	}
-	return c.JSON(http.StatusOK, map[string]interface{}{
-		"data":     items,
-		"cursor":   result.Cursor,
-		"has_more": result.HasMore,
-	})
+	return respondPaginated(c, http.StatusOK, items, result.Cursor, result.HasMore)
 }
 
 func (h *PersonHandler) Update(c echo.Context) error {
 	var req UpdatePersonRequest
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest,
-			map[string]string{"error": "invalid request body"})
+		return respondError(c, http.StatusBadRequest, "invalid request body")
 	}
 	data, _ := json.Marshal(map[string]any{
 		"givenName":  req.GivenName,
@@ -118,17 +109,15 @@ func (h *PersonHandler) Update(c echo.Context) error {
 		application.UpdateResourceCommand{ID: c.Param("id"), Data: data},
 	)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError,
-			map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
-	return c.JSON(http.StatusOK, toPersonResponse(entity))
+	return respond(c, http.StatusOK, toPersonResponse(entity))
 }
 
 func (h *PersonHandler) Delete(c echo.Context) error {
 	cmd := application.DeleteResourceCommand{ID: c.Param("id")}
 	if err := h.resourceService.Delete(c.Request().Context(), cmd); err != nil {
-		return c.JSON(http.StatusInternalServerError,
-			map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusNoContent)
 }

--- a/api/handlers/resource_handler.go
+++ b/api/handlers/resource_handler.go
@@ -275,7 +275,9 @@ func respondWithResourceData(
 	c echo.Context, status int, entity *entities.Resource, ldCtx json.RawMessage,
 ) error {
 	if wantsJSONLD(c) {
-		return respondRaw(c, status, entity.Data())
+		// JSON-LD clients expect a valid JSON-LD document at the top level,
+		// so we bypass the envelope and return the raw data directly.
+		return c.Blob(status, "application/ld+json", entity.Data())
 	}
 	simplified, err := entities.SimplifyJSONLD(entity.Data(), ldCtx)
 	if err != nil {

--- a/api/handlers/resource_handler.go
+++ b/api/handlers/resource_handler.go
@@ -57,14 +57,12 @@ type ResourceResponse struct {
 func (h *ResourceHandler) Create(c echo.Context) error {
 	typeSlug := c.Param("typeSlug")
 	if _, err := h.resourceTypeService.GetBySlug(c.Request().Context(), typeSlug); err != nil {
-		return c.JSON(http.StatusNotFound,
-			map[string]string{"error": "resource type not found"})
+		return respondError(c, http.StatusNotFound, "resource type not found")
 	}
 
 	body, err := io.ReadAll(c.Request().Body)
 	if err != nil {
-		return c.JSON(http.StatusBadRequest,
-			map[string]string{"error": "failed to read request body"})
+		return respondError(c, http.StatusBadRequest, "failed to read request body")
 	}
 
 	entity, err := h.resourceService.Create(
@@ -73,10 +71,9 @@ func (h *ResourceHandler) Create(c echo.Context) error {
 	)
 	if err != nil {
 		if errors.Is(err, entities.ErrAccessDenied) {
-			return c.JSON(http.StatusForbidden, map[string]string{"error": "access denied"})
+			return respondForbidden(c)
 		}
-		return c.JSON(http.StatusInternalServerError,
-			map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
 	return respondWithResource(c, http.StatusCreated, entity)
 }
@@ -85,17 +82,15 @@ func (h *ResourceHandler) Get(c echo.Context) error {
 	typeSlug := c.Param("typeSlug")
 	rt, err := h.resourceTypeService.GetBySlug(c.Request().Context(), typeSlug)
 	if err != nil {
-		return c.JSON(http.StatusNotFound,
-			map[string]string{"error": "resource type not found"})
+		return respondError(c, http.StatusNotFound, "resource type not found")
 	}
 
 	entity, err := h.resourceService.GetByID(c.Request().Context(), c.Param("id"))
 	if err != nil {
 		if errors.Is(err, entities.ErrAccessDenied) {
-			return c.JSON(http.StatusForbidden, map[string]string{"error": "access denied"})
+			return respondForbidden(c)
 		}
-		return c.JSON(http.StatusNotFound,
-			map[string]string{"error": "resource not found"})
+		return respondError(c, http.StatusNotFound, "resource not found")
 	}
 	return respondWithResourceData(c, http.StatusOK, entity, rt.Context())
 }
@@ -103,8 +98,7 @@ func (h *ResourceHandler) Get(c echo.Context) error {
 func (h *ResourceHandler) List(c echo.Context) error {
 	typeSlug := c.Param("typeSlug")
 	if _, err := h.resourceTypeService.GetBySlug(c.Request().Context(), typeSlug); err != nil {
-		return c.JSON(http.StatusNotFound,
-			map[string]string{"error": "resource type not found"})
+		return respondError(c, http.StatusNotFound, "resource type not found")
 	}
 
 	cursor := c.QueryParam("cursor")
@@ -142,19 +136,14 @@ func (h *ResourceHandler) List(c echo.Context) error {
 		result, err = h.resourceService.List(c.Request().Context(), typeSlug, cursor, limit, sort)
 	}
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError,
-			map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
 
 	items := make([]json.RawMessage, 0, len(result.Data))
 	for _, e := range result.Data {
 		items = append(items, e.Data())
 	}
-	return c.JSON(http.StatusOK, map[string]any{
-		"data":     items,
-		"cursor":   result.Cursor,
-		"has_more": result.HasMore,
-	})
+	return respondPaginated(c, http.StatusOK, items, result.Cursor, result.HasMore)
 }
 
 // listFlat returns flat projection rows directly for list views.
@@ -176,11 +165,7 @@ func (h *ResourceHandler) listFlat(
 		return h.listEntities(c, typeSlug, filters, cursor, limit, sort)
 	}
 
-	return c.JSON(http.StatusOK, map[string]any{
-		"data":     result.Data,
-		"cursor":   result.Cursor,
-		"has_more": result.HasMore,
-	})
+	return respondPaginated(c, http.StatusOK, result.Data, result.Cursor, result.HasMore)
 }
 
 // listEntities returns entity-based results with simplified JSON-LD.
@@ -197,8 +182,7 @@ func (h *ResourceHandler) listEntities(
 		result, err = h.resourceService.List(c.Request().Context(), typeSlug, cursor, limit, sort)
 	}
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError,
-			map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
 
 	var ldCtx json.RawMessage
@@ -214,11 +198,7 @@ func (h *ResourceHandler) listEntities(
 		}
 		items = append(items, simplified)
 	}
-	return c.JSON(http.StatusOK, map[string]any{
-		"data":     items,
-		"cursor":   result.Cursor,
-		"has_more": result.HasMore,
-	})
+	return respondPaginated(c, http.StatusOK, items, result.Cursor, result.HasMore)
 }
 
 // parseFilters extracts _filter[field][operator]=value query params.
@@ -248,14 +228,12 @@ func parseFilters(c echo.Context) []repositories.FilterCondition {
 func (h *ResourceHandler) Update(c echo.Context) error {
 	typeSlug := c.Param("typeSlug")
 	if _, err := h.resourceTypeService.GetBySlug(c.Request().Context(), typeSlug); err != nil {
-		return c.JSON(http.StatusNotFound,
-			map[string]string{"error": "resource type not found"})
+		return respondError(c, http.StatusNotFound, "resource type not found")
 	}
 
 	body, err := io.ReadAll(c.Request().Body)
 	if err != nil {
-		return c.JSON(http.StatusBadRequest,
-			map[string]string{"error": "failed to read request body"})
+		return respondError(c, http.StatusBadRequest, "failed to read request body")
 	}
 
 	entity, err := h.resourceService.Update(
@@ -264,10 +242,9 @@ func (h *ResourceHandler) Update(c echo.Context) error {
 	)
 	if err != nil {
 		if errors.Is(err, entities.ErrAccessDenied) {
-			return c.JSON(http.StatusForbidden, map[string]string{"error": "access denied"})
+			return respondForbidden(c)
 		}
-		return c.JSON(http.StatusInternalServerError,
-			map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
 	return respondWithResource(c, http.StatusOK, entity)
 }
@@ -275,17 +252,15 @@ func (h *ResourceHandler) Update(c echo.Context) error {
 func (h *ResourceHandler) Delete(c echo.Context) error {
 	typeSlug := c.Param("typeSlug")
 	if _, err := h.resourceTypeService.GetBySlug(c.Request().Context(), typeSlug); err != nil {
-		return c.JSON(http.StatusNotFound,
-			map[string]string{"error": "resource type not found"})
+		return respondError(c, http.StatusNotFound, "resource type not found")
 	}
 
 	cmd := application.DeleteResourceCommand{ID: c.Param("id")}
 	if err := h.resourceService.Delete(c.Request().Context(), cmd); err != nil {
 		if errors.Is(err, entities.ErrAccessDenied) {
-			return c.JSON(http.StatusForbidden, map[string]string{"error": "access denied"})
+			return respondForbidden(c)
 		}
-		return c.JSON(http.StatusInternalServerError,
-			map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -299,17 +274,17 @@ func respondWithResourceData(
 	c echo.Context, status int, entity *entities.Resource, ldCtx json.RawMessage,
 ) error {
 	if wantsJSONLD(c) {
-		return c.JSONBlob(status, entity.Data())
+		return respondRaw(c, status, entity.Data())
 	}
 	simplified, err := entities.SimplifyJSONLD(entity.Data(), ldCtx)
 	if err != nil {
-		return c.JSONBlob(status, entity.Data())
+		return respondRaw(c, status, entity.Data())
 	}
-	return c.JSONBlob(status, simplified)
+	return respondRaw(c, status, simplified)
 }
 
 func respondWithResource(c echo.Context, status int, entity *entities.Resource) error {
-	return c.JSON(status, ResourceResponse{
+	return respond(c, status, ResourceResponse{
 		ID:        entity.GetID(),
 		TypeSlug:  entity.TypeSlug(),
 		Data:      entity.Data(),

--- a/api/handlers/resource_handler.go
+++ b/api/handlers/resource_handler.go
@@ -262,6 +262,7 @@ func (h *ResourceHandler) Delete(c echo.Context) error {
 		}
 		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
+	// 204 No Content intentionally has no body; any accumulated messages are not sent.
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -278,6 +279,10 @@ func respondWithResourceData(
 	}
 	simplified, err := entities.SimplifyJSONLD(entity.Data(), ldCtx)
 	if err != nil {
+		entities.AddMessage(c.Request().Context(), entities.Message{
+			Type: "warning",
+			Text: "response returned in raw JSON-LD format due to simplification error",
+		})
 		return respondRaw(c, status, entity.Data())
 	}
 	return respondRaw(c, status, simplified)

--- a/api/handlers/resource_handler.go
+++ b/api/handlers/resource_handler.go
@@ -283,7 +283,7 @@ func respondWithResourceData(
 	if err != nil {
 		entities.AddMessage(c.Request().Context(), entities.Message{
 			Type: "warning",
-			Text: "response returned in raw JSON-LD format due to simplification error",
+			Text: "response contains unsimplified JSON-LD payload due to simplification error",
 		})
 		return respondRaw(c, status, entity.Data())
 	}

--- a/api/handlers/resource_permission_handler.go
+++ b/api/handlers/resource_permission_handler.go
@@ -39,20 +39,20 @@ func (h *ResourcePermissionHandler) Grant(c echo.Context) error {
 
 	body, err := io.ReadAll(c.Request().Body)
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "failed to read request body"})
+		return respondError(c, http.StatusBadRequest, "failed to read request body")
 	}
 
 	var req grantRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		return respondError(c, http.StatusBadRequest, "invalid JSON")
 	}
 	if req.AgentID == "" || len(req.Actions) == 0 {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "agent_id and actions are required"})
+		return respondError(c, http.StatusBadRequest, "agent_id and actions are required")
 	}
 
 	actionsJSON, err := json.Marshal(req.Actions)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to encode actions"})
+		return respondError(c, http.StatusInternalServerError, "failed to encode actions")
 	}
 	cmd := application.GrantPermissionCommand{
 		ResourceID: resourceID,
@@ -62,12 +62,12 @@ func (h *ResourcePermissionHandler) Grant(c echo.Context) error {
 
 	if err := h.permService.Grant(c.Request().Context(), cmd); err != nil {
 		if errors.Is(err, entities.ErrAccessDenied) {
-			return c.JSON(http.StatusForbidden, map[string]string{"error": "access denied"})
+			return respondForbidden(c)
 		}
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
 
-	return c.JSON(http.StatusCreated, map[string]string{"status": "granted"})
+	return respond(c, http.StatusCreated, map[string]string{"status": "granted"})
 }
 
 func (h *ResourcePermissionHandler) Revoke(c echo.Context) error {
@@ -81,9 +81,9 @@ func (h *ResourcePermissionHandler) Revoke(c echo.Context) error {
 
 	if err := h.permService.Revoke(c.Request().Context(), cmd); err != nil {
 		if errors.Is(err, entities.ErrAccessDenied) {
-			return c.JSON(http.StatusForbidden, map[string]string{"error": "access denied"})
+			return respondForbidden(c)
 		}
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
 
 	return c.NoContent(http.StatusNoContent)
@@ -95,9 +95,9 @@ func (h *ResourcePermissionHandler) List(c echo.Context) error {
 	perms, err := h.permService.ListForResource(c.Request().Context(), resourceID)
 	if err != nil {
 		if errors.Is(err, entities.ErrAccessDenied) {
-			return c.JSON(http.StatusForbidden, map[string]string{"error": "access denied"})
+			return respondForbidden(c)
 		}
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
 
 	items := make([]permissionResponse, 0, len(perms))
@@ -111,5 +111,5 @@ func (h *ResourcePermissionHandler) List(c echo.Context) error {
 		})
 	}
 
-	return c.JSON(http.StatusOK, map[string]any{"data": items})
+	return respond(c, http.StatusOK, items)
 }

--- a/api/handlers/resource_type_handler.go
+++ b/api/handlers/resource_type_handler.go
@@ -78,8 +78,7 @@ type ResourceTypeResponse struct {
 func (h *ResourceTypeHandler) Create(c echo.Context) error {
 	var req CreateResourceTypeRequest
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest,
-			map[string]string{"error": "invalid request body"})
+		return respondError(c, http.StatusBadRequest, "invalid request body")
 	}
 	entity, err := h.service.Create(
 		c.Request().Context(),
@@ -88,19 +87,17 @@ func (h *ResourceTypeHandler) Create(c echo.Context) error {
 		},
 	)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError,
-			map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
-	return c.JSON(http.StatusCreated, toResourceTypeResponse(entity))
+	return respond(c, http.StatusCreated, toResourceTypeResponse(entity))
 }
 
 func (h *ResourceTypeHandler) Get(c echo.Context) error {
 	entity, err := h.service.GetByID(c.Request().Context(), c.Param("id"))
 	if err != nil {
-		return c.JSON(http.StatusNotFound,
-			map[string]string{"error": "resource type not found"})
+		return respondError(c, http.StatusNotFound, "resource type not found")
 	}
-	return c.JSON(http.StatusOK, toResourceTypeResponse(entity))
+	return respond(c, http.StatusOK, toResourceTypeResponse(entity))
 }
 
 func (h *ResourceTypeHandler) List(c echo.Context) error {
@@ -111,8 +108,7 @@ func (h *ResourceTypeHandler) List(c echo.Context) error {
 	}
 	result, err := h.service.List(c.Request().Context(), cursor, limit)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError,
-			map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
 
 	includeAll := c.QueryParam("includeAll") == "true"
@@ -157,18 +153,13 @@ func (h *ResourceTypeHandler) List(c echo.Context) error {
 		items = append(items, toResourceTypeResponse(e))
 	}
 
-	return c.JSON(http.StatusOK, map[string]any{
-		"data":     items,
-		"cursor":   result.Cursor,
-		"has_more": result.HasMore,
-	})
+	return respondPaginated(c, http.StatusOK, items, result.Cursor, result.HasMore)
 }
 
 func (h *ResourceTypeHandler) Update(c echo.Context) error {
 	var req UpdateResourceTypeRequest
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest,
-			map[string]string{"error": "invalid request body"})
+		return respondError(c, http.StatusBadRequest, "invalid request body")
 	}
 	entity, err := h.service.Update(
 		c.Request().Context(),
@@ -183,17 +174,15 @@ func (h *ResourceTypeHandler) Update(c echo.Context) error {
 		},
 	)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError,
-			map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
-	return c.JSON(http.StatusOK, toResourceTypeResponse(entity))
+	return respond(c, http.StatusOK, toResourceTypeResponse(entity))
 }
 
 func (h *ResourceTypeHandler) Delete(c echo.Context) error {
 	cmd := application.DeleteResourceTypeCommand{ID: c.Param("id")}
 	if err := h.service.Delete(c.Request().Context(), cmd); err != nil {
-		return c.JSON(http.StatusInternalServerError,
-			map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusNoContent)
 }

--- a/api/handlers/resource_type_preset_handler.go
+++ b/api/handlers/resource_type_preset_handler.go
@@ -53,7 +53,7 @@ func (h *ResourceTypePresetHandler) List(c echo.Context) error {
 			Screens:     d.ScreenManifest(),
 		})
 	}
-	return c.JSON(http.StatusOK, map[string]any{"data": out})
+	return respond(c, http.StatusOK, out)
 }
 
 func (h *ResourceTypePresetHandler) Install(c echo.Context) error {
@@ -61,7 +61,7 @@ func (h *ResourceTypePresetHandler) Install(c echo.Context) error {
 	update := c.QueryParam("update") == "true"
 	result, err := h.service.InstallPreset(c.Request().Context(), name, update)
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return respondError(c, http.StatusBadRequest, err.Error())
 	}
-	return c.JSON(http.StatusOK, result)
+	return respond(c, http.StatusOK, result)
 }

--- a/api/handlers/response.go
+++ b/api/handlers/response.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"weos/domain/entities"
+
+	"github.com/labstack/echo/v4"
+)
+
+// Envelope wraps a single-entity API response with an optional messages array.
+type Envelope struct {
+	Data     any               `json:"data"`
+	Messages []entities.Message `json:"messages,omitempty"`
+}
+
+// PaginatedEnvelope wraps a paginated API response.
+type PaginatedEnvelope struct {
+	Data     any               `json:"data"`
+	Cursor   string            `json:"cursor"`
+	HasMore  bool              `json:"has_more"`
+	Messages []entities.Message `json:"messages,omitempty"`
+}
+
+// ErrorEnvelope wraps an error API response. The "error" key is kept for
+// backward compatibility; the messages array provides the structured form.
+type ErrorEnvelope struct {
+	Error    string            `json:"error"`
+	Messages []entities.Message `json:"messages,omitempty"`
+}
+
+// respond sends a JSON response wrapped in the standard envelope.
+// Messages accumulated on the request context are included automatically.
+func respond(c echo.Context, status int, data any) error {
+	msgs := entities.GetMessages(c.Request().Context())
+	return c.JSON(status, Envelope{Data: data, Messages: msgs})
+}
+
+// respondRaw sends a raw JSON blob wrapped in the standard envelope.
+// Use this for pre-serialized data (e.g., JSON-LD) to avoid double-encoding.
+func respondRaw(c echo.Context, status int, raw json.RawMessage) error {
+	msgs := entities.GetMessages(c.Request().Context())
+	return c.JSON(status, Envelope{Data: raw, Messages: msgs})
+}
+
+// respondPaginated sends a paginated JSON response in the standard envelope.
+func respondPaginated(
+	c echo.Context, status int, data any, cursor string, hasMore bool,
+) error {
+	msgs := entities.GetMessages(c.Request().Context())
+	return c.JSON(status, PaginatedEnvelope{
+		Data:     data,
+		Cursor:   cursor,
+		HasMore:  hasMore,
+		Messages: msgs,
+	})
+}
+
+// respondError sends an error JSON response in the standard envelope.
+func respondError(c echo.Context, status int, msg string) error {
+	msgs := entities.GetMessages(c.Request().Context())
+	msgs = append(msgs, entities.Message{Type: "error", Text: msg})
+	return c.JSON(status, ErrorEnvelope{Error: msg, Messages: msgs})
+}
+
+// respondForbidden is a shorthand for 403 Forbidden responses.
+func respondForbidden(c echo.Context) error {
+	return respondError(c, http.StatusForbidden, "access denied")
+}

--- a/api/handlers/response.go
+++ b/api/handlers/response.go
@@ -11,22 +11,22 @@ import (
 
 // Envelope wraps a single-entity API response with an optional messages array.
 type Envelope struct {
-	Data     any               `json:"data"`
+	Data     any                `json:"data"`
 	Messages []entities.Message `json:"messages,omitempty"`
 }
 
 // PaginatedEnvelope wraps a paginated API response.
 type PaginatedEnvelope struct {
-	Data     any               `json:"data"`
-	Cursor   string            `json:"cursor"`
-	HasMore  bool              `json:"has_more"`
+	Data     any                `json:"data"`
+	Cursor   string             `json:"cursor"`
+	HasMore  bool               `json:"has_more"`
 	Messages []entities.Message `json:"messages,omitempty"`
 }
 
 // ErrorEnvelope wraps an error API response. The "error" key is kept for
 // backward compatibility; the messages array provides the structured form.
 type ErrorEnvelope struct {
-	Error    string            `json:"error"`
+	Error    string             `json:"error"`
 	Messages []entities.Message `json:"messages,omitempty"`
 }
 

--- a/api/handlers/response.go
+++ b/api/handlers/response.go
@@ -58,9 +58,11 @@ func respondPaginated(
 }
 
 // respondError sends an error JSON response in the standard envelope.
+// The error text is in the top-level "error" field for backward compatibility.
+// The "messages" array contains only context-accumulated messages (e.g., warnings
+// from services), not the error itself, to avoid duplication on the frontend.
 func respondError(c echo.Context, status int, msg string) error {
 	msgs := entities.GetMessages(c.Request().Context())
-	msgs = append(msgs, entities.Message{Type: "error", Text: msg})
 	return c.JSON(status, ErrorEnvelope{Error: msg, Messages: msgs})
 }
 

--- a/api/handlers/response_test.go
+++ b/api/handlers/response_test.go
@@ -13,14 +13,15 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// newTestContext creates an Echo context with the Messages middleware active.
+// newTestContext creates an Echo context and injects the messages accumulator
+// directly into the request context for handler tests.
 func newTestContext(t *testing.T) (echo.Context, *httptest.ResponseRecorder) {
 	t.Helper()
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	// Inject message accumulator via middleware.
+	// Inject message accumulator directly into the request context.
 	ctx := entities.ContextWithMessages(c.Request().Context())
 	c.SetRequest(c.Request().WithContext(ctx))
 	return c, rec

--- a/api/handlers/response_test.go
+++ b/api/handlers/response_test.go
@@ -1,0 +1,226 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"weos/api/handlers"
+	apimw "weos/api/middleware"
+	"weos/domain/entities"
+
+	"github.com/labstack/echo/v4"
+)
+
+// callWithMessages creates an Echo context with the messages middleware active,
+// adds the given messages, then calls the handler and returns the response.
+func callWithMessages(
+	t *testing.T, msgs []entities.Message, handler echo.HandlerFunc,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	e := echo.New()
+	// Use the messages middleware to inject the accumulator.
+	mw := apimw.Messages()
+	wrapped := mw(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	// Add messages to context after middleware runs.
+	err := mw(func(c echo.Context) error {
+		ctx := c.Request().Context()
+		for _, m := range msgs {
+			entities.AddMessage(ctx, m)
+		}
+		return handler(c)
+	})(c)
+	_ = wrapped // satisfy linter
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	return rec
+}
+
+func TestEnvelope_SuccessWithoutMessages(t *testing.T) {
+	t.Parallel()
+	e := echo.New()
+	e.Use(apimw.Messages())
+
+	e.GET("/test", func(c echo.Context) error {
+		return c.JSON(http.StatusOK, handlers.Envelope{
+			Data:     map[string]string{"name": "widget"},
+			Messages: entities.GetMessages(c.Request().Context()),
+		})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// Data should be present.
+	data, ok := result["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected data object, got %v", result)
+	}
+	if data["name"] != "widget" {
+		t.Fatalf("expected name=widget, got %v", data["name"])
+	}
+
+	// Messages should be omitted (not null).
+	if _, exists := result["messages"]; exists {
+		t.Fatalf("expected messages to be omitted when empty, got %v", result["messages"])
+	}
+}
+
+func TestEnvelope_SuccessWithMessages(t *testing.T) {
+	t.Parallel()
+	e := echo.New()
+	e.Use(apimw.Messages())
+
+	e.GET("/test", func(c echo.Context) error {
+		ctx := c.Request().Context()
+		entities.AddMessage(ctx, entities.Message{Type: "info", Text: "hello"})
+		return c.JSON(http.StatusOK, handlers.Envelope{
+			Data:     map[string]string{"id": "123"},
+			Messages: entities.GetMessages(ctx),
+		})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	var result map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	msgs, ok := result["messages"].([]any)
+	if !ok || len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %v", result["messages"])
+	}
+	msg := msgs[0].(map[string]any)
+	if msg["type"] != "info" || msg["text"] != "hello" {
+		t.Fatalf("unexpected message: %v", msg)
+	}
+}
+
+func TestErrorEnvelope_Format(t *testing.T) {
+	t.Parallel()
+	e := echo.New()
+	e.Use(apimw.Messages())
+
+	e.GET("/test", func(c echo.Context) error {
+		return c.JSON(http.StatusBadRequest, handlers.ErrorEnvelope{
+			Error:    "invalid input",
+			Messages: []entities.Message{{Type: "error", Text: "invalid input"}},
+		})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// Should have both "error" string and "messages" array.
+	if result["error"] != "invalid input" {
+		t.Fatalf("expected error='invalid input', got %v", result["error"])
+	}
+	msgs, ok := result["messages"].([]any)
+	if !ok || len(msgs) != 1 {
+		t.Fatalf("expected 1 message in error envelope, got %v", result["messages"])
+	}
+}
+
+func TestPaginatedEnvelope_Format(t *testing.T) {
+	t.Parallel()
+	e := echo.New()
+	e.Use(apimw.Messages())
+
+	e.GET("/test", func(c echo.Context) error {
+		return c.JSON(http.StatusOK, handlers.PaginatedEnvelope{
+			Data:    []string{"a", "b"},
+			Cursor:  "abc123",
+			HasMore: true,
+		})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	var result map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if result["cursor"] != "abc123" {
+		t.Fatalf("expected cursor=abc123, got %v", result["cursor"])
+	}
+	if result["has_more"] != true {
+		t.Fatalf("expected has_more=true, got %v", result["has_more"])
+	}
+	data, ok := result["data"].([]any)
+	if !ok || len(data) != 2 {
+		t.Fatalf("expected 2 items in data, got %v", result["data"])
+	}
+	// Messages omitted when empty.
+	if _, exists := result["messages"]; exists {
+		t.Fatalf("expected messages omitted, got %v", result["messages"])
+	}
+}
+
+func TestEnvelope_OmitsFieldAndCodeWhenEmpty(t *testing.T) {
+	t.Parallel()
+	e := echo.New()
+	e.Use(apimw.Messages())
+
+	e.GET("/test", func(c echo.Context) error {
+		ctx := c.Request().Context()
+		entities.AddMessage(ctx, entities.Message{Type: "success", Text: "done"})
+		return c.JSON(http.StatusOK, handlers.Envelope{
+			Data:     nil,
+			Messages: entities.GetMessages(ctx),
+		})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	var msgs []map[string]any
+	if err := json.Unmarshal(result["messages"], &msgs); err != nil {
+		t.Fatalf("failed to parse messages: %v", err)
+	}
+	msg := msgs[0]
+	if _, ok := msg["field"]; ok {
+		t.Fatal("expected field to be omitted when empty")
+	}
+	if _, ok := msg["code"]; ok {
+		t.Fatal("expected code to be omitted when empty")
+	}
+}

--- a/api/handlers/response_test.go
+++ b/api/handlers/response_test.go
@@ -13,179 +13,189 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// callWithMessages creates an Echo context with the messages middleware active,
-// adds the given messages, then calls the handler and returns the response.
-func callWithMessages(
-	t *testing.T, msgs []entities.Message, handler echo.HandlerFunc,
-) *httptest.ResponseRecorder {
+// newTestContext creates an Echo context with the Messages middleware active.
+func newTestContext(t *testing.T) (echo.Context, *httptest.ResponseRecorder) {
 	t.Helper()
 	e := echo.New()
-	// Use the messages middleware to inject the accumulator.
-	mw := apimw.Messages()
-	wrapped := mw(handler)
-
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-
-	// Add messages to context after middleware runs.
-	err := mw(func(c echo.Context) error {
-		ctx := c.Request().Context()
-		for _, m := range msgs {
-			entities.AddMessage(ctx, m)
-		}
-		return handler(c)
-	})(c)
-	_ = wrapped // satisfy linter
-	if err != nil {
-		t.Fatalf("handler returned error: %v", err)
-	}
-	return rec
+	// Inject message accumulator via middleware.
+	ctx := entities.ContextWithMessages(c.Request().Context())
+	c.SetRequest(c.Request().WithContext(ctx))
+	return c, rec
 }
 
-func TestEnvelope_SuccessWithoutMessages(t *testing.T) {
-	t.Parallel()
-	e := echo.New()
-	e.Use(apimw.Messages())
-
-	e.GET("/test", func(c echo.Context) error {
-		return c.JSON(http.StatusOK, handlers.Envelope{
-			Data:     map[string]string{"name": "widget"},
-			Messages: entities.GetMessages(c.Request().Context()),
-		})
-	})
-
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", rec.Code)
-	}
-
+func parseJSON(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
 	var result map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
-		t.Fatalf("invalid JSON: %v", err)
+		t.Fatalf("invalid JSON: %v\nbody: %s", err, rec.Body.String())
+	}
+	return result
+}
+
+func TestRespond_WrapsDataInEnvelope(t *testing.T) {
+	t.Parallel()
+	c, rec := newTestContext(t)
+
+	err := handlers.ExportRespond(c, http.StatusCreated, map[string]string{"id": "abc"})
+	if err != nil {
+		t.Fatalf("respond error: %v", err)
+	}
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rec.Code)
 	}
 
-	// Data should be present.
+	result := parseJSON(t, rec)
 	data, ok := result["data"].(map[string]any)
 	if !ok {
 		t.Fatalf("expected data object, got %v", result)
 	}
-	if data["name"] != "widget" {
-		t.Fatalf("expected name=widget, got %v", data["name"])
+	if data["id"] != "abc" {
+		t.Fatalf("expected id=abc, got %v", data["id"])
 	}
-
-	// Messages should be omitted (not null).
 	if _, exists := result["messages"]; exists {
-		t.Fatalf("expected messages to be omitted when empty, got %v", result["messages"])
+		t.Fatal("expected messages omitted when empty")
 	}
 }
 
-func TestEnvelope_SuccessWithMessages(t *testing.T) {
+func TestRespond_IncludesContextMessages(t *testing.T) {
 	t.Parallel()
-	e := echo.New()
-	e.Use(apimw.Messages())
+	c, rec := newTestContext(t)
 
-	e.GET("/test", func(c echo.Context) error {
-		ctx := c.Request().Context()
-		entities.AddMessage(ctx, entities.Message{Type: "info", Text: "hello"})
-		return c.JSON(http.StatusOK, handlers.Envelope{
-			Data:     map[string]string{"id": "123"},
-			Messages: entities.GetMessages(ctx),
-		})
-	})
+	entities.AddMessage(c.Request().Context(), entities.Message{Type: "warning", Text: "watch out"})
 
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	var result map[string]any
-	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
-		t.Fatalf("invalid JSON: %v", err)
+	err := handlers.ExportRespond(c, http.StatusOK, nil)
+	if err != nil {
+		t.Fatalf("respond error: %v", err)
 	}
 
+	result := parseJSON(t, rec)
 	msgs, ok := result["messages"].([]any)
 	if !ok || len(msgs) != 1 {
 		t.Fatalf("expected 1 message, got %v", result["messages"])
 	}
 	msg := msgs[0].(map[string]any)
-	if msg["type"] != "info" || msg["text"] != "hello" {
+	if msg["type"] != "warning" || msg["text"] != "watch out" {
 		t.Fatalf("unexpected message: %v", msg)
 	}
 }
 
-func TestErrorEnvelope_Format(t *testing.T) {
+func TestRespondRaw_NoDoubleEncoding(t *testing.T) {
 	t.Parallel()
-	e := echo.New()
-	e.Use(apimw.Messages())
+	c, rec := newTestContext(t)
 
-	e.GET("/test", func(c echo.Context) error {
-		return c.JSON(http.StatusBadRequest, handlers.ErrorEnvelope{
-			Error:    "invalid input",
-			Messages: []entities.Message{{Type: "error", Text: "invalid input"}},
-		})
-	})
-
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d", rec.Code)
+	raw := json.RawMessage(`{"@type":"Product","name":"Widget"}`)
+	err := handlers.ExportRespondRaw(c, http.StatusOK, raw)
+	if err != nil {
+		t.Fatalf("respondRaw error: %v", err)
 	}
 
-	var result map[string]any
-	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
-		t.Fatalf("invalid JSON: %v", err)
+	result := parseJSON(t, rec)
+	data, ok := result["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected data to be an object (not double-encoded string), got %T: %v",
+			result["data"], result["data"])
 	}
-
-	// Should have both "error" string and "messages" array.
-	if result["error"] != "invalid input" {
-		t.Fatalf("expected error='invalid input', got %v", result["error"])
-	}
-	msgs, ok := result["messages"].([]any)
-	if !ok || len(msgs) != 1 {
-		t.Fatalf("expected 1 message in error envelope, got %v", result["messages"])
+	if data["@type"] != "Product" {
+		t.Fatalf("expected @type=Product, got %v", data["@type"])
 	}
 }
 
-func TestPaginatedEnvelope_Format(t *testing.T) {
+func TestRespondPaginated_IncludesAllFields(t *testing.T) {
 	t.Parallel()
-	e := echo.New()
-	e.Use(apimw.Messages())
+	c, rec := newTestContext(t)
 
-	e.GET("/test", func(c echo.Context) error {
-		return c.JSON(http.StatusOK, handlers.PaginatedEnvelope{
-			Data:    []string{"a", "b"},
-			Cursor:  "abc123",
-			HasMore: true,
-		})
-	})
+	entities.AddMessage(c.Request().Context(), entities.Message{Type: "info", Text: "filtered"})
 
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-
-	var result map[string]any
-	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
-		t.Fatalf("invalid JSON: %v", err)
+	err := handlers.ExportRespondPaginated(c, http.StatusOK, []string{"a", "b"}, "cur123", true)
+	if err != nil {
+		t.Fatalf("respondPaginated error: %v", err)
 	}
 
-	if result["cursor"] != "abc123" {
-		t.Fatalf("expected cursor=abc123, got %v", result["cursor"])
+	result := parseJSON(t, rec)
+	if result["cursor"] != "cur123" {
+		t.Fatalf("expected cursor=cur123, got %v", result["cursor"])
 	}
 	if result["has_more"] != true {
 		t.Fatalf("expected has_more=true, got %v", result["has_more"])
 	}
 	data, ok := result["data"].([]any)
 	if !ok || len(data) != 2 {
-		t.Fatalf("expected 2 items in data, got %v", result["data"])
+		t.Fatalf("expected 2-item data array, got %v", result["data"])
 	}
-	// Messages omitted when empty.
+	msgs, ok := result["messages"].([]any)
+	if !ok || len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %v", result["messages"])
+	}
+}
+
+func TestRespondError_BackwardCompatFormat(t *testing.T) {
+	t.Parallel()
+	c, rec := newTestContext(t)
+
+	err := handlers.ExportRespondError(c, http.StatusBadRequest, "invalid input")
+	if err != nil {
+		t.Fatalf("respondError error: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+
+	result := parseJSON(t, rec)
+	if result["error"] != "invalid input" {
+		t.Fatalf("expected error='invalid input', got %v", result["error"])
+	}
+	// Messages should be omitted when no context messages were accumulated.
 	if _, exists := result["messages"]; exists {
-		t.Fatalf("expected messages omitted, got %v", result["messages"])
+		t.Fatal("expected messages omitted when no context messages present")
+	}
+}
+
+func TestRespondError_PreservesContextMessages(t *testing.T) {
+	t.Parallel()
+	c, rec := newTestContext(t)
+
+	// Service added a warning before the error occurred.
+	entities.AddMessage(c.Request().Context(), entities.Message{
+		Type: "warning", Text: "schema missing", Field: "schema",
+	})
+
+	err := handlers.ExportRespondError(c, http.StatusBadRequest, "validation failed")
+	if err != nil {
+		t.Fatalf("respondError error: %v", err)
+	}
+
+	result := parseJSON(t, rec)
+	if result["error"] != "validation failed" {
+		t.Fatalf("expected error='validation failed', got %v", result["error"])
+	}
+	msgs, ok := result["messages"].([]any)
+	if !ok || len(msgs) != 1 {
+		t.Fatalf("expected 1 context message (not duplicated error), got %v", result["messages"])
+	}
+	msg := msgs[0].(map[string]any)
+	if msg["type"] != "warning" {
+		t.Fatalf("expected warning message from context, got %v", msg)
+	}
+}
+
+func TestRespondForbidden_StatusAndMessage(t *testing.T) {
+	t.Parallel()
+	c, rec := newTestContext(t)
+
+	err := handlers.ExportRespondForbidden(c)
+	if err != nil {
+		t.Fatalf("respondForbidden error: %v", err)
+	}
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+
+	result := parseJSON(t, rec)
+	if result["error"] != "access denied" {
+		t.Fatalf("expected error='access denied', got %v", result["error"])
 	}
 }
 

--- a/api/handlers/role_access_handler.go
+++ b/api/handlers/role_access_handler.go
@@ -69,18 +69,18 @@ func (h *RoleAccessHandler) Get(c echo.Context) error {
 	isAdmin, err := apimw.IsAdmin(ctx, h.accountRepo)
 	if err != nil {
 		h.logger.Error(ctx, "failed to check admin status", "error", err)
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "authorization check failed"})
+		return respondError(c, http.StatusInternalServerError, "authorization check failed")
 	}
 	if !isAdmin {
-		return c.JSON(http.StatusForbidden, map[string]string{"error": "admin role required"})
+		return respondError(c, http.StatusForbidden, "admin role required")
 	}
 
 	accessMap, err := h.repo.GetAccessMap(ctx)
 	if err != nil {
 		h.logger.Error(ctx, "failed to load role access", "error", err)
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to load role access"})
+		return respondError(c, http.StatusInternalServerError, "failed to load role access")
 	}
-	return c.JSON(http.StatusOK, roleAccessResponse{Roles: accessMap})
+	return respond(c, http.StatusOK, roleAccessResponse{Roles: accessMap})
 }
 
 // Save updates the role-resource access configuration and syncs policies to Casbin.
@@ -90,15 +90,15 @@ func (h *RoleAccessHandler) Save(c echo.Context) error {
 	isAdmin, err := apimw.IsAdmin(ctx, h.accountRepo)
 	if err != nil {
 		h.logger.Error(ctx, "failed to check admin status", "error", err)
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "authorization check failed"})
+		return respondError(c, http.StatusInternalServerError, "authorization check failed")
 	}
 	if !isAdmin {
-		return c.JSON(http.StatusForbidden, map[string]string{"error": "admin role required"})
+		return respondError(c, http.StatusForbidden, "admin role required")
 	}
 
 	var req roleAccessRequest
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return respondError(c, http.StatusBadRequest, "invalid request body")
 	}
 	if req.Roles == nil {
 		req.Roles = entities.AccessMap{}
@@ -116,13 +116,13 @@ func (h *RoleAccessHandler) Save(c echo.Context) error {
 
 	accessJSON, err := json.Marshal(req.Roles)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to encode access"})
+		return respondError(c, http.StatusInternalServerError, "failed to encode access")
 	}
 
 	settings := &models.RoleResourceAccess{Access: string(accessJSON)}
 	if err := h.repo.Save(ctx, settings); err != nil {
 		h.logger.Error(ctx, "failed to save role access", "error", err)
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to save role access"})
+		return respondError(c, http.StatusInternalServerError, "failed to save role access")
 	}
 
 	// Sync policies to Casbin enforcer, clearing stale role policies.
@@ -130,5 +130,5 @@ func (h *RoleAccessHandler) Save(c echo.Context) error {
 		h.logger.Warn(ctx, "casbin policy sync partially failed", "error", syncErr)
 	}
 
-	return c.JSON(http.StatusOK, roleAccessResponse(req))
+	return respond(c, http.StatusOK, roleAccessResponse(req))
 }

--- a/api/handlers/role_settings_handler.go
+++ b/api/handlers/role_settings_handler.go
@@ -62,18 +62,18 @@ func (h *RoleSettingsHandler) Get(c echo.Context) error {
 	isAdmin, err := apimw.IsAdmin(ctx, h.accountRepo)
 	if err != nil {
 		h.logger.Error(ctx, "failed to check admin status", "error", err)
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "authorization check failed"})
+		return respondError(c, http.StatusInternalServerError, "authorization check failed")
 	}
 	if !isAdmin {
-		return c.JSON(http.StatusForbidden, map[string]string{"error": "admin role required"})
+		return respondForbidden(c)
 	}
 
 	roles, err := h.repo.GetRoleNames(ctx)
 	if err != nil {
 		h.logger.Error(ctx, "failed to load role settings", "error", err)
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to load roles"})
+		return respondError(c, http.StatusInternalServerError, "failed to load roles")
 	}
-	return c.JSON(http.StatusOK, roleSettingsResponse{Roles: roles})
+	return respond(c, http.StatusOK, roleSettingsResponse{Roles: roles})
 }
 
 // Save updates the role list. Admin-only.
@@ -83,15 +83,15 @@ func (h *RoleSettingsHandler) Save(c echo.Context) error {
 	isAdmin, err := apimw.IsAdmin(ctx, h.accountRepo)
 	if err != nil {
 		h.logger.Error(ctx, "failed to check admin status", "error", err)
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "authorization check failed"})
+		return respondError(c, http.StatusInternalServerError, "authorization check failed")
 	}
 	if !isAdmin {
-		return c.JSON(http.StatusForbidden, map[string]string{"error": "admin role required"})
+		return respondForbidden(c)
 	}
 
 	var req roleSettingsRequest
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return respondError(c, http.StatusBadRequest, "invalid request body")
 	}
 
 	hasAdmin := false
@@ -107,7 +107,7 @@ func (h *RoleSettingsHandler) Save(c echo.Context) error {
 
 	rolesJSON, err := json.Marshal(req.Roles)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to encode roles"})
+		return respondError(c, http.StatusInternalServerError, "failed to encode roles")
 	}
 
 	settings := &models.RoleSettings{
@@ -115,8 +115,8 @@ func (h *RoleSettingsHandler) Save(c echo.Context) error {
 	}
 	if err := h.repo.Save(ctx, settings); err != nil {
 		h.logger.Error(ctx, "failed to save role settings", "error", err)
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to save roles"})
+		return respondError(c, http.StatusInternalServerError, "failed to save roles")
 	}
 
-	return c.JSON(http.StatusOK, roleSettingsResponse(req))
+	return respond(c, http.StatusOK, roleSettingsResponse(req))
 }

--- a/api/handlers/role_settings_handler.go
+++ b/api/handlers/role_settings_handler.go
@@ -65,7 +65,7 @@ func (h *RoleSettingsHandler) Get(c echo.Context) error {
 		return respondError(c, http.StatusInternalServerError, "authorization check failed")
 	}
 	if !isAdmin {
-		return respondForbidden(c)
+		return respondError(c, http.StatusForbidden, "admin role required")
 	}
 
 	roles, err := h.repo.GetRoleNames(ctx)
@@ -86,7 +86,7 @@ func (h *RoleSettingsHandler) Save(c echo.Context) error {
 		return respondError(c, http.StatusInternalServerError, "authorization check failed")
 	}
 	if !isAdmin {
-		return respondForbidden(c)
+		return respondError(c, http.StatusForbidden, "admin role required")
 	}
 
 	var req roleSettingsRequest

--- a/api/handlers/sidebar_settings_handler.go
+++ b/api/handlers/sidebar_settings_handler.go
@@ -70,10 +70,10 @@ func (h *SidebarSettingsHandler) Get(c echo.Context) error {
 	settings, err := h.repo.GetByRole(ctx, role)
 	if err != nil {
 		h.logger.Error(ctx, "failed to load sidebar settings", "error", err, "role", role)
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to load settings"})
+		return respondError(c, http.StatusInternalServerError, "failed to load settings")
 	}
 
-	return c.JSON(http.StatusOK, h.toResponse(settings))
+	return respond(c, http.StatusOK, h.toResponse(settings))
 }
 
 // Save updates sidebar settings. Admin-only.
@@ -81,15 +81,15 @@ func (h *SidebarSettingsHandler) Save(c echo.Context) error {
 	isAdmin, err := apimw.IsAdmin(c.Request().Context(), h.accountRepo)
 	if err != nil {
 		h.logger.Error(c.Request().Context(), "failed to check admin status", "error", err)
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "authorization check failed"})
+		return respondError(c, http.StatusInternalServerError, "authorization check failed")
 	}
 	if !isAdmin {
-		return c.JSON(http.StatusForbidden, map[string]string{"error": "admin role required"})
+		return respondForbidden(c)
 	}
 
 	var req sidebarSettingsRequest
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return respondError(c, http.StatusBadRequest, "invalid request body")
 	}
 
 	if req.HiddenSlugs == nil {
@@ -101,12 +101,12 @@ func (h *SidebarSettingsHandler) Save(c echo.Context) error {
 
 	hiddenJSON, err := json.Marshal(req.HiddenSlugs)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to encode settings"})
+		return respondError(c, http.StatusInternalServerError, "failed to encode settings")
 	}
 
 	groupsJSON, err := json.Marshal(req.MenuGroups)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to encode settings"})
+		return respondError(c, http.StatusInternalServerError, "failed to encode settings")
 	}
 
 	role := c.QueryParam("role")
@@ -121,10 +121,10 @@ func (h *SidebarSettingsHandler) Save(c echo.Context) error {
 
 	if err := h.repo.SaveByRole(c.Request().Context(), role, settings); err != nil {
 		h.logger.Error(c.Request().Context(), "failed to save sidebar settings", "error", err, "role", role)
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to save settings"})
+		return respondError(c, http.StatusInternalServerError, "failed to save settings")
 	}
 
-	return c.JSON(http.StatusOK, sidebarSettingsResponse(req))
+	return respond(c, http.StatusOK, sidebarSettingsResponse(req))
 }
 
 func (h *SidebarSettingsHandler) toResponse(settings *models.SidebarSettings) sidebarSettingsResponse {

--- a/api/handlers/sidebar_settings_handler.go
+++ b/api/handlers/sidebar_settings_handler.go
@@ -84,7 +84,7 @@ func (h *SidebarSettingsHandler) Save(c echo.Context) error {
 		return respondError(c, http.StatusInternalServerError, "authorization check failed")
 	}
 	if !isAdmin {
-		return respondForbidden(c)
+		return respondError(c, http.StatusForbidden, "admin role required")
 	}
 
 	var req sidebarSettingsRequest

--- a/api/handlers/user_handler.go
+++ b/api/handlers/user_handler.go
@@ -64,16 +64,16 @@ func (h *UserHandler) List(c echo.Context) error {
 	isAdmin, err := apimw.IsAdmin(ctx, h.accountRepo)
 	if err != nil {
 		h.logger.Error(ctx, "failed to check admin status", "error", err)
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "authorization check failed"})
+		return respondError(c, http.StatusInternalServerError, "authorization check failed")
 	}
 	if !isAdmin {
-		return c.JSON(http.StatusForbidden, map[string]string{"error": "admin role required"})
+		return respondError(c, http.StatusForbidden, "admin role required")
 	}
 
 	agents, err := h.agentRepo.FindAll(ctx, "", 100)
 	if err != nil {
 		h.logger.Error(ctx, "failed to list users", "error", err)
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to list users"})
+		return respondError(c, http.StatusInternalServerError, "failed to list users")
 	}
 
 	accountID := h.defaultAccountID(ctx)
@@ -83,7 +83,7 @@ func (h *UserHandler) List(c echo.Context) error {
 		users = append(users, h.buildUserResponse(ctx, agent, accountID))
 	}
 
-	return c.JSON(http.StatusOK, map[string]any{"data": users})
+	return respond(c, http.StatusOK, users)
 }
 
 // Get returns a single user by ID. Admin-only.
@@ -94,19 +94,19 @@ func (h *UserHandler) Get(c echo.Context) error {
 	isAdmin, err := apimw.IsAdmin(ctx, h.accountRepo)
 	if err != nil {
 		h.logger.Error(ctx, "failed to check admin status", "error", err)
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "authorization check failed"})
+		return respondError(c, http.StatusInternalServerError, "authorization check failed")
 	}
 	if !isAdmin {
-		return c.JSON(http.StatusForbidden, map[string]string{"error": "admin role required"})
+		return respondError(c, http.StatusForbidden, "admin role required")
 	}
 
 	agent, err := h.agentRepo.FindByID(ctx, id)
 	if err != nil || agent == nil {
-		return c.JSON(http.StatusNotFound, map[string]string{"error": "user not found"})
+		return respondError(c, http.StatusNotFound, "user not found")
 	}
 
 	accountID := h.defaultAccountID(ctx)
-	return c.JSON(http.StatusOK, h.buildUserResponse(ctx, agent, accountID))
+	return respond(c, http.StatusOK, h.buildUserResponse(ctx, agent, accountID))
 }
 
 type UpdateUserRequest struct {
@@ -122,30 +122,30 @@ func (h *UserHandler) Update(c echo.Context) error {
 	isAdmin, err := apimw.IsAdmin(ctx, h.accountRepo)
 	if err != nil {
 		h.logger.Error(ctx, "failed to check admin status", "error", err)
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "authorization check failed"})
+		return respondError(c, http.StatusInternalServerError, "authorization check failed")
 	}
 	if !isAdmin {
-		return c.JSON(http.StatusForbidden, map[string]string{"error": "admin role required"})
+		return respondError(c, http.StatusForbidden, "admin role required")
 	}
 
 	var req UpdateUserRequest
 	if err := c.Bind(&req); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request"})
+		return respondError(c, http.StatusBadRequest, "invalid request")
 	}
 
 	agent, err := h.agentRepo.FindByID(ctx, id)
 	if err != nil || agent == nil {
-		return c.JSON(http.StatusNotFound, map[string]string{"error": "user not found"})
+		return respondError(c, http.StatusNotFound, "user not found")
 	}
 
 	if req.Name != "" && req.Name != agent.Name() {
 		if err := agent.UpdateName(req.Name); err != nil {
 			h.logger.Error(ctx, "failed to update user name", "error", err, "user_id", id)
-			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to update user"})
+			return respondError(c, http.StatusInternalServerError, "failed to update user")
 		}
 		if err := h.agentRepo.Save(ctx, agent); err != nil {
 			h.logger.Error(ctx, "failed to save user", "error", err, "user_id", id)
-			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to update user"})
+			return respondError(c, http.StatusInternalServerError, "failed to update user")
 		}
 	}
 
@@ -153,11 +153,11 @@ func (h *UserHandler) Update(c echo.Context) error {
 	if req.Role != "" && accountID != "" {
 		if err := h.accountRepo.SaveMember(ctx, accountID, id, req.Role); err != nil {
 			h.logger.Error(ctx, "failed to save user role", "error", err, "user_id", id)
-			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to update user role"})
+			return respondError(c, http.StatusInternalServerError, "failed to update user role")
 		}
 	}
 
-	return c.JSON(http.StatusOK, h.buildUserResponse(ctx, agent, accountID))
+	return respond(c, http.StatusOK, h.buildUserResponse(ctx, agent, accountID))
 }
 
 func (h *UserHandler) defaultAccountID(ctx context.Context) string {

--- a/api/middleware/messages.go
+++ b/api/middleware/messages.go
@@ -1,0 +1,20 @@
+package middleware
+
+import (
+	"weos/domain/entities"
+
+	"github.com/labstack/echo/v4"
+)
+
+// Messages returns middleware that injects a message accumulator into the
+// request context. Services can call entities.AddMessage(ctx, msg) to
+// accumulate messages; handlers extract them with entities.GetMessages(ctx).
+func Messages() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			ctx := entities.ContextWithMessages(c.Request().Context())
+			c.SetRequest(c.Request().WithContext(ctx))
+			return next(c)
+		}
+	}
+}

--- a/domain/entities/message.go
+++ b/domain/entities/message.go
@@ -1,0 +1,43 @@
+package entities
+
+import "context"
+
+// Message represents a non-fatal notification that can be surfaced to the UI.
+// Services accumulate messages on the request context via AddMessage; handlers
+// extract them with GetMessages and include them in the response envelope.
+type Message struct {
+	Type  string `json:"type"`            // "error", "warning", "info", "success"
+	Text  string `json:"text"`
+	Field string `json:"field,omitempty"` // optional: ties message to a specific field
+	Code  string `json:"code,omitempty"`  // optional: machine-readable code for the UI
+}
+
+// messagesKeyType is an unexported type used as the context key for messages.
+type messagesKeyType struct{}
+
+// messagesKey is the context key. Using a private struct prevents collisions.
+var messagesKey = &messagesKeyType{}
+
+// ContextWithMessages returns a new context that carries a message accumulator.
+// Call this once per request (typically in middleware) before any service code runs.
+func ContextWithMessages(ctx context.Context) context.Context {
+	msgs := make([]Message, 0)
+	return context.WithValue(ctx, messagesKey, &msgs)
+}
+
+// AddMessage appends a message to the context's accumulator.
+// It is a no-op if the context does not carry a message accumulator.
+func AddMessage(ctx context.Context, msg Message) {
+	if ptr, ok := ctx.Value(messagesKey).(*[]Message); ok && ptr != nil {
+		*ptr = append(*ptr, msg)
+	}
+}
+
+// GetMessages returns the messages accumulated on the context, or nil if none.
+func GetMessages(ctx context.Context) []Message {
+	ptr, ok := ctx.Value(messagesKey).(*[]Message)
+	if !ok || ptr == nil || len(*ptr) == 0 {
+		return nil
+	}
+	return *ptr
+}

--- a/domain/entities/message.go
+++ b/domain/entities/message.go
@@ -6,7 +6,7 @@ import "context"
 // Services accumulate messages on the request context via AddMessage; handlers
 // extract them with GetMessages and include them in the response envelope.
 type Message struct {
-	Type  string `json:"type"`            // "error", "warning", "info", "success"
+	Type  string `json:"type"` // "error", "warning", "info", "success"
 	Text  string `json:"text"`
 	Field string `json:"field,omitempty"` // optional: ties message to a specific field
 	Code  string `json:"code,omitempty"`  // optional: machine-readable code for the UI

--- a/domain/entities/message_test.go
+++ b/domain/entities/message_test.go
@@ -1,0 +1,76 @@
+package entities_test
+
+import (
+	"context"
+	"testing"
+
+	"weos/domain/entities"
+)
+
+func TestContextWithMessages_AccumulatesMessages(t *testing.T) {
+	t.Parallel()
+	ctx := entities.ContextWithMessages(context.Background())
+
+	entities.AddMessage(ctx, entities.Message{Type: "info", Text: "hello"})
+	entities.AddMessage(ctx, entities.Message{Type: "warning", Text: "watch out", Field: "name"})
+
+	msgs := entities.GetMessages(ctx)
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+	if msgs[0].Type != "info" || msgs[0].Text != "hello" {
+		t.Fatalf("unexpected first message: %+v", msgs[0])
+	}
+	if msgs[1].Field != "name" {
+		t.Fatalf("expected field 'name', got %q", msgs[1].Field)
+	}
+}
+
+func TestGetMessages_ReturnsNilWhenEmpty(t *testing.T) {
+	t.Parallel()
+	ctx := entities.ContextWithMessages(context.Background())
+
+	msgs := entities.GetMessages(ctx)
+	if msgs != nil {
+		t.Fatalf("expected nil for empty messages, got %v", msgs)
+	}
+}
+
+func TestAddMessage_NoOpWithoutAccumulator(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background() // no accumulator
+
+	// Should not panic.
+	entities.AddMessage(ctx, entities.Message{Type: "error", Text: "ignored"})
+
+	msgs := entities.GetMessages(ctx)
+	if msgs != nil {
+		t.Fatalf("expected nil without accumulator, got %v", msgs)
+	}
+}
+
+func TestGetMessages_ReturnsNilWithoutAccumulator(t *testing.T) {
+	t.Parallel()
+	msgs := entities.GetMessages(context.Background())
+	if msgs != nil {
+		t.Fatalf("expected nil without accumulator, got %v", msgs)
+	}
+}
+
+func TestMessage_CodeAndFieldAreOptional(t *testing.T) {
+	t.Parallel()
+	ctx := entities.ContextWithMessages(context.Background())
+
+	entities.AddMessage(ctx, entities.Message{Type: "success", Text: "done"})
+	entities.AddMessage(ctx, entities.Message{
+		Type: "error", Text: "bad input", Field: "email", Code: "INVALID_EMAIL",
+	})
+
+	msgs := entities.GetMessages(ctx)
+	if msgs[0].Field != "" || msgs[0].Code != "" {
+		t.Fatalf("expected empty field/code, got field=%q code=%q", msgs[0].Field, msgs[0].Code)
+	}
+	if msgs[1].Code != "INVALID_EMAIL" {
+		t.Fatalf("expected code INVALID_EMAIL, got %q", msgs[1].Code)
+	}
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -135,6 +135,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}))
 
 	api := e.Group("/api")
+	api.Use(apimw.Messages())
 	api.GET("/health", handlers.HealthHandler)
 
 	// Auth routes (pericarp built-in handlers wrapped for Echo)

--- a/tests/e2e/setup_test.go
+++ b/tests/e2e/setup_test.go
@@ -132,6 +132,7 @@ func setupTestEnv(t *testing.T) *testEnv {
 	e.HideBanner = true
 
 	api := e.Group("/api")
+	api.Use(apimw.Messages())
 	api.GET("/health", handlers.HealthHandler)
 
 	protected := api.Group("")
@@ -197,15 +198,28 @@ func (env *testEnv) doRequest(t *testing.T, method, path, body, devAgent string)
 func readJSON(t *testing.T, resp *http.Response) map[string]any {
 	t.Helper()
 	defer resp.Body.Close()
-	data, err := io.ReadAll(resp.Body)
+	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("failed to read response: %v", err)
 	}
 	var result map[string]any
-	if err := json.Unmarshal(data, &result); err != nil {
-		t.Fatalf("failed to parse JSON: %v\nbody: %s", err, string(data))
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatalf("failed to parse JSON: %v\nbody: %s", err, string(raw))
 	}
 	return result
+}
+
+// readEnvelopeData reads the response JSON and unwraps the "data" field from the
+// standard envelope. Use this for single-entity responses where the entity is
+// wrapped in {"data": {...}}.
+func readEnvelopeData(t *testing.T, resp *http.Response) map[string]any {
+	t.Helper()
+	envelope := readJSON(t, resp)
+	data, ok := envelope["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected 'data' object in envelope, got: %v", envelope)
+	}
+	return data
 }
 
 // seedProjectForUser creates a project via the API as the given dev agent and returns its ID.
@@ -217,10 +231,10 @@ func (env *testEnv) seedProjectForUser(t *testing.T, name, email string) string 
 		result := readJSON(t, resp)
 		t.Fatalf("create project: expected 201, got %d: %v", resp.StatusCode, result)
 	}
-	result := readJSON(t, resp)
-	id, ok := result["id"].(string)
+	data := readEnvelopeData(t, resp)
+	id, ok := data["id"].(string)
 	if !ok || id == "" {
-		t.Fatalf("create project: missing id in response: %v", result)
+		t.Fatalf("create project: missing id in response: %v", data)
 	}
 	return id
 }
@@ -234,10 +248,10 @@ func (env *testEnv) seedTaskForUser(t *testing.T, name, projectID, email string)
 		result := readJSON(t, resp)
 		t.Fatalf("create task: expected 201, got %d: %v", resp.StatusCode, result)
 	}
-	result := readJSON(t, resp)
-	id, ok := result["id"].(string)
+	data := readEnvelopeData(t, resp)
+	id, ok := data["id"].(string)
 	if !ok || id == "" {
-		t.Fatalf("create task: missing id in response: %v", result)
+		t.Fatalf("create task: missing id in response: %v", data)
 	}
 	return id
 }

--- a/tests/e2e/tasks_test.go
+++ b/tests/e2e/tasks_test.go
@@ -55,12 +55,12 @@ func TestCreateProject_Anonymous(t *testing.T) {
 		result := readJSON(t, resp)
 		t.Fatalf("expected 201, got %d: %v", resp.StatusCode, result)
 	}
-	result := readJSON(t, resp)
-	if result["id"] == nil || result["id"] == "" {
+	data := readEnvelopeData(t, resp)
+	if data["id"] == nil || data["id"] == "" {
 		t.Fatal("expected non-empty id")
 	}
-	if result["type_slug"] != "project" {
-		t.Fatalf("type_slug = %v, want project", result["type_slug"])
+	if data["type_slug"] != "project" {
+		t.Fatalf("type_slug = %v, want project", data["type_slug"])
 	}
 }
 
@@ -73,17 +73,17 @@ func TestCreateProject_Authenticated(t *testing.T) {
 		result := readJSON(t, resp)
 		t.Fatalf("expected 201, got %d: %v", resp.StatusCode, result)
 	}
-	result := readJSON(t, resp)
-	id := result["id"].(string)
+	data := readEnvelopeData(t, resp)
+	id := data["id"].(string)
 
 	// Verify admin can read it back
 	getResp := env.doRequest(t, "GET", "/api/project/"+id, "", "admin@weos.dev")
 	if getResp.StatusCode != http.StatusOK {
 		t.Fatalf("get project: expected 200, got %d", getResp.StatusCode)
 	}
-	getResult := readJSON(t, getResp)
-	if getResult["id"] != id {
-		t.Fatalf("got id %v, want %v", getResult["id"], id)
+	getData := readEnvelopeData(t, getResp)
+	if getData["id"] != id {
+		t.Fatalf("got id %v, want %v", getData["id"], id)
 	}
 }
 
@@ -106,8 +106,8 @@ func TestCreateTask_WithProjectReference(t *testing.T) {
 		result := readJSON(t, resp)
 		t.Fatalf("expected 201, got %d: %v", resp.StatusCode, result)
 	}
-	result := readJSON(t, resp)
-	taskID := result["id"].(string)
+	data := readEnvelopeData(t, resp)
+	taskID := data["id"].(string)
 
 	// Verify the task exists
 	getResp := env.doRequest(t, "GET", "/api/task/"+taskID, "", "admin@weos.dev")
@@ -296,8 +296,8 @@ func TestFullWorkflow_ProjectsAndTasks(t *testing.T) {
 		result := readJSON(t, createProjResp)
 		t.Fatalf("step 1 create project: expected 201, got %d: %v", createProjResp.StatusCode, result)
 	}
-	projResult := readJSON(t, createProjResp)
-	projectID := projResult["id"].(string)
+	projData := readEnvelopeData(t, createProjResp)
+	projectID := projData["id"].(string)
 
 	// 2. Create tasks linked to the project
 	task1Body := fmt.Sprintf(`{"name":"Task Alpha","status":"open","priority":"high","dueDate":"2026-06-01","project":%q}`, projectID)
@@ -306,8 +306,8 @@ func TestFullWorkflow_ProjectsAndTasks(t *testing.T) {
 		result := readJSON(t, createTask1Resp)
 		t.Fatalf("step 2a create task: expected 201, got %d: %v", createTask1Resp.StatusCode, result)
 	}
-	task1Result := readJSON(t, createTask1Resp)
-	task1ID := task1Result["id"].(string)
+	task1Data := readEnvelopeData(t, createTask1Resp)
+	task1ID := task1Data["id"].(string)
 
 	task2Body := fmt.Sprintf(`{"name":"Task Beta","status":"in-progress","priority":"low","project":%q}`, projectID)
 	createTask2Resp := env.doRequest(t, "POST", "/api/task", task2Body, "admin@weos.dev")

--- a/tests/e2e/tasks_test.go
+++ b/tests/e2e/tasks_test.go
@@ -208,13 +208,16 @@ func TestOwnership_OtherUserDenied(t *testing.T) {
 	// Admin creates a project
 	projectID := env.seedProjectForUser(t, "Admin Private", "admin@weos.dev")
 
-	// Member tries to access it — should be denied
+	// Member tries to access it — should be denied with ErrorEnvelope
 	resp := env.doRequest(t, "GET", "/api/project/"+projectID, "", "member@weos.dev")
 	if resp.StatusCode != http.StatusForbidden {
 		result := readJSON(t, resp)
 		t.Fatalf("member access admin project: expected 403, got %d: %v", resp.StatusCode, result)
 	}
-	resp.Body.Close()
+	result := readJSON(t, resp)
+	if result["error"] == nil || result["error"] == "" {
+		t.Fatalf("expected 'error' key in 403 response, got: %v", result)
+	}
 }
 
 func TestOwnership_ListOnlyShowsOwnResources(t *testing.T) {

--- a/web/admin/app.vue
+++ b/web/admin/app.vue
@@ -26,7 +26,12 @@
       :class="['api-notification', `api-notification--${n.type}`]"
     >
       {{ n.text }}
-      <button class="api-notification__close" @click="removeNotification(n.id)">x</button>
+      <button
+        type="button"
+        class="api-notification__close"
+        aria-label="Dismiss notification"
+        @click="removeNotification(n.id)"
+      >x</button>
     </div>
   </div>
 </template>

--- a/web/admin/app.vue
+++ b/web/admin/app.vue
@@ -19,11 +19,12 @@
   <NuxtLayout>
     <NuxtPage />
   </NuxtLayout>
-  <div class="api-notifications">
+  <div class="api-notifications" aria-live="polite" role="status">
     <div
       v-for="n in notifications"
       :key="n.id"
       :class="['api-notification', `api-notification--${n.type}`]"
+      :role="n.type === 'error' ? 'alert' : undefined"
     >
       {{ n.text }}
       <button

--- a/web/admin/app.vue
+++ b/web/admin/app.vue
@@ -19,4 +19,54 @@
   <NuxtLayout>
     <NuxtPage />
   </NuxtLayout>
+  <div class="api-notifications">
+    <div
+      v-for="n in notifications"
+      :key="n.id"
+      :class="['api-notification', `api-notification--${n.type}`]"
+    >
+      {{ n.text }}
+      <button class="api-notification__close" @click="removeNotification(n.id)">x</button>
+    </div>
+  </div>
 </template>
+
+<script setup lang="ts">
+const { notifications, removeNotification } = useNotifications()
+</script>
+
+<style scoped>
+.api-notifications {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 400px;
+}
+.api-notification {
+  padding: 10px 16px;
+  border-radius: 6px;
+  color: #fff;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+.api-notification--success { background: #52c41a; }
+.api-notification--info { background: #1890ff; }
+.api-notification--warning { background: #faad14; color: #000; }
+.api-notification--error { background: #ff4d4f; }
+.api-notification__close {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0 4px;
+}
+</style>

--- a/web/admin/composables/useApi.ts
+++ b/web/admin/composables/useApi.ts
@@ -13,19 +13,48 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import type { ApiMessage } from './useNotifications'
+
+/**
+ * Checks whether a raw response looks like the API envelope
+ * (`{ data: ... }` with an optional `messages` array).
+ */
+function isEnvelope(obj: unknown): obj is { data: unknown; messages?: ApiMessage[] } {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    'data' in obj
+  )
+}
+
+/**
+ * Unwraps an API response envelope.
+ * If the response has the `{ data, messages? }` shape the payload inside
+ * `data` is returned and any `messages` are forwarded to the notification
+ * system.  Non-envelope responses are returned as-is for backward compat.
+ */
+export function unwrapEnvelope<T>(raw: unknown): T {
+  if (isEnvelope(raw)) {
+    const { processApiMessages } = useNotifications()
+    processApiMessages(raw.messages)
+    return raw.data as T
+  }
+  return raw as T
+}
+
 export function useApi() {
   async function request<T>(
     url: string,
     options?: RequestInit,
   ): Promise<T> {
-    const res = await $fetch<T>(url, {
+    const res = await $fetch<unknown>(url, {
       ...options,
       headers: {
         'Content-Type': 'application/json',
         ...(options?.headers as Record<string, string>),
       },
     } as any)
-    return res
+    return unwrapEnvelope<T>(res)
   }
 
   return { request }

--- a/web/admin/composables/useApi.ts
+++ b/web/admin/composables/useApi.ts
@@ -16,27 +16,45 @@
 import type { ApiMessage } from './useNotifications'
 
 /**
- * Checks whether a raw response looks like the API envelope
- * (`{ data: ... }` with an optional `messages` array).
+ * Checks whether a raw response is a single-entity envelope.
+ * Distinguishes from paginated responses by excluding objects
+ * that also have `cursor` or `has_more` keys.
  */
-function isEnvelope(obj: unknown): obj is { data: unknown; messages?: ApiMessage[] } {
+function isSingleEnvelope(obj: unknown): obj is { data: unknown; messages?: ApiMessage[] } {
   return (
     typeof obj === 'object' &&
     obj !== null &&
-    'data' in obj
+    'data' in obj &&
+    !('cursor' in obj) &&
+    !('has_more' in obj)
   )
 }
 
 /**
- * Unwraps an API response envelope.
- * If the response has the `{ data, messages? }` shape the payload inside
- * `data` is returned and any `messages` are forwarded to the notification
- * system.  Non-envelope responses are returned as-is for backward compat.
+ * Process messages from any API response if present.
+ * Exported so paginated endpoints can forward messages without unwrapping.
+ */
+export function forwardMessages(obj: unknown): void {
+  if (
+    typeof obj === 'object' &&
+    obj !== null &&
+    'messages' in obj &&
+    Array.isArray((obj as any).messages)
+  ) {
+    const { processApiMessages } = useNotifications()
+    processApiMessages((obj as any).messages)
+  }
+}
+
+/**
+ * Unwraps a single-entity API response envelope.
+ * If the response has the `{ data, messages? }` shape (excluding paginated),
+ * the payload inside `data` is returned and any `messages` are forwarded to
+ * the notification system. Non-envelope responses are returned as-is.
  */
 export function unwrapEnvelope<T>(raw: unknown): T {
-  if (isEnvelope(raw)) {
-    const { processApiMessages } = useNotifications()
-    processApiMessages(raw.messages)
+  forwardMessages(raw)
+  if (isSingleEnvelope(raw)) {
     return raw.data as T
   }
   return raw as T
@@ -47,14 +65,23 @@ export function useApi() {
     url: string,
     options?: RequestInit,
   ): Promise<T> {
-    const res = await $fetch<unknown>(url, {
-      ...options,
-      headers: {
-        'Content-Type': 'application/json',
-        ...(options?.headers as Record<string, string>),
-      },
-    } as any)
-    return unwrapEnvelope<T>(res)
+    try {
+      const res = await $fetch<unknown>(url, {
+        ...options,
+        headers: {
+          'Content-Type': 'application/json',
+          ...(options?.headers as Record<string, string>),
+        },
+      } as any)
+      return unwrapEnvelope<T>(res)
+    } catch (err: any) {
+      // $fetch throws FetchError on 4xx/5xx with .data containing the response body.
+      // Forward structured messages from error envelopes to the notification system.
+      if (err?.data) {
+        forwardMessages(err.data)
+      }
+      throw err
+    }
   }
 
   return { request }

--- a/web/admin/composables/useAuth.ts
+++ b/web/admin/composables/useAuth.ts
@@ -1,3 +1,5 @@
+import { unwrapEnvelope } from './useApi'
+
 interface AuthUser {
   id: string
   name: string
@@ -15,8 +17,8 @@ export function useAuth() {
 
   async function fetchUser() {
     try {
-      const data = await $fetch<AuthUser>('/api/auth/me')
-      user.value = data
+      const res = await $fetch<unknown>('/api/auth/me')
+      user.value = unwrapEnvelope<AuthUser>(res)
     } catch (err) {
       console.error('[useAuth] fetchUser failed:', err)
       user.value = null

--- a/web/admin/composables/useAuth.ts
+++ b/web/admin/composables/useAuth.ts
@@ -1,4 +1,4 @@
-import { unwrapEnvelope } from './useApi'
+import { forwardMessages } from './useApi'
 
 interface AuthUser {
   id: string
@@ -11,14 +11,14 @@ interface AuthUser {
 }
 
 export function useAuth() {
+  const { request } = useApi()
   const user = useState<AuthUser | null>('auth-user', () => null)
   const loading = useState<boolean>('auth-loading', () => true)
   const isImpersonating = computed(() => !!user.value?.impersonating)
 
   async function fetchUser() {
     try {
-      const res = await $fetch<unknown>('/api/auth/me')
-      user.value = unwrapEnvelope<AuthUser>(res)
+      user.value = await request<AuthUser>('/api/auth/me')
     } catch (err) {
       console.error('[useAuth] fetchUser failed:', err)
       user.value = null
@@ -29,9 +29,9 @@ export function useAuth() {
 
   async function startImpersonation(agentId: string) {
     try {
-      await $fetch('/api/admin/impersonate', {
+      await request('/api/admin/impersonate', {
         method: 'POST',
-        body: { agent_id: agentId },
+        body: JSON.stringify({ agent_id: agentId }),
       })
       await fetchUser()
     } catch (err) {
@@ -42,7 +42,7 @@ export function useAuth() {
 
   async function stopImpersonation() {
     try {
-      await $fetch('/api/admin/stop-impersonation', { method: 'POST' })
+      await request('/api/admin/stop-impersonation', { method: 'POST' })
       await fetchUser()
     } catch (err) {
       console.error('[useAuth] stopImpersonation failed:', err)
@@ -53,6 +53,8 @@ export function useAuth() {
   async function logout() {
     try {
       await $fetch('/api/auth/logout', { method: 'POST' })
+    } catch (err: any) {
+      if (err?.data) forwardMessages(err.data)
     } finally {
       user.value = null
       navigateTo('/login')

--- a/web/admin/composables/useNotifications.ts
+++ b/web/admin/composables/useNotifications.ts
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+export interface ApiMessage {
+  type: 'success' | 'info' | 'warning' | 'error'
+  text: string
+}
+
+export interface Notification {
+  id: number
+  type: ApiMessage['type']
+  text: string
+}
+
+let nextId = 0
+
+export function useNotifications() {
+  const notifications = useState<Notification[]>('notifications', () => [])
+
+  function addNotification(msg: ApiMessage) {
+    const id = nextId++
+    notifications.value.push({ id, type: msg.type, text: msg.text })
+    if (msg.type === 'success' || msg.type === 'info') {
+      setTimeout(() => removeNotification(id), 3000)
+    }
+  }
+
+  function removeNotification(id: number) {
+    notifications.value = notifications.value.filter((n) => n.id !== id)
+  }
+
+  function processApiMessages(messages?: ApiMessage[]) {
+    if (!messages || messages.length === 0) return
+    for (const msg of messages) {
+      addNotification(msg)
+    }
+  }
+
+  return { notifications, addNotification, removeNotification, processApiMessages }
+}

--- a/web/admin/composables/useOrganizationApi.ts
+++ b/web/admin/composables/useOrganizationApi.ts
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import { unwrapEnvelope } from './useApi'
+
 interface Organization {
   id: string
   name: string
@@ -65,26 +67,30 @@ export function useOrganizationApi() {
     )
   }
 
-  function getOrganization(id: string) {
-    return $fetch<Organization>(`/api/organizations/${id}`)
+  async function getOrganization(id: string) {
+    const res = await $fetch<unknown>(`/api/organizations/${id}`)
+    return unwrapEnvelope<Organization>(res)
   }
 
-  function createOrganization(payload: CreateOrganizationPayload) {
-    return $fetch<Organization>('/api/organizations', {
+  async function createOrganization(payload: CreateOrganizationPayload) {
+    const res = await $fetch<unknown>('/api/organizations', {
       method: 'POST',
       body: payload,
     })
+    return unwrapEnvelope<Organization>(res)
   }
 
-  function updateOrganization(id: string, payload: UpdateOrganizationPayload) {
-    return $fetch<Organization>(`/api/organizations/${id}`, {
+  async function updateOrganization(id: string, payload: UpdateOrganizationPayload) {
+    const res = await $fetch<unknown>(`/api/organizations/${id}`, {
       method: 'PUT',
       body: payload,
     })
+    return unwrapEnvelope<Organization>(res)
   }
 
-  function deleteOrganization(id: string) {
-    return $fetch(`/api/organizations/${id}`, { method: 'DELETE' })
+  async function deleteOrganization(id: string) {
+    const res = await $fetch<unknown>(`/api/organizations/${id}`, { method: 'DELETE' })
+    return unwrapEnvelope<void>(res)
   }
 
   function listMembers(orgId: string, cursor = '', limit = 20) {

--- a/web/admin/composables/useOrganizationApi.ts
+++ b/web/admin/composables/useOrganizationApi.ts
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { unwrapEnvelope } from './useApi'
+import { unwrapEnvelope, forwardMessages } from './useApi'
 
 interface Organization {
   id: string
@@ -58,13 +58,15 @@ interface Person {
 }
 
 export function useOrganizationApi() {
-  function listOrganizations(cursor = '', limit = 20) {
+  async function listOrganizations(cursor = '', limit = 20) {
     const params = new URLSearchParams()
     if (cursor) params.set('cursor', cursor)
     params.set('limit', String(limit))
-    return $fetch<PaginatedResponse<Organization>>(
+    const res = await $fetch<PaginatedResponse<Organization>>(
       `/api/organizations?${params}`,
     )
+    forwardMessages(res)
+    return res
   }
 
   async function getOrganization(id: string) {

--- a/web/admin/composables/useOrganizationApi.ts
+++ b/web/admin/composables/useOrganizationApi.ts
@@ -13,7 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { unwrapEnvelope, forwardMessages } from './useApi'
+import { forwardMessages } from './useApi'
+import type { ApiMessage } from './useNotifications'
 
 interface Organization {
   id: string
@@ -30,6 +31,7 @@ interface PaginatedResponse<T> {
   data: T[]
   cursor: string
   has_more: boolean
+  messages?: ApiMessage[]
 }
 
 interface CreateOrganizationPayload {
@@ -58,50 +60,60 @@ interface Person {
 }
 
 export function useOrganizationApi() {
+  const { request } = useApi()
+
   async function listOrganizations(cursor = '', limit = 20) {
     const params = new URLSearchParams()
     if (cursor) params.set('cursor', cursor)
     params.set('limit', String(limit))
-    const res = await $fetch<PaginatedResponse<Organization>>(
-      `/api/organizations?${params}`,
-    )
-    forwardMessages(res)
-    return res
+    try {
+      const res = await $fetch<PaginatedResponse<Organization>>(
+        `/api/organizations?${params}`,
+      )
+      forwardMessages(res)
+      return res
+    } catch (err: any) {
+      if (err?.data) forwardMessages(err.data)
+      throw err
+    }
   }
 
-  async function getOrganization(id: string) {
-    const res = await $fetch<unknown>(`/api/organizations/${id}`)
-    return unwrapEnvelope<Organization>(res)
+  function getOrganization(id: string) {
+    return request<Organization>(`/api/organizations/${id}`)
   }
 
-  async function createOrganization(payload: CreateOrganizationPayload) {
-    const res = await $fetch<unknown>('/api/organizations', {
+  function createOrganization(payload: CreateOrganizationPayload) {
+    return request<Organization>('/api/organizations', {
       method: 'POST',
-      body: payload,
+      body: JSON.stringify(payload),
     })
-    return unwrapEnvelope<Organization>(res)
   }
 
-  async function updateOrganization(id: string, payload: UpdateOrganizationPayload) {
-    const res = await $fetch<unknown>(`/api/organizations/${id}`, {
+  function updateOrganization(id: string, payload: UpdateOrganizationPayload) {
+    return request<Organization>(`/api/organizations/${id}`, {
       method: 'PUT',
-      body: payload,
+      body: JSON.stringify(payload),
     })
-    return unwrapEnvelope<Organization>(res)
   }
 
-  async function deleteOrganization(id: string) {
-    const res = await $fetch<unknown>(`/api/organizations/${id}`, { method: 'DELETE' })
-    return unwrapEnvelope<void>(res)
+  function deleteOrganization(id: string) {
+    return request<void>(`/api/organizations/${id}`, { method: 'DELETE' })
   }
 
-  function listMembers(orgId: string, cursor = '', limit = 20) {
+  async function listMembers(orgId: string, cursor = '', limit = 20) {
     const params = new URLSearchParams()
     if (cursor) params.set('cursor', cursor)
     params.set('limit', String(limit))
-    return $fetch<PaginatedResponse<Person>>(
-      `/api/organizations/${orgId}/members?${params}`,
-    )
+    try {
+      const res = await $fetch<PaginatedResponse<Person>>(
+        `/api/organizations/${orgId}/members?${params}`,
+      )
+      forwardMessages(res)
+      return res
+    } catch (err: any) {
+      if (err?.data) forwardMessages(err.data)
+      throw err
+    }
   }
 
   return {

--- a/web/admin/composables/usePersonApi.ts
+++ b/web/admin/composables/usePersonApi.ts
@@ -13,7 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { unwrapEnvelope, forwardMessages } from './useApi'
+import { forwardMessages } from './useApi'
+import type { ApiMessage } from './useNotifications'
 
 interface Person {
   id: string
@@ -30,6 +31,7 @@ interface PaginatedResponse<T> {
   data: T[]
   cursor: string
   has_more: boolean
+  messages?: ApiMessage[]
 }
 
 interface CreatePersonPayload {
@@ -47,41 +49,44 @@ interface UpdatePersonPayload {
 }
 
 export function usePersonApi() {
+  const { request } = useApi()
+
   async function listPersons(cursor = '', limit = 20) {
     const params = new URLSearchParams()
     if (cursor) params.set('cursor', cursor)
     params.set('limit', String(limit))
-    const res = await $fetch<PaginatedResponse<Person>>(
-      `/api/persons?${params}`,
-    )
-    forwardMessages(res)
-    return res
+    try {
+      const res = await $fetch<PaginatedResponse<Person>>(
+        `/api/persons?${params}`,
+      )
+      forwardMessages(res)
+      return res
+    } catch (err: any) {
+      if (err?.data) forwardMessages(err.data)
+      throw err
+    }
   }
 
-  async function getPerson(id: string) {
-    const res = await $fetch<unknown>(`/api/persons/${id}`)
-    return unwrapEnvelope<Person>(res)
+  function getPerson(id: string) {
+    return request<Person>(`/api/persons/${id}`)
   }
 
-  async function createPerson(payload: CreatePersonPayload) {
-    const res = await $fetch<unknown>('/api/persons', {
+  function createPerson(payload: CreatePersonPayload) {
+    return request<Person>('/api/persons', {
       method: 'POST',
-      body: payload,
+      body: JSON.stringify(payload),
     })
-    return unwrapEnvelope<Person>(res)
   }
 
-  async function updatePerson(id: string, payload: UpdatePersonPayload) {
-    const res = await $fetch<unknown>(`/api/persons/${id}`, {
+  function updatePerson(id: string, payload: UpdatePersonPayload) {
+    return request<Person>(`/api/persons/${id}`, {
       method: 'PUT',
-      body: payload,
+      body: JSON.stringify(payload),
     })
-    return unwrapEnvelope<Person>(res)
   }
 
-  async function deletePerson(id: string) {
-    const res = await $fetch<unknown>(`/api/persons/${id}`, { method: 'DELETE' })
-    return unwrapEnvelope<void>(res)
+  function deletePerson(id: string) {
+    return request<void>(`/api/persons/${id}`, { method: 'DELETE' })
   }
 
   return {

--- a/web/admin/composables/usePersonApi.ts
+++ b/web/admin/composables/usePersonApi.ts
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { unwrapEnvelope } from './useApi'
+import { unwrapEnvelope, forwardMessages } from './useApi'
 
 interface Person {
   id: string
@@ -47,14 +47,15 @@ interface UpdatePersonPayload {
 }
 
 export function usePersonApi() {
-  function listPersons(cursor = '', limit = 20) {
+  async function listPersons(cursor = '', limit = 20) {
     const params = new URLSearchParams()
     if (cursor) params.set('cursor', cursor)
     params.set('limit', String(limit))
-    // Paginated responses already match the envelope shape
-    return $fetch<PaginatedResponse<Person>>(
+    const res = await $fetch<PaginatedResponse<Person>>(
       `/api/persons?${params}`,
     )
+    forwardMessages(res)
+    return res
   }
 
   async function getPerson(id: string) {

--- a/web/admin/composables/usePersonApi.ts
+++ b/web/admin/composables/usePersonApi.ts
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import { unwrapEnvelope } from './useApi'
+
 interface Person {
   id: string
   given_name: string
@@ -49,31 +51,36 @@ export function usePersonApi() {
     const params = new URLSearchParams()
     if (cursor) params.set('cursor', cursor)
     params.set('limit', String(limit))
+    // Paginated responses already match the envelope shape
     return $fetch<PaginatedResponse<Person>>(
       `/api/persons?${params}`,
     )
   }
 
-  function getPerson(id: string) {
-    return $fetch<Person>(`/api/persons/${id}`)
+  async function getPerson(id: string) {
+    const res = await $fetch<unknown>(`/api/persons/${id}`)
+    return unwrapEnvelope<Person>(res)
   }
 
-  function createPerson(payload: CreatePersonPayload) {
-    return $fetch<Person>('/api/persons', {
+  async function createPerson(payload: CreatePersonPayload) {
+    const res = await $fetch<unknown>('/api/persons', {
       method: 'POST',
       body: payload,
     })
+    return unwrapEnvelope<Person>(res)
   }
 
-  function updatePerson(id: string, payload: UpdatePersonPayload) {
-    return $fetch<Person>(`/api/persons/${id}`, {
+  async function updatePerson(id: string, payload: UpdatePersonPayload) {
+    const res = await $fetch<unknown>(`/api/persons/${id}`, {
       method: 'PUT',
       body: payload,
     })
+    return unwrapEnvelope<Person>(res)
   }
 
-  function deletePerson(id: string) {
-    return $fetch(`/api/persons/${id}`, { method: 'DELETE' })
+  async function deletePerson(id: string) {
+    const res = await $fetch<unknown>(`/api/persons/${id}`, { method: 'DELETE' })
+    return unwrapEnvelope<void>(res)
   }
 
   return {

--- a/web/admin/composables/usePresetScreens.ts
+++ b/web/admin/composables/usePresetScreens.ts
@@ -15,6 +15,7 @@
 
 import type { Component } from 'vue'
 import type { ApiMessage } from './useNotifications'
+import { forwardMessages } from './useApi'
 
 export interface ScreenMeta {
   name: string
@@ -62,7 +63,8 @@ export function usePresetScreens() {
       manifest.value = mapping
       manifestLoaded.value = true
       return true
-    } catch (err) {
+    } catch (err: any) {
+      forwardMessages(err?.data)
       console.error('[usePresetScreens] fetchManifest failed:', err)
       return false
     }

--- a/web/admin/composables/usePresetScreens.ts
+++ b/web/admin/composables/usePresetScreens.ts
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { Component } from 'vue'
+import type { ApiMessage } from './useNotifications'
 
 export interface ScreenMeta {
   name: string
@@ -47,7 +48,9 @@ export function usePresetScreens() {
   async function fetchManifest(): Promise<boolean> {
     if (manifestLoaded.value) return true
     try {
-      const res = await $fetch<{ data: PresetListEntry[] }>('/api/resource-types/presets')
+      const res = await $fetch<{ data: PresetListEntry[]; messages?: ApiMessage[] }>('/api/resource-types/presets')
+      const { processApiMessages } = useNotifications()
+      processApiMessages(res.messages)
       const mapping: Record<string, SlugMapping> = {}
       for (const preset of res.data) {
         if (!preset.screens) continue

--- a/web/admin/composables/useResourceApi.ts
+++ b/web/admin/composables/useResourceApi.ts
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import { unwrapEnvelope } from './useApi'
+
 interface PaginatedResponse<T> {
   data: T[]
   cursor: string
@@ -39,31 +41,36 @@ export function useResourceApi(typeSlug: string) {
         }
       }
     }
+    // Paginated responses already match the envelope shape (data, cursor, has_more)
     return $fetch<PaginatedResponse<any>>(
       `/api/${typeSlug}?${params}`,
     )
   }
 
-  function get(id: string) {
-    return $fetch<any>(`/api/${typeSlug}/${id}`)
+  async function get(id: string) {
+    const res = await $fetch<unknown>(`/api/${typeSlug}/${id}`)
+    return unwrapEnvelope<any>(res)
   }
 
-  function create(data: Record<string, any>) {
-    return $fetch<any>(`/api/${typeSlug}`, {
+  async function create(data: Record<string, any>) {
+    const res = await $fetch<unknown>(`/api/${typeSlug}`, {
       method: 'POST',
       body: data,
     })
+    return unwrapEnvelope<any>(res)
   }
 
-  function update(id: string, data: Record<string, any>) {
-    return $fetch<any>(`/api/${typeSlug}/${id}`, {
+  async function update(id: string, data: Record<string, any>) {
+    const res = await $fetch<unknown>(`/api/${typeSlug}/${id}`, {
       method: 'PUT',
       body: data,
     })
+    return unwrapEnvelope<any>(res)
   }
 
-  function remove(id: string) {
-    return $fetch(`/api/${typeSlug}/${id}`, { method: 'DELETE' })
+  async function remove(id: string) {
+    const res = await $fetch<unknown>(`/api/${typeSlug}/${id}`, { method: 'DELETE' })
+    return unwrapEnvelope<void>(res)
   }
 
   return { list, get, create, update, remove }

--- a/web/admin/composables/useResourceApi.ts
+++ b/web/admin/composables/useResourceApi.ts
@@ -13,16 +13,18 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { unwrapEnvelope } from './useApi'
+import { unwrapEnvelope, forwardMessages } from './useApi'
+import type { ApiMessage } from './useNotifications'
 
 interface PaginatedResponse<T> {
   data: T[]
   cursor: string
   has_more: boolean
+  messages?: ApiMessage[]
 }
 
 export function useResourceApi(typeSlug: string) {
-  function list(
+  async function list(
     cursor = '',
     limit = 20,
     sortBy = '',
@@ -41,10 +43,11 @@ export function useResourceApi(typeSlug: string) {
         }
       }
     }
-    // Paginated responses already match the envelope shape (data, cursor, has_more)
-    return $fetch<PaginatedResponse<any>>(
+    const res = await $fetch<PaginatedResponse<any>>(
       `/api/${typeSlug}?${params}`,
     )
+    forwardMessages(res)
+    return res
   }
 
   async function get(id: string) {

--- a/web/admin/composables/useResourceApi.ts
+++ b/web/admin/composables/useResourceApi.ts
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { unwrapEnvelope, forwardMessages } from './useApi'
+import { forwardMessages } from './useApi'
 import type { ApiMessage } from './useNotifications'
 
 interface PaginatedResponse<T> {
@@ -24,6 +24,8 @@ interface PaginatedResponse<T> {
 }
 
 export function useResourceApi(typeSlug: string) {
+  const { request } = useApi()
+
   async function list(
     cursor = '',
     limit = 20,
@@ -43,37 +45,40 @@ export function useResourceApi(typeSlug: string) {
         }
       }
     }
-    const res = await $fetch<PaginatedResponse<any>>(
-      `/api/${typeSlug}?${params}`,
-    )
-    forwardMessages(res)
-    return res
+    // Paginated responses keep their top-level shape; forwardMessages
+    // processes any messages without unwrapping.
+    try {
+      const res = await $fetch<PaginatedResponse<any>>(
+        `/api/${typeSlug}?${params}`,
+      )
+      forwardMessages(res)
+      return res
+    } catch (err: any) {
+      if (err?.data) forwardMessages(err.data)
+      throw err
+    }
   }
 
-  async function get(id: string) {
-    const res = await $fetch<unknown>(`/api/${typeSlug}/${id}`)
-    return unwrapEnvelope<any>(res)
+  function get(id: string) {
+    return request<any>(`/api/${typeSlug}/${id}`)
   }
 
-  async function create(data: Record<string, any>) {
-    const res = await $fetch<unknown>(`/api/${typeSlug}`, {
+  function create(data: Record<string, any>) {
+    return request<any>(`/api/${typeSlug}`, {
       method: 'POST',
-      body: data,
+      body: JSON.stringify(data),
     })
-    return unwrapEnvelope<any>(res)
   }
 
-  async function update(id: string, data: Record<string, any>) {
-    const res = await $fetch<unknown>(`/api/${typeSlug}/${id}`, {
+  function update(id: string, data: Record<string, any>) {
+    return request<any>(`/api/${typeSlug}/${id}`, {
       method: 'PUT',
-      body: data,
+      body: JSON.stringify(data),
     })
-    return unwrapEnvelope<any>(res)
   }
 
-  async function remove(id: string) {
-    const res = await $fetch<unknown>(`/api/${typeSlug}/${id}`, { method: 'DELETE' })
-    return unwrapEnvelope<void>(res)
+  function remove(id: string) {
+    return request<void>(`/api/${typeSlug}/${id}`, { method: 'DELETE' })
   }
 
   return { list, get, create, update, remove }

--- a/web/admin/composables/useResourceTypeStore.ts
+++ b/web/admin/composables/useResourceTypeStore.ts
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import type { ApiMessage } from './useNotifications'
+
 export interface ResourceTypeInfo {
   id: string
   name: string
@@ -26,6 +28,7 @@ interface PaginatedResponse {
   data: ResourceTypeInfo[]
   cursor: string
   has_more: boolean
+  messages?: ApiMessage[]
 }
 
 export function useResourceTypeStore() {
@@ -35,6 +38,8 @@ export function useResourceTypeStore() {
   async function fetchResourceTypes() {
     try {
       const res = await $fetch<PaginatedResponse>('/api/resource-types?limit=100')
+      const { processApiMessages } = useNotifications()
+      processApiMessages(res.messages)
       resourceTypes.value = res.data
       loaded.value = true
     } catch {

--- a/web/admin/pages/settings/menus.vue
+++ b/web/admin/pages/settings/menus.vue
@@ -204,7 +204,7 @@ async function handleSave() {
 async function fetchRoles() {
   try {
     const raw = await $fetch<unknown>('/api/settings/roles')
-    const res = unwrapEnvelope<any>(raw)
+    const res = unwrapEnvelope<{ roles: string[] }>(raw)
     roles.value = res.roles || []
   } catch {
     roles.value = []

--- a/web/admin/pages/settings/menus.vue
+++ b/web/admin/pages/settings/menus.vue
@@ -202,7 +202,8 @@ async function handleSave() {
 
 async function fetchRoles() {
   try {
-    const res = await $fetch<{ roles: string[] }>('/api/settings/roles')
+    const raw = await $fetch<any>('/api/settings/roles')
+    const res = raw?.data !== undefined ? raw.data : raw
     roles.value = res.roles || []
   } catch {
     roles.value = []

--- a/web/admin/pages/settings/menus.vue
+++ b/web/admin/pages/settings/menus.vue
@@ -81,6 +81,7 @@
 
 <script setup lang="ts">
 import { message } from 'ant-design-vue'
+import { unwrapEnvelope } from '~/composables/useApi'
 
 const { resourceTypes, loaded, fetchResourceTypes } = useResourceTypeStore()
 const { getGlobalSettings, saveGlobalSettings } = useSidebarSettingsApi()
@@ -202,8 +203,8 @@ async function handleSave() {
 
 async function fetchRoles() {
   try {
-    const raw = await $fetch<any>('/api/settings/roles')
-    const res = raw?.data !== undefined ? raw.data : raw
+    const raw = await $fetch<unknown>('/api/settings/roles')
+    const res = unwrapEnvelope<any>(raw)
     roles.value = res.roles || []
   } catch {
     roles.value = []

--- a/web/admin/pages/settings/role-access.vue
+++ b/web/admin/pages/settings/role-access.vue
@@ -79,6 +79,7 @@
 
 <script setup lang="ts">
 import { message } from 'ant-design-vue'
+import { unwrapEnvelope } from '~/composables/useApi'
 
 type AccessMap = Record<string, Record<string, string[]>>
 
@@ -153,8 +154,8 @@ function deselectAll() {
 
 async function fetchRoles() {
   try {
-    const raw = await $fetch<any>('/api/settings/roles')
-    const res = raw?.data !== undefined ? raw.data : raw
+    const raw = await $fetch<unknown>('/api/settings/roles')
+    const res = unwrapEnvelope<any>(raw)
     roles.value = res.roles || []
   } catch {
     roles.value = []
@@ -163,8 +164,8 @@ async function fetchRoles() {
 
 async function fetchAccess() {
   try {
-    const raw = await $fetch<any>('/api/settings/role-access')
-    const res = raw?.data !== undefined ? raw.data : raw
+    const raw = await $fetch<unknown>('/api/settings/role-access')
+    const res = unwrapEnvelope<any>(raw)
     accessMap.value = res.roles || {}
   } catch {
     accessMap.value = {}
@@ -174,11 +175,11 @@ async function fetchAccess() {
 async function handleSave() {
   saving.value = true
   try {
-    const raw = await $fetch<any>('/api/settings/role-access', {
+    const raw = await $fetch<unknown>('/api/settings/role-access', {
       method: 'PUT',
       body: { roles: accessMap.value },
     })
-    const res = raw?.data !== undefined ? raw.data : raw
+    const res = unwrapEnvelope<any>(raw)
     accessMap.value = res.roles || accessMap.value
     message.success('Role access saved')
   } catch {

--- a/web/admin/pages/settings/role-access.vue
+++ b/web/admin/pages/settings/role-access.vue
@@ -155,7 +155,7 @@ function deselectAll() {
 async function fetchRoles() {
   try {
     const raw = await $fetch<unknown>('/api/settings/roles')
-    const res = unwrapEnvelope<any>(raw)
+    const res = unwrapEnvelope<{ roles: string[] }>(raw)
     roles.value = res.roles || []
   } catch {
     roles.value = []
@@ -165,7 +165,7 @@ async function fetchRoles() {
 async function fetchAccess() {
   try {
     const raw = await $fetch<unknown>('/api/settings/role-access')
-    const res = unwrapEnvelope<any>(raw)
+    const res = unwrapEnvelope<{ roles: AccessMap }>(raw)
     accessMap.value = res.roles || {}
   } catch {
     accessMap.value = {}
@@ -179,7 +179,7 @@ async function handleSave() {
       method: 'PUT',
       body: { roles: accessMap.value },
     })
-    const res = unwrapEnvelope<any>(raw)
+    const res = unwrapEnvelope<{ roles: AccessMap }>(raw)
     accessMap.value = res.roles || accessMap.value
     message.success('Role access saved')
   } catch {

--- a/web/admin/pages/settings/role-access.vue
+++ b/web/admin/pages/settings/role-access.vue
@@ -153,7 +153,8 @@ function deselectAll() {
 
 async function fetchRoles() {
   try {
-    const res = await $fetch<{ roles: string[] }>('/api/settings/roles')
+    const raw = await $fetch<any>('/api/settings/roles')
+    const res = raw?.data !== undefined ? raw.data : raw
     roles.value = res.roles || []
   } catch {
     roles.value = []
@@ -162,7 +163,8 @@ async function fetchRoles() {
 
 async function fetchAccess() {
   try {
-    const res = await $fetch<{ roles: AccessMap }>('/api/settings/role-access')
+    const raw = await $fetch<any>('/api/settings/role-access')
+    const res = raw?.data !== undefined ? raw.data : raw
     accessMap.value = res.roles || {}
   } catch {
     accessMap.value = {}
@@ -172,10 +174,11 @@ async function fetchAccess() {
 async function handleSave() {
   saving.value = true
   try {
-    const res = await $fetch<{ roles: AccessMap }>('/api/settings/role-access', {
+    const raw = await $fetch<any>('/api/settings/role-access', {
       method: 'PUT',
       body: { roles: accessMap.value },
     })
+    const res = raw?.data !== undefined ? raw.data : raw
     accessMap.value = res.roles || accessMap.value
     message.success('Role access saved')
   } catch {

--- a/web/admin/pages/settings/roles.vue
+++ b/web/admin/pages/settings/roles.vue
@@ -52,6 +52,7 @@
 
 <script setup lang="ts">
 import { message } from 'ant-design-vue'
+import { unwrapEnvelope } from '~/composables/useApi'
 
 const roles = ref<string[]>([])
 const newRoleName = ref('')
@@ -59,8 +60,8 @@ const saving = ref(false)
 
 async function fetchRoles() {
   try {
-    const raw = await $fetch<any>('/api/settings/roles')
-    const res = raw?.data !== undefined ? raw.data : raw
+    const raw = await $fetch<unknown>('/api/settings/roles')
+    const res = unwrapEnvelope<any>(raw)
     roles.value = res.roles || []
   } catch {
     roles.value = ['admin', 'instructor']
@@ -85,11 +86,11 @@ function removeRole(role: string) {
 async function handleSave() {
   saving.value = true
   try {
-    const raw = await $fetch<any>('/api/settings/roles', {
+    const raw = await $fetch<unknown>('/api/settings/roles', {
       method: 'PUT',
       body: { roles: roles.value },
     })
-    const res = raw?.data !== undefined ? raw.data : raw
+    const res = unwrapEnvelope<any>(raw)
     roles.value = res.roles || roles.value
     message.success('Roles saved')
   } catch {

--- a/web/admin/pages/settings/roles.vue
+++ b/web/admin/pages/settings/roles.vue
@@ -59,7 +59,8 @@ const saving = ref(false)
 
 async function fetchRoles() {
   try {
-    const res = await $fetch<{ roles: string[] }>('/api/settings/roles')
+    const raw = await $fetch<any>('/api/settings/roles')
+    const res = raw?.data !== undefined ? raw.data : raw
     roles.value = res.roles || []
   } catch {
     roles.value = ['admin', 'instructor']
@@ -84,10 +85,11 @@ function removeRole(role: string) {
 async function handleSave() {
   saving.value = true
   try {
-    const res = await $fetch<{ roles: string[] }>('/api/settings/roles', {
+    const raw = await $fetch<any>('/api/settings/roles', {
       method: 'PUT',
       body: { roles: roles.value },
     })
+    const res = raw?.data !== undefined ? raw.data : raw
     roles.value = res.roles || roles.value
     message.success('Roles saved')
   } catch {

--- a/web/admin/pages/settings/roles.vue
+++ b/web/admin/pages/settings/roles.vue
@@ -61,7 +61,7 @@ const saving = ref(false)
 async function fetchRoles() {
   try {
     const raw = await $fetch<unknown>('/api/settings/roles')
-    const res = unwrapEnvelope<any>(raw)
+    const res = unwrapEnvelope<{ roles: string[] }>(raw)
     roles.value = res.roles || []
   } catch {
     roles.value = ['admin', 'instructor']
@@ -90,7 +90,7 @@ async function handleSave() {
       method: 'PUT',
       body: { roles: roles.value },
     })
-    const res = unwrapEnvelope<any>(raw)
+    const res = unwrapEnvelope<{ roles: string[] }>(raw)
     roles.value = res.roles || roles.value
     message.success('Roles saved')
   } catch {

--- a/web/admin/pages/users/index.vue
+++ b/web/admin/pages/users/index.vue
@@ -115,7 +115,7 @@ const columns = computed(() => {
 async function fetchRoles() {
   try {
     const raw = await $fetch<unknown>('/api/settings/roles')
-    const res = unwrapEnvelope<any>(raw)
+    const res = unwrapEnvelope<{ roles: string[] }>(raw)
     availableRoles.value = res.roles || []
   } catch (err) {
     console.warn('[users] fetchRoles failed, using defaults:', err)
@@ -126,9 +126,8 @@ async function fetchRoles() {
 async function fetchUsers() {
   loading.value = true
   try {
-    const raw = await $fetch<any>('/api/users')
-    // Users list endpoint returns paginated envelope with data array
-    users.value = raw.data || []
+    const raw = await $fetch<unknown>('/api/users')
+    users.value = unwrapEnvelope<any[]>(raw) || []
   } catch (err: any) {
     message.error('Failed to load users')
     console.error('[users] fetchUsers failed:', err)

--- a/web/admin/pages/users/index.vue
+++ b/web/admin/pages/users/index.vue
@@ -73,6 +73,7 @@
 
 <script setup lang="ts">
 import { message } from 'ant-design-vue'
+import { unwrapEnvelope } from '~/composables/useApi'
 
 const { user, startImpersonation } = useAuth()
 const router = useRouter()
@@ -113,8 +114,8 @@ const columns = computed(() => {
 
 async function fetchRoles() {
   try {
-    const raw = await $fetch<any>('/api/settings/roles')
-    const res = raw?.data !== undefined ? raw.data : raw
+    const raw = await $fetch<unknown>('/api/settings/roles')
+    const res = unwrapEnvelope<any>(raw)
     availableRoles.value = res.roles || []
   } catch (err) {
     console.warn('[users] fetchRoles failed, using defaults:', err)

--- a/web/admin/pages/users/index.vue
+++ b/web/admin/pages/users/index.vue
@@ -73,7 +73,7 @@
 
 <script setup lang="ts">
 import { message } from 'ant-design-vue'
-import { unwrapEnvelope } from '~/composables/useApi'
+import { unwrapEnvelope, forwardMessages } from '~/composables/useApi'
 
 const { user, startImpersonation } = useAuth()
 const router = useRouter()
@@ -129,6 +129,7 @@ async function fetchUsers() {
     const raw = await $fetch<unknown>('/api/users')
     users.value = unwrapEnvelope<any[]>(raw) || []
   } catch (err: any) {
+    if (err?.data) forwardMessages(err.data)
     message.error('Failed to load users')
     console.error('[users] fetchUsers failed:', err)
   } finally {

--- a/web/admin/pages/users/index.vue
+++ b/web/admin/pages/users/index.vue
@@ -113,7 +113,8 @@ const columns = computed(() => {
 
 async function fetchRoles() {
   try {
-    const res = await $fetch<{ roles: string[] }>('/api/settings/roles')
+    const raw = await $fetch<any>('/api/settings/roles')
+    const res = raw?.data !== undefined ? raw.data : raw
     availableRoles.value = res.roles || []
   } catch (err) {
     console.warn('[users] fetchRoles failed, using defaults:', err)
@@ -124,8 +125,9 @@ async function fetchRoles() {
 async function fetchUsers() {
   loading.value = true
   try {
-    const res = await $fetch<any>('/api/users')
-    users.value = res.data || []
+    const raw = await $fetch<any>('/api/users')
+    // Users list endpoint returns paginated envelope with data array
+    users.value = raw.data || []
   } catch (err: any) {
     message.error('Failed to load users')
     console.error('[users] fetchUsers failed:', err)


### PR DESCRIPTION
- [x] Add standard message envelope to API responses
- [x] Add `Message` struct and context helpers
- [x] Add `respond`/`respondPaginated`/`respondError`/`respondRaw` helpers
- [x] Update admin frontend to unwrap envelope and display toast notifications
- [x] Fix CLAUDE.md documentation for respondError and respondPaginated envelope shapes
- [x] Fix type safety in Vue composables (unwrapEnvelope with proper generics)
- [x] Fix usePresetScreens.ts fetchManifest to forward error messages via `forwardMessages(err?.data)` in catch block