### PR TITLE
Reframe docs around digital twin / knowledge graph for LLMs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,17 +4,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**WeOS** is an open source Go application for building a **digital twin** — of yourself or your business — that gives any LLM context-rich access to the information from the apps and devices you use. WeOS stores that information as a knowledge graph and exposes an MCP server so any MCP-compatible LLM (Claude, GPT, Gemini, Ollama) can query it. WeOS never calls an LLM directly.
+**WeOS** is an open source Go application for building a **digital twin** — of yourself or your business — that gives any LLM context-rich access to the information from the apps and devices you use. WeOS stores that information as a knowledge graph and exposes an MCP server so any MCP-compatible LLM (Claude, GPT, Gemini, Ollama) can query it. WeOS is MCP-first by default; optional built-in agent integrations (e.g. Google ADK/Gemini) are available when configured.
 
 See `.claude/local-context.md` for full product vision, user personas, and business context.
 
 ### What the Go Binary Does
-1. **Stores data as a knowledge graph** — JSON-LD resources plus RDF triples for relationships, using ontology-typed entities (Schema.org, FOAF, vCard, etc.)
+1. **Stores data as a knowledge graph** — JSON-LD resources plus RDF triples for relationships, using ontology-typed entities (Schema.org, FOAF, etc.)
 2. **Runs the MCP server** — LLMs connect over MCP to query the graph for grounded responses
 3. **Optionally serves a static site and REST API** — the same graph can drive HTML output or be accessed programmatically
 
 ### Key Design Decisions
-- **LLM-agnostic** — MCP server interface, no direct LLM calls
+- **LLM-agnostic** — MCP-first by default; optional provider-backed agents (Google ADK/Gemini) when configured
 - **Static HTML output is optional** — sites are one way to surface the graph, not the core purpose; server-side rendering is opt-in
 - **Ontology-backed entities** — content objects (products, events, services) are RDF-typed using Schema.org, FOAF, etc. — gives free SEO structured data and grounded LLM reasoning
 - **Resource types with dynamic projection tables** — when a resource type is created, a dedicated projection table is generated from its JSON Schema. All content (websites, pages, products, etc.) is modeled as resource types + resources.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 See `.claude/local-context.md` for full product vision, user personas, and business context.
 
 ### What the Go Binary Does
-1. **Stores data as a knowledge graph** — RDF triples and ontology-typed resources (Schema.org, FOAF, vCard, etc.)
+1. **Stores data as a knowledge graph** — JSON-LD resources plus RDF triples for relationships, using ontology-typed entities (Schema.org, FOAF, vCard, etc.)
 2. **Runs the MCP server** — LLMs connect over MCP to query the graph for grounded responses
 3. **Optionally serves a static site and REST API** — the same graph can drive HTML output or be accessed programmatically
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,18 +4,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**WeOS**  is an open source website system where your AI is the webmaster. Users describe what they want in natural language and the site updates accordingly. WeOS never calls any LLM directly — it exposes an MCP server that any MCP-compatible LLM (Claude, GPT, Gemini, Ollama) connects to for driving edits. Output is static-first HTML.
+**WeOS** is an open source Go application for building a **digital twin** — of yourself or your business — that gives any LLM context-rich access to the information from the apps and devices you use. WeOS stores that information as a knowledge graph and exposes an MCP server so any MCP-compatible LLM (Claude, GPT, Gemini, Ollama) can query it. WeOS never calls an LLM directly.
 
 See `.claude/local-context.md` for full product vision, user personas, and business context.
 
 ### What the Go Binary Does
-1. **Generates and serves the static site** — templates + content → HTML
-2. **Runs the MCP server** — LLM-driven edits via MCP protocol
-3. **Serves as the API backend** — escape hatch for dynamic needs
+1. **Stores data as a knowledge graph** — RDF triples and ontology-typed resources (Schema.org, FOAF, vCard, etc.)
+2. **Runs the MCP server** — LLMs connect over MCP to query the graph for grounded responses
+3. **Optionally serves a static site and REST API** — the same graph can drive HTML output or be accessed programmatically
 
 ### Key Design Decisions
 - **LLM-agnostic** — MCP server interface, no direct LLM calls
-- **Static-first** — static HTML output, server-side rendering only when opted in
+- **Static HTML output is optional** — sites are one way to surface the graph, not the core purpose; server-side rendering is opt-in
 - **Ontology-backed entities** — content objects (products, events, services) are RDF-typed using Schema.org, FOAF, etc. — gives free SEO structured data and grounded LLM reasoning
 - **Resource types with dynamic projection tables** — when a resource type is created, a dedicated projection table is generated from its JSON Schema. All content (websites, pages, products, etc.) is modeled as resource types + resources.
 - **Template system** — bring-your-own HTML templates annotated with `data-weos-*` attributes (e.g., `data-weos-entity="Product"`, `data-weos-slot="hero.headline"`)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # WeOS
 
-A Go microservices template following Clean Architecture principles with event sourcing support.
+WeOS is an open source Go application for building a **digital twin** of yourself or your business — a knowledge graph of the information from the apps and devices you use, exposed to any LLM so it can answer with your real context. WeOS never calls an LLM directly; it exposes an MCP server that any MCP-compatible LLM (Claude, GPT, Gemini, Ollama) connects to.
 
-## Features
+## What it does
+
+1. **Stores your data as a knowledge graph** — resources are modeled as RDF triples typed with Schema.org, FOAF, vCard and other ontologies, so people, events, products, places, messages and the relationships between them are first-class.
+2. **Runs an MCP server** — any MCP-compatible LLM connects and queries your graph for grounded, context-rich responses.
+3. **Optionally renders sites and APIs** — the same graph can drive a static-first HTML site or a REST API when you want to publish or integrate.
+
+## Under the hood
 
 - **Clean Architecture** with domain-driven design
 - **Event Sourcing** via [pericarp](https://github.com/akeemphilbert/pericarp) library

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ WeOS is an open source Go application for building a **digital twin** of yoursel
 
 ## What it does
 
-1. **Stores your data as a knowledge graph** — resources are modeled as RDF triples typed with Schema.org, FOAF, vCard and other ontologies, so people, events, products, places, messages and the relationships between them are first-class.
+1. **Stores your data as a knowledge graph** — resources are stored as JSON-LD documents typed with Schema.org, FOAF, vCard and other ontologies, with relationships between resources modeled as RDF triples, so people, events, products, places, messages and the relationships between them are first-class.
 2. **Runs an MCP server** — any MCP-compatible LLM connects and queries your graph for grounded, context-rich responses.
 3. **Optionally renders sites and APIs** — the same graph can drive a static-first HTML site or a REST API when you want to publish or integrate.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # WeOS
 
-WeOS is an open source Go application for building a **digital twin** of yourself or your business — a knowledge graph of the information from the apps and devices you use, exposed to any LLM so it can answer with your real context. WeOS never calls an LLM directly; it exposes an MCP server that any MCP-compatible LLM (Claude, GPT, Gemini, Ollama) connects to.
+WeOS is an open source Go application for building a **digital twin** of yourself or your business — a knowledge graph of the information from the apps and devices you use, exposed to any LLM so it can answer with your real context. By default WeOS is MCP-first: it exposes an MCP server that any MCP-compatible LLM (Claude, GPT, Gemini, Ollama) connects to. Optional built-in agent integrations (e.g. Google ADK/Gemini) are available when configured.
 
 ## What it does
 
-1. **Stores your data as a knowledge graph** — resources are stored as JSON-LD documents typed with Schema.org, FOAF, vCard and other ontologies, with relationships between resources modeled as RDF triples, so people, events, products, places, messages and the relationships between them are first-class.
+1. **Stores your data as a knowledge graph** — resources are stored as JSON-LD documents typed with ontologies like Schema.org and FOAF, with relationships between resources modeled as RDF triples, so people, events, products, places, messages and the relationships between them are first-class.
 2. **Runs an MCP server** — any MCP-compatible LLM connects and queries your graph for grounded, context-rich responses.
 3. **Optionally renders sites and APIs** — the same graph can drive a static-first HTML site or a REST API when you want to publish or integrate.
 
@@ -67,10 +67,10 @@ weos/
 
 ## Getting Started
 
-1. Clone and rename the module:
+1. Clone the repository:
 ```bash
-# Update go.mod module name
-# Find and replace "weos" with your module name across all Go files
+git clone https://github.com/wepala/weos.git
+cd weos
 ```
 
 2. Install dependencies:
@@ -78,14 +78,10 @@ weos/
 make deps
 ```
 
-3. Run the API server:
-```bash
-make run
-```
-
-4. Build all binaries:
+3. Build and run:
 ```bash
 make build
+./bin/weos serve
 ```
 
 ## Key Patterns

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 title: WeOS Documentation
-description: "AI-powered website system — developer documentation"
+description: "Open source digital twin and knowledge graph for LLMs — developer documentation"
 url: "https://wepala.github.io"
 baseurl: "/weos"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,19 +6,19 @@ nav_order: 0
 
 # WeOS Documentation
 
-WeOS is an open source website system where your AI is the webmaster. Users describe what they want in natural language and the site updates accordingly. WeOS never calls any LLM directly — it exposes an [MCP server]({% link _explanation/mcp-protocol.md %}) that any MCP-compatible LLM (Claude, GPT, Gemini, Ollama) connects to for driving edits. Output is static-first HTML.
+WeOS is an open source Go application for building a **digital twin** of yourself or your business — a knowledge graph of the information from the apps and devices you use, exposed to any LLM so it can answer with your real context. WeOS never calls any LLM directly; it exposes an [MCP server]({% link _explanation/mcp-protocol.md %}) that any MCP-compatible LLM (Claude, GPT, Gemini, Ollama) connects to.
 
 The Go binary does three things:
 
-1. **Generates and serves the static site** — templates + content = HTML
-2. **Runs the MCP server** — LLM-driven edits via Model Context Protocol
-3. **Serves as the API backend** — REST API for programmatic access
+1. **Stores your data as a knowledge graph** — resources are modeled as RDF triples typed with Schema.org, FOAF, vCard and other ontologies, so people, events, products, places, messages and the relationships between them are first-class.
+2. **Runs the MCP server** — any MCP-compatible LLM connects and queries your graph for grounded, context-rich responses.
+3. **Optionally renders sites and APIs** — the same graph can drive a static-first HTML site or a REST API when you want to publish or integrate.
 
 ---
 
 ## Where to Start
 
-### Building a site with WeOS?
+### Setting up your digital twin?
 
 Start with the **[Tutorials]({% link _tutorials/index.md %})** — they walk you through running WeOS, connecting an LLM, creating content types, and customizing your site step by step.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,11 +6,11 @@ nav_order: 0
 
 # WeOS Documentation
 
-WeOS is an open source Go application for building a **digital twin** of yourself or your business — a knowledge graph of the information from the apps and devices you use, exposed to any LLM so it can answer with your real context. WeOS never calls any LLM directly; it exposes an [MCP server]({% link _explanation/mcp-protocol.md %}) that any MCP-compatible LLM (Claude, GPT, Gemini, Ollama) connects to.
+WeOS is an open source Go application for building a **digital twin** of yourself or your business — a knowledge graph of the information from the apps and devices you use, exposed to any LLM so it can answer with your real context. By default WeOS is MCP-first: it exposes an [MCP server]({% link _explanation/mcp-protocol.md %}) that any MCP-compatible LLM (Claude, GPT, Gemini, Ollama) connects to. Optional built-in agent integrations (e.g. Google ADK/Gemini) are available when configured.
 
 The Go binary does three things:
 
-1. **Stores your data as a knowledge graph** — resources are represented as JSON-LD entities, and relationships between them are modeled as RDF triples using Schema.org, FOAF, vCard and other ontologies, so people, events, products, places, messages and the relationships between them are first-class.
+1. **Stores your data as a knowledge graph** — resources are represented as JSON-LD entities, and relationships between them are modeled as RDF triples using ontologies like Schema.org and FOAF, so people, events, products, places, messages and the relationships between them are first-class.
 2. **Runs the MCP server** — any MCP-compatible LLM connects and queries your graph for grounded, context-rich responses.
 3. **Optionally renders sites and APIs** — the same graph can drive a static-first HTML site or a REST API when you want to publish or integrate.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ WeOS is an open source Go application for building a **digital twin** of yoursel
 
 The Go binary does three things:
 
-1. **Stores your data as a knowledge graph** — resources are modeled as RDF triples typed with Schema.org, FOAF, vCard and other ontologies, so people, events, products, places, messages and the relationships between them are first-class.
+1. **Stores your data as a knowledge graph** — resources are represented as JSON-LD entities, and relationships between them are modeled as RDF triples using Schema.org, FOAF, vCard and other ontologies, so people, events, products, places, messages and the relationships between them are first-class.
 2. **Runs the MCP server** — any MCP-compatible LLM connects and queries your graph for grounded, context-rich responses.
 3. **Optionally renders sites and APIs** — the same graph can drive a static-first HTML site or a REST API when you want to publish or integrate.
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -23,8 +23,8 @@ var (
 	// rootCmd represents the base command when called without any subcommands
 	rootCmd = &cobra.Command{
 		Use:     "weos",
-		Short:   "WeOS - AI-powered website system",
-		Long:    `WeOS is an open source website system where your AI is the webmaster.`,
+		Short:   "WeOS - open source digital twin for LLMs",
+		Long:    `WeOS is an open source Go application for building a digital twin — a knowledge graph of the information from the apps and devices you use, exposed to any LLM via MCP for context-rich responses.`,
 		Version: "0.1.0",
 	}
 )


### PR DESCRIPTION
## Summary
- Reframes WeOS documentation away from "website system where your AI is the webmaster" toward what it actually is: a Go application for building a **digital twin** (of yourself or your business) — a knowledge graph of data from the apps and devices you use, exposed to any LLM via MCP for context-rich responses.
- Static HTML/REST API output is repositioned as an optional way to surface the graph rather than the headline.
- Files updated: `docs/index.md`, `CLAUDE.md`, `README.md` (replaced stale microservices-template boilerplate), `docs/_config.yml`, and `internal/cli/root.go` (CLI `--help` text).

## Test plan
- [ ] Visual review of `docs/index.md`, `CLAUDE.md`, `README.md` — confirm the three "what it does" bullets consistently lead with knowledge graph → MCP → optional site/API
- [ ] Confirm `grep -rE "webmaster|website system"` returns zero hits
- [ ] `weos --help` shows the new short/long description

https://claude.ai/code/session_01PH2K7YJshFcpU3w7ctsEEj