### PR TITLE
feat: expose extension points for downstream binaries

### DIFF
--- a/application/presets/register.go
+++ b/application/presets/register.go
@@ -16,6 +16,17 @@ import (
 
 var customRegistrars []func(*application.PresetRegistry)
 
+// Register adds a custom preset registrar that will be invoked by RegisterAll
+// after the built-in presets have been registered. Downstream services that
+// embed the weos binary can call this from a package init() to plug custom
+// presets into the default registry before cli.Execute() runs.
+func Register(fn func(*application.PresetRegistry)) {
+	if fn == nil {
+		return
+	}
+	customRegistrars = append(customRegistrars, fn)
+}
+
 // RegisterAll registers all built-in presets with the given registry.
 func RegisterAll(registry *application.PresetRegistry) {
 	core.Register(registry)

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1,0 +1,34 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// Package cli provides a public wrapper around the internal weos CLI for use
+// by downstream services that embed the weos binary as a library.
+//
+// The primary CLI implementation lives in weos/internal/cli. Go's internal
+// package rules prevent that package from being imported outside the weos
+// module, so this thin re-export exists to give downstream binaries a stable
+// public entry point.
+package cli
+
+import internalcli "weos/internal/cli"
+
+// Execute runs the weos CLI root command.
+//
+// Downstream services embedding weos typically call this from main() after
+// loading environment variables and calling presets.Register() for any
+// custom presets they want to plug into the default registry.
+func Execute() error {
+	return internalcli.Execute()
+}


### PR DESCRIPTION
## Summary

Two small additive extension points so downstream services can embed the weos binary as a library without forking the repo.

- **`application/presets.Register(fn)`** — new public function that appends a custom preset registrar to the existing package-private `customRegistrars` slice. The slice is already iterated by `RegisterAll()`, so custom presets join the default registry automatically. Intended for init()-time use by downstream binaries.
- **`pkg/cli`** — new public package with a thin `Execute()` wrapper around `internal/cli.Execute()`. Go's internal-package rule prevents external modules from importing `internal/cli` directly, so this re-export gives downstream binaries a stable public entry point.

Both changes are additive only. No existing behavior changes, no deletions, no API breaks.

## Motivation

We're converting `ic-crm` from a heavy fork of weos (~66 Go files across `api/`, `application/`, `domain/`, `infrastructure/`, `internal/`, `migrations/`, `pkg/`, `tests/`, `web/`) into a single-file thin wrap that:

1. imports weos core as a library
2. calls `presets.Register(education.Register)` in an `init()` to plug the `education` preset from `weos-private-presets` into the default registry
3. delegates all CLI / HTTP / MCP / resource-type handling to `cli.Execute()`

Without these two hooks a downstream binary would have to either re-fork weos or copy-paste the CLI bootstrap. With them, the entire ic-crm service becomes ~25 lines of Go.

The same pattern is reusable by any future downstream that wants to ship a weos-based binary bundling a specific preset set.

## Test plan

- [x] `go build ./...` from `services/core` — clean
- [x] `go vet ./application/presets/... ./pkg/cli/...` — clean
- [x] `go test ./application/presets/...` — passes (no test files, but no breakage)
- [x] Downstream thin-wrap binary (ic-crm) builds against this branch and its `init()`-time `presets.Register(education.Register)` call causes `education` to appear in `./ic-crm resource-type preset list` alongside the built-in presets
- [x] Downstream `./ic-crm resource-type preset install education` creates all 14 education resource types without error
- [x] Downstream `./ic-crm serve` + `GET /api/health` returns `HTTP 200 {"status":"ok"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)