### PR TITLE
Add HMAC invite token service (implements pericarp InviteTokenService)

### DIFF
--- a/application/module.go
+++ b/application/module.go
@@ -5,6 +5,7 @@ import (
 
 	"weos/domain/entities"
 	"weos/domain/repositories"
+	"weos/infrastructure/auth"
 	"weos/infrastructure/database/gorm"
 	"weos/infrastructure/email"
 	"weos/infrastructure/events"
@@ -90,6 +91,7 @@ func Module(cfg config.Config, registry *PresetRegistry) fx.Option {
 		fx.Provide(ProvideAuthorizationChecker),
 		fx.Provide(ProvideAuthenticationService),
 		fx.Provide(ProvideSessionManager),
+		fx.Provide(auth.ProvideInviteTokenService),
 
 		// Resource behavior registries (must come before ProvideResourceService).
 		// The lazy resource writer breaks the construction cycle between

--- a/infrastructure/auth/hmac_invite_token_service.go
+++ b/infrastructure/auth/hmac_invite_token_service.go
@@ -1,0 +1,132 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// Package auth provides infrastructure implementations for authentication
+// services defined in pericarp's auth application layer.
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"weos/internal/config"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth/application"
+	gojwt "github.com/golang-jwt/jwt/v5"
+	"github.com/segmentio/ksuid"
+)
+
+const (
+	// inviteTokenIssuer is the "iss" claim value for invite tokens signed by WeOS.
+	inviteTokenIssuer = "weos"
+)
+
+// HMACInviteTokenService implements pericarp's application.InviteTokenService
+// using HMAC-SHA256 signed JWTs. It reuses the existing session secret so
+// WeOS deployments can issue invite tokens without any new infrastructure.
+type HMACInviteTokenService struct {
+	secret []byte
+	issuer string
+}
+
+// NewHMACInviteTokenService creates a new HMAC-SHA256 invite token service
+// from the given secret. The secret must be non-empty.
+func NewHMACInviteTokenService(secret string) (*HMACInviteTokenService, error) {
+	if secret == "" {
+		return nil, application.ErrNoSigningKey
+	}
+	return &HMACInviteTokenService{
+		secret: []byte(secret),
+		issuer: inviteTokenIssuer,
+	}, nil
+}
+
+// IssueInviteToken creates an HMAC-SHA256 signed JWT for the given invite.
+// The token's subject and custom invite_id claim are both set to inviteID,
+// and it expires after the given duration.
+func (s *HMACInviteTokenService) IssueInviteToken(
+	ctx context.Context, inviteID string, expiry time.Duration,
+) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if inviteID == "" {
+		return "", fmt.Errorf("authentication: invite ID must not be empty")
+	}
+	if expiry <= 0 {
+		return "", fmt.Errorf("authentication: invite token expiry must be positive")
+	}
+
+	now := time.Now()
+	claims := application.InviteClaims{
+		RegisteredClaims: gojwt.RegisteredClaims{
+			Issuer:    s.issuer,
+			Subject:   inviteID,
+			IssuedAt:  gojwt.NewNumericDate(now),
+			ExpiresAt: gojwt.NewNumericDate(now.Add(expiry)),
+			ID:        ksuid.New().String(),
+		},
+		InviteID: inviteID,
+	}
+
+	token := gojwt.NewWithClaims(gojwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString(s.secret)
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", application.ErrSigningFailed, err)
+	}
+
+	return tokenString, nil
+}
+
+// ValidateInviteToken parses and validates an HMAC-SHA256 signed invite token,
+// returning the claims. Expired tokens return application.ErrTokenExpired and
+// all other parse/signature failures return application.ErrTokenInvalid.
+func (s *HMACInviteTokenService) ValidateInviteToken(
+	ctx context.Context, tokenString string,
+) (*application.InviteClaims, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if tokenString == "" {
+		return nil, application.ErrTokenInvalid
+	}
+
+	claims := &application.InviteClaims{}
+	token, err := gojwt.ParseWithClaims(tokenString, claims, func(token *gojwt.Token) (any, error) {
+		if _, ok := token.Method.(*gojwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return s.secret, nil
+	})
+	if err != nil {
+		if errors.Is(err, gojwt.ErrTokenExpired) {
+			return nil, application.ErrTokenExpired
+		}
+		return nil, fmt.Errorf("%w: %v", application.ErrTokenInvalid, err)
+	}
+	if !token.Valid {
+		return nil, application.ErrTokenInvalid
+	}
+
+	return claims, nil
+}
+
+// ProvideInviteTokenService is the Fx provider that wires an
+// HMACInviteTokenService using the configured SESSION_SECRET.
+func ProvideInviteTokenService(cfg config.Config) (application.InviteTokenService, error) {
+	return NewHMACInviteTokenService(cfg.SessionSecret)
+}

--- a/infrastructure/auth/hmac_invite_token_service.go
+++ b/infrastructure/auth/hmac_invite_token_service.go
@@ -125,7 +125,7 @@ func (s *HMACInviteTokenService) ValidateInviteToken(
 		return nil, application.ErrTokenInvalid
 	}
 
-	// Semantic claim validation — defence in depth beyond JWT's built-in
+	// Semantic claim validation — defense in depth beyond JWT's built-in
 	// signature/expiry checks. A token signed with the correct secret but
 	// missing required fields is still invalid for our use case.
 	if claims.Issuer != s.issuer {

--- a/infrastructure/auth/hmac_invite_token_service.go
+++ b/infrastructure/auth/hmac_invite_token_service.go
@@ -107,7 +107,10 @@ func (s *HMACInviteTokenService) ValidateInviteToken(
 
 	claims := &application.InviteClaims{}
 	token, err := gojwt.ParseWithClaims(tokenString, claims, func(token *gojwt.Token) (any, error) {
-		if _, ok := token.Method.(*gojwt.SigningMethodHMAC); !ok {
+		// Enforce HS256 specifically — accepting any HMAC variant would
+		// allow a caller-chosen hash strength that doesn't match the
+		// documented algorithm.
+		if token.Method != gojwt.SigningMethodHS256 {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		return s.secret, nil
@@ -122,6 +125,22 @@ func (s *HMACInviteTokenService) ValidateInviteToken(
 		return nil, application.ErrTokenInvalid
 	}
 
+	// Semantic claim validation — defence in depth beyond JWT's built-in
+	// signature/expiry checks. A token signed with the correct secret but
+	// missing required fields is still invalid for our use case.
+	if claims.Issuer != s.issuer {
+		return nil, fmt.Errorf("%w: unexpected issuer %q", application.ErrTokenInvalid, claims.Issuer)
+	}
+	if claims.ExpiresAt == nil {
+		return nil, fmt.Errorf("%w: missing expiry", application.ErrTokenInvalid)
+	}
+	if claims.InviteID == "" {
+		return nil, fmt.Errorf("%w: missing invite_id", application.ErrTokenInvalid)
+	}
+	if claims.Subject != claims.InviteID {
+		return nil, fmt.Errorf("%w: subject does not match invite_id", application.ErrTokenInvalid)
+	}
+
 	return claims, nil
 }
 
@@ -130,3 +149,8 @@ func (s *HMACInviteTokenService) ValidateInviteToken(
 func ProvideInviteTokenService(cfg config.Config) (application.InviteTokenService, error) {
 	return NewHMACInviteTokenService(cfg.SessionSecret)
 }
+
+// Compile-time assertion that HMACInviteTokenService satisfies the pericarp
+// InviteTokenService interface. Lives in the implementation file so normal
+// `go build` catches interface drift.
+var _ application.InviteTokenService = (*HMACInviteTokenService)(nil)

--- a/infrastructure/auth/hmac_invite_token_service_test.go
+++ b/infrastructure/auth/hmac_invite_token_service_test.go
@@ -156,6 +156,107 @@ func TestValidateInviteToken_WrongAlgorithm(t *testing.T) {
 	}
 }
 
+// signedClaims is a test helper that HS256-signs the given claims with the
+// given secret, bypassing the service's own IssueInviteToken to produce
+// intentionally malformed tokens for validation tests.
+func signedClaims(t *testing.T, secret string, claims application.InviteClaims) string {
+	t.Helper()
+	token := gojwt.NewWithClaims(gojwt.SigningMethodHS256, claims)
+	s, err := token.SignedString([]byte(secret))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return s
+}
+
+func TestValidateInviteToken_HS384_Rejected(t *testing.T) {
+	svc, _ := NewHMACInviteTokenService("shhh")
+
+	// HS384 is a valid HMAC variant but should be rejected — we only
+	// accept HS256 to match the documented algorithm.
+	claims := application.InviteClaims{
+		RegisteredClaims: gojwt.RegisteredClaims{
+			Issuer:    "weos",
+			Subject:   "invite-1",
+			ExpiresAt: gojwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+		InviteID: "invite-1",
+	}
+	token := gojwt.NewWithClaims(gojwt.SigningMethodHS384, claims)
+	signed, err := token.SignedString(svc.secret)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	_, err = svc.ValidateInviteToken(context.Background(), signed)
+	if !errors.Is(err, application.ErrTokenInvalid) {
+		t.Fatalf("expected ErrTokenInvalid for HS384, got %v", err)
+	}
+}
+
+func TestValidateInviteToken_WrongIssuer(t *testing.T) {
+	svc, _ := NewHMACInviteTokenService("shhh")
+	signed := signedClaims(t, "shhh", application.InviteClaims{
+		RegisteredClaims: gojwt.RegisteredClaims{
+			Issuer:    "not-weos",
+			Subject:   "invite-1",
+			ExpiresAt: gojwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+		InviteID: "invite-1",
+	})
+	_, err := svc.ValidateInviteToken(context.Background(), signed)
+	if !errors.Is(err, application.ErrTokenInvalid) {
+		t.Fatalf("expected ErrTokenInvalid, got %v", err)
+	}
+}
+
+func TestValidateInviteToken_MissingExpiry(t *testing.T) {
+	svc, _ := NewHMACInviteTokenService("shhh")
+	signed := signedClaims(t, "shhh", application.InviteClaims{
+		RegisteredClaims: gojwt.RegisteredClaims{
+			Issuer:  "weos",
+			Subject: "invite-1",
+		},
+		InviteID: "invite-1",
+	})
+	_, err := svc.ValidateInviteToken(context.Background(), signed)
+	if !errors.Is(err, application.ErrTokenInvalid) {
+		t.Fatalf("expected ErrTokenInvalid, got %v", err)
+	}
+}
+
+func TestValidateInviteToken_MissingInviteID(t *testing.T) {
+	svc, _ := NewHMACInviteTokenService("shhh")
+	signed := signedClaims(t, "shhh", application.InviteClaims{
+		RegisteredClaims: gojwt.RegisteredClaims{
+			Issuer:    "weos",
+			Subject:   "invite-1",
+			ExpiresAt: gojwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+		// InviteID intentionally empty
+	})
+	_, err := svc.ValidateInviteToken(context.Background(), signed)
+	if !errors.Is(err, application.ErrTokenInvalid) {
+		t.Fatalf("expected ErrTokenInvalid, got %v", err)
+	}
+}
+
+func TestValidateInviteToken_SubjectMismatch(t *testing.T) {
+	svc, _ := NewHMACInviteTokenService("shhh")
+	signed := signedClaims(t, "shhh", application.InviteClaims{
+		RegisteredClaims: gojwt.RegisteredClaims{
+			Issuer:    "weos",
+			Subject:   "different-id",
+			ExpiresAt: gojwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+		InviteID: "invite-1",
+	})
+	_, err := svc.ValidateInviteToken(context.Background(), signed)
+	if !errors.Is(err, application.ErrTokenInvalid) {
+		t.Fatalf("expected ErrTokenInvalid, got %v", err)
+	}
+}
+
 func TestValidateInviteToken_Malformed(t *testing.T) {
 	svc, _ := NewHMACInviteTokenService("shhh")
 	_, err := svc.ValidateInviteToken(context.Background(), "not.a.jwt")
@@ -202,7 +303,3 @@ func TestProvideInviteTokenService_NoSecret(t *testing.T) {
 		t.Fatalf("expected ErrNoSigningKey, got %v", err)
 	}
 }
-
-// Compile-time assertion that HMACInviteTokenService satisfies the pericarp
-// InviteTokenService interface.
-var _ application.InviteTokenService = (*HMACInviteTokenService)(nil)

--- a/infrastructure/auth/hmac_invite_token_service_test.go
+++ b/infrastructure/auth/hmac_invite_token_service_test.go
@@ -1,0 +1,208 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"weos/internal/config"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth/application"
+	gojwt "github.com/golang-jwt/jwt/v5"
+)
+
+func TestNewHMACInviteTokenService_EmptySecret(t *testing.T) {
+	svc, err := NewHMACInviteTokenService("")
+	if svc != nil {
+		t.Fatal("expected nil service for empty secret")
+	}
+	if !errors.Is(err, application.ErrNoSigningKey) {
+		t.Fatalf("expected ErrNoSigningKey, got %v", err)
+	}
+}
+
+func TestNewHMACInviteTokenService_WithSecret(t *testing.T) {
+	svc, err := NewHMACInviteTokenService("shhh")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if svc == nil {
+		t.Fatal("expected non-nil service")
+	}
+}
+
+func TestIssueAndValidate_RoundTrip(t *testing.T) {
+	svc, err := NewHMACInviteTokenService("shhh")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	token, err := svc.IssueInviteToken(context.Background(), "invite-123", time.Hour)
+	if err != nil {
+		t.Fatalf("unexpected error issuing token: %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected non-empty token")
+	}
+
+	claims, err := svc.ValidateInviteToken(context.Background(), token)
+	if err != nil {
+		t.Fatalf("unexpected error validating token: %v", err)
+	}
+	if claims.InviteID != "invite-123" {
+		t.Fatalf("expected invite_id=invite-123, got %s", claims.InviteID)
+	}
+	if claims.Subject != "invite-123" {
+		t.Fatalf("expected sub=invite-123, got %s", claims.Subject)
+	}
+	if claims.Issuer != "weos" {
+		t.Fatalf("expected iss=weos, got %s", claims.Issuer)
+	}
+}
+
+func TestIssueInviteToken_EmptyInviteID(t *testing.T) {
+	svc, _ := NewHMACInviteTokenService("shhh")
+	_, err := svc.IssueInviteToken(context.Background(), "", time.Hour)
+	if err == nil {
+		t.Fatal("expected error for empty invite ID")
+	}
+}
+
+func TestIssueInviteToken_NonPositiveExpiry(t *testing.T) {
+	svc, _ := NewHMACInviteTokenService("shhh")
+	_, err := svc.IssueInviteToken(context.Background(), "invite-1", 0)
+	if err == nil {
+		t.Fatal("expected error for zero expiry")
+	}
+	_, err = svc.IssueInviteToken(context.Background(), "invite-1", -time.Second)
+	if err == nil {
+		t.Fatal("expected error for negative expiry")
+	}
+}
+
+func TestIssueInviteToken_ContextCancelled(t *testing.T) {
+	svc, _ := NewHMACInviteTokenService("shhh")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := svc.IssueInviteToken(ctx, "invite-1", time.Hour)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestValidateInviteToken_Expired(t *testing.T) {
+	svc, _ := NewHMACInviteTokenService("shhh")
+
+	// Build a token that expired 1 second ago by signing claims manually.
+	now := time.Now()
+	claims := application.InviteClaims{
+		RegisteredClaims: gojwt.RegisteredClaims{
+			Issuer:    "weos",
+			Subject:   "invite-1",
+			IssuedAt:  gojwt.NewNumericDate(now.Add(-time.Hour)),
+			ExpiresAt: gojwt.NewNumericDate(now.Add(-time.Second)),
+		},
+		InviteID: "invite-1",
+	}
+	token := gojwt.NewWithClaims(gojwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString(svc.secret)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	_, err = svc.ValidateInviteToken(context.Background(), signed)
+	if !errors.Is(err, application.ErrTokenExpired) {
+		t.Fatalf("expected ErrTokenExpired, got %v", err)
+	}
+}
+
+func TestValidateInviteToken_WrongSecret(t *testing.T) {
+	issuer, _ := NewHMACInviteTokenService("secret-A")
+	validator, _ := NewHMACInviteTokenService("secret-B")
+
+	token, err := issuer.IssueInviteToken(context.Background(), "invite-1", time.Hour)
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+
+	_, err = validator.ValidateInviteToken(context.Background(), token)
+	if !errors.Is(err, application.ErrTokenInvalid) {
+		t.Fatalf("expected ErrTokenInvalid, got %v", err)
+	}
+}
+
+func TestValidateInviteToken_WrongAlgorithm(t *testing.T) {
+	svc, _ := NewHMACInviteTokenService("shhh")
+
+	// A token with "alg: none" must be rejected — the service only
+	// accepts HMAC signatures.
+	claims := application.InviteClaims{
+		RegisteredClaims: gojwt.RegisteredClaims{
+			Subject:   "invite-1",
+			ExpiresAt: gojwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+		InviteID: "invite-1",
+	}
+	token := gojwt.NewWithClaims(gojwt.SigningMethodNone, claims)
+	signed, err := token.SignedString(gojwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	_, err = svc.ValidateInviteToken(context.Background(), signed)
+	if !errors.Is(err, application.ErrTokenInvalid) {
+		t.Fatalf("expected ErrTokenInvalid, got %v", err)
+	}
+}
+
+func TestValidateInviteToken_Malformed(t *testing.T) {
+	svc, _ := NewHMACInviteTokenService("shhh")
+	_, err := svc.ValidateInviteToken(context.Background(), "not.a.jwt")
+	if !errors.Is(err, application.ErrTokenInvalid) {
+		t.Fatalf("expected ErrTokenInvalid, got %v", err)
+	}
+}
+
+func TestValidateInviteToken_EmptyString(t *testing.T) {
+	svc, _ := NewHMACInviteTokenService("shhh")
+	_, err := svc.ValidateInviteToken(context.Background(), "")
+	if !errors.Is(err, application.ErrTokenInvalid) {
+		t.Fatalf("expected ErrTokenInvalid, got %v", err)
+	}
+}
+
+func TestValidateInviteToken_ContextCancelled(t *testing.T) {
+	svc, _ := NewHMACInviteTokenService("shhh")
+	token, _ := svc.IssueInviteToken(context.Background(), "invite-1", time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := svc.ValidateInviteToken(ctx, token)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestProvideInviteTokenService_WithSecret(t *testing.T) {
+	cfg := config.Config{SessionSecret: "shhh"}
+	svc, err := ProvideInviteTokenService(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if svc == nil {
+		t.Fatal("expected non-nil service")
+	}
+}
+
+func TestProvideInviteTokenService_NoSecret(t *testing.T) {
+	cfg := config.Config{}
+	_, err := ProvideInviteTokenService(cfg)
+	if !errors.Is(err, application.ErrNoSigningKey) {
+		t.Fatalf("expected ErrNoSigningKey, got %v", err)
+	}
+}
+
+// Compile-time assertion that HMACInviteTokenService satisfies the pericarp
+// InviteTokenService interface.
+var _ application.InviteTokenService = (*HMACInviteTokenService)(nil)


### PR DESCRIPTION
## Summary
- Implements pericarp's `application.InviteTokenService` interface with HMAC-SHA256 signed JWTs
- Reuses the existing `SESSION_SECRET` config — no new environment variables or external infrastructure
- No new external dependencies (`golang-jwt/jwt/v5` was already in `go.sum`)
- Wired into Fx via `auth.ProvideInviteTokenService` in the auth infrastructure section of `application/module.go`
- Includes a compile-time assertion (`var _ application.InviteTokenService = (*HMACInviteTokenService)(nil)`) to prevent interface drift

## Security properties
- **HMAC-only allowlist** in `ParseWithClaims` rejects `alg: none` and RSA tokens (prevents algorithm confusion attacks)
- **Error mapping** — expired tokens return `application.ErrTokenExpired`, all other parse/signature failures wrap `application.ErrTokenInvalid`
- **Context cancellation** honored on both methods
- **Defensive checks** — empty `inviteID`, non-positive `expiry`, and empty token strings are rejected explicitly

Closes #321

## Test plan
- [x] 14 unit tests in `infrastructure/auth/hmac_invite_token_service_test.go` covering: round-trip issue+validate, empty/valid secret, empty inviteID, zero/negative expiry, context cancellation on both methods, expired token, wrong secret, `alg: none` rejection, malformed JWT, empty token, provider with/without secret
- [x] Compile-time interface assertion
- [x] `go build ./...` compiles cleanly
- [x] `go vet` passes

https://claude.ai/code/session_01PH2K7YJshFcpU3w7ctsEEj