### PR TITLE
Add ResourceWriter for cross-resource writes from behavior hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ bin/
 # Dev seed manifest
 .dev-seed.json
 
+# Private preset registration (local only, build-tag-gated)
+application/presets/register_custom.go
+
 # Configuration files with secrets
 config/local.yaml
 config/secrets.yaml

--- a/application/module.go
+++ b/application/module.go
@@ -90,7 +90,11 @@ func Module(cfg config.Config, registry *PresetRegistry) fx.Option {
 		fx.Provide(ProvideAuthenticationService),
 		fx.Provide(ProvideSessionManager),
 
-		// Resource behavior registries (must come before ProvideResourceService)
+		// Resource behavior registries (must come before ProvideResourceService).
+		// The lazy resource writer breaks the construction cycle between
+		// ResourceService and ResourceBehaviorRegistry; WireResourceWriter
+		// (fx.Invoke below) installs the real service into it at startup.
+		fx.Provide(newLazyResourceWriter),
 		fx.Provide(ProvideResourceBehaviorRegistry),
 		fx.Provide(ProvideBehaviorMetaRegistry),
 		fx.Provide(gorm.ProvideBehaviorSettingsRepository),
@@ -99,6 +103,11 @@ func Module(cfg config.Config, registry *PresetRegistry) fx.Option {
 		fx.Provide(ProvideResourceTypeService),
 		fx.Provide(ProvideResourceService),
 		fx.Provide(ProvideResourcePermissionService),
+
+		// Install the real ResourceService into the lazy writer proxy now that
+		// both exist. Behaviors close over the proxy at factory time; this
+		// invoke must run before any hook can be called.
+		fx.Invoke(WireResourceWriter),
 
 		// Subscribe event handlers (projections)
 		fx.Invoke(subscribeEventHandlers),

--- a/application/resource_behaviors.go
+++ b/application/resource_behaviors.go
@@ -209,7 +209,7 @@ func ProvideResourceBehaviorRegistry(
 		return nil, fmt.Errorf("ProvideResourceBehaviorRegistry: nil Logger")
 	}
 	if writer == nil {
-		return nil, fmt.Errorf("ProvideResourceBehaviorRegistry: nil ResourceWriter")
+		return nil, fmt.Errorf("ProvideResourceBehaviorRegistry: nil lazyResourceWriter")
 	}
 	services := BehaviorServices{
 		Resources:     resources,
@@ -233,10 +233,21 @@ func ProvideResourceBehaviorRegistry(
 }
 
 // WireResourceWriter installs the real ResourceService into the lazy writer
-// proxy after both have been constructed by Fx. Register this as an fx.Invoke
-// that runs after ProvideResourceService; Fx will detect the dependency and
-// order it correctly. Returns an error on nil svc, self-target, or double-set
-// so Fx aborts startup loudly instead of silently installing a broken proxy.
+// proxy after both have been constructed by Fx.
+//
+// Fx guarantees that lazyResourceWriter and ResourceService are available
+// before this invoke runs (parameter-level dependency ordering), but it does
+// NOT impose ordering relative to other fx.Invoke calls that also depend on
+// ResourceService. Any startup invoke that may call ResourceService.Create,
+// Update, or Delete — and thus trigger behavior hooks that use
+// BehaviorServices.Writer — MUST be registered after WireResourceWriter in
+// application/module.go. Today the only such invoke is
+// ensureBuiltInResourceTypes, and the module registers WireResourceWriter
+// first; adding a new hook-triggering invoke earlier would silently regress
+// this contract.
+//
+// Returns an error on nil svc, self-target, or double-set so Fx aborts
+// startup loudly instead of silently installing a broken proxy.
 func WireResourceWriter(writer *lazyResourceWriter, svc ResourceService) error {
 	if writer == nil {
 		return fmt.Errorf("WireResourceWriter: nil lazyResourceWriter")

--- a/application/resource_behaviors.go
+++ b/application/resource_behaviors.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"sync/atomic"
 
 	"weos/domain/entities"
 	"weos/domain/repositories"
@@ -42,6 +43,107 @@ func isNilInterface(v any) bool {
 	}
 }
 
+// ResourceWriter is the subset of ResourceService that behaviors need to
+// create, update, and delete other resources from inside a hook. It
+// intentionally omits queries — use BehaviorServices.Resources for reads.
+//
+// Write methods go through the full ResourceService pipeline: schema
+// validation, JSON-LD graph assembly, triple extraction, event recording, and
+// UnitOfWork commit, including nested behavior dispatch on the affected
+// resources.
+type ResourceWriter interface {
+	Create(ctx context.Context, cmd CreateResourceCommand) (*entities.Resource, error)
+	Update(ctx context.Context, cmd UpdateResourceCommand) (*entities.Resource, error)
+	Delete(ctx context.Context, cmd DeleteResourceCommand) error
+}
+
+// lazyResourceWriter is a ResourceWriter proxy that is constructed before the
+// real ResourceService exists and populated via SetTarget once the Fx
+// container has wired ResourceService. It breaks the Fx construction cycle
+// ResourceService -> ResourceBehaviorRegistry -> ResourceService (the inner
+// step runs through BehaviorServices.Writer, which the registry provider
+// populates with this proxy).
+//
+// Behaviors receive this proxy at factory time and close over it; by the time
+// any hook runs (during a request), Fx has invoked SetTarget so the proxy
+// forwards cleanly to the real service. Calls before wiring return a clear
+// error instead of panicking.
+//
+// Because behaviors write through this proxy, each forwarded call enters
+// resourceService.Create/Update/Delete, which apply a recursion-depth guard
+// (see maxBehaviorRecursionDepth in resource_service.go) so runaway cascades
+// fail fast instead of blowing the stack.
+type lazyResourceWriter struct {
+	// svc is set exactly once by SetTarget and then read concurrently by every
+	// behavior hook. The atomic store/load pair gives a happens-before edge
+	// independent of Fx ordering, so there is no data race even if a future
+	// refactor reorders construction.
+	svc atomic.Pointer[ResourceWriter]
+}
+
+func newLazyResourceWriter() *lazyResourceWriter { return &lazyResourceWriter{} }
+
+// SetTarget installs the real ResourceWriter. It must be called exactly once,
+// before any behavior hook can fire — in production that ordering is enforced
+// by registering WireResourceWriter as an Fx invoke that runs after
+// ProvideResourceService but before any invoke or lifecycle hook that can
+// trigger a resource write (see application/module.go for the current order).
+// Returns an error on nil input or double-set so misuse fails startup rather
+// than silently installing a broken target.
+func (l *lazyResourceWriter) SetTarget(svc ResourceWriter) error {
+	if isNilInterface(svc) {
+		return fmt.Errorf("lazyResourceWriter.SetTarget: nil ResourceWriter")
+	}
+	if svc == ResourceWriter(l) {
+		return fmt.Errorf("lazyResourceWriter.SetTarget: refusing to target self (would infinite-loop)")
+	}
+	if !l.svc.CompareAndSwap(nil, &svc) {
+		return fmt.Errorf("lazyResourceWriter.SetTarget: already wired")
+	}
+	return nil
+}
+
+// target returns the installed ResourceWriter or an error if SetTarget has
+// not run yet. The error phrasing points at the likely cause — a behavior
+// fired before Fx wiring completed.
+func (l *lazyResourceWriter) target(op string) (ResourceWriter, error) {
+	p := l.svc.Load()
+	if p == nil {
+		return nil, fmt.Errorf(
+			"ResourceWriter.%s called before wiring; behavior invoked during startup?", op,
+		)
+	}
+	return *p, nil
+}
+
+func (l *lazyResourceWriter) Create(
+	ctx context.Context, cmd CreateResourceCommand,
+) (*entities.Resource, error) {
+	svc, err := l.target("Create")
+	if err != nil {
+		return nil, err
+	}
+	return svc.Create(ctx, cmd)
+}
+
+func (l *lazyResourceWriter) Update(
+	ctx context.Context, cmd UpdateResourceCommand,
+) (*entities.Resource, error) {
+	svc, err := l.target("Update")
+	if err != nil {
+		return nil, err
+	}
+	return svc.Update(ctx, cmd)
+}
+
+func (l *lazyResourceWriter) Delete(ctx context.Context, cmd DeleteResourceCommand) error {
+	svc, err := l.target("Delete")
+	if err != nil {
+		return err
+	}
+	return svc.Delete(ctx, cmd)
+}
+
 // BehaviorServices bundles application services that ResourceBehavior factories
 // may depend on. All fields are required when constructed by
 // ProvideResourceBehaviorRegistry; tests that build BehaviorServices directly
@@ -51,6 +153,10 @@ type BehaviorServices struct {
 	Triples       repositories.TripleRepository
 	ResourceTypes repositories.ResourceTypeRepository
 	Logger        entities.Logger
+	// Writer lets behaviors create, update, or delete other resources through
+	// the full ResourceService pipeline. See lazyResourceWriter for the
+	// cycle-breaking rationale behind how this is wired.
+	Writer ResourceWriter
 }
 
 // BehaviorFactory constructs a ResourceBehavior given the available application
@@ -76,13 +182,16 @@ type ResourceBehaviorRegistry map[string]entities.ResourceBehavior
 
 // ProvideResourceBehaviorRegistry builds the behavior registry from all
 // registered presets, invoking each factory with the supplied services. Fails
-// startup if any injected dependency is nil or any factory returns nil.
+// startup if any injected dependency is nil or any factory returns nil. The
+// writer parameter is an unwired *lazyResourceWriter — see that type for the
+// cycle-breaking rationale.
 func ProvideResourceBehaviorRegistry(
 	registry *PresetRegistry,
 	resources repositories.ResourceRepository,
 	triples repositories.TripleRepository,
 	resourceTypes repositories.ResourceTypeRepository,
 	logger entities.Logger,
+	writer *lazyResourceWriter,
 ) (ResourceBehaviorRegistry, error) {
 	if registry == nil {
 		return nil, fmt.Errorf("ProvideResourceBehaviorRegistry: nil PresetRegistry")
@@ -99,11 +208,15 @@ func ProvideResourceBehaviorRegistry(
 	if isNilInterface(logger) {
 		return nil, fmt.Errorf("ProvideResourceBehaviorRegistry: nil Logger")
 	}
+	if writer == nil {
+		return nil, fmt.Errorf("ProvideResourceBehaviorRegistry: nil ResourceWriter")
+	}
 	services := BehaviorServices{
 		Resources:     resources,
 		Triples:       triples,
 		ResourceTypes: resourceTypes,
 		Logger:        logger,
+		Writer:        writer,
 	}
 	behaviors, err := registry.Behaviors(services)
 	if err != nil {
@@ -117,6 +230,21 @@ func ProvideResourceBehaviorRegistry(
 	logger.Info(context.Background(), "resource behaviors registered",
 		"count", len(slugs), "slugs", slugs)
 	return behaviors, nil
+}
+
+// WireResourceWriter installs the real ResourceService into the lazy writer
+// proxy after both have been constructed by Fx. Register this as an fx.Invoke
+// that runs after ProvideResourceService; Fx will detect the dependency and
+// order it correctly. Returns an error on nil svc, self-target, or double-set
+// so Fx aborts startup loudly instead of silently installing a broken proxy.
+func WireResourceWriter(writer *lazyResourceWriter, svc ResourceService) error {
+	if writer == nil {
+		return fmt.Errorf("WireResourceWriter: nil lazyResourceWriter")
+	}
+	if err := writer.SetTarget(svc); err != nil {
+		return fmt.Errorf("WireResourceWriter: %w", err)
+	}
+	return nil
 }
 
 // BehaviorMetaRegistry maps resource type slugs to their behavior metadata.

--- a/application/resource_behaviors_test.go
+++ b/application/resource_behaviors_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"weos/domain/entities"
@@ -656,21 +657,22 @@ func TestPresetRegistry_BehaviorsMultiPresetMergeLastWins(t *testing.T) {
 func TestProvideResourceBehaviorRegistry_RejectsTypedNilDeps(t *testing.T) {
 	t.Parallel()
 	registry := NewPresetRegistry()
+	writer := newLazyResourceWriter()
 	var typedNilResources *stubResourceRepo
 	var typedNilTriples *stubTripleRepo
 	var typedNilTypes *stubTypeRepo
 	if _, err := ProvideResourceBehaviorRegistry(
-		registry, typedNilResources, &stubTripleRepo{}, &stubTypeRepo{}, noopLogger{},
+		registry, typedNilResources, &stubTripleRepo{}, &stubTypeRepo{}, noopLogger{}, writer,
 	); err == nil {
 		t.Error("expected error for typed-nil Resources")
 	}
 	if _, err := ProvideResourceBehaviorRegistry(
-		registry, &stubResourceRepo{}, typedNilTriples, &stubTypeRepo{}, noopLogger{},
+		registry, &stubResourceRepo{}, typedNilTriples, &stubTypeRepo{}, noopLogger{}, writer,
 	); err == nil {
 		t.Error("expected error for typed-nil Triples")
 	}
 	if _, err := ProvideResourceBehaviorRegistry(
-		registry, &stubResourceRepo{}, &stubTripleRepo{}, typedNilTypes, noopLogger{},
+		registry, &stubResourceRepo{}, &stubTripleRepo{}, typedNilTypes, noopLogger{}, writer,
 	); err == nil {
 		t.Error("expected error for typed-nil ResourceTypes")
 	}
@@ -679,17 +681,21 @@ func TestProvideResourceBehaviorRegistry_RejectsTypedNilDeps(t *testing.T) {
 func TestProvideResourceBehaviorRegistry_RejectsNilDeps(t *testing.T) {
 	t.Parallel()
 	registry := NewPresetRegistry()
-	if _, err := ProvideResourceBehaviorRegistry(registry, nil, &stubTripleRepo{}, &stubTypeRepo{}, noopLogger{}); err == nil {
+	writer := newLazyResourceWriter()
+	if _, err := ProvideResourceBehaviorRegistry(registry, nil, &stubTripleRepo{}, &stubTypeRepo{}, noopLogger{}, writer); err == nil {
 		t.Error("expected error when Resources is nil")
 	}
-	if _, err := ProvideResourceBehaviorRegistry(registry, &stubResourceRepo{}, nil, &stubTypeRepo{}, noopLogger{}); err == nil {
+	if _, err := ProvideResourceBehaviorRegistry(registry, &stubResourceRepo{}, nil, &stubTypeRepo{}, noopLogger{}, writer); err == nil {
 		t.Error("expected error when Triples is nil")
 	}
-	if _, err := ProvideResourceBehaviorRegistry(registry, &stubResourceRepo{}, &stubTripleRepo{}, nil, noopLogger{}); err == nil {
+	if _, err := ProvideResourceBehaviorRegistry(registry, &stubResourceRepo{}, &stubTripleRepo{}, nil, noopLogger{}, writer); err == nil {
 		t.Error("expected error when ResourceTypes is nil")
 	}
-	if _, err := ProvideResourceBehaviorRegistry(registry, &stubResourceRepo{}, &stubTripleRepo{}, &stubTypeRepo{}, nil); err == nil {
+	if _, err := ProvideResourceBehaviorRegistry(registry, &stubResourceRepo{}, &stubTripleRepo{}, &stubTypeRepo{}, nil, writer); err == nil {
 		t.Error("expected error when Logger is nil")
+	}
+	if _, err := ProvideResourceBehaviorRegistry(registry, &stubResourceRepo{}, &stubTripleRepo{}, &stubTypeRepo{}, noopLogger{}, nil); err == nil {
+		t.Error("expected error when Writer is nil")
 	}
 }
 
@@ -719,7 +725,7 @@ func TestProvideResourceBehaviorRegistry_RejectsNilReturningFactory(t *testing.T
 		},
 	})
 	_, err := ProvideResourceBehaviorRegistry(
-		registry, &stubResourceRepo{}, &stubTripleRepo{}, &stubTypeRepo{}, noopLogger{},
+		registry, &stubResourceRepo{}, &stubTripleRepo{}, &stubTypeRepo{}, noopLogger{}, newLazyResourceWriter(),
 	)
 	if err == nil {
 		t.Fatal("expected error when factory returns nil")
@@ -742,13 +748,164 @@ func TestProvideResourceBehaviorRegistry_PassesThroughDeps(t *testing.T) {
 	triples := &stubTripleRepo{}
 	types := &stubTypeRepo{}
 	logger := noopLogger{}
-	merged, err := ProvideResourceBehaviorRegistry(registry, resources, triples, types, logger)
+	writer := newLazyResourceWriter()
+	merged, err := ProvideResourceBehaviorRegistry(registry, resources, triples, types, logger, writer)
 	if err != nil {
 		t.Fatalf("ProvideResourceBehaviorRegistry returned error: %v", err)
 	}
 	b := merged["t"].(*serviceAwareBehavior)
 	if b.services.Resources != resources || b.services.Triples != triples ||
-		b.services.ResourceTypes != types || b.services.Logger != logger {
+		b.services.ResourceTypes != types || b.services.Logger != logger ||
+		b.services.Writer != writer {
 		t.Fatal("provider did not pass dependencies through to factory")
+	}
+	// Registry build-time invariant: the proxy is constructed but not yet
+	// targeted. This guards the two-phase wiring contract — WireResourceWriter
+	// must still be able to install the real service later.
+	if writer.svc.Load() != nil {
+		t.Fatal("lazyResourceWriter.svc should be nil at registry build time")
+	}
+}
+
+// fakeResourceWriter records the calls made through ResourceWriter so tests
+// can assert the lazy proxy forwards to the right method with the right args.
+type fakeResourceWriter struct {
+	createCalls []CreateResourceCommand
+	updateCalls []UpdateResourceCommand
+	deleteCalls []DeleteResourceCommand
+	createErr   error
+	updateErr   error
+	deleteErr   error
+	createRes   *entities.Resource
+	updateRes   *entities.Resource
+}
+
+func (f *fakeResourceWriter) Create(
+	_ context.Context, cmd CreateResourceCommand,
+) (*entities.Resource, error) {
+	f.createCalls = append(f.createCalls, cmd)
+	return f.createRes, f.createErr
+}
+
+func (f *fakeResourceWriter) Update(
+	_ context.Context, cmd UpdateResourceCommand,
+) (*entities.Resource, error) {
+	f.updateCalls = append(f.updateCalls, cmd)
+	return f.updateRes, f.updateErr
+}
+
+func (f *fakeResourceWriter) Delete(_ context.Context, cmd DeleteResourceCommand) error {
+	f.deleteCalls = append(f.deleteCalls, cmd)
+	return f.deleteErr
+}
+
+func TestLazyResourceWriter_PreWireReturnsError(t *testing.T) {
+	t.Parallel()
+	w := newLazyResourceWriter()
+	ctx := context.Background()
+
+	if _, err := w.Create(ctx, CreateResourceCommand{TypeSlug: "t"}); err == nil {
+		t.Error("expected error from Create before wiring")
+	} else if !strings.Contains(err.Error(), "before wiring") {
+		t.Errorf("Create error = %q, want contains 'before wiring'", err.Error())
+	}
+
+	if _, err := w.Update(ctx, UpdateResourceCommand{ID: "id"}); err == nil {
+		t.Error("expected error from Update before wiring")
+	} else if !strings.Contains(err.Error(), "before wiring") {
+		t.Errorf("Update error = %q, want contains 'before wiring'", err.Error())
+	}
+
+	if err := w.Delete(ctx, DeleteResourceCommand{ID: "id"}); err == nil {
+		t.Error("expected error from Delete before wiring")
+	} else if !strings.Contains(err.Error(), "before wiring") {
+		t.Errorf("Delete error = %q, want contains 'before wiring'", err.Error())
+	}
+}
+
+func TestLazyResourceWriter_ForwardsAfterSetTarget(t *testing.T) {
+	t.Parallel()
+	w := newLazyResourceWriter()
+	fake := &fakeResourceWriter{}
+	if err := w.SetTarget(fake); err != nil {
+		t.Fatalf("SetTarget returned error: %v", err)
+	}
+
+	ctx := context.Background()
+	createCmd := CreateResourceCommand{TypeSlug: "t", Data: json.RawMessage(`{"x":1}`)}
+	if _, err := w.Create(ctx, createCmd); err != nil {
+		t.Fatalf("Create after wiring returned error: %v", err)
+	}
+	updateCmd := UpdateResourceCommand{ID: "id-1", Data: json.RawMessage(`{"x":2}`)}
+	if _, err := w.Update(ctx, updateCmd); err != nil {
+		t.Fatalf("Update after wiring returned error: %v", err)
+	}
+	deleteCmd := DeleteResourceCommand{ID: "id-2"}
+	if err := w.Delete(ctx, deleteCmd); err != nil {
+		t.Fatalf("Delete after wiring returned error: %v", err)
+	}
+
+	// Each method must forward to its matching target method with the exact
+	// command value — catches a wiring regression like Update calling Create.
+	if len(fake.createCalls) != 1 || fake.createCalls[0].TypeSlug != "t" {
+		t.Errorf("Create forwarding: got %+v, want one call with TypeSlug=t", fake.createCalls)
+	}
+	if len(fake.updateCalls) != 1 || fake.updateCalls[0].ID != "id-1" {
+		t.Errorf("Update forwarding: got %+v, want one call with ID=id-1", fake.updateCalls)
+	}
+	if len(fake.deleteCalls) != 1 || fake.deleteCalls[0].ID != "id-2" {
+		t.Errorf("Delete forwarding: got %+v, want one call with ID=id-2", fake.deleteCalls)
+	}
+}
+
+func TestLazyResourceWriter_SetTargetRejectsNil(t *testing.T) {
+	t.Parallel()
+	w := newLazyResourceWriter()
+	if err := w.SetTarget(nil); err == nil {
+		t.Error("SetTarget(nil) = nil error, want rejection")
+	}
+	// Typed-nil interface: a nil *fakeResourceWriter wrapped in the ResourceWriter
+	// interface is != nil but still unusable. isNilInterface must catch it.
+	var typedNil *fakeResourceWriter
+	if err := w.SetTarget(typedNil); err == nil {
+		t.Error("SetTarget(typed-nil) = nil error, want rejection")
+	}
+}
+
+func TestLazyResourceWriter_SetTargetRejectsDoubleSet(t *testing.T) {
+	t.Parallel()
+	w := newLazyResourceWriter()
+	if err := w.SetTarget(&fakeResourceWriter{}); err != nil {
+		t.Fatalf("first SetTarget returned error: %v", err)
+	}
+	if err := w.SetTarget(&fakeResourceWriter{}); err == nil {
+		t.Error("second SetTarget = nil error, want 'already wired'")
+	}
+}
+
+func TestLazyResourceWriter_SetTargetRejectsSelf(t *testing.T) {
+	t.Parallel()
+	w := newLazyResourceWriter()
+	// Targeting self would infinite-loop on the first forwarded call.
+	if err := w.SetTarget(w); err == nil {
+		t.Error("SetTarget(self) = nil error, want refusal")
+	}
+}
+
+func TestWireResourceWriter_RejectsNilService(t *testing.T) {
+	t.Parallel()
+	w := newLazyResourceWriter()
+	// A nil ResourceService interface must cause Fx to fail startup, not
+	// silently install a nil target that panics at the first hook.
+	if err := WireResourceWriter(w, nil); err == nil {
+		t.Error("WireResourceWriter with nil svc = nil error, want rejection")
+	}
+}
+
+func TestWireResourceWriter_RejectsNilWriter(t *testing.T) {
+	t.Parallel()
+	// A nil *lazyResourceWriter must fail startup rather than nil-deref.
+	if err := WireResourceWriter(nil, nil); err == nil {
+		t.Error("WireResourceWriter with nil writer = nil error, want rejection")
 	}
 }

--- a/application/resource_service.go
+++ b/application/resource_service.go
@@ -73,13 +73,14 @@ type behaviorDepthKey struct{}
 // inflates the counter, which is the intended accounting.
 func enterResourceCall(ctx context.Context) (context.Context, error) {
 	depth, _ := ctx.Value(behaviorDepthKey{}).(int)
+	nextDepth := depth + 1
 	if depth >= maxBehaviorRecursionDepth {
 		return ctx, fmt.Errorf(
-			"resource behavior recursion depth %d exceeds max %d (likely cycle)",
-			depth, maxBehaviorRecursionDepth,
+			"resource behavior recursion depth reached max %d; attempted next depth %d would exceed it (likely cycle)",
+			maxBehaviorRecursionDepth, nextDepth,
 		)
 	}
-	return context.WithValue(ctx, behaviorDepthKey{}, depth+1), nil
+	return context.WithValue(ctx, behaviorDepthKey{}, nextDepth), nil
 }
 
 func (s *resourceService) behaviorFor(ctx context.Context, rt *entities.ResourceType) entities.ResourceBehavior {

--- a/application/resource_service.go
+++ b/application/resource_service.go
@@ -51,6 +51,37 @@ type resourceService struct {
 	behaviorSettings repositories.BehaviorSettingsRepository
 }
 
+// maxBehaviorRecursionDepth caps how deep a behavior cascade can go. Behaviors
+// can legitimately create/update/delete other resources (via
+// BehaviorServices.Writer), and those cross-resource writes run the target's
+// own behaviors, so cascades are expected (e.g. course-instance creates
+// education-events, which create attendance-records). A small depth limit
+// catches accidental cycles fast instead of blowing the stack or hanging on
+// exponential fan-out.
+const maxBehaviorRecursionDepth = 8
+
+type behaviorDepthKey struct{}
+
+// enterResourceCall increments the cascade depth counter in ctx and returns
+// the updated context. It fails if the depth would exceed
+// maxBehaviorRecursionDepth — an indicator of a cycle or runaway cascade.
+// On failure it returns the original (unchanged) ctx alongside the error so a
+// caller that forgets to guard the error still gets a usable context.
+//
+// Because context values are immutable, sibling writes from the same hook
+// each see the parent's depth N (not N+1 and N+2) — only true nesting
+// inflates the counter, which is the intended accounting.
+func enterResourceCall(ctx context.Context) (context.Context, error) {
+	depth, _ := ctx.Value(behaviorDepthKey{}).(int)
+	if depth >= maxBehaviorRecursionDepth {
+		return ctx, fmt.Errorf(
+			"resource behavior recursion depth %d exceeds max %d (likely cycle)",
+			depth, maxBehaviorRecursionDepth,
+		)
+	}
+	return context.WithValue(ctx, behaviorDepthKey{}, depth+1), nil
+}
+
 func (s *resourceService) behaviorFor(ctx context.Context, rt *entities.ResourceType) entities.ResourceBehavior {
 	if rt == nil {
 		return entities.DefaultBehavior{}
@@ -172,6 +203,10 @@ func ProvideResourceService(params struct {
 func (s *resourceService) Create(
 	ctx context.Context, cmd CreateResourceCommand,
 ) (*entities.Resource, error) {
+	ctx, err := enterResourceCall(ctx)
+	if err != nil {
+		return nil, err
+	}
 	rt, err := s.typeRepo.FindBySlug(ctx, cmd.TypeSlug)
 	if err != nil {
 		return nil, fmt.Errorf("resource type %q not found: %w", cmd.TypeSlug, err)
@@ -348,6 +383,10 @@ func (s *resourceService) ListWithFilters(
 func (s *resourceService) Update(
 	ctx context.Context, cmd UpdateResourceCommand,
 ) (*entities.Resource, error) {
+	ctx, err := enterResourceCall(ctx)
+	if err != nil {
+		return nil, err
+	}
 	entity, err := s.repo.FindByID(ctx, cmd.ID)
 	if err != nil {
 		return nil, err
@@ -422,6 +461,10 @@ func (s *resourceService) Update(
 func (s *resourceService) Delete(
 	ctx context.Context, cmd DeleteResourceCommand,
 ) error {
+	ctx, err := enterResourceCall(ctx)
+	if err != nil {
+		return err
+	}
 	entity, err := s.repo.FindByID(ctx, cmd.ID)
 	if err != nil {
 		return err

--- a/application/resource_service_test.go
+++ b/application/resource_service_test.go
@@ -1,0 +1,181 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestEnterResourceCall_IncrementsBelowLimit verifies the happy path: depths
+// 0..maxBehaviorRecursionDepth-1 succeed and each returned context carries
+// depth+1.
+func TestEnterResourceCall_IncrementsBelowLimit(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	for i := range maxBehaviorRecursionDepth {
+		next, err := enterResourceCall(ctx)
+		if err != nil {
+			t.Fatalf("depth %d: unexpected error: %v", i, err)
+		}
+		got, _ := next.Value(behaviorDepthKey{}).(int)
+		if got != i+1 {
+			t.Errorf("depth %d: next ctx depth = %d, want %d", i, got, i+1)
+		}
+		ctx = next
+	}
+}
+
+// TestEnterResourceCall_RejectsAtLimit verifies that the guard refuses once
+// the depth is already at maxBehaviorRecursionDepth — i.e. the call that
+// would push it to depth+1 beyond the max is the one that fails.
+func TestEnterResourceCall_RejectsAtLimit(t *testing.T) {
+	t.Parallel()
+	ctx := context.WithValue(context.Background(), behaviorDepthKey{}, maxBehaviorRecursionDepth)
+	gotCtx, err := enterResourceCall(ctx)
+	if err == nil {
+		t.Fatal("expected error at limit, got nil")
+	}
+	if !strings.Contains(err.Error(), "recursion depth") {
+		t.Errorf("error = %q, want contains 'recursion depth'", err.Error())
+	}
+	// On error the original ctx must be returned (not nil) so callers that
+	// forget to guard the error don't null-deref on subsequent ctx use.
+	if gotCtx != ctx {
+		t.Errorf("error path should return the original ctx, got a different value")
+	}
+}
+
+// TestEnterResourceCall_BoundaryOffByOne pins the exact edge: depth 7
+// (maxBehaviorRecursionDepth-1) must succeed, depth 8 must fail. This is the
+// most likely place for an off-by-one regression.
+func TestEnterResourceCall_BoundaryOffByOne(t *testing.T) {
+	t.Parallel()
+	justUnder := context.WithValue(context.Background(), behaviorDepthKey{}, maxBehaviorRecursionDepth-1)
+	if _, err := enterResourceCall(justUnder); err != nil {
+		t.Errorf("depth %d should succeed (last legal level), got %v", maxBehaviorRecursionDepth-1, err)
+	}
+	atLimit := context.WithValue(context.Background(), behaviorDepthKey{}, maxBehaviorRecursionDepth)
+	if _, err := enterResourceCall(atLimit); err == nil {
+		t.Errorf("depth %d should fail (exceeds max), got nil", maxBehaviorRecursionDepth)
+	}
+}
+
+// TestEnterResourceCall_SiblingsDoNotInflateCounter proves the sibling-write
+// accounting. Two calls derived from the same parent ctx each produce a
+// child at depth parent+1 — not parent+1 and parent+2. This works because
+// context values are immutable: the increment lives only on the returned
+// child ctx. A regression that switched to a mutable counter would falsely
+// trip the guard on legitimate fan-out (e.g. an enrollment behavior creating
+// N attendance records).
+func TestEnterResourceCall_SiblingsDoNotInflateCounter(t *testing.T) {
+	t.Parallel()
+	parent := context.WithValue(context.Background(), behaviorDepthKey{}, 3)
+
+	sibling1, err := enterResourceCall(parent)
+	if err != nil {
+		t.Fatalf("first sibling errored: %v", err)
+	}
+	sibling2, err := enterResourceCall(parent)
+	if err != nil {
+		t.Fatalf("second sibling errored: %v", err)
+	}
+
+	got1, _ := sibling1.Value(behaviorDepthKey{}).(int)
+	got2, _ := sibling2.Value(behaviorDepthKey{}).(int)
+	if got1 != 4 || got2 != 4 {
+		t.Errorf("sibling depths = (%d, %d), want (4, 4); parent ctx leaked a mutation", got1, got2)
+	}
+
+	// Parent itself must be unchanged after its children were derived.
+	parentDepth, _ := parent.Value(behaviorDepthKey{}).(int)
+	if parentDepth != 3 {
+		t.Errorf("parent depth = %d, want 3 (context value should be immutable)", parentDepth)
+	}
+}
+
+// TestEnterResourceCall_MissingKeyStartsAtZero verifies the zero-value path:
+// a ctx with no depth key must be treated as depth 0 and produce a child at
+// depth 1, not panic on the type assertion.
+func TestEnterResourceCall_MissingKeyStartsAtZero(t *testing.T) {
+	t.Parallel()
+	next, err := enterResourceCall(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error on fresh ctx: %v", err)
+	}
+	got, _ := next.Value(behaviorDepthKey{}).(int)
+	if got != 1 {
+		t.Errorf("fresh ctx child depth = %d, want 1", got)
+	}
+}
+
+// TestResourceService_CreateEnforcesDepthGuard asserts that Create calls
+// enterResourceCall before any repository work — a ctx seeded at the limit
+// must be rejected without touching the stub repos (which would panic on
+// method invocation since they only embed the interface).
+func TestResourceService_CreateEnforcesDepthGuard(t *testing.T) {
+	t.Parallel()
+	svc := &resourceService{
+		repo:     &stubResourceRepo{},
+		typeRepo: &stubTypeRepo{},
+		logger:   noopLogger{},
+	}
+	ctx := context.WithValue(context.Background(), behaviorDepthKey{}, maxBehaviorRecursionDepth)
+	_, err := svc.Create(ctx, CreateResourceCommand{TypeSlug: "anything"})
+	if err == nil {
+		t.Fatal("expected depth-limit error from Create, got nil")
+	}
+	if !strings.Contains(err.Error(), "recursion depth") {
+		t.Errorf("Create error = %q, want contains 'recursion depth' (guard did not fire)", err.Error())
+	}
+}
+
+// TestResourceService_UpdateEnforcesDepthGuard — symmetric check for Update.
+func TestResourceService_UpdateEnforcesDepthGuard(t *testing.T) {
+	t.Parallel()
+	svc := &resourceService{
+		repo:     &stubResourceRepo{},
+		typeRepo: &stubTypeRepo{},
+		logger:   noopLogger{},
+	}
+	ctx := context.WithValue(context.Background(), behaviorDepthKey{}, maxBehaviorRecursionDepth)
+	_, err := svc.Update(ctx, UpdateResourceCommand{ID: "anything"})
+	if err == nil {
+		t.Fatal("expected depth-limit error from Update, got nil")
+	}
+	if !strings.Contains(err.Error(), "recursion depth") {
+		t.Errorf("Update error = %q, want contains 'recursion depth' (guard did not fire)", err.Error())
+	}
+}
+
+// TestResourceService_DeleteEnforcesDepthGuard — symmetric check for Delete.
+func TestResourceService_DeleteEnforcesDepthGuard(t *testing.T) {
+	t.Parallel()
+	svc := &resourceService{
+		repo:     &stubResourceRepo{},
+		typeRepo: &stubTypeRepo{},
+		logger:   noopLogger{},
+	}
+	ctx := context.WithValue(context.Background(), behaviorDepthKey{}, maxBehaviorRecursionDepth)
+	err := svc.Delete(ctx, DeleteResourceCommand{ID: "anything"})
+	if err == nil {
+		t.Fatal("expected depth-limit error from Delete, got nil")
+	}
+	if !strings.Contains(err.Error(), "recursion depth") {
+		t.Errorf("Delete error = %q, want contains 'recursion depth' (guard did not fire)", err.Error())
+	}
+}

--- a/application/resource_type_presets_test.go
+++ b/application/resource_type_presets_test.go
@@ -60,14 +60,19 @@ func testRegistry() *application.PresetRegistry {
 
 func TestPresets_AllPresetsExist(t *testing.T) {
 	t.Parallel()
+	// The canonical built-in presets. Custom presets registered via the
+	// "custom" build tag (weos-private-presets) may add more on top of this
+	// list, so the assertion is a subset check, not strict equality.
 	expected := []string{"auth", "core", "ecommerce", "events", "knowledge", "meal-planning", "tasks", "website"}
 	defs := testRegistry().List()
-	if len(defs) != len(expected) {
-		t.Fatalf("expected %d presets, got %d", len(expected), len(defs))
+	present := make(map[string]application.PresetDefinition, len(defs))
+	for _, d := range defs {
+		present[d.Name] = d
 	}
-	for i, d := range defs {
-		if d.Name != expected[i] {
-			t.Fatalf("preset[%d] = %q, want %q", i, d.Name, expected[i])
+	for _, name := range expected {
+		d, ok := present[name]
+		if !ok {
+			t.Fatalf("expected built-in preset %q not registered", name)
 		}
 		if len(d.Types) == 0 {
 			t.Fatalf("preset %q has no types", d.Name)

--- a/docs/_howto/create-behavior.md
+++ b/docs/_howto/create-behavior.md
@@ -125,10 +125,15 @@ dependencies (like the one above), `application.StaticBehavior` wraps a plain in
 ## 3a. Inject Application Services
 
 If your behavior needs a repository or logger, write a real factory instead of
-`StaticBehavior`. The factory receives a populated `application.BehaviorServices`,
-whose fields are `Resources` (`repositories.ResourceRepository`), `Triples`
-(`repositories.TripleRepository`), `ResourceTypes` (`repositories.ResourceTypeRepository`),
-and `Logger` (`entities.Logger`).
+`StaticBehavior`. The factory receives a populated `application.BehaviorServices`:
+
+| Field | Type | Use for |
+|---|---|---|
+| `Resources` | `repositories.ResourceRepository` | reading other resources (queries, lookups) |
+| `Triples` | `repositories.TripleRepository` | reading relationships between resources |
+| `ResourceTypes` | `repositories.ResourceTypeRepository` | loading a type's schema/context (e.g. to call `application.EdgeValue`) |
+| `Logger` | `entities.Logger` | structured logging |
+| `Writer` | `application.ResourceWriter` | **creating, updating, or deleting other resources** through the full service pipeline |
 
 Example (showing imports):
 
@@ -156,6 +161,65 @@ Behaviors: map[string]application.BehaviorFactory{
 ```
 
 The factory is called once, at startup, by `application.ProvideResourceBehaviorRegistry`.
+
+### Creating or updating other resources
+
+When a hook needs to write *other* resources (not just transform the current
+one), use `services.Writer`. It is a `ResourceWriter` that forwards to the real
+`ResourceService`, so writes go through schema validation, JSON-LD graph
+assembly, triple extraction, event recording, UnitOfWork commit, and nested
+behavior dispatch — i.e. creating a resource from a behavior runs that
+resource's own behaviors in turn.
+
+Example: a `comment` behavior that bumps a `replyCount` on the parent post:
+
+```go
+type commentBehavior struct {
+    entities.DefaultBehavior
+    writer    application.ResourceWriter
+    resources repositories.ResourceRepository
+    types     repositories.ResourceTypeRepository
+    logger    entities.Logger
+}
+
+func newCommentBehavior(s application.BehaviorServices) entities.ResourceBehavior {
+    return &commentBehavior{
+        writer:    s.Writer,
+        resources: s.Resources,
+        types:     s.ResourceTypes,
+        logger:    s.Logger,
+    }
+}
+
+func (b *commentBehavior) AfterCreate(ctx context.Context, r *entities.Resource) error {
+    commentType, err := b.types.FindBySlug(ctx, r.TypeSlug())
+    if err != nil {
+        return err
+    }
+    postID := application.EdgeValue(r.Data(), commentType.Context(), "postId")
+    if postID == "" {
+        return nil
+    }
+    post, err := b.resources.FindByID(ctx, postID)
+    if err != nil {
+        return err
+    }
+    // Build newData by round-tripping post.Data() through json.Unmarshal /
+    // json.Marshal and incrementing the replyCount field. Preserve `@id` and
+    // `@context` on the result — Update revalidates the full JSON-LD graph
+    // and will reject a payload that has lost them.
+    _, err = b.writer.Update(ctx, application.UpdateResourceCommand{
+        ID:   post.GetID(),
+        Data: newData,
+    })
+    return err
+}
+```
+
+Behavior cascades are bounded: `ResourceService` caps the nesting depth
+(see `maxBehaviorRecursionDepth` in `application/resource_service.go`) to
+catch accidental cycles. If you hit that limit, you probably have a loop —
+check that two behaviors aren't triggering each other indefinitely.
 
 ## 4. Register the Preset
 

--- a/docs/decisions/behavior-resource-writer.md
+++ b/docs/decisions/behavior-resource-writer.md
@@ -1,0 +1,210 @@
+---
+title: "ADR: Cross-Resource Writes from ResourceBehavior Hooks"
+parent: Architecture Decision Records
+layout: default
+nav_order: 4
+---
+
+# ADR: Cross-Resource Writes from ResourceBehavior Hooks
+
+**Status:** Accepted (Implemented)
+**Date:** 2026-04-07
+**Context:** With the factory-based service injection from the [Injecting Services into ResourceBehavior]({% link decisions/behavior-service-injection.md %}) ADR, behaviors can now hold references to application services. This ADR decides **which** service behaviors use when they need to create, update, or delete *other* resources, and how that dependency is wired without breaking Fx construction ordering.
+
+## Problem
+
+Presets increasingly need reactive logic that spans more than one resource type. A concrete driver: porting the legacy `education` preset from ic-crm ([`wepala/weos-private-presets#1`](https://github.com/wepala/weos-private-presets/issues/1)) requires behaviors that:
+
+- create N `attendance-record`s when an `enrollment` is created
+- generate `education-event`s from a `course-instance`'s schedule
+- delete all `attendance-record`s when an `education-event` is deleted
+- mark an `invoice` as `paid` when a `payment` arrives
+
+The previous ADR added a `BehaviorServices` struct with `Resources` (`ResourceRepository`), `Triples` (`TripleRepository`), `ResourceTypes` (`ResourceTypeRepository`), and `Logger`. These are sufficient for **reads**, but not for creating, updating, or deleting other resources.
+
+### Why `ResourceRepository.Save()` is the wrong answer
+
+`BehaviorServices.Resources` is a `ResourceRepository`, which does expose `Save`, `Update`, `Delete`. But those methods take already-constructed `*entities.Resource` values and write them to the projection/event store directly. Using them from a behavior would bypass:
+
+- Schema validation (`validateAgainstSchema`)
+- JSON-LD graph assembly (`BuildResourceGraph`)
+- Reference extraction into triple events (`ExtractAndStripReferences`)
+- `Resource.Published` signal recording
+- `BeforeCreate` / `BeforeCreateCommit` / `AfterCreate` hooks on the target type
+- UnitOfWork transactional commit with atomic triple events
+
+Every one of those is load-bearing. Skipping them would corrupt projections, lose references, and silently break other behaviors.
+
+The correct write path is `application.ResourceService.Create` / `Update` / `Delete`, which runs the full pipeline. The question is how to hand that to behaviors.
+
+### Why we can't put `ResourceService` directly in `BehaviorServices`
+
+`resourceService` holds a `ResourceBehaviorRegistry` (the `behaviors` field in `application/resource_service.go`) so it can dispatch hooks. `ResourceBehaviorRegistry` is built by `ProvideResourceBehaviorRegistry`, which (after the factory ADR) invokes each preset factory with a `BehaviorServices`. If `BehaviorServices` carried a `ResourceService`, Fx would need:
+
+```
+ResourceService  →  ResourceBehaviorRegistry  →  BehaviorServices  →  ResourceService
+```
+
+A cycle. Fx detects this at container build and fails.
+
+We need a way to give behaviors a full-pipeline write capability without creating that construction cycle.
+
+## Options
+
+---
+
+### Option 1: Expose the full `ResourceService` via a lazy proxy
+
+Define a narrow `ResourceWriter` interface containing just `Create`, `Update`, `Delete` — the subset behaviors actually need. Add a `lazyResourceWriter` struct that satisfies `ResourceWriter` but starts with a nil inner target. Construct it early, hand it to `BehaviorServices`, build the registry with factories closing over it. Then, after `ProvideResourceService` has returned the real service, run an `fx.Invoke` (`WireResourceWriter`) that sets the proxy's target. By the time any hook fires during a request, the proxy forwards to the real service.
+
+**Example:**
+```go
+type ResourceWriter interface {
+    Create(ctx context.Context, cmd CreateResourceCommand) (*entities.Resource, error)
+    Update(ctx context.Context, cmd UpdateResourceCommand) (*entities.Resource, error)
+    Delete(ctx context.Context, cmd DeleteResourceCommand) error
+}
+
+type lazyResourceWriter struct {
+    svc ResourceWriter // set post-construction
+}
+
+func (l *lazyResourceWriter) Create(ctx context.Context, cmd CreateResourceCommand) (*entities.Resource, error) {
+    if l.svc == nil {
+        return nil, fmt.Errorf("ResourceWriter.Create called before wiring")
+    }
+    return l.svc.Create(ctx, cmd)
+}
+// Update, Delete similarly.
+
+func (l *lazyResourceWriter) SetTarget(svc ResourceWriter) { l.svc = svc }
+```
+
+Fx wiring in `application/module.go`:
+```go
+fx.Provide(newLazyResourceWriter),
+fx.Provide(ProvideResourceBehaviorRegistry),       // receives *lazyResourceWriter
+// ...
+fx.Provide(ProvideResourceService),
+fx.Invoke(WireResourceWriter),                      // svc -> proxy
+```
+
+Behaviors close over the proxy via `BehaviorServices.Writer`:
+```go
+func newEnrollmentBehavior(s application.BehaviorServices) entities.ResourceBehavior {
+    return &enrollmentBehavior{writer: s.Writer, resources: s.Resources, logger: s.Logger}
+}
+```
+
+**Pros:**
+- **Breaks the cycle cleanly.** Construction order is `proxy → registry → service → invoke wires proxy`. No Fx-visible cycle.
+- **Preserves full semantics.** Writes go through schema validation, graph assembly, triple extraction, event recording, UoW commit, and nested behavior dispatch. The target type's own behaviors fire naturally — a course-instance behavior creating education-events correctly triggers the education-event behavior that seeds attendance.
+- **Narrow interface.** `ResourceWriter` has three methods. Behaviors never see `List*` / `GetByID` via the writer; they use `BehaviorServices.Resources` for reads, which is already the correct separation.
+- **Fails loudly on misuse.** If a factory or something else accidentally invokes a hook during startup (before `WireResourceWriter` runs), the proxy returns a clear error instead of a nil-pointer panic.
+- **Zero changes to existing behaviors.** `personBehavior` and `organizationBehavior` ignore `Writer` — they continue to work unchanged. `StaticBehavior` still hides service plumbing for pure-transform hooks.
+- **Idiomatic Go proxy pattern.** The two-phase setup is an explicit, readable seam, not hidden magic.
+
+**Cons:**
+- **Two-phase construction is explicit.** There's a brief window — between `newLazyResourceWriter` returning and `WireResourceWriter` running — when calls through the proxy fail. This is an intentional trade-off: it's how we break the cycle. The failure mode is clear and the window is startup-only.
+- **Mutable state in a singleton.** The proxy's target is set exactly once, but it is mutated after construction. This can look surprising compared to fully immutable DI. Mitigation: `SetTarget` is doc'd as one-shot, `WireResourceWriter` is the only caller in production code.
+- **Slight indirection at runtime.** Every write through a behavior pays one extra interface hop. Negligible compared to the work the real service does.
+- **Requires a recursion guard.** Now that behaviors can create resources, we have to bound cascades. This is actually a benefit (see §"Recursion guard" below), but it's a new piece of surface area.
+
+---
+
+### Option 2: Split `resourceService` into an author + a behavior dispatcher
+
+Factor `resourceService` into two pieces: a `resourceAuthor` that does the full write pipeline (validation, graph assembly, event recording, UoW commit) **without** calling any behaviors, and a thin `resourceService` that wraps it and layers behavior dispatch on top. `BehaviorServices.Writer` gets the `resourceAuthor`. Because the author has no behavior dependency, there is no cycle.
+
+**Pros:**
+- **No lazy state.** The author is fully constructed, nothing is set after the fact.
+- **Architecturally cleaner.** Separates "write a resource" from "run user-supplied hooks around writes".
+- **No fx.Invoke dance.** Standard constructor injection.
+
+**Cons:**
+- **Kills nested behaviors.** If a course-instance behavior creates an education-event via the author, the education-event's own behavior never fires. That means the education-event behavior would not create attendance records when the course-instance behavior generates events. We would need to re-implement the entire cascade inside the course-instance behavior, manually invoking every downstream behavior. This is exactly the logic we want to avoid writing by hand — it's the whole reason behaviors exist.
+- **Silent semantic divergence.** Writes initiated by a user through the HTTP API run behaviors; writes initiated by a behavior do not. Two code paths with the same signature and different semantics is a bug magnet.
+- **Double implementation.** The author needs its own test coverage of validation, graph assembly, triple extraction, etc. — a duplication of what `resourceService` already does.
+- **More refactor surface.** Tests that construct `resourceService` have to decide which piece they want.
+
+---
+
+### Option 3: Provide the full `ResourceService` via lazy proxy (no interface narrowing)
+
+Same as Option 1 but the proxy satisfies the full `ResourceService` interface (queries included), not a narrow `ResourceWriter`. Behaviors get one thing that does everything.
+
+**Pros:**
+- One service instead of two on `BehaviorServices` (the `Resources` repo becomes redundant for most purposes).
+- Slightly less code in `resource_behaviors.go`.
+
+**Cons:**
+- **Blurs the read/write seam.** Reads should go through `Resources` (the repository, which respects visibility scopes via `FindAllByTypeWithFilters`'s scope parameter). Writes should go through the service (which enforces permissions via `checkInstanceAccess`). Merging them tempts behaviors to do both through the service and forget the scope arguments.
+- **Wider surface for mistakes.** A behavior calling `ResourceService.List` inside a hook is almost always wrong — it's doing per-row work in a per-request context. Keeping the query methods out of `BehaviorServices.Writer` discourages this.
+- **Ties `BehaviorServices` to the larger interface.** Every time `ResourceService` grows a method, the behavior surface grows with it.
+
+---
+
+### Option 4: Require the `education` preset (and anything like it) to subscribe to domain events instead of using behaviors
+
+Accept that behaviors remain read-only + same-entity mutation. Cross-resource work goes through `Resource.Published` event subscribers (per the [Event Handler Data Availability ADR]({% link decisions/event-handler-data-availability.md %})). The preset would export a `Subscribe` function that `presets/register_custom.go` (or the core module) wires to the event dispatcher.
+
+**Pros:**
+- No changes to `BehaviorServices` or the behavior interface.
+- Reuses the existing `Resource.Published` signal and event subscription infrastructure.
+- Preset handlers get full DI via Fx.
+
+**Cons:**
+- **Splits preset logic across two mechanisms.** Type definitions + trivial transforms go in `Behaviors`; anything touching another resource goes in `Subscribe`. A preset author has to learn both models and keep them in sync.
+- **Presets lose self-containment at the Fx level.** Subscribing to events requires an `fx.Invoke` or similar wiring outside the `PresetDefinition` struct. The private-preset package would need to export more than just `Register(registry)` — a real breaking change to the custom-preset contract.
+- **Weaker story for account-level toggling.** `BehaviorMeta.Manageable` already gives per-account behavior on/off. Event subscribers don't benefit from that — we'd need to reinvent it.
+- **Harder to test.** Event subscribers need the dispatcher and pericarp plumbing to exercise; behaviors can be called directly from a unit test.
+
+---
+
+## Comparison Matrix
+
+| Criteria | Option 1: Lazy `ResourceWriter` | Option 2: Author split | Option 3: Lazy full `ResourceService` | Option 4: Event subscribers |
+|---|---|---|---|---|
+| **Breaks the construction cycle** | Yes (post-construct wire) | Yes (no dependency) | Yes (post-construct wire) | N/A (no dependency) |
+| **Preserves nested behavior cascade** | Yes | No | Yes | N/A (behaviors unused) |
+| **Write path runs full pipeline** | Yes | Yes (in author) | Yes | Yes (via service) |
+| **Read/write API clearly separated** | Yes | Yes | No | N/A |
+| **Changes to `BehaviorServices`** | Adds `Writer` field | Adds `Writer` field | Adds `Writer` field | None |
+| **Changes to preset registration contract** | None | None | None | Yes — preset must export subscribers |
+| **Changes to existing behaviors** | None | None | None | None |
+| **Ease of writing an `education`-scale preset** | Direct: all logic in behaviors | Painful: cascade must be hand-rolled | Direct | Split across behaviors + handlers |
+| **Failure mode on misuse** | Clear error (proxy not wired) | N/A | Clear error | N/A |
+| **New machinery to maintain** | Proxy + 1 `fx.Invoke` + recursion guard | Two services with overlapping code | Proxy + 1 `fx.Invoke` + recursion guard | Event wiring in private-preset package |
+
+## Decision
+
+**Option 1 (lazy `ResourceWriter`).** It preserves nested behavior semantics — the whole reason we have behaviors — while cleanly breaking the construction cycle. The narrow interface keeps the write surface small and discourages behaviors from doing per-request queries through the service. Existing behaviors don't change; new behaviors opt into the `Writer` field only when they need it.
+
+Option 2 was tempting for its architectural purity, but losing the nested cascade would force preset authors to reimplement the dispatch loop by hand — exactly the boilerplate that behaviors exist to eliminate.
+
+Option 3 is a strict superset of Option 1 and adds nothing we need; the narrow interface is a better default.
+
+Option 4 remains valid for *cross-aggregate* reactions spanning multiple UoW commits (the case the Event Handler Data Availability ADR was written for). It is not the right tool for the in-request, same-transaction cascades the `education` preset needs.
+
+## Recursion guard
+
+Now that behaviors can create resources, runaway cascades are a real risk. A bug in behavior A that (indirectly) triggers behavior A again would hang or blow the stack. `application/resource_service.go` tracks a behavior-cascade depth on `context.Context` via the unexported `enterResourceCall` helper and a `maxBehaviorRecursionDepth` constant; `Create`, `Update`, and `Delete` each call it at their top.
+
+Two properties matter:
+
+- **Sibling-safe accounting.** Because `context.Context` is immutable, two writes issued from the same hook both derive children at depth N+1 — not N+1 and N+2. Legitimate fan-out (an enrollment behavior creating many attendance records) does not inflate the counter.
+- **Conservative ceiling.** The limit of 8 was chosen to comfortably fit the deepest legitimate education-preset cascade (course-instance → education-event → attendance-record → invoice → payment → invoice-update, ~6 levels) with headroom, while still failing fast on cycles.
+
+If a real-world preset needs deeper nesting, raising the constant is a one-line change and a new test. It is not a config knob because it should be a code-reviewed decision, not per-deployment tuning.
+
+## Implementation
+
+- [x] `services/core/application/resource_behaviors.go`: define `ResourceWriter`, `lazyResourceWriter`, `newLazyResourceWriter`, `WireResourceWriter`
+- [x] `services/core/application/resource_behaviors.go`: add `Writer ResourceWriter` field to `BehaviorServices`
+- [x] `services/core/application/resource_behaviors.go`: `ProvideResourceBehaviorRegistry` takes `*lazyResourceWriter` and passes it in `BehaviorServices`
+- [x] `services/core/application/module.go`: `fx.Provide(newLazyResourceWriter)` + `fx.Invoke(WireResourceWriter)` after `ProvideResourceService`
+- [x] `services/core/application/resource_service.go`: `enterResourceCall` + `maxBehaviorRecursionDepth` + calls at the top of `Create`, `Update`, `Delete`
+- [x] `services/core/application/resource_behaviors_test.go`: test fixtures supply a fake or real `*lazyResourceWriter`
+- [x] `services/core/application/resource_service_test.go`: direct tests for `enterResourceCall` (boundary, sibling immutability) and per-method guard enforcement
+- [x] `services/core/docs/_howto/create-behavior.md`: §3a mentions `Writer` and shows a cross-resource example
+- [ ] End-to-end cascade test once a consumer (e.g. the education preset) lands

--- a/docs/decisions/behavior-resource-writer.md
+++ b/docs/decisions/behavior-resource-writer.md
@@ -199,12 +199,12 @@ If a real-world preset needs deeper nesting, raising the constant is a one-line 
 
 ## Implementation
 
-- [x] `services/core/application/resource_behaviors.go`: define `ResourceWriter`, `lazyResourceWriter`, `newLazyResourceWriter`, `WireResourceWriter`
-- [x] `services/core/application/resource_behaviors.go`: add `Writer ResourceWriter` field to `BehaviorServices`
-- [x] `services/core/application/resource_behaviors.go`: `ProvideResourceBehaviorRegistry` takes `*lazyResourceWriter` and passes it in `BehaviorServices`
-- [x] `services/core/application/module.go`: `fx.Provide(newLazyResourceWriter)` + `fx.Invoke(WireResourceWriter)` after `ProvideResourceService`
-- [x] `services/core/application/resource_service.go`: `enterResourceCall` + `maxBehaviorRecursionDepth` + calls at the top of `Create`, `Update`, `Delete`
-- [x] `services/core/application/resource_behaviors_test.go`: test fixtures supply a fake or real `*lazyResourceWriter`
-- [x] `services/core/application/resource_service_test.go`: direct tests for `enterResourceCall` (boundary, sibling immutability) and per-method guard enforcement
-- [x] `services/core/docs/_howto/create-behavior.md`: §3a mentions `Writer` and shows a cross-resource example
+- [x] `application/resource_behaviors.go`: define `ResourceWriter`, `lazyResourceWriter`, `newLazyResourceWriter`, `WireResourceWriter`
+- [x] `application/resource_behaviors.go`: add `Writer ResourceWriter` field to `BehaviorServices`
+- [x] `application/resource_behaviors.go`: `ProvideResourceBehaviorRegistry` takes `*lazyResourceWriter` and passes it in `BehaviorServices`
+- [x] `application/module.go`: `fx.Provide(newLazyResourceWriter)` + `fx.Invoke(WireResourceWriter)` after `ProvideResourceService`
+- [x] `application/resource_service.go`: `enterResourceCall` + `maxBehaviorRecursionDepth` + calls at the top of `Create`, `Update`, `Delete`
+- [x] `application/resource_behaviors_test.go`: test fixtures supply a fake or real `*lazyResourceWriter`
+- [x] `application/resource_service_test.go`: direct tests for `enterResourceCall` (boundary, sibling immutability) and per-method guard enforcement
+- [x] `docs/_howto/create-behavior.md`: §3a mentions `Writer` and shows a cross-resource example
 - [ ] End-to-end cascade test once a consumer (e.g. the education preset) lands

--- a/docs/decisions/behavior-service-injection.md
+++ b/docs/decisions/behavior-service-injection.md
@@ -1,0 +1,376 @@
+---
+title: "ADR: Injecting Services into ResourceBehavior Implementations"
+parent: Architecture Decision Records
+layout: default
+nav_order: 3
+---
+
+# ADR: Injecting Services into ResourceBehavior Implementations
+
+**Status:** Proposed
+**Date:** 2026-04-07
+**Context:** Preset-defined `ResourceBehavior` implementations need access to application services (repositories, domain services, loggers, HTTP clients, etc.) but are currently instantiated before Fx wires the container.
+
+## Problem
+
+Preset packages register `ResourceBehavior` implementations at package-init time via `application.PresetRegistry.MustAdd()` (see `application/presets/core/preset.go:17`). The `PresetDefinition.Behaviors` map stores fully-constructed behavior instances:
+
+```go
+Behaviors: map[string]entities.ResourceBehavior{
+    "person":       &personBehavior{},
+    "organization": &organizationBehavior{},
+},
+```
+
+Because behaviors are zero-valued structs built during `init()`, they cannot hold references to anything that Fx wires later — repositories, loggers, the event dispatcher, HTTP clients, other services, etc. Today this is tolerable because the only behaviors in the codebase are pure data transforms (e.g. `personBehavior` concatenates `givenName + familyName`). As soon as a behavior needs to:
+
+- query a related resource from the `ResourceRepository`
+- read triples via the `TripleRepository`
+- call another domain service
+- publish a metric or log through the typed `entities.Logger`
+- make an outbound HTTP call through an injected client
+
+...there is no clean way to give the behavior what it needs. The current workarounds are all bad: package-level globals, service locator lookups inside hooks, or stuffing dependencies into `context.Context` ad hoc.
+
+The `ResourceBehavior` interface (`domain/entities/resource_behavior.go:24`) currently looks like this:
+
+```go
+type ResourceBehavior interface {
+    BeforeCreate(ctx context.Context, data json.RawMessage, rt *ResourceType) (json.RawMessage, error)
+    BeforeCreateCommit(ctx context.Context, resource *Resource) error
+    AfterCreate(ctx context.Context, resource *Resource) error
+    BeforeUpdate(ctx context.Context, existing *Resource, data json.RawMessage, rt *ResourceType) (json.RawMessage, error)
+    BeforeUpdateCommit(ctx context.Context, resource *Resource) error
+    AfterUpdate(ctx context.Context, resource *Resource) error
+    BeforeDelete(ctx context.Context, resource *Resource) error
+    AfterDelete(ctx context.Context, resource *Resource) error
+}
+```
+
+We need a way for preset authors to write behaviors that depend on services, without breaking the existing pure-transform behaviors or the preset registration model.
+
+## Options
+
+---
+
+### Option 1: Variadic `services ...Service` Argument on Every Method
+
+Add a variadic parameter to each method of `ResourceBehavior`. The service layer passes whatever services are relevant at each call site; behaviors that don't need services ignore the argument.
+
+**Example:**
+```go
+type Service any // or a narrow marker interface
+
+type ResourceBehavior interface {
+    BeforeCreate(ctx context.Context, data json.RawMessage, rt *ResourceType, services ...Service) (json.RawMessage, error)
+    BeforeCreateCommit(ctx context.Context, resource *Resource, services ...Service) error
+    // ... and so on for every method
+}
+
+// In resource_service.go:
+data, err := behavior.BeforeCreate(ctx, cmd.Data, rt, s.repo, s.tripleRepo, s.logger)
+```
+
+**Pros:**
+- Source-level backward compatible: existing behavior implementations that don't declare the parameter still satisfy the interface because Go's variadic rule allows the implementation to omit the parameter? *(Not actually true — see Cons.)*
+- The service layer stays in control of which services are exposed.
+- No two-phase initialization.
+
+**Cons:**
+- **Not actually backward compatible.** Go interface satisfaction is structural: if `ResourceBehavior.BeforeCreate` declares `services ...Service`, then every implementation must declare the same parameter. Existing behaviors like `personBehavior.BeforeCreate` will stop compiling. Variadic only makes the *call site* optional, not the *definition*.
+- **No type safety.** The only way to accept heterogeneous services through a single variadic is `...any` or a marker interface. Every behavior that needs, say, a `ResourceRepository`, must iterate the slice and type-assert — error-prone and verbose.
+- **Ordering is fragile.** Either the service layer establishes a convention ("repo is always element 0, logger is element 1") — which is brittle — or behaviors scan the slice by type, which hides wiring errors until runtime.
+- **Every method signature gets polluted** with a parameter that most behaviors don't use. Eight methods, one mostly-ignored parameter each.
+- **Every call site must enumerate services.** `resource_service.go` has to pass the full service list at 8+ call sites; easy to pass a partial list and have a behavior fail at runtime.
+- **`CompositeBehavior` must forward the slice** on every hop, adding noise to the chain logic.
+- Doesn't scale: adding a new service means touching every call site.
+
+---
+
+### Option 2: Optional Initializer Interface (Setter Injection)
+
+Leave the `ResourceBehavior` interface untouched. Introduce a separate optional interface that behaviors implement if they need services. After Fx wires the container, the registry builder iterates all registered behaviors and calls `Init` on those that opt in.
+
+**Example:**
+```go
+// New — in domain/entities/resource_behavior.go
+type BehaviorServices struct {
+    Resources    repositories.ResourceRepository
+    Triples      repositories.TripleRepository
+    ResourceTypes repositories.ResourceTypeRepository
+    Logger       Logger
+    // extend as needed
+}
+
+type BehaviorInitializer interface {
+    Init(services BehaviorServices) error
+}
+```
+
+```go
+// In application/resource_behaviors.go
+func ProvideResourceBehaviorRegistry(
+    registry *PresetRegistry,
+    services entities.BehaviorServices,
+) (ResourceBehaviorRegistry, error) {
+    behaviors := registry.Behaviors()
+    for slug, b := range behaviors {
+        if init, ok := b.(entities.BehaviorInitializer); ok {
+            if err := init.Init(services); err != nil {
+                return nil, fmt.Errorf("init behavior %q: %w", slug, err)
+            }
+        }
+    }
+    return behaviors, nil
+}
+```
+
+```go
+// A behavior that needs services
+type productBehavior struct {
+    entities.DefaultBehavior
+    triples repositories.TripleRepository
+}
+
+func (b *productBehavior) Init(s entities.BehaviorServices) error {
+    b.triples = s.Triples
+    return nil
+}
+```
+
+**Pros:**
+- **Fully backward compatible.** The `ResourceBehavior` interface doesn't change, so `personBehavior`, `organizationBehavior`, and any existing user-written behaviors continue to compile unchanged.
+- **Opt-in.** Only behaviors that need services implement `BehaviorInitializer`. The vast majority stay simple.
+- **Type-safe.** Services are accessed as named fields on a struct, not by position or type assertion.
+- **Services are resolved once at startup**, not on every hook call. Behaviors close over references; hooks run without reflection.
+- **Single place to extend.** Adding a new service means adding a field to `BehaviorServices` and a provider in `ProvideResourceBehaviorRegistry`. No changes to call sites or interface methods.
+- Natural idiom for Go codebases (e.g. how many stdlib libraries use optional interfaces like `io.Closer`).
+
+**Cons:**
+- **Two-phase construction.** A behavior exists briefly between `new(productBehavior)` and `Init(services)` with nil service fields. If someone calls hooks during that window (they shouldn't, but still), nil-pointer panics are possible. Mitigation: assert initialization happened in the registry builder before returning, or panic on first use.
+- **Mutable state.** Behaviors become mutable after construction. Presets can no longer rely on "what I registered is what runs" without trusting that nobody calls `Init` twice. Mitigation: document that `Init` is called exactly once, or use `sync.Once` inside the behavior.
+- **The `BehaviorServices` struct becomes a god-bag.** Every service anyone ever needs gets a field, and all behaviors get access to all services even if they only use one. Mitigation: keep the struct small, or introduce sub-scoped service interfaces over time.
+- **Two interfaces to document.** New contributors must know to check for both `ResourceBehavior` and `BehaviorInitializer`.
+
+---
+
+### Option 3: Behavior Factories in Presets (Closure-Based DI)
+
+Change `PresetDefinition.Behaviors` from a map of instances to a map of factory functions. Each factory receives a `BehaviorServices` struct and returns a ready-to-use behavior. The registry builder calls each factory once at startup.
+
+**Example:**
+```go
+// application/preset_registry.go
+type BehaviorFactory func(services entities.BehaviorServices) entities.ResourceBehavior
+
+type PresetDefinition struct {
+    Name         string
+    Description  string
+    Types        []PresetResourceType
+    Behaviors    map[string]BehaviorFactory  // changed from map[string]entities.ResourceBehavior
+    BehaviorMeta map[string]entities.BehaviorMeta
+    // ...
+}
+```
+
+```go
+// application/presets/core/preset.go
+Behaviors: map[string]application.BehaviorFactory{
+    "person": func(s entities.BehaviorServices) entities.ResourceBehavior {
+        return &personBehavior{} // doesn't use services
+    },
+    "organization": func(s entities.BehaviorServices) entities.ResourceBehavior {
+        return &organizationBehavior{triples: s.Triples} // uses services via closure
+    },
+},
+```
+
+```go
+// application/resource_behaviors.go
+func ProvideResourceBehaviorRegistry(
+    registry *PresetRegistry,
+    services entities.BehaviorServices,
+) ResourceBehaviorRegistry {
+    factories := registry.BehaviorFactories()
+    built := make(ResourceBehaviorRegistry, len(factories))
+    for slug, factory := range factories {
+        built[slug] = factory(services)
+    }
+    return built
+}
+```
+
+**Pros:**
+- **No two-phase state.** Behaviors are constructed with services in hand; they are immutable for their lifetime.
+- **Type-safe.** Services closed over at construction, no assertions.
+- **Explicit per-preset.** The factory body makes it obvious what a behavior depends on.
+- **No `ResourceBehavior` interface change** — hooks still take `(ctx, data, rt)`, so existing signatures stay clean.
+- **Services resolved once.** Same performance characteristics as Option 2.
+- Scales naturally: adding a service means adding a field to `BehaviorServices`.
+
+**Cons:**
+- **Breaking change to `PresetDefinition`.** Every existing preset (currently just `core`) and any third-party preset must migrate from `map[string]ResourceBehavior` to `map[string]BehaviorFactory`. A shim could preserve the old field temporarily.
+- **Slightly more ceremony for trivial behaviors.** `func(_ entities.BehaviorServices) entities.ResourceBehavior { return &personBehavior{} }` is wordier than `&personBehavior{}`. A helper like `application.StaticBehavior(&personBehavior{})` can hide the boilerplate.
+- **Preset registration is no longer purely declarative.** The factory is code, not data — harder to serialize or introspect if presets ever need to be loaded from YAML/JSON.
+- **Tests that build a registry manually** (see `application/resource_behaviors_test.go`) must wrap each test behavior in a factory.
+
+---
+
+### Option 4: Fx-Provided Behaviors with Group Tags
+
+Move behavior construction out of the preset registry entirely. Each behavior becomes an Fx provider tagged into a group; the `ResourceBehaviorRegistry` is built by Fx from the group. Preset metadata (names, display names, screens) stays in the registry; behavior *construction* becomes an Fx concern.
+
+**Example:**
+```go
+// application/presets/core/module.go
+var Module = fx.Module("core-preset",
+    fx.Provide(
+        fx.Annotate(
+            NewPersonBehavior,
+            fx.ResultTags(`name:"behavior-person"`, `group:"behaviors"`),
+        ),
+        fx.Annotate(
+            NewOrganizationBehavior,
+            fx.ResultTags(`name:"behavior-organization"`, `group:"behaviors"`),
+        ),
+    ),
+)
+
+func NewPersonBehavior() SlugBehavior {
+    return SlugBehavior{Slug: "person", Behavior: &personBehavior{}}
+}
+
+func NewOrganizationBehavior(triples repositories.TripleRepository) SlugBehavior {
+    return SlugBehavior{Slug: "organization", Behavior: &organizationBehavior{triples: triples}}
+}
+```
+
+```go
+// application/resource_behaviors.go
+type SlugBehavior struct {
+    Slug     string
+    Behavior entities.ResourceBehavior
+}
+
+func ProvideResourceBehaviorRegistry(in struct {
+    fx.In
+    Behaviors []SlugBehavior `group:"behaviors"`
+}) ResourceBehaviorRegistry {
+    reg := make(ResourceBehaviorRegistry, len(in.Behaviors))
+    for _, sb := range in.Behaviors {
+        reg[sb.Slug] = sb.Behavior
+    }
+    return reg
+}
+```
+
+**Pros:**
+- **Full DI.** Behaviors receive whatever Fx can provide — no shared `BehaviorServices` struct, no god-bag.
+- **Idiomatic Fx.** Uses the same group-tag pattern already employed elsewhere in the module.
+- **Per-behavior scoping.** Each behavior declares exactly what it needs.
+- Clean separation: `PresetRegistry` holds declarative metadata; Fx holds constructed behaviors.
+
+**Cons:**
+- **Largest refactor.** Every preset must expose an Fx module, not just a `Register` function. The `RegisterAll` pattern is replaced by composing Fx modules in `application/module.go`.
+- **Presets are no longer self-contained.** Behavior construction moves from `presets/core/preset.go` to `presets/core/module.go`; metadata stays behind. Reading a preset now means reading two files.
+- **Harder to support dynamic presets.** If WeOS ever wants to load presets from disk or a plugin system at runtime, Fx providers are harder to register after the container is built than entries in a map.
+- **More Fx boilerplate.** `fx.Annotate`, `fx.ResultTags`, and group wiring are unfamiliar to new contributors; the current preset model is just "put a struct in a map".
+- **Behavior discovery is implicit.** You can no longer inspect `PresetDefinition.Behaviors` to see what a preset provides — you have to trace Fx group membership.
+- Testing becomes harder: tests that want to exercise the registry with fake behaviors now either spin up an Fx container or bypass it entirely.
+
+---
+
+### Option 5: Stash Services in `context.Context`
+
+Don't change the interface. Before calling any behavior hook, the service layer attaches a `BehaviorServices` value to the context. Behaviors retrieve it via a typed helper.
+
+**Example:**
+```go
+// domain/entities/resource_behavior.go
+type behaviorServicesKey struct{}
+
+func WithBehaviorServices(ctx context.Context, s BehaviorServices) context.Context {
+    return context.WithValue(ctx, behaviorServicesKey{}, s)
+}
+
+func ServicesFromContext(ctx context.Context) (BehaviorServices, bool) {
+    s, ok := ctx.Value(behaviorServicesKey{}).(BehaviorServices)
+    return s, ok
+}
+```
+
+```go
+// In resource_service.go before calling hooks:
+ctx = entities.WithBehaviorServices(ctx, s.behaviorServices)
+data, err := behavior.BeforeCreate(ctx, cmd.Data, rt)
+```
+
+```go
+// In a behavior:
+func (b *productBehavior) BeforeCreate(ctx context.Context, data json.RawMessage, rt *entities.ResourceType) (json.RawMessage, error) {
+    services, ok := entities.ServicesFromContext(ctx)
+    if !ok {
+        return nil, errors.New("behavior services not available")
+    }
+    related, err := services.Resources.FindByID(ctx, "...")
+    // ...
+}
+```
+
+**Pros:**
+- **Zero interface changes.** Fully backward compatible with all existing behaviors.
+- **Every hook already has `ctx`** — no new plumbing.
+- **No two-phase construction** of behaviors.
+- **Opt-in per hook.** Only the hooks that need services look them up.
+
+**Cons:**
+- **Implicit, "magic" dependency.** `context.Context` is documented as a mechanism for request-scoped values, cancellation, and deadlines — using it for a DI container is an anti-pattern widely discouraged in Go (including by the `context` package docs themselves).
+- **Compile-time guarantees lost.** Forgetting to call `WithBehaviorServices` before invoking a hook fails at runtime inside the behavior, with an unhelpful error.
+- **Testing is awkward.** Every behavior test must now construct a context with the services attached, even when the behavior only reads one field.
+- **Leaks up the stack.** Once services are in the context, they flow into every downstream call the behavior makes (repository calls, other services), creating accidental coupling.
+- **Services become visible everywhere.** Any code with the context can pull services out — weakens the encapsulation that DI normally provides.
+
+---
+
+## Comparison Matrix
+
+| Criteria | Option 1: Variadic | Option 2: Initializer | Option 3: Factory | Option 4: Fx Groups | Option 5: Context |
+|---|---|---|---|---|---|
+| **Interface change** | Yes (breaking) | No | No | No | No |
+| **`PresetDefinition` change** | No | No | Yes (breaking) | Yes (moves to Fx) | No |
+| **Source-level backward compat** | No* | Yes | No (shim possible) | No | Yes |
+| **Behaviors are immutable after build** | Yes | No | Yes | Yes | Yes |
+| **Type-safe service access** | No | Yes | Yes | Yes | Yes |
+| **Services resolved once vs. per-call** | Per-call | Once | Once | Once | Per-call |
+| **Per-behavior service scoping** | Yes (caller-decided) | No (shared struct) | No (shared struct) | Yes (per provider) | No (shared struct) |
+| **Works for dynamic/plugin presets** | Yes | Yes | Yes | No | Yes |
+| **Migration burden for existing presets** | High (every hook) | None | Low (wrap in factory) | High (Fx modules) | None |
+| **Migration burden for tests** | High | None | Low | High | Medium |
+| **Fits existing Fx/preset patterns** | Poor | Good | Good | Excellent (Fx) | Poor |
+| **Risk of nil-deref at runtime** | Low | Medium | Low | Low | Medium |
+
+\* Option 1 claimed backward compat in the original proposal, but Go interface satisfaction requires identical signatures on the implementation — existing behaviors would stop compiling until updated.
+
+## Recommendation
+
+**Option 3 (Factory in `PresetDefinition`)** is the preferred approach. It keeps the `ResourceBehavior` interface clean, makes dependencies explicit at construction, avoids two-phase state, and leaves preset self-containment intact. The breaking change to `PresetDefinition.Behaviors` is small (only the `core` preset exists today; migration is one file) and can be eased with a helper like `application.StaticBehavior(&personBehavior{})` for behaviors that don't need services.
+
+**Option 2 (Initializer interface)** is the recommended fallback if the project prioritizes zero breaking changes. It is fully backward compatible at the source level, requires no preset migration, and gives service-needing behaviors a clean way to opt in. The main downsides — two-phase construction and mutable state — are manageable with a single point of initialization in `ProvideResourceBehaviorRegistry`.
+
+**Option 1 (Variadic on interface methods)** — the original proposal — should be rejected. The claimed backward-compat benefit is illusory because Go requires the implementation's signature to match the interface; every existing behavior would need to be updated anyway. Once you accept that breakage, Options 2 and 3 give strictly better type safety, call-site ergonomics, and testability for the same migration cost.
+
+**Option 4 (Fx group tags)** is a valid long-term direction if WeOS moves toward more Fx-native composition, but it is overkill for today's needs and makes dynamic preset loading harder in the future.
+
+**Option 5 (context-based DI)** should be rejected as an anti-pattern — `context.Context` is explicitly not for passing dependencies, and the implicit wiring creates runtime failure modes that the other options avoid.
+
+## Follow-Up Work (If Option 3 Is Accepted)
+
+- [ ] Define `entities.BehaviorServices` with an initial set of fields (`Resources`, `Triples`, `ResourceTypes`, `Logger`) in `domain/entities/resource_behavior.go`
+- [ ] Change `PresetDefinition.Behaviors` to `map[string]BehaviorFactory` in `application/preset_registry.go`
+- [ ] Add `application.StaticBehavior(b entities.ResourceBehavior) BehaviorFactory` helper for no-dep behaviors
+- [ ] Update `ProvideResourceBehaviorRegistry` in `application/resource_behaviors.go` to accept `BehaviorServices` and call factories
+- [ ] Wire `entities.BehaviorServices` in `application/module.go` as an Fx provider that assembles the struct from existing repositories
+- [ ] Migrate `application/presets/core/preset.go` to the factory form
+- [ ] Update `application/resource_behaviors_test.go` test helpers to wrap test behaviors in factories
+- [ ] Update `docs/_howto/create-behavior.md` with the new factory form and an example behavior that uses a service
+- [ ] Update `docs/_explanation/behaviors.md` to describe service injection

--- a/docs/decisions/behavior-service-injection.md
+++ b/docs/decisions/behavior-service-injection.md
@@ -7,7 +7,7 @@ nav_order: 3
 
 # ADR: Injecting Services into ResourceBehavior Implementations
 
-**Status:** Proposed
+**Status:** Accepted (Implemented)
 **Date:** 2026-04-07
 **Context:** Preset-defined `ResourceBehavior` implementations need access to application services (repositories, domain services, loggers, HTTP clients, etc.) but are currently instantiated before Fx wires the container.
 

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -13,3 +13,5 @@ Architecture Decision Records (ADRs) capture significant technical decisions mad
 |-----|--------|------|
 | [Event Handler Data Availability]({% link decisions/event-handler-data-availability.md %}) | Accepted (Option 5) | 2026-04-04 |
 | [Transaction ID and Projection Consolidation]({% link decisions/transaction-id-and-projection-consolidation.md %}) | Accepted (Implemented) | 2026-04-04 |
+| [Injecting Services into ResourceBehavior]({% link decisions/behavior-service-injection.md %}) | Proposed | 2026-04-07 |
+| [Cross-Resource Writes from ResourceBehavior Hooks]({% link decisions/behavior-resource-writer.md %}) | Accepted (Implemented) | 2026-04-07 |

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -13,5 +13,5 @@ Architecture Decision Records (ADRs) capture significant technical decisions mad
 |-----|--------|------|
 | [Event Handler Data Availability]({% link decisions/event-handler-data-availability.md %}) | Accepted (Option 5) | 2026-04-04 |
 | [Transaction ID and Projection Consolidation]({% link decisions/transaction-id-and-projection-consolidation.md %}) | Accepted (Implemented) | 2026-04-04 |
-| [Injecting Services into ResourceBehavior]({% link decisions/behavior-service-injection.md %}) | Proposed | 2026-04-07 |
+| [Injecting Services into ResourceBehavior]({% link decisions/behavior-service-injection.md %}) | Accepted (Implemented) | 2026-04-07 |
 | [Cross-Resource Writes from ResourceBehavior Hooks]({% link decisions/behavior-resource-writer.md %}) | Accepted (Implemented) | 2026-04-07 |


### PR DESCRIPTION
Introduces application.ResourceWriter — a narrow Create/Update/Delete subset of ResourceService that behaviors can use to mutate other resources from inside a hook, running those writes through the full pipeline (schema validation, JSON-LD graph assembly, triple extraction, event recording, UoW commit, nested behavior dispatch).

The Fx construction cycle ResourceService -> ResourceBehaviorRegistry -> ResourceService is broken by a lazyResourceWriter proxy: constructed before ResourceService, handed to BehaviorServices.Writer, then populated post-construction via WireResourceWriter (an fx.Invoke that runs after ProvideResourceService). The proxy uses atomic.Pointer so SetTarget's one-shot publish has a happens-before edge independent of Fx ordering, and it rejects nil, self-targeting, and double-set so misuse fails startup loudly.

To bound legitimate cascades and catch accidental cycles fast, resourceService.Create/Update/Delete each call a new enterResourceCall helper that tracks a behavior-cascade depth on context.Context and rejects at maxBehaviorRecursionDepth (8). Sibling writes from the same hook each see the parent's depth — only true nesting inflates the counter.

Tests cover the depth guard's boundary, sibling immutability, and per-method enforcement, plus the lazy proxy's pre-wire error path, forwarding, and all three SetTarget rejection modes. Two ADRs (behavior-service-injection, behavior-resource-writer) capture the options considered and rationale. The Howto documents Writer usage with a cross-resource example.

Also loosens the built-in preset count check in
resource_type_presets_test.go to a subset assertion so the weos-private-presets build tag can register additional presets without breaking the canonical test.