### PR TITLE
feat(admin): register Ant Design Vue globally for preset screens

### DIFF
--- a/web/admin/plugins/ant-design-vue.client.ts
+++ b/web/admin/plugins/ant-design-vue.client.ts
@@ -1,0 +1,45 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// Registers all Ant Design Vue components on the app-level Vue instance so
+// they're resolvable from *runtime-compiled* templates — specifically the
+// string templates inside preset screen .mjs modules loaded via Blob URL.
+//
+// The `@ant-design-vue/nuxt` module handles component auto-imports for
+// Nuxt-built SFCs at build time. That auto-import is invisible to modules
+// imported via `import(blobUrl)` at runtime, so preset screens see
+// <a-button>, <a-form>, <a-table> etc. as unresolved custom elements and
+// render them as raw HTML.
+//
+// Calling `app.use(Antd)` installs ant-design-vue as a Vue plugin, which
+// runs its install() function and registers every component globally.
+// Global registration is the first thing Vue's resolveComponent() checks
+// when it can't find a component locally, so preset screens pick them up.
+//
+// Bundle impact: the auto-import module tree-shakes unused components;
+// this plugin registers them all. For the admin app today, most ant
+// components are already bundled because the SFC pages use them; shipping
+// the rest to preset screens costs a small fraction of the already-large
+// admin bundle and keeps preset-screen authoring ergonomic.
+//
+// Client-only (.client.ts) because SSR is disabled for this app
+// (nuxt.config.ts: `ssr: false`) and preset screens only ever load in
+// the browser via a Blob URL.
+
+import Antd from 'ant-design-vue'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.use(Antd)
+})


### PR DESCRIPTION
## Summary

Adds a single Nuxt client plugin (`web/admin/plugins/ant-design-vue.client.ts`) that calls `app.use(Antd)`. This makes every Ant Design Vue component resolvable from *runtime-compiled* templates — specifically the string templates inside preset screen `.mjs` modules loaded via Blob URL.

## The problem this fixes

Today, `@ant-design-vue/nuxt` handles component auto-imports for Nuxt-built SFCs at build time. Those auto-imports are invisible to modules imported via `import(blobUrl)` at runtime, so preset screens render `<a-button>`, `<a-form>`, `<a-table>`, etc. as unresolved custom elements (raw HTML, no styling or behavior).

Reproduced by navigating to any preset screen that uses `<a-*>` components — including the known-good `education/screens/dist/course-instance/Dashboard.mjs`, whose `<a-button>` / `<a-divider>` / `<a-tag>` smoke-test elements were rendering as empty custom tags.

## The fix

`app.use(Antd)` registers every component on the Vue app instance globally. Vue's `resolveComponent()` checks the app-level registry when a component isn't found locally, so preset screens pick them up automatically.

## What this unlocks

Any preset shipping custom detail/create/dashboard screens under `screens/dist/<typeSlug>/<Name>.mjs` can now use the same ant-design component set that the built-in admin SFC pages use — without having to inline every component, ship plain HTML, or move the screens into core.

Next on the stack: wepala/weos-private-presets will land Detail.mjs / Create.mjs for course-instance using full ant components, with `resource_type_preset_handler` + `preset_screen_handler` already wired up.

## Trade-offs

- **Bundle size:** the auto-import module tree-shakes unused components; this plugin registers them all. For the admin app today most ant components are already bundled because the SFC pages use them. Shipping the rest costs a small fraction of the admin bundle and keeps preset-screen authoring ergonomic.
- **Client-only:** `.client.ts` suffix keeps this out of SSR. The app already has `ssr: false` in `nuxt.config.ts`, and preset screens only load in the browser via Blob URL, so there's no SSR concern here.

## Test plan
- [x] Built the admin bundle (`make dev-build-frontend`) and confirmed the plugin is included.
- [x] Rebuilt ic-crm; navigated to a preset `.mjs` screen using 25+ ant-design components (`<a-page-header>`, `<a-descriptions>`, `<a-table>`, `<a-checkbox>`, `<a-modal>`, `<a-form>`, `<a-select>`, `<a-input>`, etc.); zero unresolved `<a-*>` tags, 19+ `.ant-*` rendered classes, 0 console errors.
- [x] Confirmed the existing built-in SFC pages (Dashboard, resource list/detail/edit) still render correctly after the change.
- [x] End-to-end interaction: clicked an `<a-checkbox>` in a preset screen, observed the `@change` handler fired, POST landed, and state persisted across reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)