### PR TITLE
feat: add invite user functionality

### DIFF
--- a/api/handlers/invite_handler.go
+++ b/api/handlers/invite_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"time"
 
 	"weos/domain/entities"
 
@@ -112,8 +113,8 @@ func (h *InviteHandler) Create(c echo.Context) error {
 		Role:      invite.RoleID(),
 		Status:    invite.Status(),
 		Token:     token,
-		ExpiresAt: invite.ExpiresAt().Format("2006-01-02T15:04:05Z"),
-		CreatedAt: invite.CreatedAt().Format("2006-01-02T15:04:05Z"),
+		ExpiresAt: invite.ExpiresAt().UTC().Format(time.RFC3339),
+		CreatedAt: invite.CreatedAt().UTC().Format(time.RFC3339),
 	})
 }
 
@@ -160,8 +161,8 @@ func (h *InviteHandler) List(c echo.Context) error {
 			Email:     inv.Email(),
 			Role:      inv.RoleID(),
 			Status:    inv.Status(),
-			ExpiresAt: inv.ExpiresAt().Format("2006-01-02T15:04:05Z"),
-			CreatedAt: inv.CreatedAt().Format("2006-01-02T15:04:05Z"),
+			ExpiresAt: inv.ExpiresAt().UTC().Format(time.RFC3339),
+			CreatedAt: inv.CreatedAt().UTC().Format(time.RFC3339),
 		})
 	}
 

--- a/api/handlers/invite_handler.go
+++ b/api/handlers/invite_handler.go
@@ -225,7 +225,10 @@ func (h *InviteHandler) Accept(c echo.Context) error {
 		Email string `json:"email"`
 		Name  string `json:"name"`
 	}
-	if err := c.Bind(&req); err != nil || req.Token == "" {
+	if err := c.Bind(&req); err != nil {
+		return respondError(c, http.StatusBadRequest, "invalid request")
+	}
+	if req.Token == "" {
 		return respondError(c, http.StatusBadRequest, "token is required")
 	}
 

--- a/api/handlers/invite_handler.go
+++ b/api/handlers/invite_handler.go
@@ -290,15 +290,16 @@ func (h *InviteHandler) Accept(c echo.Context) error {
 		}
 	}
 
-	credEmail := ""
-	if credential != nil {
+	credEmail := email
+	if credential != nil && credential.Email() != "" {
 		credEmail = credential.Email()
 	}
 
 	return respond(c, http.StatusOK, UserResponse{
-		ID:    agent.GetID(),
-		Name:  agent.Name(),
-		Email: credEmail,
+		ID:     agent.GetID(),
+		Name:   agent.Name(),
+		Email:  credEmail,
+		Status: agent.Status(),
 	})
 }
 

--- a/api/handlers/invite_handler.go
+++ b/api/handlers/invite_handler.go
@@ -226,12 +226,25 @@ func (h *InviteHandler) Accept(c echo.Context) error {
 	}
 
 	// When authenticated, derive email from the session to prevent spoofing.
+	// Fail closed: if authenticated but email cannot be determined, reject.
 	email := req.Email
 	name := req.Name
-	if identity := auth.AgentFromCtx(ctx); identity != nil && h.credentialRepo != nil {
+	if identity := auth.AgentFromCtx(ctx); identity != nil {
+		if h.credentialRepo == nil {
+			h.logger.Error(ctx, "credential repository unavailable for authenticated accept")
+			return respondError(c, http.StatusInternalServerError, "failed to accept invite")
+		}
 		creds, credErr := h.credentialRepo.FindByAgent(ctx, identity.AgentID)
-		if credErr == nil && len(creds) > 0 {
-			email = creds[0].Email()
+		if credErr != nil {
+			h.logger.Error(ctx, "failed to derive authenticated email", "error", credErr, "agent_id", identity.AgentID)
+			return respondError(c, http.StatusInternalServerError, "failed to accept invite")
+		}
+		if len(creds) == 0 || creds[0].Email() == "" {
+			return respondError(c, http.StatusUnauthorized, "authenticated email could not be determined")
+		}
+		email = creds[0].Email()
+		if req.Email != "" && req.Email != email {
+			return respondError(c, http.StatusBadRequest, "email does not match authenticated user")
 		}
 	}
 

--- a/api/handlers/invite_handler.go
+++ b/api/handlers/invite_handler.go
@@ -1,0 +1,273 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"weos/domain/entities"
+
+	apimw "weos/api/middleware"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
+	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
+	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
+	"github.com/labstack/echo/v4"
+)
+
+type InviteHandler struct {
+	inviteService *authapp.InviteService
+	inviteRepo    authrepos.InviteRepository
+	accountRepo   authrepos.AccountRepository
+	logger        entities.Logger
+}
+
+type InviteHandlerConfig struct {
+	InviteService *authapp.InviteService
+	InviteRepo    authrepos.InviteRepository
+	AccountRepo   authrepos.AccountRepository
+	Logger        entities.Logger
+}
+
+func NewInviteHandler(cfg InviteHandlerConfig) *InviteHandler {
+	return &InviteHandler{
+		inviteService: cfg.InviteService,
+		inviteRepo:    cfg.InviteRepo,
+		accountRepo:   cfg.AccountRepo,
+		logger:        cfg.Logger,
+	}
+}
+
+type CreateInviteRequest struct {
+	Email string `json:"email"`
+	Role  string `json:"role"`
+}
+
+type InviteResponse struct {
+	ID        string `json:"id"`
+	Email     string `json:"email"`
+	Role      string `json:"role"`
+	Status    string `json:"status"`
+	Token     string `json:"token,omitempty"`
+	ExpiresAt string `json:"expires_at"`
+	CreatedAt string `json:"created_at"`
+}
+
+// Create handles POST /api/invites — creates an invite and returns it with a token.
+func (h *InviteHandler) Create(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	isAdmin, err := apimw.IsAdmin(ctx, h.accountRepo)
+	if err != nil {
+		h.logger.Error(ctx, "failed to check admin status", "error", err)
+		return respondError(c, http.StatusInternalServerError, "authorization check failed")
+	}
+	if !isAdmin {
+		return respondError(c, http.StatusForbidden, "admin role required")
+	}
+
+	var req CreateInviteRequest
+	if err := c.Bind(&req); err != nil {
+		return respondError(c, http.StatusBadRequest, "invalid request")
+	}
+	if req.Email == "" {
+		return respondError(c, http.StatusBadRequest, "email is required")
+	}
+	if req.Role == "" {
+		return respondError(c, http.StatusBadRequest, "role is required")
+	}
+
+	identity := auth.AgentFromCtx(ctx)
+	if identity == nil {
+		return respondError(c, http.StatusUnauthorized, "not authenticated")
+	}
+
+	accountID := identity.ActiveAccountID
+	if accountID == "" {
+		var acctErr error
+		accountID, acctErr = h.defaultAccountID(ctx)
+		if acctErr != nil {
+			h.logger.Error(ctx, "failed to resolve account", "error", acctErr)
+			return respondError(c, http.StatusInternalServerError, "failed to resolve account")
+		}
+	}
+	if accountID == "" {
+		return respondError(c, http.StatusInternalServerError, "no account found")
+	}
+
+	invite, token, err := h.inviteService.CreateInvite(ctx, accountID, req.Email, req.Role, identity.AgentID)
+	if err != nil {
+		h.logger.Error(ctx, "failed to create invite", "error", err)
+		switch {
+		case errors.Is(err, authapp.ErrNotAccountAdmin):
+			return respondError(c, http.StatusForbidden, "admin role required for this account")
+		default:
+			return respondError(c, http.StatusInternalServerError, "failed to create invite")
+		}
+	}
+
+	return respond(c, http.StatusCreated, InviteResponse{
+		ID:        invite.GetID(),
+		Email:     invite.Email(),
+		Role:      invite.RoleID(),
+		Status:    invite.Status(),
+		Token:     token,
+		ExpiresAt: invite.ExpiresAt().Format("2006-01-02T15:04:05Z"),
+		CreatedAt: invite.CreatedAt().Format("2006-01-02T15:04:05Z"),
+	})
+}
+
+// List handles GET /api/invites — lists all invites for the current account.
+func (h *InviteHandler) List(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	isAdmin, err := apimw.IsAdmin(ctx, h.accountRepo)
+	if err != nil {
+		h.logger.Error(ctx, "failed to check admin status", "error", err)
+		return respondError(c, http.StatusInternalServerError, "authorization check failed")
+	}
+	if !isAdmin {
+		return respondError(c, http.StatusForbidden, "admin role required")
+	}
+
+	identity := auth.AgentFromCtx(ctx)
+	accountID := ""
+	if identity != nil {
+		accountID = identity.ActiveAccountID
+	}
+	if accountID == "" {
+		var acctErr error
+		accountID, acctErr = h.defaultAccountID(ctx)
+		if acctErr != nil {
+			h.logger.Error(ctx, "failed to resolve account", "error", acctErr)
+			return respondError(c, http.StatusInternalServerError, "failed to resolve account")
+		}
+	}
+	if accountID == "" {
+		return respond(c, http.StatusOK, []InviteResponse{})
+	}
+
+	invites, err := h.inviteRepo.FindByAccount(ctx, accountID)
+	if err != nil {
+		h.logger.Error(ctx, "failed to list invites", "error", err)
+		return respondError(c, http.StatusInternalServerError, "failed to list invites")
+	}
+
+	result := make([]InviteResponse, 0, len(invites))
+	for _, inv := range invites {
+		result = append(result, InviteResponse{
+			ID:        inv.GetID(),
+			Email:     inv.Email(),
+			Role:      inv.RoleID(),
+			Status:    inv.Status(),
+			ExpiresAt: inv.ExpiresAt().Format("2006-01-02T15:04:05Z"),
+			CreatedAt: inv.CreatedAt().Format("2006-01-02T15:04:05Z"),
+		})
+	}
+
+	return respond(c, http.StatusOK, result)
+}
+
+// Revoke handles DELETE /api/invites/:id — revokes a pending invite.
+func (h *InviteHandler) Revoke(c echo.Context) error {
+	id := c.Param("id")
+	ctx := c.Request().Context()
+
+	isAdmin, err := apimw.IsAdmin(ctx, h.accountRepo)
+	if err != nil {
+		h.logger.Error(ctx, "failed to check admin status", "error", err)
+		return respondError(c, http.StatusInternalServerError, "authorization check failed")
+	}
+	if !isAdmin {
+		return respondError(c, http.StatusForbidden, "admin role required")
+	}
+
+	identity := auth.AgentFromCtx(ctx)
+	if identity == nil {
+		return respondError(c, http.StatusUnauthorized, "not authenticated")
+	}
+
+	if err := h.inviteService.RevokeInvite(ctx, id, identity.AgentID); err != nil {
+		h.logger.Error(ctx, "failed to revoke invite", "error", err, "invite_id", id)
+		switch {
+		case errors.Is(err, authapp.ErrInviteNotFound):
+			return respondError(c, http.StatusNotFound, "invite not found")
+		case errors.Is(err, authapp.ErrInviteNotPending):
+			return respondError(c, http.StatusConflict, "invite is no longer pending")
+		case errors.Is(err, authapp.ErrNotAccountAdmin):
+			return respondError(c, http.StatusForbidden, "admin role required for this account")
+		default:
+			return respondError(c, http.StatusInternalServerError, "failed to revoke invite")
+		}
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+// Accept handles POST /api/invites/accept — accepts an invite using the token.
+// This is a public endpoint (no auth required) — the token IS the authorization.
+// The invitee provides their info so AcceptInvite can create the credential
+// and verify the email matches the invite.
+func (h *InviteHandler) Accept(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	var req struct {
+		Token string `json:"token"`
+		Email string `json:"email"`
+		Name  string `json:"name"`
+	}
+	if err := c.Bind(&req); err != nil || req.Token == "" {
+		return respondError(c, http.StatusBadRequest, "token is required")
+	}
+	if req.Email == "" {
+		return respondError(c, http.StatusBadRequest, "email is required")
+	}
+
+	userInfo := authapp.UserInfo{
+		Provider:       "invite",
+		ProviderUserID: req.Email,
+		Email:          req.Email,
+		DisplayName:    req.Name,
+	}
+
+	agent, credential, _, err := h.inviteService.AcceptInvite(ctx, req.Token, userInfo)
+	if err != nil {
+		h.logger.Error(ctx, "failed to accept invite", "error", err)
+		switch {
+		case errors.Is(err, authapp.ErrInviteTokenInvalid):
+			return respondError(c, http.StatusBadRequest, "invite token is invalid")
+		case errors.Is(err, authapp.ErrInviteExpired):
+			return respondError(c, http.StatusBadRequest, "invite has expired")
+		case errors.Is(err, authapp.ErrInviteNotPending):
+			return respondError(c, http.StatusConflict, "invite is no longer pending")
+		case errors.Is(err, authapp.ErrInviteEmailMismatch):
+			return respondError(c, http.StatusBadRequest, "email does not match invite")
+		case errors.Is(err, authapp.ErrInviteNotFound):
+			return respondError(c, http.StatusNotFound, "invite not found")
+		default:
+			return respondError(c, http.StatusInternalServerError, "failed to accept invite")
+		}
+	}
+
+	email := ""
+	if credential != nil {
+		email = credential.Email()
+	}
+
+	return respond(c, http.StatusOK, UserResponse{
+		ID:    agent.GetID(),
+		Name:  agent.Name(),
+		Email: email,
+	})
+}
+
+func (h *InviteHandler) defaultAccountID(ctx context.Context) (string, error) {
+	accounts, err := h.accountRepo.FindAll(ctx, "", 1)
+	if err != nil {
+		return "", err
+	}
+	if len(accounts.Data) == 0 {
+		return "", nil
+	}
+	return accounts.Data[0].GetID(), nil
+}

--- a/api/handlers/invite_handler.go
+++ b/api/handlers/invite_handler.go
@@ -17,25 +17,28 @@ import (
 )
 
 type InviteHandler struct {
-	inviteService *authapp.InviteService
-	inviteRepo    authrepos.InviteRepository
-	accountRepo   authrepos.AccountRepository
-	logger        entities.Logger
+	inviteService  *authapp.InviteService
+	inviteRepo     authrepos.InviteRepository
+	accountRepo    authrepos.AccountRepository
+	credentialRepo authrepos.CredentialRepository
+	logger         entities.Logger
 }
 
 type InviteHandlerConfig struct {
-	InviteService *authapp.InviteService
-	InviteRepo    authrepos.InviteRepository
-	AccountRepo   authrepos.AccountRepository
-	Logger        entities.Logger
+	InviteService  *authapp.InviteService
+	InviteRepo     authrepos.InviteRepository
+	AccountRepo    authrepos.AccountRepository
+	CredentialRepo authrepos.CredentialRepository
+	Logger         entities.Logger
 }
 
 func NewInviteHandler(cfg InviteHandlerConfig) *InviteHandler {
 	return &InviteHandler{
-		inviteService: cfg.InviteService,
-		inviteRepo:    cfg.InviteRepo,
-		accountRepo:   cfg.AccountRepo,
-		logger:        cfg.Logger,
+		inviteService:  cfg.InviteService,
+		inviteRepo:     cfg.InviteRepo,
+		accountRepo:    cfg.AccountRepo,
+		credentialRepo: cfg.CredentialRepo,
+		logger:         cfg.Logger,
 	}
 }
 
@@ -58,6 +61,11 @@ type InviteResponse struct {
 func (h *InviteHandler) Create(c echo.Context) error {
 	ctx := c.Request().Context()
 
+	identity := auth.AgentFromCtx(ctx)
+	if identity == nil {
+		return respondError(c, http.StatusUnauthorized, "not authenticated")
+	}
+
 	isAdmin, err := apimw.IsAdmin(ctx, h.accountRepo)
 	if err != nil {
 		h.logger.Error(ctx, "failed to check admin status", "error", err)
@@ -76,11 +84,6 @@ func (h *InviteHandler) Create(c echo.Context) error {
 	}
 	if req.Role == "" {
 		return respondError(c, http.StatusBadRequest, "role is required")
-	}
-
-	identity := auth.AgentFromCtx(ctx)
-	if identity == nil {
-		return respondError(c, http.StatusUnauthorized, "not authenticated")
 	}
 
 	accountID := identity.ActiveAccountID
@@ -122,6 +125,11 @@ func (h *InviteHandler) Create(c echo.Context) error {
 func (h *InviteHandler) List(c echo.Context) error {
 	ctx := c.Request().Context()
 
+	identity := auth.AgentFromCtx(ctx)
+	if identity == nil {
+		return respondError(c, http.StatusUnauthorized, "not authenticated")
+	}
+
 	isAdmin, err := apimw.IsAdmin(ctx, h.accountRepo)
 	if err != nil {
 		h.logger.Error(ctx, "failed to check admin status", "error", err)
@@ -131,10 +139,6 @@ func (h *InviteHandler) List(c echo.Context) error {
 		return respondError(c, http.StatusForbidden, "admin role required")
 	}
 
-	identity := auth.AgentFromCtx(ctx)
-	if identity == nil {
-		return respondError(c, http.StatusUnauthorized, "not authenticated")
-	}
 	accountID := identity.ActiveAccountID
 	if accountID == "" {
 		var acctErr error
@@ -174,6 +178,11 @@ func (h *InviteHandler) Revoke(c echo.Context) error {
 	id := c.Param("id")
 	ctx := c.Request().Context()
 
+	identity := auth.AgentFromCtx(ctx)
+	if identity == nil {
+		return respondError(c, http.StatusUnauthorized, "not authenticated")
+	}
+
 	isAdmin, err := apimw.IsAdmin(ctx, h.accountRepo)
 	if err != nil {
 		h.logger.Error(ctx, "failed to check admin status", "error", err)
@@ -181,11 +190,6 @@ func (h *InviteHandler) Revoke(c echo.Context) error {
 	}
 	if !isAdmin {
 		return respondError(c, http.StatusForbidden, "admin role required")
-	}
-
-	identity := auth.AgentFromCtx(ctx)
-	if identity == nil {
-		return respondError(c, http.StatusUnauthorized, "not authenticated")
 	}
 
 	if err := h.inviteService.RevokeInvite(ctx, id, identity.AgentID); err != nil {
@@ -207,8 +211,8 @@ func (h *InviteHandler) Revoke(c echo.Context) error {
 
 // Accept handles POST /api/invites/accept — accepts an invite using the token.
 // This is a public endpoint (no auth required) — the token IS the authorization.
-// The invitee provides their info so AcceptInvite can create the credential
-// and verify the email matches the invite.
+// When the caller is authenticated (post-OAuth), the email is derived from
+// the session identity rather than trusting the request body.
 func (h *InviteHandler) Accept(c echo.Context) error {
 	ctx := c.Request().Context()
 
@@ -220,15 +224,26 @@ func (h *InviteHandler) Accept(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.Token == "" {
 		return respondError(c, http.StatusBadRequest, "token is required")
 	}
-	if req.Email == "" {
+
+	// When authenticated, derive email from the session to prevent spoofing.
+	email := req.Email
+	name := req.Name
+	if identity := auth.AgentFromCtx(ctx); identity != nil && h.credentialRepo != nil {
+		creds, credErr := h.credentialRepo.FindByAgent(ctx, identity.AgentID)
+		if credErr == nil && len(creds) > 0 {
+			email = creds[0].Email()
+		}
+	}
+
+	if email == "" {
 		return respondError(c, http.StatusBadRequest, "email is required")
 	}
 
 	userInfo := authapp.UserInfo{
 		Provider:       "invite",
-		ProviderUserID: req.Email,
-		Email:          req.Email,
-		DisplayName:    req.Name,
+		ProviderUserID: email,
+		Email:          email,
+		DisplayName:    name,
 	}
 
 	agent, credential, _, err := h.inviteService.AcceptInvite(ctx, req.Token, userInfo)
@@ -250,15 +265,15 @@ func (h *InviteHandler) Accept(c echo.Context) error {
 		}
 	}
 
-	email := ""
+	credEmail := ""
 	if credential != nil {
-		email = credential.Email()
+		credEmail = credential.Email()
 	}
 
 	return respond(c, http.StatusOK, UserResponse{
 		ID:    agent.GetID(),
 		Name:  agent.Name(),
-		Email: email,
+		Email: credEmail,
 	})
 }
 

--- a/api/handlers/invite_handler.go
+++ b/api/handlers/invite_handler.go
@@ -101,11 +101,12 @@ func (h *InviteHandler) Create(c echo.Context) error {
 
 	invite, token, err := h.inviteService.CreateInvite(ctx, accountID, req.Email, req.Role, identity.AgentID)
 	if err != nil {
-		h.logger.Error(ctx, "failed to create invite", "error", err)
 		switch {
 		case errors.Is(err, authapp.ErrNotAccountAdmin):
+			h.logger.Warn(ctx, "invite create forbidden", "error", err)
 			return respondError(c, http.StatusForbidden, "admin role required for this account")
 		default:
+			h.logger.Error(ctx, "failed to create invite", "error", err)
 			return respondError(c, http.StatusInternalServerError, "failed to create invite")
 		}
 	}
@@ -193,15 +194,18 @@ func (h *InviteHandler) Revoke(c echo.Context) error {
 	}
 
 	if err := h.inviteService.RevokeInvite(ctx, id, identity.AgentID); err != nil {
-		h.logger.Error(ctx, "failed to revoke invite", "error", err, "invite_id", id)
 		switch {
 		case errors.Is(err, authapp.ErrInviteNotFound):
+			h.logger.Warn(ctx, "invite not found for revoke", "invite_id", id)
 			return respondError(c, http.StatusNotFound, "invite not found")
 		case errors.Is(err, authapp.ErrInviteNotPending):
+			h.logger.Warn(ctx, "invite not pending for revoke", "invite_id", id)
 			return respondError(c, http.StatusConflict, "invite is no longer pending")
 		case errors.Is(err, authapp.ErrNotAccountAdmin):
+			h.logger.Warn(ctx, "revoke forbidden", "error", err, "invite_id", id)
 			return respondError(c, http.StatusForbidden, "admin role required for this account")
 		default:
+			h.logger.Error(ctx, "failed to revoke invite", "error", err, "invite_id", id)
 			return respondError(c, http.StatusInternalServerError, "failed to revoke invite")
 		}
 	}
@@ -261,19 +265,24 @@ func (h *InviteHandler) Accept(c echo.Context) error {
 
 	agent, credential, _, err := h.inviteService.AcceptInvite(ctx, req.Token, userInfo)
 	if err != nil {
-		h.logger.Error(ctx, "failed to accept invite", "error", err)
 		switch {
 		case errors.Is(err, authapp.ErrInviteTokenInvalid):
+			h.logger.Warn(ctx, "invalid invite token", "error", err)
 			return respondError(c, http.StatusBadRequest, "invite token is invalid")
 		case errors.Is(err, authapp.ErrInviteExpired):
+			h.logger.Warn(ctx, "expired invite token", "error", err)
 			return respondError(c, http.StatusBadRequest, "invite has expired")
 		case errors.Is(err, authapp.ErrInviteNotPending):
+			h.logger.Warn(ctx, "invite not pending", "error", err)
 			return respondError(c, http.StatusConflict, "invite is no longer pending")
 		case errors.Is(err, authapp.ErrInviteEmailMismatch):
+			h.logger.Warn(ctx, "invite email mismatch", "error", err)
 			return respondError(c, http.StatusBadRequest, "email does not match invite")
 		case errors.Is(err, authapp.ErrInviteNotFound):
+			h.logger.Warn(ctx, "invite not found", "error", err)
 			return respondError(c, http.StatusNotFound, "invite not found")
 		default:
+			h.logger.Error(ctx, "failed to accept invite", "error", err)
 			return respondError(c, http.StatusInternalServerError, "failed to accept invite")
 		}
 	}

--- a/api/handlers/invite_handler.go
+++ b/api/handlers/invite_handler.go
@@ -86,7 +86,7 @@ func (h *InviteHandler) Create(c echo.Context) error {
 	accountID := identity.ActiveAccountID
 	if accountID == "" {
 		var acctErr error
-		accountID, acctErr = h.defaultAccountID(ctx)
+		accountID, acctErr = h.agentAccountID(ctx, identity.AgentID)
 		if acctErr != nil {
 			h.logger.Error(ctx, "failed to resolve account", "error", acctErr)
 			return respondError(c, http.StatusInternalServerError, "failed to resolve account")
@@ -132,13 +132,13 @@ func (h *InviteHandler) List(c echo.Context) error {
 	}
 
 	identity := auth.AgentFromCtx(ctx)
-	accountID := ""
-	if identity != nil {
-		accountID = identity.ActiveAccountID
+	if identity == nil {
+		return respondError(c, http.StatusUnauthorized, "not authenticated")
 	}
+	accountID := identity.ActiveAccountID
 	if accountID == "" {
 		var acctErr error
-		accountID, acctErr = h.defaultAccountID(ctx)
+		accountID, acctErr = h.agentAccountID(ctx, identity.AgentID)
 		if acctErr != nil {
 			h.logger.Error(ctx, "failed to resolve account", "error", acctErr)
 			return respondError(c, http.StatusInternalServerError, "failed to resolve account")
@@ -262,13 +262,13 @@ func (h *InviteHandler) Accept(c echo.Context) error {
 	})
 }
 
-func (h *InviteHandler) defaultAccountID(ctx context.Context) (string, error) {
-	accounts, err := h.accountRepo.FindAll(ctx, "", 1)
+func (h *InviteHandler) agentAccountID(ctx context.Context, agentID string) (string, error) {
+	accounts, err := h.accountRepo.FindByMember(ctx, agentID)
 	if err != nil {
 		return "", err
 	}
-	if len(accounts.Data) == 0 {
+	if len(accounts) == 0 {
 		return "", nil
 	}
-	return accounts.Data[0].GetID(), nil
+	return accounts[0].GetID(), nil
 }

--- a/api/middleware/optional_auth.go
+++ b/api/middleware/optional_auth.go
@@ -1,0 +1,43 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
+	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
+	"github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/session"
+)
+
+// OptionalAuth loads session identity into the request context when a valid
+// session exists, but passes through anonymously when it does not. Use this
+// for endpoints that behave differently for authenticated vs. anonymous
+// callers (e.g., invite acceptance derives email from the session when
+// available).
+func OptionalAuth(
+	sm session.SessionManager,
+	as authapp.AuthenticationService,
+) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			sessionData, err := sm.GetHTTPSession(r)
+			if err != nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			sessionInfo, err := as.ValidateSession(r.Context(), sessionData.SessionID)
+			if err != nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			id := &auth.Identity{
+				AgentID:         sessionInfo.AgentID,
+				AccountIDs:      []string{sessionInfo.AccountID},
+				ActiveAccountID: sessionInfo.AccountID,
+			}
+			ctx := auth.ContextWithAgent(r.Context(), id)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}

--- a/application/module.go
+++ b/application/module.go
@@ -13,6 +13,7 @@ import (
 	storageprovider "weos/infrastructure/storage/provider"
 	"weos/internal/config"
 
+	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
 	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
 	authgorm "github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/database/gorm"
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
@@ -86,6 +87,7 @@ func Module(cfg config.Config, registry *PresetRegistry) fx.Option {
 			return authgorm.NewAuthSessionRepository(db)
 		}),
 		fx.Provide(func(db *gormdb.DB) authrepos.AccountRepository { return authgorm.NewAccountRepository(db) }),
+		fx.Provide(func(db *gormdb.DB) authrepos.InviteRepository { return authgorm.NewInviteRepository(db) }),
 
 		// Auth infrastructure
 		fx.Provide(ProvideOAuthProviderRegistry),
@@ -93,6 +95,18 @@ func Module(cfg config.Config, registry *PresetRegistry) fx.Option {
 		fx.Provide(ProvideAuthenticationService),
 		fx.Provide(ProvideSessionManager),
 		fx.Provide(auth.ProvideInviteTokenService),
+		fx.Provide(func(
+			invites authrepos.InviteRepository,
+			agents authrepos.AgentRepository,
+			accounts authrepos.AccountRepository,
+			creds authrepos.CredentialRepository,
+			tokenSvc authapp.InviteTokenService,
+			logger entities.Logger,
+		) *authapp.InviteService {
+			return authapp.NewInviteService(invites, agents, accounts, creds, tokenSvc,
+				authapp.WithInviteLogger(logger),
+			)
+		}),
 
 		// Resource behavior registries (must come before ProvideResourceService).
 		// The lazy resource writer breaks the construction cycle between

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -307,10 +307,11 @@ func runServe(cmd *cobra.Command, args []string) error {
 	protected.PUT("/users/:id", userHandler.Update)
 
 	inviteHandler := handlers.NewInviteHandler(handlers.InviteHandlerConfig{
-		InviteService: inviteService,
-		InviteRepo:    inviteRepo,
-		AccountRepo:   accountRepo,
-		Logger:        logger,
+		InviteService:  inviteService,
+		InviteRepo:     inviteRepo,
+		AccountRepo:    accountRepo,
+		CredentialRepo: credentialRepo,
+		Logger:         logger,
 	})
 	protected.POST("/invites", inviteHandler.Create)
 	protected.GET("/invites", inviteHandler.List)

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -316,7 +316,17 @@ func runServe(cmd *cobra.Command, args []string) error {
 	protected.POST("/invites", inviteHandler.Create)
 	protected.GET("/invites", inviteHandler.List)
 	protected.DELETE("/invites/:id", inviteHandler.Revoke)
-	api.POST("/invites/accept", inviteHandler.Accept)
+
+	// Accept uses a separate group that loads session identity when present
+	// (so the handler can verify email from the session) but does not require
+	// auth — the invite token itself is the authorization.
+	acceptGroup := api.Group("")
+	if appCfg.OAuthEnabled() {
+		acceptGroup.Use(echo.WrapMiddleware(apimw.OptionalAuth(sessionManager, authService)))
+	} else {
+		acceptGroup.Use(apimw.SoftAuth(credentialRepo, agentRepo, accountRepo, logger))
+	}
+	acceptGroup.POST("/invites/accept", inviteHandler.Accept)
 
 	protected.POST("/admin/impersonate", impersonationHandler.Start)
 	protected.POST("/admin/stop-impersonation", impersonationHandler.Stop)

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -320,11 +320,13 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// Accept uses a separate group that loads session identity when present
 	// (so the handler can verify email from the session) but does not require
 	// auth — the invite token itself is the authorization.
+	// In dev mode (no OAuth), no auth middleware is applied so the handler
+	// runs anonymously and uses the request-body email. SoftAuth is NOT used
+	// here because it defaults to admin@weos.dev, which would force the
+	// fail-closed session-email path for every accept request.
 	acceptGroup := api.Group("")
 	if appCfg.OAuthEnabled() {
 		acceptGroup.Use(echo.WrapMiddleware(apimw.OptionalAuth(sessionManager, authService)))
-	} else {
-		acceptGroup.Use(apimw.SoftAuth(credentialRepo, agentRepo, accountRepo, logger))
 	}
 	acceptGroup.POST("/invites/accept", inviteHandler.Accept)
 

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -90,6 +90,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 	var roleAccessRepo *gormdb.RoleResourceAccessRepository
 	var authzChecker *authcasbin.CasbinAuthorizationChecker
 	var jwtService authapp.JWTService
+	var inviteService *authapp.InviteService
+	var inviteRepo authrepos.InviteRepository
 	var db *gormlib.DB
 
 	registry := presets.NewDefaultRegistry()
@@ -114,6 +116,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 		fx.Populate(&roleAccessRepo),
 		fx.Populate(&authzChecker),
 		fx.Populate(&jwtService),
+		fx.Populate(&inviteService),
+		fx.Populate(&inviteRepo),
 		fx.Populate(&db),
 	)
 
@@ -301,6 +305,17 @@ func runServe(cmd *cobra.Command, args []string) error {
 	protected.GET("/users", userHandler.List)
 	protected.GET("/users/:id", userHandler.Get)
 	protected.PUT("/users/:id", userHandler.Update)
+
+	inviteHandler := handlers.NewInviteHandler(handlers.InviteHandlerConfig{
+		InviteService: inviteService,
+		InviteRepo:    inviteRepo,
+		AccountRepo:   accountRepo,
+		Logger:        logger,
+	})
+	protected.POST("/invites", inviteHandler.Create)
+	protected.GET("/invites", inviteHandler.List)
+	protected.DELETE("/invites/:id", inviteHandler.Revoke)
+	api.POST("/invites/accept", inviteHandler.Accept)
 
 	protected.POST("/admin/impersonate", impersonationHandler.Start)
 	protected.POST("/admin/stop-impersonation", impersonationHandler.Stop)

--- a/web/admin/middleware/auth.global.ts
+++ b/web/admin/middleware/auth.global.ts
@@ -1,7 +1,7 @@
 export default defineNuxtRouteMiddleware(async (to) => {
   // Auth check only runs client-side — during SSR the API proxy isn't available
   if (import.meta.server) return
-  if (to.path === '/login') return
+  if (to.path === '/login' || to.path === '/invite') return
 
   const { user, loading, fetchUser } = useAuth()
 

--- a/web/admin/pages/invite.vue
+++ b/web/admin/pages/invite.vue
@@ -39,13 +39,14 @@
 </template>
 
 <script setup lang="ts">
-import { forwardMessages } from '~/composables/useApi'
+import { unwrapEnvelope, forwardMessages } from '~/composables/useApi'
 
 definePageMeta({
   layout: false,
 })
 
 const route = useRoute()
+const { user, fetchUser } = useAuth()
 const token = computed(() => (route.query.token as string) || '')
 const error = ref('')
 const accepting = ref(false)
@@ -56,9 +57,6 @@ async function acceptOrLogin() {
     error.value = 'No invite token provided.'
     return
   }
-  // Redirect to OAuth login with a redirect back to this page (preserving the token).
-  // After login, the auth middleware will recognize the user and onMounted will
-  // auto-accept below.
   const redirectBack = `/invite?token=${encodeURIComponent(token.value)}`
   window.location.href = '/api/auth/login?redirect=' + encodeURIComponent(redirectBack)
 }
@@ -71,13 +69,12 @@ onMounted(async () => {
 
   // Check if user is already authenticated (e.g., after OAuth redirect back).
   // If so, auto-accept the invite.
-  const { user, fetchUser } = useAuth()
   await fetchUser()
 
   if (user.value) {
     accepting.value = true
     try {
-      await $fetch('/api/invites/accept', {
+      const raw = await $fetch<unknown>('/api/invites/accept', {
         method: 'POST',
         body: {
           token: token.value,
@@ -85,6 +82,7 @@ onMounted(async () => {
           name: user.value.name || '',
         },
       })
+      forwardMessages(raw)
       accepted.value = true
       setTimeout(() => navigateTo('/'), 1500)
     } catch (err: any) {

--- a/web/admin/pages/invite.vue
+++ b/web/admin/pages/invite.vue
@@ -39,6 +39,8 @@
 </template>
 
 <script setup lang="ts">
+import { forwardMessages } from '~/composables/useApi'
+
 definePageMeta({
   layout: false,
 })
@@ -86,7 +88,9 @@ onMounted(async () => {
       accepted.value = true
       setTimeout(() => navigateTo('/'), 1500)
     } catch (err: any) {
+      if (err?.data) forwardMessages(err.data)
       error.value = err?.data?.error || 'Failed to accept invite.'
+      console.error('[invite] accept failed:', err)
     } finally {
       accepting.value = false
     }

--- a/web/admin/pages/invite.vue
+++ b/web/admin/pages/invite.vue
@@ -25,6 +25,26 @@
         <a-spin size="large" />
       </template>
 
+      <template v-else-if="needsEmail">
+        <h1 style="margin-bottom: 8px">You're Invited</h1>
+        <p style="color: #666; margin-bottom: 24px">
+          Enter your details to accept this invitation.
+        </p>
+        <a-form layout="vertical">
+          <a-form-item label="Email" :required="true">
+            <a-input v-model:value="manualEmail" placeholder="you@example.com" />
+          </a-form-item>
+          <a-form-item label="Name">
+            <a-input v-model:value="manualName" placeholder="Your name" />
+          </a-form-item>
+          <a-form-item>
+            <a-button type="primary" block @click="acceptWithEmail">
+              Accept Invite
+            </a-button>
+          </a-form-item>
+        </a-form>
+      </template>
+
       <template v-else>
         <h1 style="margin-bottom: 8px">You're Invited</h1>
         <p style="color: #666; margin-bottom: 24px">
@@ -39,7 +59,8 @@
 </template>
 
 <script setup lang="ts">
-import { unwrapEnvelope, forwardMessages } from '~/composables/useApi'
+import { message } from 'ant-design-vue'
+import { forwardMessages } from '~/composables/useApi'
 
 definePageMeta({
   layout: false,
@@ -51,6 +72,9 @@ const token = computed(() => (route.query.token as string) || '')
 const error = ref('')
 const accepting = ref(false)
 const accepted = ref(false)
+const needsEmail = ref(false)
+const manualEmail = ref('')
+const manualName = ref('')
 
 async function acceptOrLogin() {
   if (!token.value) {
@@ -61,6 +85,33 @@ async function acceptOrLogin() {
   window.location.href = '/api/auth/login?redirect=' + encodeURIComponent(redirectBack)
 }
 
+async function submitAccept(email: string, name: string) {
+  if (!email) {
+    message.error('Email is required')
+    return
+  }
+  accepting.value = true
+  try {
+    const raw = await $fetch<unknown>('/api/invites/accept', {
+      method: 'POST',
+      body: { token: token.value, email, name },
+    })
+    forwardMessages(raw)
+    accepted.value = true
+    setTimeout(() => navigateTo('/'), 1500)
+  } catch (err: any) {
+    if (err?.data) forwardMessages(err.data)
+    error.value = err?.data?.error || 'Failed to accept invite.'
+    console.error('[invite] accept failed:', err)
+  } finally {
+    accepting.value = false
+  }
+}
+
+async function acceptWithEmail() {
+  await submitAccept(manualEmail.value, manualName.value)
+}
+
 onMounted(async () => {
   if (!token.value) {
     error.value = 'No invite token provided.'
@@ -68,30 +119,16 @@ onMounted(async () => {
   }
 
   // Check if user is already authenticated (e.g., after OAuth redirect back).
-  // If so, auto-accept the invite.
+  // If so, auto-accept the invite using the session email.
   await fetchUser()
 
   if (user.value) {
-    accepting.value = true
-    try {
-      const raw = await $fetch<unknown>('/api/invites/accept', {
-        method: 'POST',
-        body: {
-          token: token.value,
-          email: user.value.email,
-          name: user.value.name || '',
-        },
-      })
-      forwardMessages(raw)
-      accepted.value = true
-      setTimeout(() => navigateTo('/'), 1500)
-    } catch (err: any) {
-      if (err?.data) forwardMessages(err.data)
-      error.value = err?.data?.error || 'Failed to accept invite.'
-      console.error('[invite] accept failed:', err)
-    } finally {
-      accepting.value = false
-    }
+    await submitAccept(user.value.email, user.value.name || '')
+  } else {
+    // No authenticated user — show email form so the user can accept
+    // without OAuth (e.g., dev mode where SoftAuth is not applied to
+    // the accept endpoint).
+    needsEmail.value = true
   }
 })
 </script>

--- a/web/admin/pages/invite.vue
+++ b/web/admin/pages/invite.vue
@@ -1,0 +1,95 @@
+<template>
+  <div
+    style="
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      background: #f0f2f5;
+    "
+  >
+    <a-card style="width: 400px; text-align: center">
+      <template v-if="error">
+        <h2 style="color: #ff4d4f">Invalid Invite</h2>
+        <p style="color: #666">{{ error }}</p>
+        <a-button type="primary" @click="navigateTo('/login')">Go to Login</a-button>
+      </template>
+
+      <template v-else-if="accepted">
+        <h2 style="color: #52c41a">Invite Accepted</h2>
+        <p style="color: #666">Your account has been activated. Redirecting...</p>
+      </template>
+
+      <template v-else-if="accepting">
+        <h2>Accepting Invite...</h2>
+        <a-spin size="large" />
+      </template>
+
+      <template v-else>
+        <h1 style="margin-bottom: 8px">You're Invited</h1>
+        <p style="color: #666; margin-bottom: 24px">
+          Sign in to accept this invitation and join the team.
+        </p>
+        <a-button type="primary" size="large" block @click="acceptOrLogin">
+          Sign in with Google
+        </a-button>
+      </template>
+    </a-card>
+  </div>
+</template>
+
+<script setup lang="ts">
+definePageMeta({
+  layout: false,
+})
+
+const route = useRoute()
+const token = computed(() => (route.query.token as string) || '')
+const error = ref('')
+const accepting = ref(false)
+const accepted = ref(false)
+
+async function acceptOrLogin() {
+  if (!token.value) {
+    error.value = 'No invite token provided.'
+    return
+  }
+  // Redirect to OAuth login with a redirect back to this page (preserving the token).
+  // After login, the auth middleware will recognize the user and onMounted will
+  // auto-accept below.
+  const redirectBack = `/invite?token=${encodeURIComponent(token.value)}`
+  window.location.href = '/api/auth/login?redirect=' + encodeURIComponent(redirectBack)
+}
+
+onMounted(async () => {
+  if (!token.value) {
+    error.value = 'No invite token provided.'
+    return
+  }
+
+  // Check if user is already authenticated (e.g., after OAuth redirect back).
+  // If so, auto-accept the invite.
+  const { user, fetchUser } = useAuth()
+  await fetchUser()
+
+  if (user.value) {
+    accepting.value = true
+    try {
+      await $fetch('/api/invites/accept', {
+        method: 'POST',
+        body: {
+          token: token.value,
+          email: user.value.email,
+          name: user.value.name || '',
+        },
+      })
+      accepted.value = true
+      setTimeout(() => navigateTo('/'), 1500)
+    } catch (err: any) {
+      error.value = err?.data?.error || 'Failed to accept invite.'
+    } finally {
+      accepting.value = false
+    }
+  }
+})
+</script>

--- a/web/admin/pages/users/index.vue
+++ b/web/admin/pages/users/index.vue
@@ -19,6 +19,7 @@
   <div>
     <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px">
       <h2 style="margin: 0">Users</h2>
+      <a-button type="primary" @click="openInviteModal">Invite User</a-button>
     </div>
 
     <a-table
@@ -46,6 +47,38 @@
       </template>
     </a-table>
 
+    <!-- Pending Invites -->
+    <div v-if="invites.length > 0" style="margin-top: 32px">
+      <h3>Pending Invites</h3>
+      <a-table
+        :columns="inviteColumns"
+        :data-source="invites"
+        :pagination="false"
+        :scroll="{ x: 'max-content' }"
+        row-key="id"
+      >
+        <template #bodyCell="{ column, record }">
+          <template v-if="column.key === 'role'">
+            {{ capitalize(record.role) }}
+          </template>
+          <template v-if="column.key === 'status'">
+            <a-tag :color="record.status === 'pending' ? 'blue' : 'default'">
+              {{ capitalize(record.status) }}
+            </a-tag>
+          </template>
+          <template v-if="column.key === 'actions'">
+            <a-button
+              v-if="record.status === 'pending'"
+              size="small"
+              danger
+              @click="revokeInvite(record.id)"
+            >Revoke</a-button>
+          </template>
+        </template>
+      </a-table>
+    </div>
+
+    <!-- Edit User Modal -->
     <a-modal
       v-model:open="showEditModal"
       title="Edit User"
@@ -68,6 +101,45 @@
         </a-form-item>
       </a-form>
     </a-modal>
+
+    <!-- Invite User Modal -->
+    <a-modal
+      v-model:open="showInviteModalFlag"
+      title="Invite User"
+      :footer="null"
+    >
+      <a-form layout="vertical">
+        <a-form-item label="Email" :required="true">
+          <a-input v-model:value="inviteForm.email" placeholder="user@example.com" />
+        </a-form-item>
+        <a-form-item label="Role">
+          <a-select v-model:value="inviteForm.role">
+            <a-select-option v-for="r in availableRoles" :key="r" :value="r">
+              {{ capitalize(r) }}
+            </a-select-option>
+          </a-select>
+        </a-form-item>
+
+        <div v-if="inviteLink" style="margin-bottom: 16px">
+          <a-form-item label="Invite Link">
+            <a-input-group compact>
+              <a-input :value="inviteLink" readonly style="width: calc(100% - 80px)" />
+              <a-button type="primary" @click="copyLink">Copy</a-button>
+            </a-input-group>
+          </a-form-item>
+        </div>
+
+        <a-form-item>
+          <a-button
+            type="primary"
+            :loading="inviting"
+            @click="handleInvite"
+          >
+            {{ inviteLink ? 'Generate New Link' : 'Generate Invite Link' }}
+          </a-button>
+        </a-form-item>
+      </a-form>
+    </a-modal>
   </div>
 </template>
 
@@ -79,13 +151,22 @@ const { user, startImpersonation } = useAuth()
 const router = useRouter()
 const loading = ref(true)
 const users = ref<any[]>([])
+const invites = ref<any[]>([])
 const availableRoles = ref<string[]>([])
 const showEditModal = ref(false)
 const editing = ref(false)
+const showInviteModalFlag = ref(false)
+const inviting = ref(false)
+const inviteLink = ref('')
 
 const editForm = reactive({
   id: '',
   name: '',
+  email: '',
+  role: '',
+})
+
+const inviteForm = reactive({
   email: '',
   role: '',
 })
@@ -112,13 +193,22 @@ const columns = computed(() => {
   ]
 })
 
+const inviteColumns = [
+  { title: 'Email', dataIndex: 'email', key: 'email' },
+  { title: 'Role', dataIndex: 'role', key: 'role' },
+  { title: 'Status', dataIndex: 'status', key: 'status' },
+  { title: 'Expires', dataIndex: 'expires_at', key: 'expires_at' },
+  { title: 'Actions', key: 'actions', width: 100 },
+]
+
 async function fetchRoles() {
   try {
     const raw = await $fetch<unknown>('/api/settings/roles')
     const res = unwrapEnvelope<{ roles: string[] }>(raw)
     availableRoles.value = res.roles || []
   } catch (err) {
-    console.warn('[users] fetchRoles failed, using defaults:', err)
+    message.warning('Could not load roles — using defaults')
+    console.error('[users] fetchRoles failed:', err)
     availableRoles.value = ['admin', 'instructor']
   }
 }
@@ -134,6 +224,18 @@ async function fetchUsers() {
     console.error('[users] fetchUsers failed:', err)
   } finally {
     loading.value = false
+  }
+}
+
+async function fetchInvites() {
+  try {
+    const raw = await $fetch<unknown>('/api/invites')
+    const all = unwrapEnvelope<any[]>(raw) || []
+    invites.value = all.filter((i) => i.status === 'pending')
+  } catch (err: any) {
+    if (err?.data) forwardMessages(err.data)
+    message.error('Failed to load invites')
+    console.error('[users] fetchInvites failed:', err)
   }
 }
 
@@ -162,6 +264,58 @@ async function handleEdit() {
   }
 }
 
+function openInviteModal() {
+  inviteForm.email = ''
+  inviteForm.role = availableRoles.value[0] ?? ''
+  inviteLink.value = ''
+  showInviteModalFlag.value = true
+}
+
+async function handleInvite() {
+  if (!inviteForm.email) {
+    message.error('Email is required')
+    return
+  }
+  if (!inviteForm.role) {
+    message.error('Role is required')
+    return
+  }
+  inviting.value = true
+  try {
+    const raw = await $fetch<unknown>('/api/invites', {
+      method: 'POST',
+      body: { email: inviteForm.email, role: inviteForm.role },
+    })
+    const res = unwrapEnvelope<any>(raw)
+    inviteLink.value = `${window.location.origin}/invite?token=${res.token}`
+    message.success('Invite link generated')
+    await fetchInvites()
+  } catch (err: any) {
+    message.error(err?.data?.error || 'Failed to create invite')
+  } finally {
+    inviting.value = false
+  }
+}
+
+async function copyLink() {
+  try {
+    await navigator.clipboard.writeText(inviteLink.value)
+    message.success('Link copied to clipboard')
+  } catch {
+    message.error('Failed to copy link')
+  }
+}
+
+async function revokeInvite(id: string) {
+  try {
+    await $fetch(`/api/invites/${id}`, { method: 'DELETE' })
+    message.success('Invite revoked')
+    await fetchInvites()
+  } catch (err: any) {
+    message.error(err?.data?.error || 'Failed to revoke invite')
+  }
+}
+
 async function impersonate(agentId: string) {
   try {
     await startImpersonation(agentId)
@@ -174,5 +328,6 @@ async function impersonate(agentId: string) {
 onMounted(() => {
   fetchRoles()
   fetchUsers()
+  fetchInvites()
 })
 </script>

--- a/web/admin/pages/users/index.vue
+++ b/web/admin/pages/users/index.vue
@@ -287,7 +287,7 @@ async function handleInvite() {
       body: { email: inviteForm.email, role: inviteForm.role },
     })
     const res = unwrapEnvelope<any>(raw)
-    inviteLink.value = `${window.location.origin}/invite?token=${res.token}`
+    inviteLink.value = `${window.location.origin}/invite?token=${encodeURIComponent(res.token)}`
     message.success('Invite link generated')
     await fetchInvites()
   } catch (err: any) {

--- a/web/admin/pages/users/index.vue
+++ b/web/admin/pages/users/index.vue
@@ -276,8 +276,8 @@ async function handleInvite() {
     message.error('Email is required')
     return
   }
-  if (!inviteForm.role) {
-    message.error('Role is required')
+  if (!inviteForm.role || !availableRoles.value.includes(inviteForm.role)) {
+    message.error('Please select a valid role')
     return
   }
   inviting.value = true
@@ -291,7 +291,9 @@ async function handleInvite() {
     message.success('Invite link generated')
     await fetchInvites()
   } catch (err: any) {
+    if (err?.data) forwardMessages(err.data)
     message.error(err?.data?.error || 'Failed to create invite')
+    console.error('[users] handleInvite failed:', err)
   } finally {
     inviting.value = false
   }
@@ -312,7 +314,9 @@ async function revokeInvite(id: string) {
     message.success('Invite revoked')
     await fetchInvites()
   } catch (err: any) {
+    if (err?.data) forwardMessages(err.data)
     message.error(err?.data?.error || 'Failed to revoke invite')
+    console.error('[users] revokeInvite failed:', err)
   }
 }
 


### PR DESCRIPTION
## Summary

- Wire up `InviteService` and `InviteRepository` from pericarp into the DI container and register invite API routes
- Add `InviteHandler` with typed error responses using `errors.Is` against pericarp sentinel errors (not raw `err.Error()`)
- Add invite UI to admin users page: invite modal, pending invites table, revoke button
- Add `invite.vue` acceptance page for the token-based invite flow

## Security hardening (from code review)

- Accept handler (public endpoint) never leaks internal error messages — uses `errors.Is` to map sentinel errors to safe HTTP responses (400/404/409), generic 500 for unknown errors
- Provider changed from hardcoded `"google"` to `"invite"` to distinguish invite-created credentials from OAuth credentials
- `defaultAccountID` now returns errors instead of swallowing DB failures
- Frontend shows error messages for all failed API calls (no silent drops)
- Client-side role validation before invite submission

## Test plan

- [x] `make test` — all 15 packages pass
- [x] `make lint` — 0 issues
- [x] Manual: admin can create invite → generates link → pending invites table shows it
- [x] Manual: revoking an invite removes it from pending list
- [ ] Manual: accepting an invite with valid token creates the user
- [ ] Manual: accepting with invalid/expired token returns appropriate error message (not internal details)
- [ ] Manual: non-admin users cannot access invite endpoints (403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)