### PR TITLE
Add meal planning preset with 14 resource types

### DIFF
--- a/application/presets/mealplanning/preset.go
+++ b/application/presets/mealplanning/preset.go
@@ -261,7 +261,7 @@ func mealPlanType() application.PresetResourceType {
 		Name:        "Meal Plan",
 		Slug:        "meal-plan",
 		Description: "A weekly or custom-period meal plan",
-		Context: mpTypeContext("MealPlan", ""),
+		Context:     mpTypeContext("MealPlan", ""),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -341,7 +341,7 @@ func pantryType() application.PresetResourceType {
 		Name:        "Pantry",
 		Slug:        "pantry",
 		Description: "A named storage context for food items (e.g. Home, Beach House)",
-		Context: mpTypeContext("Pantry", ""),
+		Context:     mpTypeContext("Pantry", ""),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{

--- a/application/presets/mealplanning/preset.go
+++ b/application/presets/mealplanning/preset.go
@@ -1,0 +1,426 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package mealplanning
+
+import (
+	"encoding/json"
+
+	"weos/application"
+)
+
+// Register adds the meal-planning preset to the registry.
+func Register(registry *application.PresetRegistry) {
+	registry.MustAdd(application.PresetDefinition{
+		Name:        "meal-planning",
+		Description: "Recipe management, meal planning, pantry tracking, and shopping lists",
+		Types: []application.PresetResourceType{
+			recipeType(),
+			howToStepType(),
+			ingredientType(),
+			recipeIngredientType(),
+			nutritionInformationType(),
+			cookbookType(),
+			mealPlanType(),
+			scheduledMealType(),
+			mealOccurrenceType(),
+			pantryType(),
+			foodItemType(),
+			shoppingListType(),
+			shoppingListItemType(),
+			restrictedDietType(),
+		},
+		Sidebar: &application.PresetSidebarConfig{
+			HiddenSlugs: []string{
+				"how-to-step", "recipe-ingredient", "nutrition-information",
+				"meal-occurrence", "food-item", "shopping-list-item", "restricted-diet",
+			},
+			MenuGroups: map[string]string{
+				"scheduled-meal":     "meal-plan",
+				"shopping-list-item": "shopping-list",
+				"food-item":          "pantry",
+			},
+		},
+	})
+}
+
+// -- contexts ----------------------------------------------------------------
+
+const mpContext = `{
+	"@vocab":"https://schema.org/",
+	"mp":"https://weos.org/vocab/meal-planning#",
+	"fo":"http://purl.org/foodontology#",
+	"skos":"http://www.w3.org/2004/02/skos/core#"
+}`
+
+const ingredientContext = `{
+	"@vocab":"https://schema.org/",
+	"@type":"fo:Food",
+	"fo":"http://purl.org/foodontology#",
+	"skos":"http://www.w3.org/2004/02/skos/core#",
+	"mp":"https://weos.org/vocab/meal-planning#"
+}`
+
+// -- type constructors -------------------------------------------------------
+
+func recipeType() application.PresetResourceType {
+	return application.PresetResourceType{
+		Name:        "Recipe",
+		Slug:        "recipe",
+		Description: "A food recipe with ingredients, steps, and nutritional information",
+		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","@type":"Recipe","mp":"https://weos.org/vocab/meal-planning#","fo":"http://purl.org/foodontology#"}`),
+		Schema: json.RawMessage(`{
+	"type":"object",
+	"properties":{
+		"name":{"type":"string"},
+		"description":{"type":"string"},
+		"recipeYield":{"type":"string"},
+		"prepTime":{"type":"string","description":"ISO 8601 duration, e.g. PT15M"},
+		"cookTime":{"type":"string","description":"ISO 8601 duration"},
+		"totalTime":{"type":"string","description":"ISO 8601 duration"},
+		"recipeCuisine":{"type":"string"},
+		"recipeCategory":{"type":"string"},
+		"keywords":{"type":"array","items":{"type":"string"}},
+		"suitableForDiet":{"type":"array","items":{"type":"string","x-resource-type":"restricted-diet","x-display-property":"name"}},
+		"image":{"type":"string","format":"uri"}
+	},
+	"required":["name"]
+}`),
+	}
+}
+
+func howToStepType() application.PresetResourceType {
+	return application.PresetResourceType{
+		Name:        "How-To Step",
+		Slug:        "how-to-step",
+		Description: "A single step in a recipe's instructions",
+		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","@type":"HowToStep"}`),
+		Schema: json.RawMessage(`{
+	"type":"object",
+	"properties":{
+		"position":{"type":"integer"},
+		"text":{"type":"string"},
+		"image":{"type":"string","format":"uri"}
+	},
+	"required":["text"]
+}`),
+	}
+}
+
+func ingredientType() application.PresetResourceType {
+	return application.PresetResourceType{
+		Name:        "Ingredient",
+		Slug:        "ingredient",
+		Description: "A type-level food ingredient (e.g. garlic, chicken breast)",
+		Context:     json.RawMessage(ingredientContext),
+		Schema: json.RawMessage(`{
+	"type":"object",
+	"properties":{
+		"name":{"type":"string"},
+		"description":{"type":"string"},
+		"alternateNames":{"type":"array","items":{"type":"string"}},
+		"shoppingCategory":{"type":"string","enum":["produce","meat","seafood","dairy","bakery","pantry","frozen","beverages","condiments","spices","other"]},
+		"season":{"type":"array","items":{"type":"string","enum":["spring","summer","autumn","winter"]}},
+		"suitableForDiet":{"type":"array","items":{"type":"string","x-resource-type":"restricted-diet","x-display-property":"name"}},
+		"defaultUnit":{"type":"string"},
+		"image":{"type":"string","format":"uri"}
+	},
+	"required":["name"]
+}`),
+		Fixtures: ingredientFixtures(),
+	}
+}
+
+func recipeIngredientType() application.PresetResourceType {
+	return application.PresetResourceType{
+		Name:        "Recipe Ingredient",
+		Slug:        "recipe-ingredient",
+		Description: "A reified relation linking a recipe to an ingredient with quantity and preparation",
+		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","mp":"https://weos.org/vocab/meal-planning#","@type":"mp:RecipeIngredient"}`),
+		Schema: json.RawMessage(`{
+	"type":"object",
+	"properties":{
+		"quantity":{"type":"number"},
+		"unit":{"type":"string"},
+		"preparation":{"type":"string"},
+		"optional":{"type":"boolean"},
+		"recipe":{"type":"string","x-resource-type":"recipe","x-display-property":"name"},
+		"ingredient":{"type":"string","x-resource-type":"ingredient","x-display-property":"name"}
+	},
+	"required":["quantity","unit"]
+}`),
+	}
+}
+
+func nutritionInformationType() application.PresetResourceType {
+	return application.PresetResourceType{
+		Name:        "Nutrition Information",
+		Slug:        "nutrition-information",
+		Description: "Nutritional data for a recipe or ingredient",
+		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","@type":"NutritionInformation"}`),
+		Schema: json.RawMessage(`{
+	"type":"object",
+	"properties":{
+		"servingSize":{"type":"string"},
+		"calories":{"type":"string"},
+		"proteinContent":{"type":"string"},
+		"carbohydrateContent":{"type":"string"},
+		"fatContent":{"type":"string"},
+		"saturatedFatContent":{"type":"string"},
+		"fiberContent":{"type":"string"},
+		"sugarContent":{"type":"string"},
+		"sodiumContent":{"type":"string"}
+	},
+	"required":["servingSize"]
+}`),
+	}
+}
+
+func cookbookType() application.PresetResourceType {
+	return application.PresetResourceType{
+		Name:        "Cookbook",
+		Slug:        "cookbook",
+		Description: "A named collection of recipes",
+		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","mp":"https://weos.org/vocab/meal-planning#","@type":"mp:Cookbook"}`),
+		Schema: json.RawMessage(`{
+	"type":"object",
+	"properties":{
+		"name":{"type":"string"},
+		"description":{"type":"string"},
+		"image":{"type":"string","format":"uri"},
+		"keywords":{"type":"array","items":{"type":"string"}}
+	},
+	"required":["name"]
+}`),
+	}
+}
+
+func mealPlanType() application.PresetResourceType {
+	return application.PresetResourceType{
+		Name:        "Meal Plan",
+		Slug:        "meal-plan",
+		Description: "A weekly or custom-period meal plan",
+		Context:     json.RawMessage(mpContext),
+		Schema: json.RawMessage(`{
+	"type":"object",
+	"properties":{
+		"name":{"type":"string"},
+		"description":{"type":"string"},
+		"startDate":{"type":"string","format":"date"},
+		"endDate":{"type":"string","format":"date"},
+		"suitableForDiet":{"type":"array","items":{"type":"string","x-resource-type":"restricted-diet","x-display-property":"name"}}
+	},
+	"required":["name","startDate","endDate"]
+}`),
+	}
+}
+
+func scheduledMealType() application.PresetResourceType {
+	return application.PresetResourceType{
+		Name:        "Scheduled Meal",
+		Slug:        "scheduled-meal",
+		Description: "A scheduled (possibly recurring) meal within a meal plan",
+		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","mp":"https://weos.org/vocab/meal-planning#","@type":"mp:ScheduledMeal"}`),
+		Schema: json.RawMessage(`{
+	"type":"object",
+	"properties":{
+		"startDate":{"type":"string","format":"date"},
+		"endDate":{"type":"string","format":"date"},
+		"startTime":{"type":"string"},
+		"endTime":{"type":"string"},
+		"duration":{"type":"string","description":"ISO 8601 duration"},
+		"repeatFrequency":{"type":"string","description":"ISO 8601 duration, e.g. P1W for weekly"},
+		"repeatCount":{"type":"integer"},
+		"byDay":{"type":"array","items":{"type":"string","enum":["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"]}},
+		"byMonth":{"type":"array","items":{"type":"integer","minimum":1,"maximum":12}},
+		"byMonthDay":{"type":"array","items":{"type":"integer","minimum":1,"maximum":31}},
+		"exceptDate":{"type":"array","items":{"type":"string","format":"date"}},
+		"scheduleTimezone":{"type":"string"},
+		"mealType":{"type":"string","enum":["breakfast","lunch","dinner","snack"]},
+		"servings":{"type":"number"},
+		"notes":{"type":"string"},
+		"recipe":{"type":"string","x-resource-type":"recipe","x-display-property":"name"},
+		"mealPlan":{"type":"string","x-resource-type":"meal-plan","x-display-property":"name"}
+	},
+	"required":["startDate","mealType"]
+}`),
+	}
+}
+
+func mealOccurrenceType() application.PresetResourceType {
+	return application.PresetResourceType{
+		Name:        "Meal Occurrence",
+		Slug:        "meal-occurrence",
+		Description: "A concrete single-date instance of a scheduled meal",
+		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","mp":"https://weos.org/vocab/meal-planning#","@type":"mp:MealOccurrence"}`),
+		Schema: json.RawMessage(`{
+	"type":"object",
+	"properties":{
+		"date":{"type":"string","format":"date"},
+		"mealType":{"type":"string","enum":["breakfast","lunch","dinner","snack"]},
+		"servings":{"type":"number"},
+		"status":{"type":"string","enum":["planned","cooked","skipped"]},
+		"cookedAt":{"type":"string","format":"date-time"},
+		"notes":{"type":"string"},
+		"scheduledMeal":{"type":"string","x-resource-type":"scheduled-meal","x-display-property":"mealType"}
+	},
+	"required":["date","mealType","status"]
+}`),
+	}
+}
+
+func pantryType() application.PresetResourceType {
+	return application.PresetResourceType{
+		Name:        "Pantry",
+		Slug:        "pantry",
+		Description: "A named storage context for food items (e.g. Home, Beach House)",
+		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","mp":"https://weos.org/vocab/meal-planning#","@type":"mp:Pantry"}`),
+		Schema: json.RawMessage(`{
+	"type":"object",
+	"properties":{
+		"name":{"type":"string"},
+		"description":{"type":"string"},
+		"location":{"type":"string"},
+		"isDefault":{"type":"boolean"}
+	},
+	"required":["name"]
+}`),
+	}
+}
+
+func foodItemType() application.PresetResourceType {
+	return application.PresetResourceType{
+		Name:        "Food Item",
+		Slug:        "food-item",
+		Description: "A physical food item in a pantry (instance of an ingredient)",
+		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","mp":"https://weos.org/vocab/meal-planning#","@type":"mp:FoodItem"}`),
+		Schema: json.RawMessage(`{
+	"type":"object",
+	"properties":{
+		"quantity":{"type":"number"},
+		"unit":{"type":"string"},
+		"storage":{"type":"string","enum":["pantry","fridge","freezer","other"]},
+		"purchaseDate":{"type":"string","format":"date"},
+		"expirationDate":{"type":"string","format":"date"},
+		"notes":{"type":"string"},
+		"ingredient":{"type":"string","x-resource-type":"ingredient","x-display-property":"name"},
+		"pantry":{"type":"string","x-resource-type":"pantry","x-display-property":"name"}
+	},
+	"required":["quantity","unit"]
+}`),
+	}
+}
+
+func shoppingListType() application.PresetResourceType {
+	return application.PresetResourceType{
+		Name:        "Shopping List",
+		Slug:        "shopping-list",
+		Description: "A grocery shopping list, optionally derived from a meal plan",
+		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","mp":"https://weos.org/vocab/meal-planning#","@type":"mp:ShoppingList"}`),
+		Schema: json.RawMessage(`{
+	"type":"object",
+	"properties":{
+		"name":{"type":"string"},
+		"status":{"type":"string","enum":["draft","active","completed"]},
+		"mealPlan":{"type":"string","x-resource-type":"meal-plan","x-display-property":"name"},
+		"pantry":{"type":"string","x-resource-type":"pantry","x-display-property":"name"}
+	},
+	"required":["name"]
+}`),
+	}
+}
+
+func shoppingListItemType() application.PresetResourceType {
+	return application.PresetResourceType{
+		Name:        "Shopping List Item",
+		Slug:        "shopping-list-item",
+		Description: "A line item on a shopping list",
+		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","mp":"https://weos.org/vocab/meal-planning#","@type":"mp:ShoppingListItem"}`),
+		Schema: json.RawMessage(`{
+	"type":"object",
+	"properties":{
+		"quantity":{"type":"number"},
+		"unit":{"type":"string"},
+		"checked":{"type":"boolean"},
+		"notes":{"type":"string"},
+		"ingredient":{"type":"string","x-resource-type":"ingredient","x-display-property":"name"},
+		"shoppingList":{"type":"string","x-resource-type":"shopping-list","x-display-property":"name"}
+	},
+	"required":["quantity","unit"]
+}`),
+	}
+}
+
+func restrictedDietType() application.PresetResourceType {
+	return application.PresetResourceType{
+		Name:        "Restricted Diet",
+		Slug:        "restricted-diet",
+		Description: "A dietary restriction (e.g. gluten-free, vegan)",
+		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","@type":"RestrictedDiet"}`),
+		Schema: json.RawMessage(`{
+	"type":"object",
+	"properties":{
+		"name":{"type":"string"},
+		"description":{"type":"string"},
+		"identifier":{"type":"string","description":"Schema.org RestrictedDiet identifier"}
+	},
+	"required":["name"]
+}`),
+		Fixtures: restrictedDietFixtures(),
+	}
+}
+
+// -- fixtures ----------------------------------------------------------------
+
+func restrictedDietFixtures() []json.RawMessage {
+	return []json.RawMessage{
+		json.RawMessage(`{"name":"Diabetic Diet","identifier":"schema:DiabeticDiet"}`),
+		json.RawMessage(`{"name":"Gluten-Free Diet","identifier":"schema:GlutenFreeDiet"}`),
+		json.RawMessage(`{"name":"Halal Diet","identifier":"schema:HalalDiet"}`),
+		json.RawMessage(`{"name":"Hindu Diet","identifier":"schema:HinduDiet"}`),
+		json.RawMessage(`{"name":"Kosher Diet","identifier":"schema:KosherDiet"}`),
+		json.RawMessage(`{"name":"Low Calorie Diet","identifier":"schema:LowCalorieDiet"}`),
+		json.RawMessage(`{"name":"Low Fat Diet","identifier":"schema:LowFatDiet"}`),
+		json.RawMessage(`{"name":"Low Lactose Diet","identifier":"schema:LowLactoseDiet"}`),
+		json.RawMessage(`{"name":"Low Salt Diet","identifier":"schema:LowSaltDiet"}`),
+		json.RawMessage(`{"name":"Vegan Diet","identifier":"schema:VeganDiet"}`),
+		json.RawMessage(`{"name":"Vegetarian Diet","identifier":"schema:VegetarianDiet"}`),
+	}
+}
+
+func ingredientFixtures() []json.RawMessage {
+	return []json.RawMessage{
+		json.RawMessage(`{"name":"Salt","shoppingCategory":"spices","defaultUnit":"tsp"}`),
+		json.RawMessage(`{"name":"Black Pepper","shoppingCategory":"spices","defaultUnit":"tsp"}`),
+		json.RawMessage(`{"name":"Olive Oil","shoppingCategory":"condiments","defaultUnit":"tbsp"}`),
+		json.RawMessage(`{"name":"Butter","shoppingCategory":"dairy","defaultUnit":"tbsp"}`),
+		json.RawMessage(`{"name":"Garlic","shoppingCategory":"produce","defaultUnit":"clove"}`),
+		json.RawMessage(`{"name":"Onion","shoppingCategory":"produce","defaultUnit":"each"}`),
+		json.RawMessage(`{"name":"Tomato","shoppingCategory":"produce","defaultUnit":"each"}`),
+		json.RawMessage(`{"name":"Chicken Breast","shoppingCategory":"meat","defaultUnit":"g"}`),
+		json.RawMessage(`{"name":"Ground Beef","shoppingCategory":"meat","defaultUnit":"g"}`),
+		json.RawMessage(`{"name":"Egg","shoppingCategory":"dairy","defaultUnit":"each"}`),
+		json.RawMessage(`{"name":"Milk","shoppingCategory":"dairy","defaultUnit":"ml"}`),
+		json.RawMessage(`{"name":"All-Purpose Flour","shoppingCategory":"pantry","defaultUnit":"g"}`),
+		json.RawMessage(`{"name":"Sugar","shoppingCategory":"pantry","defaultUnit":"g"}`),
+		json.RawMessage(`{"name":"Rice","shoppingCategory":"pantry","defaultUnit":"g"}`),
+		json.RawMessage(`{"name":"Pasta","shoppingCategory":"pantry","defaultUnit":"g"}`),
+		json.RawMessage(`{"name":"Carrot","shoppingCategory":"produce","defaultUnit":"each"}`),
+		json.RawMessage(`{"name":"Potato","shoppingCategory":"produce","defaultUnit":"each"}`),
+		json.RawMessage(`{"name":"Lemon","shoppingCategory":"produce","defaultUnit":"each"}`),
+		json.RawMessage(`{"name":"Cheese","shoppingCategory":"dairy","defaultUnit":"g"}`),
+		json.RawMessage(`{"name":"Soy Sauce","shoppingCategory":"condiments","defaultUnit":"tbsp"}`),
+	}
+}

--- a/application/presets/mealplanning/preset.go
+++ b/application/presets/mealplanning/preset.go
@@ -59,14 +59,19 @@ func Register(registry *application.PresetRegistry) {
 // -- contexts ----------------------------------------------------------------
 
 // mpTypeContext returns a JSON-LD context for a meal-planning type (mp:<typeName>).
-// Most resource types in this preset share this pattern.
-func mpTypeContext(typeName string) json.RawMessage {
-	return json.RawMessage(
-		`{"@vocab":"https://schema.org/",` +
-			`"mp":"https://weos.org/vocab/meal-planning#",` +
-			`"mealType":"mp:mealType",` +
-			`"servings":"mp:servings",` +
-			`"@type":"mp:` + typeName + `"}`)
+// extraTerms is a JSON object fragment of additional term mappings (without
+// surrounding braces) to include — used by types that have reference properties
+// needing explicit predicate IRIs.
+func mpTypeContext(typeName, extraTerms string) json.RawMessage {
+	terms := `"@vocab":"https://schema.org/",` +
+		`"mp":"https://weos.org/vocab/meal-planning#",` +
+		`"mealType":"mp:mealType",` +
+		`"servings":"mp:servings",` +
+		`"@type":"mp:` + typeName + `"`
+	if extraTerms != "" {
+		terms += "," + extraTerms
+	}
+	return json.RawMessage("{" + terms + "}")
 }
 
 // -- type constructors -------------------------------------------------------
@@ -79,7 +84,11 @@ func recipeType() application.PresetResourceType {
 		Context: json.RawMessage(`{
 	"@vocab":"https://schema.org/","@type":"Recipe",
 	"mp":"https://weos.org/vocab/meal-planning#",
-	"fo":"http://purl.org/foodontology#"
+	"fo":"http://purl.org/foodontology#",
+	"recipeInstructions":"https://schema.org/recipeInstructions",
+	"recipeIngredient":"fo:hasIngredient",
+	"nutrition":"https://schema.org/nutrition",
+	"suitableForDiet":"https://schema.org/suitableForDiet"
 }`),
 		Schema: json.RawMessage(`{
 	"type":"object",
@@ -117,7 +126,11 @@ func howToStepType() application.PresetResourceType {
 		Name:        "How-To Step",
 		Slug:        "how-to-step",
 		Description: "A single step in a recipe's instructions",
-		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","@type":"HowToStep"}`),
+		Context: json.RawMessage(`{
+	"@vocab":"https://schema.org/","@type":"HowToStep",
+	"mp":"https://weos.org/vocab/meal-planning#",
+	"recipe":"https://schema.org/isPartOf"
+}`),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -174,7 +187,9 @@ func recipeIngredientType() application.PresetResourceType {
 		Name:        "Recipe Ingredient",
 		Slug:        "recipe-ingredient",
 		Description: "A reified relation linking a recipe to an ingredient with quantity and preparation",
-		Context:     mpTypeContext("RecipeIngredient"),
+		Context: mpTypeContext("RecipeIngredient",
+			`"recipe":"mp:recipe","ingredient":"fo:ingredient",`+
+				`"fo":"http://purl.org/foodontology#"`),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -195,7 +210,11 @@ func nutritionInformationType() application.PresetResourceType {
 		Name:        "Nutrition Information",
 		Slug:        "nutrition-information",
 		Description: "Nutritional data for a recipe or ingredient",
-		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","@type":"NutritionInformation"}`),
+		Context: json.RawMessage(`{
+	"@vocab":"https://schema.org/","@type":"NutritionInformation",
+	"recipe":"https://schema.org/isPartOf",
+	"ingredient":"https://schema.org/about"
+}`),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -221,7 +240,8 @@ func cookbookType() application.PresetResourceType {
 		Name:        "Cookbook",
 		Slug:        "cookbook",
 		Description: "A named collection of recipes",
-		Context:     mpTypeContext("Cookbook"),
+		Context: mpTypeContext("Cookbook",
+			`"recipes":"https://schema.org/hasPart"`),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -241,7 +261,7 @@ func mealPlanType() application.PresetResourceType {
 		Name:        "Meal Plan",
 		Slug:        "meal-plan",
 		Description: "A weekly or custom-period meal plan",
-		Context:     mpTypeContext("MealPlan"),
+		Context: mpTypeContext("MealPlan", ""),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -263,7 +283,8 @@ func scheduledMealType() application.PresetResourceType {
 		Name:        "Scheduled Meal",
 		Slug:        "scheduled-meal",
 		Description: "A scheduled (possibly recurring) meal within a meal plan",
-		Context:     mpTypeContext("ScheduledMeal"),
+		Context: mpTypeContext("ScheduledMeal",
+			`"recipe":"mp:recipe","mealPlan":"mp:mealPlan"`),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -297,7 +318,8 @@ func mealOccurrenceType() application.PresetResourceType {
 		Name:        "Meal Occurrence",
 		Slug:        "meal-occurrence",
 		Description: "A concrete single-date instance of a scheduled meal",
-		Context:     mpTypeContext("MealOccurrence"),
+		Context: mpTypeContext("MealOccurrence",
+			`"scheduledMeal":"mp:occurrenceOf"`),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -319,7 +341,7 @@ func pantryType() application.PresetResourceType {
 		Name:        "Pantry",
 		Slug:        "pantry",
 		Description: "A named storage context for food items (e.g. Home, Beach House)",
-		Context:     mpTypeContext("Pantry"),
+		Context: mpTypeContext("Pantry", ""),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -338,7 +360,8 @@ func foodItemType() application.PresetResourceType {
 		Name:        "Food Item",
 		Slug:        "food-item",
 		Description: "A physical food item in a pantry (instance of an ingredient)",
-		Context:     mpTypeContext("FoodItem"),
+		Context: mpTypeContext("FoodItem",
+			`"ingredient":"mp:isInstanceOf","pantry":"mp:pantry"`),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -361,7 +384,9 @@ func shoppingListType() application.PresetResourceType {
 		Name:        "Shopping List",
 		Slug:        "shopping-list",
 		Description: "A grocery shopping list, optionally derived from a meal plan",
-		Context:     mpTypeContext("ShoppingList"),
+		Context: mpTypeContext("ShoppingList",
+			`"mealPlan":"http://www.w3.org/ns/prov#wasDerivedFrom",`+
+				`"pantry":"mp:targetsPantry"`),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -381,7 +406,8 @@ func shoppingListItemType() application.PresetResourceType {
 		Name:        "Shopping List Item",
 		Slug:        "shopping-list-item",
 		Description: "A line item on a shopping list",
-		Context:     mpTypeContext("ShoppingListItem"),
+		Context: mpTypeContext("ShoppingListItem",
+			`"ingredient":"mp:ingredient","shoppingList":"mp:hasItem"`),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{

--- a/application/presets/mealplanning/preset.go
+++ b/application/presets/mealplanning/preset.go
@@ -58,20 +58,14 @@ func Register(registry *application.PresetRegistry) {
 
 // -- contexts ----------------------------------------------------------------
 
-const mpContext = `{
-	"@vocab":"https://schema.org/",
-	"mp":"https://weos.org/vocab/meal-planning#",
-	"fo":"http://purl.org/foodontology#",
-	"skos":"http://www.w3.org/2004/02/skos/core#"
-}`
-
-const ingredientContext = `{
-	"@vocab":"https://schema.org/",
-	"@type":"fo:Food",
-	"fo":"http://purl.org/foodontology#",
-	"skos":"http://www.w3.org/2004/02/skos/core#",
-	"mp":"https://weos.org/vocab/meal-planning#"
-}`
+// mpTypeContext returns a JSON-LD context for a meal-planning type (mp:<typeName>).
+// Most resource types in this preset share this pattern.
+func mpTypeContext(typeName string) json.RawMessage {
+	return json.RawMessage(
+		`{"@vocab":"https://schema.org/",` +
+			`"mp":"https://weos.org/vocab/meal-planning#",` +
+			`"@type":"mp:` + typeName + `"}`)
+}
 
 // -- type constructors -------------------------------------------------------
 
@@ -80,7 +74,11 @@ func recipeType() application.PresetResourceType {
 		Name:        "Recipe",
 		Slug:        "recipe",
 		Description: "A food recipe with ingredients, steps, and nutritional information",
-		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","@type":"Recipe","mp":"https://weos.org/vocab/meal-planning#","fo":"http://purl.org/foodontology#"}`),
+		Context: json.RawMessage(`{
+	"@vocab":"https://schema.org/","@type":"Recipe",
+	"mp":"https://weos.org/vocab/meal-planning#",
+	"fo":"http://purl.org/foodontology#"
+}`),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -93,7 +91,9 @@ func recipeType() application.PresetResourceType {
 		"recipeCuisine":{"type":"string"},
 		"recipeCategory":{"type":"string"},
 		"keywords":{"type":"array","items":{"type":"string"}},
-		"suitableForDiet":{"type":"array","items":{"type":"string","x-resource-type":"restricted-diet","x-display-property":"name"}},
+		"suitableForDiet":{"type":"array","items":{
+			"type":"string","x-resource-type":"restricted-diet",
+			"x-display-property":"name"}},
 		"image":{"type":"string","format":"uri"}
 	},
 	"required":["name"]
@@ -112,7 +112,8 @@ func howToStepType() application.PresetResourceType {
 	"properties":{
 		"position":{"type":"integer"},
 		"text":{"type":"string"},
-		"image":{"type":"string","format":"uri"}
+		"image":{"type":"string","format":"uri"},
+		"recipe":{"type":"string","x-resource-type":"recipe","x-display-property":"name"}
 	},
 	"required":["text"]
 }`),
@@ -124,16 +125,26 @@ func ingredientType() application.PresetResourceType {
 		Name:        "Ingredient",
 		Slug:        "ingredient",
 		Description: "A type-level food ingredient (e.g. garlic, chicken breast)",
-		Context:     json.RawMessage(ingredientContext),
+		Context: json.RawMessage(`{
+	"@vocab":"https://schema.org/",
+	"@type":"fo:Food",
+	"fo":"http://purl.org/foodontology#",
+	"skos":"http://www.w3.org/2004/02/skos/core#",
+	"mp":"https://weos.org/vocab/meal-planning#"
+}`),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
 		"name":{"type":"string"},
 		"description":{"type":"string"},
 		"alternateNames":{"type":"array","items":{"type":"string"}},
-		"shoppingCategory":{"type":"string","enum":["produce","meat","seafood","dairy","bakery","pantry","frozen","beverages","condiments","spices","other"]},
+		"shoppingCategory":{"type":"string","enum":[
+			"produce","meat","seafood","dairy","bakery","pantry",
+			"frozen","beverages","condiments","spices","other"]},
 		"season":{"type":"array","items":{"type":"string","enum":["spring","summer","autumn","winter"]}},
-		"suitableForDiet":{"type":"array","items":{"type":"string","x-resource-type":"restricted-diet","x-display-property":"name"}},
+		"suitableForDiet":{"type":"array","items":{
+			"type":"string","x-resource-type":"restricted-diet",
+			"x-display-property":"name"}},
 		"defaultUnit":{"type":"string"},
 		"image":{"type":"string","format":"uri"}
 	},
@@ -148,7 +159,7 @@ func recipeIngredientType() application.PresetResourceType {
 		Name:        "Recipe Ingredient",
 		Slug:        "recipe-ingredient",
 		Description: "A reified relation linking a recipe to an ingredient with quantity and preparation",
-		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","mp":"https://weos.org/vocab/meal-planning#","@type":"mp:RecipeIngredient"}`),
+		Context:     mpTypeContext("RecipeIngredient"),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -181,7 +192,9 @@ func nutritionInformationType() application.PresetResourceType {
 		"saturatedFatContent":{"type":"string"},
 		"fiberContent":{"type":"string"},
 		"sugarContent":{"type":"string"},
-		"sodiumContent":{"type":"string"}
+		"sodiumContent":{"type":"string"},
+		"recipe":{"type":"string","x-resource-type":"recipe","x-display-property":"name"},
+		"ingredient":{"type":"string","x-resource-type":"ingredient","x-display-property":"name"}
 	},
 	"required":["servingSize"]
 }`),
@@ -193,14 +206,15 @@ func cookbookType() application.PresetResourceType {
 		Name:        "Cookbook",
 		Slug:        "cookbook",
 		Description: "A named collection of recipes",
-		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","mp":"https://weos.org/vocab/meal-planning#","@type":"mp:Cookbook"}`),
+		Context:     mpTypeContext("Cookbook"),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
 		"name":{"type":"string"},
 		"description":{"type":"string"},
 		"image":{"type":"string","format":"uri"},
-		"keywords":{"type":"array","items":{"type":"string"}}
+		"keywords":{"type":"array","items":{"type":"string"}},
+		"recipes":{"type":"array","items":{"type":"string","x-resource-type":"recipe","x-display-property":"name"}}
 	},
 	"required":["name"]
 }`),
@@ -212,7 +226,7 @@ func mealPlanType() application.PresetResourceType {
 		Name:        "Meal Plan",
 		Slug:        "meal-plan",
 		Description: "A weekly or custom-period meal plan",
-		Context:     json.RawMessage(mpContext),
+		Context:     mpTypeContext("MealPlan"),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -220,7 +234,9 @@ func mealPlanType() application.PresetResourceType {
 		"description":{"type":"string"},
 		"startDate":{"type":"string","format":"date"},
 		"endDate":{"type":"string","format":"date"},
-		"suitableForDiet":{"type":"array","items":{"type":"string","x-resource-type":"restricted-diet","x-display-property":"name"}}
+		"suitableForDiet":{"type":"array","items":{
+			"type":"string","x-resource-type":"restricted-diet",
+			"x-display-property":"name"}}
 	},
 	"required":["name","startDate","endDate"]
 }`),
@@ -232,7 +248,7 @@ func scheduledMealType() application.PresetResourceType {
 		Name:        "Scheduled Meal",
 		Slug:        "scheduled-meal",
 		Description: "A scheduled (possibly recurring) meal within a meal plan",
-		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","mp":"https://weos.org/vocab/meal-planning#","@type":"mp:ScheduledMeal"}`),
+		Context:     mpTypeContext("ScheduledMeal"),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -243,7 +259,9 @@ func scheduledMealType() application.PresetResourceType {
 		"duration":{"type":"string","description":"ISO 8601 duration"},
 		"repeatFrequency":{"type":"string","description":"ISO 8601 duration, e.g. P1W for weekly"},
 		"repeatCount":{"type":"integer"},
-		"byDay":{"type":"array","items":{"type":"string","enum":["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"]}},
+		"byDay":{"type":"array","items":{"type":"string","enum":[
+			"Monday","Tuesday","Wednesday","Thursday",
+			"Friday","Saturday","Sunday"]}},
 		"byMonth":{"type":"array","items":{"type":"integer","minimum":1,"maximum":12}},
 		"byMonthDay":{"type":"array","items":{"type":"integer","minimum":1,"maximum":31}},
 		"exceptDate":{"type":"array","items":{"type":"string","format":"date"}},
@@ -264,7 +282,7 @@ func mealOccurrenceType() application.PresetResourceType {
 		Name:        "Meal Occurrence",
 		Slug:        "meal-occurrence",
 		Description: "A concrete single-date instance of a scheduled meal",
-		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","mp":"https://weos.org/vocab/meal-planning#","@type":"mp:MealOccurrence"}`),
+		Context:     mpTypeContext("MealOccurrence"),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -286,7 +304,7 @@ func pantryType() application.PresetResourceType {
 		Name:        "Pantry",
 		Slug:        "pantry",
 		Description: "A named storage context for food items (e.g. Home, Beach House)",
-		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","mp":"https://weos.org/vocab/meal-planning#","@type":"mp:Pantry"}`),
+		Context:     mpTypeContext("Pantry"),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -305,7 +323,7 @@ func foodItemType() application.PresetResourceType {
 		Name:        "Food Item",
 		Slug:        "food-item",
 		Description: "A physical food item in a pantry (instance of an ingredient)",
-		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","mp":"https://weos.org/vocab/meal-planning#","@type":"mp:FoodItem"}`),
+		Context:     mpTypeContext("FoodItem"),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -328,7 +346,7 @@ func shoppingListType() application.PresetResourceType {
 		Name:        "Shopping List",
 		Slug:        "shopping-list",
 		Description: "A grocery shopping list, optionally derived from a meal plan",
-		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","mp":"https://weos.org/vocab/meal-planning#","@type":"mp:ShoppingList"}`),
+		Context:     mpTypeContext("ShoppingList"),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -347,7 +365,7 @@ func shoppingListItemType() application.PresetResourceType {
 		Name:        "Shopping List Item",
 		Slug:        "shopping-list-item",
 		Description: "A line item on a shopping list",
-		Context:     json.RawMessage(`{"@vocab":"https://schema.org/","mp":"https://weos.org/vocab/meal-planning#","@type":"mp:ShoppingListItem"}`),
+		Context:     mpTypeContext("ShoppingListItem"),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{

--- a/application/presets/mealplanning/preset.go
+++ b/application/presets/mealplanning/preset.go
@@ -107,7 +107,16 @@ func recipeType() application.PresetResourceType {
 	"properties":{
 		"name":{"type":"string"},
 		"description":{"type":"string"},
-		"recipeYield":{"type":"string"},
+		"recipeYield":{
+			"type":"object",
+			"description":"Structured yield for scaling/shopping-list math",
+			"properties":{
+				"@type":{"type":"string","enum":["QuantitativeValue"]},
+				"value":{"type":"number"},
+				"unitText":{"type":"string"}
+			},
+			"required":["value","unitText"]
+		},
 		"prepTime":{"type":"string","description":"ISO 8601 duration, e.g. PT15M"},
 		"cookTime":{"type":"string","description":"ISO 8601 duration"},
 		"totalTime":{"type":"string","description":"ISO 8601 duration"},

--- a/application/presets/mealplanning/preset.go
+++ b/application/presets/mealplanning/preset.go
@@ -96,6 +96,15 @@ func recipeType() application.PresetResourceType {
 		"suitableForDiet":{"type":"array","items":{
 			"type":"string","x-resource-type":"restricted-diet",
 			"x-display-property":"name"}},
+		"recipeInstructions":{"type":"array","items":{
+			"type":"string","x-resource-type":"how-to-step",
+			"x-display-property":"text"}},
+		"recipeIngredient":{"type":"array","items":{
+			"type":"string","x-resource-type":"recipe-ingredient",
+			"x-display-property":"unit"}},
+		"nutrition":{"type":"string",
+			"x-resource-type":"nutrition-information",
+			"x-display-property":"servingSize"},
 		"image":{"type":"string","format":"uri"}
 	},
 	"required":["name"]
@@ -117,7 +126,7 @@ func howToStepType() application.PresetResourceType {
 		"image":{"type":"string","format":"uri"},
 		"recipe":{"type":"string","x-resource-type":"recipe","x-display-property":"name"}
 	},
-	"required":["text"]
+	"required":["position","text","recipe"]
 }`),
 	}
 }
@@ -357,6 +366,7 @@ func shoppingListType() application.PresetResourceType {
 	"type":"object",
 	"properties":{
 		"name":{"type":"string"},
+		"createdAt":{"type":"string","format":"date-time"},
 		"status":{"type":"string","enum":["draft","active","completed"]},
 		"mealPlan":{"type":"string","x-resource-type":"meal-plan","x-display-property":"name"},
 		"pantry":{"type":"string","x-resource-type":"pantry","x-display-property":"name"}
@@ -410,17 +420,17 @@ func restrictedDietType() application.PresetResourceType {
 
 func restrictedDietFixtures() []json.RawMessage {
 	return []json.RawMessage{
-		json.RawMessage(`{"name":"Diabetic Diet","identifier":"schema:DiabeticDiet"}`),
-		json.RawMessage(`{"name":"Gluten-Free Diet","identifier":"schema:GlutenFreeDiet"}`),
-		json.RawMessage(`{"name":"Halal Diet","identifier":"schema:HalalDiet"}`),
-		json.RawMessage(`{"name":"Hindu Diet","identifier":"schema:HinduDiet"}`),
-		json.RawMessage(`{"name":"Kosher Diet","identifier":"schema:KosherDiet"}`),
-		json.RawMessage(`{"name":"Low Calorie Diet","identifier":"schema:LowCalorieDiet"}`),
-		json.RawMessage(`{"name":"Low Fat Diet","identifier":"schema:LowFatDiet"}`),
-		json.RawMessage(`{"name":"Low Lactose Diet","identifier":"schema:LowLactoseDiet"}`),
-		json.RawMessage(`{"name":"Low Salt Diet","identifier":"schema:LowSaltDiet"}`),
-		json.RawMessage(`{"name":"Vegan Diet","identifier":"schema:VeganDiet"}`),
-		json.RawMessage(`{"name":"Vegetarian Diet","identifier":"schema:VegetarianDiet"}`),
+		json.RawMessage(`{"name":"Diabetic Diet","identifier":"https://schema.org/DiabeticDiet"}`),
+		json.RawMessage(`{"name":"Gluten-Free Diet","identifier":"https://schema.org/GlutenFreeDiet"}`),
+		json.RawMessage(`{"name":"Halal Diet","identifier":"https://schema.org/HalalDiet"}`),
+		json.RawMessage(`{"name":"Hindu Diet","identifier":"https://schema.org/HinduDiet"}`),
+		json.RawMessage(`{"name":"Kosher Diet","identifier":"https://schema.org/KosherDiet"}`),
+		json.RawMessage(`{"name":"Low Calorie Diet","identifier":"https://schema.org/LowCalorieDiet"}`),
+		json.RawMessage(`{"name":"Low Fat Diet","identifier":"https://schema.org/LowFatDiet"}`),
+		json.RawMessage(`{"name":"Low Lactose Diet","identifier":"https://schema.org/LowLactoseDiet"}`),
+		json.RawMessage(`{"name":"Low Salt Diet","identifier":"https://schema.org/LowSaltDiet"}`),
+		json.RawMessage(`{"name":"Vegan Diet","identifier":"https://schema.org/VeganDiet"}`),
+		json.RawMessage(`{"name":"Vegetarian Diet","identifier":"https://schema.org/VegetarianDiet"}`),
 	}
 }
 

--- a/application/presets/mealplanning/preset.go
+++ b/application/presets/mealplanning/preset.go
@@ -307,7 +307,8 @@ func scheduledMealType() application.PresetResourceType {
 		Slug:        "scheduled-meal",
 		Description: "A scheduled (possibly recurring) meal within a meal plan",
 		Context: schemaTypeContext("Schedule",
-			`"recipe":"mp:recipe","mealPlan":"mp:mealPlan"`),
+			`"recipe":"mp:recipe","mealPlan":"mp:mealPlan",`+
+				`"notes":"https://schema.org/description"`),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -342,7 +343,8 @@ func mealOccurrenceType() application.PresetResourceType {
 		Slug:        "meal-occurrence",
 		Description: "A concrete single-date instance of a scheduled meal",
 		Context: mpTypeContext("MealOccurrence",
-			`"scheduledMeal":"mp:occurrenceOf"`),
+			`"scheduledMeal":"mp:occurrenceOf",`+
+				`"notes":"https://schema.org/description"`),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -384,7 +386,8 @@ func foodItemType() application.PresetResourceType {
 		Slug:        "food-item",
 		Description: "A physical food item in a pantry (instance of an ingredient)",
 		Context: mpTypeContext("FoodItem",
-			`"ingredient":"mp:isInstanceOf","pantry":"mp:pantry"`),
+			`"ingredient":"mp:isInstanceOf","pantry":"mp:pantry",`+
+				`"notes":"https://schema.org/description"`),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -430,7 +433,8 @@ func shoppingListItemType() application.PresetResourceType {
 		Slug:        "shopping-list-item",
 		Description: "A line item on a shopping list",
 		Context: mpTypeContext("ShoppingListItem",
-			`"ingredient":"mp:ingredient","shoppingList":"mp:hasItem"`),
+			`"ingredient":"mp:ingredient","shoppingList":"mp:hasItem",`+
+				`"notes":"https://schema.org/description"`),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{

--- a/application/presets/mealplanning/preset.go
+++ b/application/presets/mealplanning/preset.go
@@ -58,16 +58,28 @@ func Register(registry *application.PresetRegistry) {
 
 // -- contexts ----------------------------------------------------------------
 
-// mpTypeContext returns a JSON-LD context for a meal-planning type (mp:<typeName>).
-// extraTerms is a JSON object fragment of additional term mappings (without
-// surrounding braces) to include — used by types that have reference properties
-// needing explicit predicate IRIs.
+// mpTypeContext returns a JSON-LD context for a meal-planning type whose
+// @type is the custom mp:<typeName>. extraTerms is a JSON object fragment of
+// additional term mappings (without surrounding braces) for types that have
+// reference properties needing explicit predicate IRIs.
 func mpTypeContext(typeName, extraTerms string) json.RawMessage {
+	return mpContext("mp:"+typeName, extraTerms)
+}
+
+// schemaTypeContext returns a JSON-LD context whose @type is a schema.org type
+// (e.g. "MealPlan", "Schedule", "Collection"). The mp: namespace and shared
+// custom-term mappings are still declared so types can use mp: predicates.
+func schemaTypeContext(schemaType, extraTerms string) json.RawMessage {
+	return mpContext(schemaType, extraTerms)
+}
+
+// mpContext is the shared builder for both helpers.
+func mpContext(typeIRI, extraTerms string) json.RawMessage {
 	terms := `"@vocab":"https://schema.org/",` +
 		`"mp":"https://weos.org/vocab/meal-planning#",` +
 		`"mealType":"mp:mealType",` +
 		`"servings":"mp:servings",` +
-		`"@type":"mp:` + typeName + `"`
+		`"@type":"` + typeIRI + `"`
 	if extraTerms != "" {
 		terms += "," + extraTerms
 	}
@@ -102,15 +114,18 @@ func recipeType() application.PresetResourceType {
 		"recipeCuisine":{"type":"string"},
 		"recipeCategory":{"type":"string"},
 		"keywords":{"type":"array","items":{"type":"string"}},
-		"suitableForDiet":{"type":"array","items":{
-			"type":"string","x-resource-type":"restricted-diet",
-			"x-display-property":"name"}},
-		"recipeInstructions":{"type":"array","items":{
-			"type":"string","x-resource-type":"how-to-step",
-			"x-display-property":"text"}},
-		"recipeIngredient":{"type":"array","items":{
-			"type":"string","x-resource-type":"recipe-ingredient",
-			"x-display-property":"unit"}},
+		"suitableForDiet":{"type":"array",
+			"x-resource-type":"restricted-diet",
+			"x-display-property":"name",
+			"items":{"type":"string"}},
+		"recipeInstructions":{"type":"array",
+			"x-resource-type":"how-to-step",
+			"x-display-property":"text",
+			"items":{"type":"string"}},
+		"recipeIngredient":{"type":"array",
+			"x-resource-type":"recipe-ingredient",
+			"x-display-property":"unit",
+			"items":{"type":"string"}},
 		"nutrition":{"type":"string",
 			"x-resource-type":"nutrition-information",
 			"x-display-property":"servingSize"},
@@ -170,9 +185,10 @@ func ingredientType() application.PresetResourceType {
 			"produce","meat","seafood","dairy","bakery","pantry",
 			"frozen","beverages","condiments","spices","other"]},
 		"season":{"type":"array","items":{"type":"string","enum":["spring","summer","autumn","winter"]}},
-		"suitableForDiet":{"type":"array","items":{
-			"type":"string","x-resource-type":"restricted-diet",
-			"x-display-property":"name"}},
+		"suitableForDiet":{"type":"array",
+			"x-resource-type":"restricted-diet",
+			"x-display-property":"name",
+			"items":{"type":"string"}},
 		"defaultUnit":{"type":"string"},
 		"image":{"type":"string","format":"uri"}
 	},
@@ -230,7 +246,11 @@ func nutritionInformationType() application.PresetResourceType {
 		"recipe":{"type":"string","x-resource-type":"recipe","x-display-property":"name"},
 		"ingredient":{"type":"string","x-resource-type":"ingredient","x-display-property":"name"}
 	},
-	"required":["servingSize"]
+	"required":["servingSize"],
+	"anyOf":[
+		{"required":["recipe"]},
+		{"required":["ingredient"]}
+	]
 }`),
 	}
 }
@@ -240,7 +260,7 @@ func cookbookType() application.PresetResourceType {
 		Name:        "Cookbook",
 		Slug:        "cookbook",
 		Description: "A named collection of recipes",
-		Context: mpTypeContext("Cookbook",
+		Context: schemaTypeContext("Collection",
 			`"recipes":"https://schema.org/hasPart"`),
 		Schema: json.RawMessage(`{
 	"type":"object",
@@ -249,7 +269,9 @@ func cookbookType() application.PresetResourceType {
 		"description":{"type":"string"},
 		"image":{"type":"string","format":"uri"},
 		"keywords":{"type":"array","items":{"type":"string"}},
-		"recipes":{"type":"array","items":{"type":"string","x-resource-type":"recipe","x-display-property":"name"}}
+		"recipes":{"type":"array",
+			"x-resource-type":"recipe","x-display-property":"name",
+			"items":{"type":"string"}}
 	},
 	"required":["name"]
 }`),
@@ -261,7 +283,7 @@ func mealPlanType() application.PresetResourceType {
 		Name:        "Meal Plan",
 		Slug:        "meal-plan",
 		Description: "A weekly or custom-period meal plan",
-		Context:     mpTypeContext("MealPlan", ""),
+		Context:     schemaTypeContext("MealPlan", ""),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{
@@ -269,9 +291,10 @@ func mealPlanType() application.PresetResourceType {
 		"description":{"type":"string"},
 		"startDate":{"type":"string","format":"date"},
 		"endDate":{"type":"string","format":"date"},
-		"suitableForDiet":{"type":"array","items":{
-			"type":"string","x-resource-type":"restricted-diet",
-			"x-display-property":"name"}}
+		"suitableForDiet":{"type":"array",
+			"x-resource-type":"restricted-diet",
+			"x-display-property":"name",
+			"items":{"type":"string"}}
 	},
 	"required":["name","startDate","endDate"]
 }`),
@@ -283,7 +306,7 @@ func scheduledMealType() application.PresetResourceType {
 		Name:        "Scheduled Meal",
 		Slug:        "scheduled-meal",
 		Description: "A scheduled (possibly recurring) meal within a meal plan",
-		Context: mpTypeContext("ScheduledMeal",
+		Context: schemaTypeContext("Schedule",
 			`"recipe":"mp:recipe","mealPlan":"mp:mealPlan"`),
 		Schema: json.RawMessage(`{
 	"type":"object",

--- a/application/presets/mealplanning/preset.go
+++ b/application/presets/mealplanning/preset.go
@@ -64,6 +64,8 @@ func mpTypeContext(typeName string) json.RawMessage {
 	return json.RawMessage(
 		`{"@vocab":"https://schema.org/",` +
 			`"mp":"https://weos.org/vocab/meal-planning#",` +
+			`"mealType":"mp:mealType",` +
+			`"servings":"mp:servings",` +
 			`"@type":"mp:` + typeName + `"}`)
 }
 
@@ -130,7 +132,11 @@ func ingredientType() application.PresetResourceType {
 	"@type":"fo:Food",
 	"fo":"http://purl.org/foodontology#",
 	"skos":"http://www.w3.org/2004/02/skos/core#",
-	"mp":"https://weos.org/vocab/meal-planning#"
+	"mp":"https://weos.org/vocab/meal-planning#",
+	"alternateNames":"skos:altLabel",
+	"shoppingCategory":"fo:ShoppingCategory",
+	"season":"fo:at_its_best",
+	"defaultUnit":"mp:defaultUnit"
 }`),
 		Schema: json.RawMessage(`{
 	"type":"object",
@@ -170,7 +176,7 @@ func recipeIngredientType() application.PresetResourceType {
 		"recipe":{"type":"string","x-resource-type":"recipe","x-display-property":"name"},
 		"ingredient":{"type":"string","x-resource-type":"ingredient","x-display-property":"name"}
 	},
-	"required":["quantity","unit"]
+	"required":["quantity","unit","recipe","ingredient"]
 }`),
 	}
 }
@@ -272,7 +278,7 @@ func scheduledMealType() application.PresetResourceType {
 		"recipe":{"type":"string","x-resource-type":"recipe","x-display-property":"name"},
 		"mealPlan":{"type":"string","x-resource-type":"meal-plan","x-display-property":"name"}
 	},
-	"required":["startDate","mealType"]
+	"required":["startDate","mealType","recipe","mealPlan"]
 }`),
 	}
 }
@@ -294,7 +300,7 @@ func mealOccurrenceType() application.PresetResourceType {
 		"notes":{"type":"string"},
 		"scheduledMeal":{"type":"string","x-resource-type":"scheduled-meal","x-display-property":"mealType"}
 	},
-	"required":["date","mealType","status"]
+	"required":["date","mealType","status","scheduledMeal"]
 }`),
 	}
 }
@@ -336,7 +342,7 @@ func foodItemType() application.PresetResourceType {
 		"ingredient":{"type":"string","x-resource-type":"ingredient","x-display-property":"name"},
 		"pantry":{"type":"string","x-resource-type":"pantry","x-display-property":"name"}
 	},
-	"required":["quantity","unit"]
+	"required":["quantity","unit","ingredient","pantry"]
 }`),
 	}
 }
@@ -376,7 +382,7 @@ func shoppingListItemType() application.PresetResourceType {
 		"ingredient":{"type":"string","x-resource-type":"ingredient","x-display-property":"name"},
 		"shoppingList":{"type":"string","x-resource-type":"shopping-list","x-display-property":"name"}
 	},
-	"required":["quantity","unit"]
+	"required":["quantity","unit","ingredient","shoppingList"]
 }`),
 	}
 }

--- a/application/presets/register.go
+++ b/application/presets/register.go
@@ -9,6 +9,7 @@ import (
 	"weos/application/presets/ecommerce"
 	"weos/application/presets/events"
 	"weos/application/presets/knowledge"
+	"weos/application/presets/mealplanning"
 	"weos/application/presets/tasks"
 	"weos/application/presets/website"
 )
@@ -24,6 +25,7 @@ func RegisterAll(registry *application.PresetRegistry) {
 	website.Register(registry)
 	events.Register(registry)
 	knowledge.Register(registry)
+	mealplanning.Register(registry)
 	for _, r := range customRegistrars {
 		r(registry)
 	}

--- a/application/resource_type_presets_test.go
+++ b/application/resource_type_presets_test.go
@@ -32,7 +32,7 @@ func testRegistry() *application.PresetRegistry {
 
 func TestPresets_AllPresetsExist(t *testing.T) {
 	t.Parallel()
-	expected := []string{"auth", "core", "ecommerce", "events", "knowledge", "tasks", "website"}
+	expected := []string{"auth", "core", "ecommerce", "events", "knowledge", "meal-planning", "tasks", "website"}
 	defs := testRegistry().List()
 	if len(defs) != len(expected) {
 		t.Fatalf("expected %d presets, got %d", len(expected), len(defs))


### PR DESCRIPTION
## Summary
- Add "meal-planning" preset with 14 resource types for recipe management, meal planning, pantry tracking, and shopping lists
- Each type has full JSON-LD context (schema.org + custom `mp:`/`fo:` namespaces) and JSON Schema with property types, enums, required fields, and `x-resource-type` references
- Fixture data: 11 RestrictedDiet entries (schema.org diet types) + 20 common Ingredients with shopping categories
- Sidebar config hides implementation-detail types and nests related types under parents
- Behaviors deferred to follow-up PRs

Closes #303

## Resource Types
Recipe, HowToStep, Ingredient, RecipeIngredient, NutritionInformation, Cookbook, MealPlan, ScheduledMeal, MealOccurrence, Pantry, FoodItem, ShoppingList, ShoppingListItem, RestrictedDiet

## Test plan
- [x] All 19 preset validation tests pass (count, slugs, JSON contexts, schemas, fixtures, no reserved slug collisions, no duplicate slugs)
- [x] Full test suite passes with `-race` flag
- [ ] Manual: install preset via MCP/CLI, verify all 14 types created with correct schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)