### PR TITLE
Add BehaviorFactory pattern for service injection (#314)

### DIFF
--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -50,11 +50,11 @@ type PresetDefinition struct {
 	Name         string
 	Description  string
 	Types        []PresetResourceType
-	Behaviors    map[string]BehaviorFactory           // slug -> factory invoked at startup with services
-	BehaviorMeta map[string]entities.BehaviorMeta     // slug -> metadata for UI/config
-	Screens      fs.FS                                // optional embedded screen components
-	Sidebar      *PresetSidebarConfig                 // optional sidebar defaults
-	AutoInstall  bool                                 // if true, types are auto-created at startup
+	Behaviors    map[string]BehaviorFactory       // slug -> factory invoked at startup with services
+	BehaviorMeta map[string]entities.BehaviorMeta // slug -> metadata for UI/config
+	Screens      fs.FS                            // optional embedded screen components
+	Sidebar      *PresetSidebarConfig             // optional sidebar defaults
+	AutoInstall  bool                             // if true, types are auto-created at startup
 }
 
 // InstallPresetResult reports which types were created, updated, or skipped.
@@ -231,22 +231,35 @@ func (d PresetDefinition) ScreenManifest() map[string][]string {
 // invoking each preset's BehaviorFactory exactly once with the supplied services.
 // Presets are processed in alphabetical order; if multiple presets declare a behavior
 // for the same slug, the last preset alphabetically wins and a warning is logged
-// (when services.Logger is non-nil). Returns an error if any factory is nil —
-// Add() rejects nil factories at registration time, so this is a defense in depth.
+// (when services.Logger is non-nil). Returns an error if any factory is nil or
+// returns a nil ResourceBehavior — Add() rejects nil factories at registration time,
+// so the nil-factory branch here is defense in depth.
 func (r *PresetRegistry) Behaviors(services BehaviorServices) (ResourceBehaviorRegistry, error) {
+	// Snapshot presets under the lock so we don't hold it while invoking
+	// factories or the logger (either of which could be slow or call back
+	// into the registry).
 	r.mu.RLock()
-	defer r.mu.RUnlock()
-	// Sort preset names for deterministic merge order.
 	names := make([]string, 0, len(r.presets))
-	for name := range r.presets {
+	snapshot := make(map[string]map[string]BehaviorFactory, len(r.presets))
+	for name, def := range r.presets {
 		names = append(names, name)
+		if len(def.Behaviors) == 0 {
+			continue
+		}
+		factories := make(map[string]BehaviorFactory, len(def.Behaviors))
+		for slug, f := range def.Behaviors {
+			factories[slug] = f
+		}
+		snapshot[name] = factories
 	}
+	r.mu.RUnlock()
+
 	sort.Strings(names)
 
 	behaviors := make(ResourceBehaviorRegistry)
 	source := make(map[string]string) // slug -> preset name that registered it
 	for _, name := range names {
-		for slug, factory := range r.presets[name].Behaviors {
+		for slug, factory := range snapshot[name] {
 			if factory == nil {
 				return nil, fmt.Errorf("preset %q: behavior factory for slug %q is nil", name, slug)
 			}
@@ -255,7 +268,11 @@ func (r *PresetRegistry) Behaviors(services BehaviorServices) (ResourceBehaviorR
 					"resource behavior overridden by later preset",
 					"slug", slug, "previousPreset", prev, "newPreset", name)
 			}
-			behaviors[slug] = factory(services)
+			behavior := factory(services)
+			if behavior == nil {
+				return nil, fmt.Errorf("preset %q: behavior factory for slug %q returned nil", name, slug)
+			}
+			behaviors[slug] = behavior
 			source[slug] = name
 		}
 	}

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -263,7 +263,7 @@ func (r *PresetRegistry) Behaviors(services BehaviorServices) (ResourceBehaviorR
 			if factory == nil {
 				return nil, fmt.Errorf("preset %q: behavior factory for slug %q is nil", name, slug)
 			}
-			if prev, ok := source[slug]; ok && services.Logger != nil {
+			if prev, ok := source[slug]; ok && !isNilInterface(services.Logger) {
 				services.Logger.Warn(context.Background(),
 					"resource behavior overridden by later preset",
 					"slug", slug, "previousPreset", prev, "newPreset", name)

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -16,6 +16,7 @@
 package application
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/fs"
@@ -49,7 +50,7 @@ type PresetDefinition struct {
 	Name         string
 	Description  string
 	Types        []PresetResourceType
-	Behaviors    map[string]entities.ResourceBehavior // slug -> behavior implementation
+	Behaviors    map[string]BehaviorFactory           // slug -> factory invoked at startup with services
 	BehaviorMeta map[string]entities.BehaviorMeta     // slug -> metadata for UI/config
 	Screens      fs.FS                                // optional embedded screen components
 	Sidebar      *PresetSidebarConfig                 // optional sidebar defaults
@@ -89,6 +90,11 @@ func (r *PresetRegistry) Add(def PresetDefinition) error {
 		}
 		if err := pt.validateFixtures(); err != nil {
 			return fmt.Errorf("preset %q: %w", def.Name, err)
+		}
+	}
+	for slug, factory := range def.Behaviors {
+		if factory == nil {
+			return fmt.Errorf("preset %q: behavior factory for slug %q is nil", def.Name, slug)
 		}
 	}
 	r.mu.Lock()
@@ -150,7 +156,7 @@ func (d PresetDefinition) clone() PresetDefinition {
 		d.Types = types
 	}
 	if d.Behaviors != nil {
-		behaviors := make(map[string]entities.ResourceBehavior, len(d.Behaviors))
+		behaviors := make(map[string]BehaviorFactory, len(d.Behaviors))
 		for k, v := range d.Behaviors {
 			behaviors[k] = v
 		}
@@ -221,10 +227,13 @@ func (d PresetDefinition) ScreenManifest() map[string][]string {
 	return manifest
 }
 
-// Behaviors returns a merged ResourceBehaviorRegistry from all registered presets.
+// Behaviors returns a merged ResourceBehaviorRegistry from all registered presets,
+// invoking each preset's BehaviorFactory exactly once with the supplied services.
 // Presets are processed in alphabetical order; if multiple presets declare a behavior
-// for the same slug, the last preset alphabetically wins (silent overwrite).
-func (r *PresetRegistry) Behaviors() ResourceBehaviorRegistry {
+// for the same slug, the last preset alphabetically wins and a warning is logged
+// (when services.Logger is non-nil). Returns an error if any factory is nil —
+// Add() rejects nil factories at registration time, so this is a defense in depth.
+func (r *PresetRegistry) Behaviors(services BehaviorServices) (ResourceBehaviorRegistry, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	// Sort preset names for deterministic merge order.
@@ -235,12 +244,22 @@ func (r *PresetRegistry) Behaviors() ResourceBehaviorRegistry {
 	sort.Strings(names)
 
 	behaviors := make(ResourceBehaviorRegistry)
+	source := make(map[string]string) // slug -> preset name that registered it
 	for _, name := range names {
-		for slug, behavior := range r.presets[name].Behaviors {
-			behaviors[slug] = behavior
+		for slug, factory := range r.presets[name].Behaviors {
+			if factory == nil {
+				return nil, fmt.Errorf("preset %q: behavior factory for slug %q is nil", name, slug)
+			}
+			if prev, ok := source[slug]; ok && services.Logger != nil {
+				services.Logger.Warn(context.Background(),
+					"resource behavior overridden by later preset",
+					"slug", slug, "previousPreset", prev, "newPreset", name)
+			}
+			behaviors[slug] = factory(services)
+			source[slug] = name
 		}
 	}
-	return behaviors
+	return behaviors, nil
 }
 
 // validateFixtures checks that fixture data is well-formed at registration time.

--- a/application/presets/core/preset.go
+++ b/application/presets/core/preset.go
@@ -49,9 +49,9 @@ func Register(registry *application.PresetRegistry) {
 				}`,
 			),
 		},
-		Behaviors: map[string]entities.ResourceBehavior{
-			"person":       &personBehavior{},
-			"organization": &organizationBehavior{},
+		Behaviors: map[string]application.BehaviorFactory{
+			"person":       application.StaticBehavior(&personBehavior{}),
+			"organization": application.StaticBehavior(&organizationBehavior{}),
 		},
 		BehaviorMeta: map[string]entities.BehaviorMeta{
 			"person": {

--- a/application/resource_behaviors.go
+++ b/application/resource_behaviors.go
@@ -18,11 +18,29 @@ package application
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sort"
 
 	"weos/domain/entities"
 	"weos/domain/repositories"
 )
+
+// isNilInterface returns true if v is a nil interface value or an interface
+// holding a typed-nil pointer/map/slice/chan/func. This catches the common Go
+// pitfall where `var p *T = nil; var i I = p` produces an interface that
+// compares != nil but still panics when dereferenced.
+func isNilInterface(v any) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func, reflect.Interface:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}
 
 // BehaviorServices bundles application services that ResourceBehavior factories
 // may depend on. All fields are required when constructed by
@@ -69,16 +87,16 @@ func ProvideResourceBehaviorRegistry(
 	if registry == nil {
 		return nil, fmt.Errorf("ProvideResourceBehaviorRegistry: nil PresetRegistry")
 	}
-	if resources == nil {
+	if isNilInterface(resources) {
 		return nil, fmt.Errorf("ProvideResourceBehaviorRegistry: nil Resources")
 	}
-	if triples == nil {
+	if isNilInterface(triples) {
 		return nil, fmt.Errorf("ProvideResourceBehaviorRegistry: nil Triples")
 	}
-	if resourceTypes == nil {
+	if isNilInterface(resourceTypes) {
 		return nil, fmt.Errorf("ProvideResourceBehaviorRegistry: nil ResourceTypes")
 	}
-	if logger == nil {
+	if isNilInterface(logger) {
 		return nil, fmt.Errorf("ProvideResourceBehaviorRegistry: nil Logger")
 	}
 	services := BehaviorServices{

--- a/application/resource_behaviors.go
+++ b/application/resource_behaviors.go
@@ -68,8 +68,17 @@ func ProvideResourceBehaviorRegistry(
 	if registry == nil {
 		return nil, fmt.Errorf("ProvideResourceBehaviorRegistry: nil PresetRegistry")
 	}
-	if resources == nil || triples == nil || resourceTypes == nil || logger == nil {
-		return nil, fmt.Errorf("ProvideResourceBehaviorRegistry: nil dependency injected")
+	if resources == nil {
+		return nil, fmt.Errorf("ProvideResourceBehaviorRegistry: nil Resources")
+	}
+	if triples == nil {
+		return nil, fmt.Errorf("ProvideResourceBehaviorRegistry: nil Triples")
+	}
+	if resourceTypes == nil {
+		return nil, fmt.Errorf("ProvideResourceBehaviorRegistry: nil ResourceTypes")
+	}
+	if logger == nil {
+		return nil, fmt.Errorf("ProvideResourceBehaviorRegistry: nil Logger")
 	}
 	services := BehaviorServices{
 		Resources:     resources,
@@ -81,10 +90,7 @@ func ProvideResourceBehaviorRegistry(
 	if err != nil {
 		return nil, err
 	}
-	for slug, b := range behaviors {
-		if b == nil {
-			return nil, fmt.Errorf("ProvideResourceBehaviorRegistry: factory for slug %q returned nil", slug)
-		}
+	for slug := range behaviors {
 		logger.Info(context.Background(), "resource behavior registered", "slug", slug)
 	}
 	return behaviors, nil

--- a/application/resource_behaviors.go
+++ b/application/resource_behaviors.go
@@ -16,17 +16,78 @@
 package application
 
 import (
+	"context"
+	"fmt"
+
 	"weos/domain/entities"
+	"weos/domain/repositories"
 )
+
+// BehaviorServices bundles application services that ResourceBehavior factories
+// may depend on. All fields are required when constructed by
+// ProvideResourceBehaviorRegistry; tests that build BehaviorServices directly
+// must supply real or fake implementations for any field their behavior touches.
+type BehaviorServices struct {
+	Resources     repositories.ResourceRepository
+	Triples       repositories.TripleRepository
+	ResourceTypes repositories.ResourceTypeRepository
+	Logger        entities.Logger
+}
+
+// BehaviorFactory constructs a ResourceBehavior given the available application
+// services. Factories are invoked once at startup, after the Fx container is
+// wired, allowing behaviors to close over real repositories and loggers.
+// A factory must not return nil — that is treated as a programmer error and
+// fails startup.
+type BehaviorFactory func(services BehaviorServices) entities.ResourceBehavior
+
+// StaticBehavior wraps a pre-constructed ResourceBehavior in a BehaviorFactory.
+// Use this for behaviors that have no service dependencies, so presets can
+// declare them inline without writing a factory function. Panics if b is nil.
+func StaticBehavior(b entities.ResourceBehavior) BehaviorFactory {
+	if b == nil {
+		panic("application.StaticBehavior: behavior must not be nil")
+	}
+	return func(BehaviorServices) entities.ResourceBehavior { return b }
+}
 
 // ResourceBehaviorRegistry maps resource type slugs to their custom behaviors.
 // Types without a registered behavior use DefaultBehavior (no-op).
 type ResourceBehaviorRegistry map[string]entities.ResourceBehavior
 
 // ProvideResourceBehaviorRegistry builds the behavior registry from all
-// registered presets. Each preset can declare behaviors for its resource types.
-func ProvideResourceBehaviorRegistry(registry *PresetRegistry) ResourceBehaviorRegistry {
-	return registry.Behaviors()
+// registered presets, invoking each factory with the supplied services. Fails
+// startup if any injected dependency is nil or any factory returns nil.
+func ProvideResourceBehaviorRegistry(
+	registry *PresetRegistry,
+	resources repositories.ResourceRepository,
+	triples repositories.TripleRepository,
+	resourceTypes repositories.ResourceTypeRepository,
+	logger entities.Logger,
+) (ResourceBehaviorRegistry, error) {
+	if registry == nil {
+		return nil, fmt.Errorf("ProvideResourceBehaviorRegistry: nil PresetRegistry")
+	}
+	if resources == nil || triples == nil || resourceTypes == nil || logger == nil {
+		return nil, fmt.Errorf("ProvideResourceBehaviorRegistry: nil dependency injected")
+	}
+	services := BehaviorServices{
+		Resources:     resources,
+		Triples:       triples,
+		ResourceTypes: resourceTypes,
+		Logger:        logger,
+	}
+	behaviors, err := registry.Behaviors(services)
+	if err != nil {
+		return nil, err
+	}
+	for slug, b := range behaviors {
+		if b == nil {
+			return nil, fmt.Errorf("ProvideResourceBehaviorRegistry: factory for slug %q returned nil", slug)
+		}
+		logger.Info(context.Background(), "resource behavior registered", "slug", slug)
+	}
+	return behaviors, nil
 }
 
 // BehaviorMetaRegistry maps resource type slugs to their behavior metadata.

--- a/application/resource_behaviors.go
+++ b/application/resource_behaviors.go
@@ -18,6 +18,7 @@ package application
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"weos/domain/entities"
 	"weos/domain/repositories"
@@ -90,9 +91,13 @@ func ProvideResourceBehaviorRegistry(
 	if err != nil {
 		return nil, err
 	}
+	slugs := make([]string, 0, len(behaviors))
 	for slug := range behaviors {
-		logger.Info(context.Background(), "resource behavior registered", "slug", slug)
+		slugs = append(slugs, slug)
 	}
+	sort.Strings(slugs)
+	logger.Info(context.Background(), "resource behaviors registered",
+		"count", len(slugs), "slugs", slugs)
 	return behaviors, nil
 }
 

--- a/application/resource_behaviors_test.go
+++ b/application/resource_behaviors_test.go
@@ -507,7 +507,9 @@ type serviceAwareBehavior struct {
 // stubResourceRepo embeds the interface so it satisfies the type without
 // implementing methods. Method calls on the nil embedded field panic — these
 // stubs are only used for identity checks, not invocation.
-type stubResourceRepo struct{ repositories.ResourceRepository }
+type stubResourceRepo struct {
+	repositories.ResourceRepository
+}
 type stubTripleRepo struct{ repositories.TripleRepository }
 
 // recordingLogger captures Warn calls for assertion in merge tests.
@@ -668,6 +670,21 @@ func TestProvideResourceBehaviorRegistry_RejectsNilDeps(t *testing.T) {
 	}
 }
 
+func TestPresetRegistry_BehaviorsRejectsNilReturningFactory(t *testing.T) {
+	t.Parallel()
+	registry := NewPresetRegistry()
+	registry.MustAdd(PresetDefinition{
+		Name:  "p",
+		Types: []PresetResourceType{NewPresetType("T", "t", "d", "", "")},
+		Behaviors: map[string]BehaviorFactory{
+			"t": func(BehaviorServices) entities.ResourceBehavior { return nil },
+		},
+	})
+	if _, err := registry.Behaviors(BehaviorServices{}); err == nil {
+		t.Fatal("expected error when factory returns nil")
+	}
+}
+
 func TestProvideResourceBehaviorRegistry_RejectsNilReturningFactory(t *testing.T) {
 	t.Parallel()
 	registry := NewPresetRegistry()
@@ -712,4 +729,3 @@ func TestProvideResourceBehaviorRegistry_PassesThroughDeps(t *testing.T) {
 		t.Fatal("provider did not pass dependencies through to factory")
 	}
 }
-

--- a/application/resource_behaviors_test.go
+++ b/application/resource_behaviors_test.go
@@ -653,6 +653,29 @@ func TestPresetRegistry_BehaviorsMultiPresetMergeLastWins(t *testing.T) {
 	}
 }
 
+func TestProvideResourceBehaviorRegistry_RejectsTypedNilDeps(t *testing.T) {
+	t.Parallel()
+	registry := NewPresetRegistry()
+	var typedNilResources *stubResourceRepo
+	var typedNilTriples *stubTripleRepo
+	var typedNilTypes *stubTypeRepo
+	if _, err := ProvideResourceBehaviorRegistry(
+		registry, typedNilResources, &stubTripleRepo{}, &stubTypeRepo{}, noopLogger{},
+	); err == nil {
+		t.Error("expected error for typed-nil Resources")
+	}
+	if _, err := ProvideResourceBehaviorRegistry(
+		registry, &stubResourceRepo{}, typedNilTriples, &stubTypeRepo{}, noopLogger{},
+	); err == nil {
+		t.Error("expected error for typed-nil Triples")
+	}
+	if _, err := ProvideResourceBehaviorRegistry(
+		registry, &stubResourceRepo{}, &stubTripleRepo{}, typedNilTypes, noopLogger{},
+	); err == nil {
+		t.Error("expected error for typed-nil ResourceTypes")
+	}
+}
+
 func TestProvideResourceBehaviorRegistry_RejectsNilDeps(t *testing.T) {
 	t.Parallel()
 	registry := NewPresetRegistry()

--- a/application/resource_behaviors_test.go
+++ b/application/resource_behaviors_test.go
@@ -497,3 +497,219 @@ func TestBehaviorFor_NonManageableNotAffectedByOverride(t *testing.T) {
 		t.Errorf("expected [person.BeforeCreate] (non-manageable, ignores override), got %v", calls)
 	}
 }
+
+// serviceAwareBehavior records the services it received at construction.
+type serviceAwareBehavior struct {
+	entities.DefaultBehavior
+	services BehaviorServices
+}
+
+// stubResourceRepo embeds the interface so it satisfies the type without
+// implementing methods. Method calls on the nil embedded field panic — these
+// stubs are only used for identity checks, not invocation.
+type stubResourceRepo struct{ repositories.ResourceRepository }
+type stubTripleRepo struct{ repositories.TripleRepository }
+
+// recordingLogger captures Warn calls for assertion in merge tests.
+type recordingLogger struct {
+	noopLogger
+	warns []string
+}
+
+func (l *recordingLogger) Warn(_ context.Context, msg string, _ ...any) {
+	l.warns = append(l.warns, msg)
+}
+
+func TestStaticBehavior_IgnoresServices(t *testing.T) {
+	t.Parallel()
+	want := &serviceAwareBehavior{}
+	factory := StaticBehavior(want)
+	got := factory(BehaviorServices{})
+	if got != want {
+		t.Fatalf("StaticBehavior should return the same instance regardless of services")
+	}
+}
+
+func TestStaticBehavior_PanicsOnNil(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("StaticBehavior(nil) should panic")
+		}
+	}()
+	_ = StaticBehavior(nil)
+}
+
+func TestPresetRegistry_BehaviorsInjectsAllServices(t *testing.T) {
+	t.Parallel()
+	registry := NewPresetRegistry()
+	registry.MustAdd(PresetDefinition{
+		Name:  "p",
+		Types: []PresetResourceType{NewPresetType("Thing", "thing", "desc", "", "")},
+		Behaviors: map[string]BehaviorFactory{
+			"thing": func(s BehaviorServices) entities.ResourceBehavior {
+				return &serviceAwareBehavior{services: s}
+			},
+		},
+	})
+
+	resources := &stubResourceRepo{}
+	triples := &stubTripleRepo{}
+	types := &stubTypeRepo{}
+	logger := noopLogger{}
+	services := BehaviorServices{
+		Resources:     resources,
+		Triples:       triples,
+		ResourceTypes: types,
+		Logger:        logger,
+	}
+	merged, err := registry.Behaviors(services)
+	if err != nil {
+		t.Fatalf("Behaviors() returned error: %v", err)
+	}
+
+	b, ok := merged["thing"].(*serviceAwareBehavior)
+	if !ok {
+		t.Fatalf("expected serviceAwareBehavior, got %T", merged["thing"])
+	}
+	if b.services.Resources != resources {
+		t.Errorf("Resources field not propagated")
+	}
+	if b.services.Triples != triples {
+		t.Errorf("Triples field not propagated")
+	}
+	if b.services.ResourceTypes != types {
+		t.Errorf("ResourceTypes field not propagated")
+	}
+	if b.services.Logger != logger {
+		t.Errorf("Logger field not propagated")
+	}
+}
+
+func TestPresetRegistry_AddRejectsNilFactory(t *testing.T) {
+	t.Parallel()
+	registry := NewPresetRegistry()
+	err := registry.Add(PresetDefinition{
+		Name:  "p",
+		Types: []PresetResourceType{NewPresetType("T", "t", "d", "", "")},
+		Behaviors: map[string]BehaviorFactory{
+			"t": nil,
+		},
+	})
+	if err == nil {
+		t.Fatal("Add should reject nil factory")
+	}
+}
+
+func TestPresetRegistry_BehaviorsFactoryInvokedOncePerSlug(t *testing.T) {
+	t.Parallel()
+	registry := NewPresetRegistry()
+	calls := 0
+	registry.MustAdd(PresetDefinition{
+		Name:  "p",
+		Types: []PresetResourceType{NewPresetType("T", "t", "d", "", "")},
+		Behaviors: map[string]BehaviorFactory{
+			"t": func(BehaviorServices) entities.ResourceBehavior {
+				calls++
+				return &serviceAwareBehavior{}
+			},
+		},
+	})
+	if _, err := registry.Behaviors(BehaviorServices{}); err != nil {
+		t.Fatalf("Behaviors() returned error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected factory to be invoked exactly once, got %d", calls)
+	}
+}
+
+func TestPresetRegistry_BehaviorsMultiPresetMergeLastWins(t *testing.T) {
+	t.Parallel()
+	winner := &serviceAwareBehavior{}
+	loser := &serviceAwareBehavior{}
+	registry := NewPresetRegistry()
+	registry.MustAdd(PresetDefinition{
+		Name:      "a-first",
+		Types:     []PresetResourceType{NewPresetType("T", "t", "d", "", "")},
+		Behaviors: map[string]BehaviorFactory{"t": StaticBehavior(loser)},
+	})
+	registry.MustAdd(PresetDefinition{
+		Name:      "b-second",
+		Types:     []PresetResourceType{NewPresetType("T", "t", "d", "", "")},
+		Behaviors: map[string]BehaviorFactory{"t": StaticBehavior(winner)},
+	})
+	logger := &recordingLogger{}
+	merged, err := registry.Behaviors(BehaviorServices{Logger: logger})
+	if err != nil {
+		t.Fatalf("Behaviors() returned error: %v", err)
+	}
+	if merged["t"] != winner {
+		t.Fatalf("expected later preset to win the merge")
+	}
+	if len(logger.warns) != 1 {
+		t.Fatalf("expected exactly one override warning, got %d", len(logger.warns))
+	}
+}
+
+func TestProvideResourceBehaviorRegistry_RejectsNilDeps(t *testing.T) {
+	t.Parallel()
+	registry := NewPresetRegistry()
+	if _, err := ProvideResourceBehaviorRegistry(registry, nil, &stubTripleRepo{}, &stubTypeRepo{}, noopLogger{}); err == nil {
+		t.Error("expected error when Resources is nil")
+	}
+	if _, err := ProvideResourceBehaviorRegistry(registry, &stubResourceRepo{}, nil, &stubTypeRepo{}, noopLogger{}); err == nil {
+		t.Error("expected error when Triples is nil")
+	}
+	if _, err := ProvideResourceBehaviorRegistry(registry, &stubResourceRepo{}, &stubTripleRepo{}, nil, noopLogger{}); err == nil {
+		t.Error("expected error when ResourceTypes is nil")
+	}
+	if _, err := ProvideResourceBehaviorRegistry(registry, &stubResourceRepo{}, &stubTripleRepo{}, &stubTypeRepo{}, nil); err == nil {
+		t.Error("expected error when Logger is nil")
+	}
+}
+
+func TestProvideResourceBehaviorRegistry_RejectsNilReturningFactory(t *testing.T) {
+	t.Parallel()
+	registry := NewPresetRegistry()
+	registry.MustAdd(PresetDefinition{
+		Name:  "p",
+		Types: []PresetResourceType{NewPresetType("T", "t", "d", "", "")},
+		Behaviors: map[string]BehaviorFactory{
+			"t": func(BehaviorServices) entities.ResourceBehavior { return nil },
+		},
+	})
+	_, err := ProvideResourceBehaviorRegistry(
+		registry, &stubResourceRepo{}, &stubTripleRepo{}, &stubTypeRepo{}, noopLogger{},
+	)
+	if err == nil {
+		t.Fatal("expected error when factory returns nil")
+	}
+}
+
+func TestProvideResourceBehaviorRegistry_PassesThroughDeps(t *testing.T) {
+	t.Parallel()
+	registry := NewPresetRegistry()
+	registry.MustAdd(PresetDefinition{
+		Name:  "p",
+		Types: []PresetResourceType{NewPresetType("T", "t", "d", "", "")},
+		Behaviors: map[string]BehaviorFactory{
+			"t": func(s BehaviorServices) entities.ResourceBehavior {
+				return &serviceAwareBehavior{services: s}
+			},
+		},
+	})
+	resources := &stubResourceRepo{}
+	triples := &stubTripleRepo{}
+	types := &stubTypeRepo{}
+	logger := noopLogger{}
+	merged, err := ProvideResourceBehaviorRegistry(registry, resources, triples, types, logger)
+	if err != nil {
+		t.Fatalf("ProvideResourceBehaviorRegistry returned error: %v", err)
+	}
+	b := merged["t"].(*serviceAwareBehavior)
+	if b.services.Resources != resources || b.services.Triples != triples ||
+		b.services.ResourceTypes != types || b.services.Logger != logger {
+		t.Fatal("provider did not pass dependencies through to factory")
+	}
+}
+

--- a/application/resource_type_presets_test.go
+++ b/application/resource_type_presets_test.go
@@ -16,6 +16,7 @@
 package application_test
 
 import (
+	"context"
 	"encoding/json"
 	"io/fs"
 	"testing"
@@ -24,7 +25,34 @@ import (
 	"weos/application"
 	"weos/application/presets"
 	"weos/domain/entities"
+	"weos/domain/repositories"
 )
+
+// Minimal interface-embedding stubs so this external test package can build a
+// non-nil BehaviorServices. Methods on the embedded nil interface panic if
+// called, which is fine — these stubs are only used for identity, never invoked.
+type stubResources struct {
+	repositories.ResourceRepository
+}
+type stubTriples struct{ repositories.TripleRepository }
+type stubTypes struct {
+	repositories.ResourceTypeRepository
+}
+
+type stubLogger struct{}
+
+func (stubLogger) Info(context.Context, string, ...any)  {}
+func (stubLogger) Warn(context.Context, string, ...any)  {}
+func (stubLogger) Error(context.Context, string, ...any) {}
+
+func testBehaviorServices() application.BehaviorServices {
+	return application.BehaviorServices{
+		Resources:     &stubResources{},
+		Triples:       &stubTriples{},
+		ResourceTypes: &stubTypes{},
+		Logger:        stubLogger{},
+	}
+}
 
 func testRegistry() *application.PresetRegistry {
 	return presets.NewDefaultRegistry()
@@ -145,7 +173,7 @@ func TestPresets_CoreHasBehaviors(t *testing.T) {
 
 func TestPresets_BehaviorsRegistry(t *testing.T) {
 	t.Parallel()
-	behaviors, err := testRegistry().Behaviors(application.BehaviorServices{})
+	behaviors, err := testRegistry().Behaviors(testBehaviorServices())
 	if err != nil {
 		t.Fatalf("Behaviors() returned error: %v", err)
 	}

--- a/application/resource_type_presets_test.go
+++ b/application/resource_type_presets_test.go
@@ -145,7 +145,10 @@ func TestPresets_CoreHasBehaviors(t *testing.T) {
 
 func TestPresets_BehaviorsRegistry(t *testing.T) {
 	t.Parallel()
-	behaviors := testRegistry().Behaviors()
+	behaviors, err := testRegistry().Behaviors(application.BehaviorServices{})
+	if err != nil {
+		t.Fatalf("Behaviors() returned error: %v", err)
+	}
 	if _, ok := behaviors["person"]; !ok {
 		t.Fatal("merged behaviors should include 'person'")
 	}

--- a/docs/_howto/create-behavior.md
+++ b/docs/_howto/create-behavior.md
@@ -125,20 +125,20 @@ dependencies (like the one above), `application.StaticBehavior` wraps a plain in
 ## 3a. Inject Application Services
 
 If your behavior needs a repository or logger, write a real factory instead of
-`StaticBehavior`. The factory receives a populated `application.BehaviorServices`:
+`StaticBehavior`. The factory receives a populated `application.BehaviorServices`,
+whose fields are `Resources` (`repositories.ResourceRepository`), `Triples`
+(`repositories.TripleRepository`), `ResourceTypes` (`repositories.ResourceTypeRepository`),
+and `Logger` (`entities.Logger`).
+
+Example (showing imports):
 
 ```go
-type BehaviorServices struct {
-    Resources     repositories.ResourceRepository
-    Triples       repositories.TripleRepository
-    ResourceTypes repositories.ResourceTypeRepository
-    Logger        entities.Logger
-}
-```
+import (
+    "weos/application"
+    "weos/domain/entities"
+    "weos/domain/repositories"
+)
 
-Example:
-
-```go
 type blogPostBehavior struct {
     entities.DefaultBehavior
     resources repositories.ResourceRepository

--- a/docs/_howto/create-behavior.md
+++ b/docs/_howto/create-behavior.md
@@ -108,14 +108,54 @@ func Register(registry *application.PresetRegistry) {
                 }`,
             ),
         },
-        Behaviors: map[string]entities.ResourceBehavior{
-            "blog-post": &blogPostBehavior{},
+        Behaviors: map[string]application.BehaviorFactory{
+            "blog-post": application.StaticBehavior(&blogPostBehavior{}),
         },
     })
 }
 ```
 
 The slug key (`"blog-post"`) must match the resource type's slug exactly.
+
+`Behaviors` is a map of **factory functions**, not pre-built instances. Factories are
+invoked at startup, after the dependency injection container is wired, so a behavior
+can close over real repositories and loggers. For a behavior with no service
+dependencies (like the one above), `application.StaticBehavior` wraps a plain instance.
+
+## 3a. Inject Application Services
+
+If your behavior needs a repository or logger, write a real factory instead of
+`StaticBehavior`. The factory receives a populated `application.BehaviorServices`:
+
+```go
+type BehaviorServices struct {
+    Resources     repositories.ResourceRepository
+    Triples       repositories.TripleRepository
+    ResourceTypes repositories.ResourceTypeRepository
+    Logger        entities.Logger
+}
+```
+
+Example:
+
+```go
+type blogPostBehavior struct {
+    entities.DefaultBehavior
+    resources repositories.ResourceRepository
+    logger    entities.Logger
+}
+
+func newBlogPostBehavior(s application.BehaviorServices) entities.ResourceBehavior {
+    return &blogPostBehavior{resources: s.Resources, logger: s.Logger}
+}
+
+// In Register():
+Behaviors: map[string]application.BehaviorFactory{
+    "blog-post": newBlogPostBehavior,
+},
+```
+
+The factory is called once, at startup, by `application.ProvideResourceBehaviorRegistry`.
 
 ## 4. Register the Preset
 


### PR DESCRIPTION
## Summary
- Convert `PresetDefinition.Behaviors` from `map[string]ResourceBehavior` to `map[string]BehaviorFactory` so preset behaviors can receive injected services (Resources, Triples, ResourceTypes, Logger) instead of being limited to pure data transforms.
- Add `BehaviorServices`, `BehaviorFactory`, and `StaticBehavior` helper for behaviors with no service dependencies.
- Fail-fast validation: nil factories rejected at `Add()`, `StaticBehavior(nil)` panics, `ProvideResourceBehaviorRegistry` rejects nil deps and nil-returning factories, and duplicate-slug merges across presets log a warning.
- Migrate the `core` preset to `StaticBehavior` wrappers and update the `create-behavior` how-to with the factory pattern.

Closes #314.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all packages pass
- [x] New tests cover: StaticBehavior nil/identity, factory injection of all four services, nil-factory rejection at Add, single-invocation, multi-preset last-wins merge with warning, provider nil-dep rejection, provider nil-return rejection, and provider pass-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)