### PR TITLE
feat(web): add SetStaticFS for thin-wrap admin SPA override

### DIFF
--- a/docs/_tutorials/customizing-the-ui.md
+++ b/docs/_tutorials/customizing-the-ui.md
@@ -151,7 +151,7 @@ func StaticFS() fs.FS { return staticFS }
 func SetStaticFS(fsys fs.FS) { /* ... */ }
 ```
 
-See [`docs/decisions/admin-index-override.md`](../decisions/admin-index-override.md)
+See [`docs/decisions/admin-index-override.md`]({% link decisions/admin-index-override.md %})
 for the override pattern thin-wrap binaries use.
 
 The SPA middleware serves these assets:

--- a/docs/_tutorials/customizing-the-ui.md
+++ b/docs/_tutorials/customizing-the-ui.md
@@ -134,12 +134,25 @@ Themes control the visual appearance of your site:
 
 ## Static Asset Embedding
 
-The frontend assets are embedded at build time via `web/embed.go`:
+The frontend assets are embedded at build time via `web/embed.go`,
+which exposes them through a getter so a thin-wrap host binary can
+swap in its own SPA dist before the serve command runs:
 
 ```go
 //go:embed all:dist
-var StaticFS embed.FS
+var embeddedAdmin embed.FS
+
+var staticFS fs.FS = embeddedAdmin
+
+// StaticFS returns the active admin static filesystem.
+func StaticFS() fs.FS { return staticFS }
+
+// SetStaticFS replaces the FS — call from main() before serve.
+func SetStaticFS(fsys fs.FS) { /* ... */ }
 ```
+
+See [`docs/decisions/admin-index-override.md`](../decisions/admin-index-override.md)
+for the override pattern thin-wrap binaries use.
 
 The SPA middleware serves these assets:
 - Requests to `/api/*` go to API handlers

--- a/docs/decisions/admin-index-override.md
+++ b/docs/decisions/admin-index-override.md
@@ -1,0 +1,232 @@
+---
+title: "ADR: Admin Index Override for Thin-Wrap Binaries"
+parent: Architecture Decision Records
+layout: default
+nav_order: 5
+---
+
+# ADR: Admin Index Override for Thin-Wrap Binaries
+
+**Status:** Proposed
+**Date:** 2026-04-14
+**Context:** weos core ships a compiled Nuxt admin SPA embedded into every binary via `//go:embed all:dist` in `web/embed.go`. Thin-wrap products built on top of weos (e.g., `ic-crm`) want to replace just the admin's index page (`/`) with a product-specific dashboard, without forking the admin SPA or re-implementing the rest of its routes, components, and composables. This ADR decides the mechanism weos core exposes for that override.
+
+## Problem
+
+`ic-crm` is a thin-wrap binary around weos that registers the `education` and `finance` presets and delegates everything else to weos core. Its `CLAUDE.md` is explicit: any CRM-shaped behavior beyond preset wiring belongs upstream, not in the wrapper. That design goal is being tested by a real requirement: ic-crm has a product-specific `Dashboard.vue` (billing summary, weekly class schedule, outstanding invoices) that should render at `/`. Core's generic resource-types grid at `pages/index.vue` is wrong for this product.
+
+The preset screen system (today's `PresetDefinition.Screens` + `/api/resource-types/presets/:name/screens/:typeSlug/:file`) is scoped per resource type: files live at `<typeSlug>/<ScreenName>.mjs` and are reachable only at `/resources/<typeSlug>[/<id>]/screens/<name>`. There is **no top-level app-page hook**. ic-crm's Dashboard.vue has therefore been parked at `services/ic-crm/web/admin/src/pages/Dashboard.vue` with a README documenting the block.
+
+We need a way for a host binary to replace the admin's index without dragging in a general-purpose preset-app-pages framework (which would be a much larger design than this one requirement justifies).
+
+### Why each naive approach fails
+
+- **Edit `services/core/web/admin/pages/index.vue` directly from ic-crm.** Requires ic-crm to touch `services/core`'s working tree at build time, which means every thin-wrap build dirties a different repo. Concurrent branch work in core is at risk and any Makefile failure mid-build leaves core in a modified state.
+- **Swap only `dist/index.html` at serve time.** Nuxt's generated `index.html` is a 1-KB shell that imports hashed `_nuxt/*.js` chunks; the index route's component lives inside one of those chunks, not in the HTML. Swapping `index.html` alone does not change what renders at `/`.
+- **Fork the admin SPA into the thin-wrap.** Defeats the point of the thin-wrap pattern. Every admin-side improvement in core would then need to be manually reconciled in every product.
+
+## Constraints
+
+Verified during exploration. Any option must respect these.
+
+- **`web/embed.go:21`** — `var StaticFS embed.FS` is today a concrete `embed.FS`. Read from exactly one place.
+- **`internal/cli/serve.go:147-150`** — the single consumer:
+  ```go
+  e.Use(apimw.Static(apimw.StaticConfig{
+      Filesystem: web.StaticFS,
+      Root:       "dist",
+  }))
+  ```
+- **`api/middleware/static.go:29-34`** — `StaticConfig.Filesystem` is already typed as `fs.FS` (interface). Any implementation satisfies it.
+- **`api/middleware/static.go:73-81`** — SPA fallback: for any path that isn't `/api/*` and doesn't match a real file, the middleware rewrites the URL to `/` and serves `index.html` from the FS. This means any override mechanism that replaces the FS must ship a complete SPA tree (including `index.html` and the `_nuxt/` chunks).
+- **`web/admin/composables/usePresetScreens.ts:99-102`** — existing preset-screen dynamic-import pattern is Blob-URL + `import()` of a module fetched from an API endpoint. Already-proven in-tree.
+- **Preset `.mjs` files are hand-maintained** in Options API + string-template format. There is no Vite/SFC build in the education preset today (confirmed in `presets/weos-private-presets/education/screens/src/README.md`).
+- **`services/core/web/admin/nuxt.config.ts`** — no `extends` / layers config today; Nuxt layers are a greenfield option.
+
+## Options
+
+---
+
+### Option 1 — Host-replaceable admin FS (whole-SPA substitution via Nuxt layers)
+
+Expose the admin's static FS as a settable value on the `web` package. A host binary provides its own `fs.FS` at startup; the static middleware reads through it.
+
+**Core change (~5-10 LOC):**
+- `services/core/web/embed.go`: change the package-level var to an `fs.FS` typed accessor, and add a setter:
+  ```go
+  var embeddedFS embed.FS // the //go:embed target
+
+  var staticFS fs.FS = embeddedFS
+
+  // StaticFS returns the admin static filesystem.
+  // Thin-wrap binaries can replace it with SetStaticFS before Execute().
+  func StaticFS() fs.FS { return staticFS }
+
+  // SetStaticFS replaces the admin static filesystem.
+  // Must be called before the serve command constructs the HTTP stack.
+  func SetStaticFS(fsys fs.FS) { staticFS = fsys }
+  ```
+- `services/core/internal/cli/serve.go:148`: read via `web.StaticFS()`.
+- No middleware changes — `StaticConfig.Filesystem` is already `fs.FS`.
+
+**Host binary responsibilities:**
+- Produce a complete admin SPA dist and ship it as an `fs.FS`.
+- Easiest path to that dist: **Nuxt layers**. Host has a minimal Nuxt project:
+  ```
+  services/ic-crm/web/admin/
+    nuxt.config.ts        # export default defineNuxtConfig({ extends: ['../../../core/web/admin'] })
+    pages/index.vue       # the product dashboard (shadows core's pages/index.vue)
+    package.json          # nuxt generate
+  ```
+  `nuxt generate` walks the layer chain and emits a full dist in which the host's `pages/index.vue` wins for `/`. Every other admin file (components, composables, Ant Design plugin, other routes) is inherited from core.
+- `//go:embed` the generated dist into an `fs.FS` and call `web.SetStaticFS(hostFS)` from `main.go` before `weoscli.Execute()`.
+
+**Pros:**
+- **Smallest core change of all options.** Two-method public API on `web`; no new routes, handlers, composables, or Vue refactors.
+- **Full Vue SFC authoring on the host.** `<script setup>`, computed, Ant Design components, Nuxt auto-imports, TypeScript type-checking — all preserved.
+- **Layer inheritance is free.** The host project typically needs only `nuxt.config.ts` + `pages/index.vue` + `package.json`. Every admin route not explicitly shadowed is inherited.
+- **Generalizes.** The same mechanism lets a host shadow any number of pages by dropping files into its own `pages/`. The core API does not need to grow to support a second slot.
+- **Matches Nuxt's intended extension model.** Layers exist precisely for this use case.
+
+**Cons:**
+- **Host binary gains a Node/Nuxt build stage.** The `services/ic-crm/CLAUDE.md` note that currently says "drop the frontend stage" was about avoiding a *fork* of the admin; a 1-file layer is not a fork, but the note needs updating.
+- **Host ships its own full compiled dist.** Most of it is byte-identical to core's (the layer only changes the one shadowed page), so the admin bundle exists in two places in the build tree. At runtime only the host's copy is served; no duplication in the binary.
+- **Layer resolution happens at the host's Nuxt build time.** A core admin change requires the host to re-run `nuxt generate` to pick it up. (Same constraint as any embedded SPA, and the same Makefile target already orchestrates it.)
+
+---
+
+### Option 2 — Runtime index-component slot
+
+Keep the admin SPA single-sourced in core. Add a registration point for a single `.mjs` component that core's `pages/index.vue` loads at runtime and renders in place of its default content.
+
+**Core change (~60-80 LOC across Go + Vue + TS):**
+- Registration point: `application.SetIndexComponent(fs.FS, filename string)` (or a method on a dedicated registry).
+- New handler `GET /api/admin/index-component` that serves the registered `.mjs` (404 if none).
+- Rewrite `services/core/web/admin/pages/index.vue`:
+  - Extract today's resource-types grid into a new `components/DefaultResourceGrid.vue`.
+  - On mount, `$fetch('/api/admin/index-component')`. If a body comes back, Blob-URL + `import()` (copy the pattern from `usePresetScreens.ts:99-102`). Render the imported component via `<component :is="...">`.
+  - If 404, render `<DefaultResourceGrid />`.
+- New composable `useIndexComponent.ts` (parallel to `usePresetScreens.ts`).
+- Tests for the handler, the fallback behavior, and the error path.
+
+**Host binary responsibilities:**
+- Hand-maintain an `.mjs` in Options API + string-template format (matching `education/screens/src/README.md` conventions):
+  ```js
+  export const meta = { name: 'Dashboard', label: 'Dashboard' }
+  export default {
+    props: { /* ... */ },
+    data() { return { /* ... */ } },
+    computed: { /* ... */ },
+    template: `
+      <div>
+        <h2>Dashboard</h2>
+        <a-row :gutter="[16, 16]"> ... </a-row>
+        ...
+      </div>
+    `
+  }
+  ```
+- `//go:embed` the `.mjs` and call the setter at startup.
+
+**Pros:**
+- **No Node / Nuxt build stage in the host.** A host binary stays pure Go + one hand-written `.mjs`.
+- **Surgical slot.** Only the index is overridable; the mechanism cannot accidentally affect any other route.
+- **Reuses the already-proven dynamic-import pattern** from preset screens.
+
+**Cons:**
+- **Cannot reuse the existing ic-crm `Dashboard.vue`.** It's a full SFC with `<script setup>`, `computed`, Ant Design components, multiple composables — roughly 300 lines. Converting it to Options API with a string template means a rewrite, not a mechanical transform.
+- **Ongoing maintenance burden.** Every future edit to the dashboard lives in the hand-maintained `.mjs`: no `.vue` SFC tooling, no template type-checking, no component import linting, no IDE auto-complete inside the string template.
+- **Larger core footprint.** New Go handler + new TS composable + pages/index.vue refactor + tests. Roughly 10× the core LOC of Option 1, for one slot.
+- **Single-slot by design.** If a future thin-wrap wants to also override a settings index or a reports landing page, that's another round of the same surgery. The mechanism does not generalize without rework.
+- **Fetch-at-mount cost.** Every `/` load does an extra round-trip to `/api/admin/index-component` before showing anything. Avoidable with SSG only if the slot is known at build time, which defeats the point of runtime registration.
+
+---
+
+### Option 3 — FS overlay (partial substitution)
+
+Accept a second `fs.FS` on the static middleware and consult it before the main one. Files present in the overlay win; everything else falls through to the main FS and the existing SPA fallback.
+
+**Core change (~20 LOC):** extend `StaticConfig` with an optional `Overlay fs.FS`; the request handler tries `Overlay.Open(filePath)` first, then `root.Open(filePath)`.
+
+**Host binary responsibilities:** ship only the files it wants to override, embedded into its own `fs.FS`.
+
+**Pros:**
+- Feels minimal: "just overlay my files on top of core's."
+
+**Cons — critical:**
+- **Does not solve the stated problem.** Nuxt's `index.html` is a shell that imports hashed `_nuxt/*.js` chunks. The component that renders at `/` lives inside one of those chunks, not in `index.html`. Swapping just `index.html` does not change what renders at `/`.
+- **To actually change `/`, the overlay must include a compiled replacement chunk and patch `index.html` to load it.** At that point the host is shipping a full Nuxt build anyway — functionally identical to Option 1 but without the Nuxt-layer ergonomics that make Option 1 pleasant.
+- **Serves static files only.** No way to hot-swap SFC-level components without a full build on the host; see above.
+
+Included so the ADR records explicitly why "just overlay the files" doesn't work, and so future readers don't try to revisit it.
+
+---
+
+### Option 4 — No core change; dirty overlay in the host build
+
+Host `make build` target copies its `Dashboard.vue` over `services/core/web/admin/pages/index.vue`, runs `nuxt generate` inside `services/core`, runs `go build` of the host, then reverts the core file.
+
+**Pros:**
+- Zero upstream change.
+
+**Cons:**
+- **Dirties `services/core`'s working tree on every host build.** Any concurrent branch work in core is at risk.
+- **Fails open on Makefile errors.** If `nuxt generate` or `go build` fails between the copy and the revert, core is left in a modified state.
+- **Each host binary reinvents this dance.** Not one upstream mechanism but N brittle host-side scripts.
+- **Blocks sharing the admin among multiple products running in the same workspace.** Two wrappers trying to build concurrently race on core's `pages/index.vue`.
+
+Included so the ADR records explicitly why "do nothing upstream" is not an option, even though it is technically possible today.
+
+---
+
+## Comparison Matrix
+
+| Criteria | Option 1: Host-replaceable FS | Option 2: Runtime slot | Option 3: FS overlay | Option 4: Dirty host build |
+|---|---|---|---|---|
+| **Solves the stated problem** | Yes | Yes | No (see Cons) | Yes |
+| **Core LOC** | ~5-10 Go | ~60-80 Go + Vue + TS | ~20 Go | 0 |
+| **Host needs Node/Nuxt build** | Yes (minimal — 1 layer project) | No | Yes (see Cons) | Yes (in core's tree) |
+| **Keeps `.vue` SFC authoring for the override** | Yes | No (Options API + string template) | Yes | Yes |
+| **Generalizes to N overridden pages** | Yes (just add more files to host layer) | No (one slot per rewrite) | N/A (doesn't work) | Yes (but with worse tradeoffs per page) |
+| **Touches `services/core`'s working tree at build time** | No | No | No | Yes — the core concern |
+| **Fetch-at-mount latency for `/`** | None (static) | Extra round-trip | None | None |
+| **Preserves thin-wrap boundary** | Yes | Yes | Yes | No |
+| **Idiomatic to the ecosystem** | Yes (Nuxt layers are the intended extension model) | Reinvents what layers already do | No | No |
+
+## Recommendation
+
+**Option 1 — Host-replaceable admin FS via Nuxt layers.** The smallest core change, the cleanest separation of concerns, and the only option that preserves the thin-wrap invariant while keeping full SFC authoring on the host. The Node-build cost in the host is bounded: a host binary that only wants to override one page ships a 3-file Nuxt layer project, and `nuxt generate` becomes one step in the host's existing `make build` chain. The two-method `web` API is small enough that we can ship it without committing to a general-purpose preset-app-pages framework, and any future requirement to override additional pages is handled by the host dropping more files into its `pages/` directory with zero further core change.
+
+## Decision
+
+**TBD — pending owner sign-off.** The decision will be recorded here once accepted.
+
+## Consequences
+
+The consequences depend on which option is chosen. Written conditionally so the ADR captures the trade-offs each path imposes; update to reflect the chosen option once the decision lands.
+
+**If Option 1 is accepted:**
+- `web.SetStaticFS` / `web.StaticFS` become part of the `weos` public API. Breaking changes to that signature become a semver concern.
+- `services/ic-crm/CLAUDE.md` needs a follow-up edit: the "drop the frontend stage" note should be amended to "no fork; a host layer project is expected and supported."
+- `services/ic-crm`'s build gains a Node/Nuxt step. Its `Makefile`, CI, and Dockerfile need updating to run `nuxt generate` on the layer project before `go build`.
+- `services/ic-crm/web/admin/src/` (the `src/pages/Dashboard.vue` staging area and its README) gets replaced by a real Nuxt layer project. The old README's "blocked" note is resolved.
+- Future thin-wrap products follow the same pattern at no additional core cost.
+
+**If Option 2 is accepted:**
+- `application.SetIndexComponent` (or equivalent) becomes a new public registration point. Its contract (slot name semantics, precedence when called more than once, lifecycle) is part of the weos API.
+- `pages/index.vue` and its companion composable get shipped as a small new subsystem. Tests for the fallback path and the error path are required.
+- ic-crm's Dashboard.vue is rewritten as a hand-maintained `.mjs`. Future ic-crm dashboard changes live in that file.
+- A future requirement to override another page requires another ADR or an extension of this one to a multi-slot model.
+
+**If Option 3 or 4 is accepted:**
+- Not recommended; both have load-bearing problems documented above. Accepting either should include a written explanation of why the recommendation was overturned.
+
+## References
+
+- `services/core/web/embed.go` — current static FS declaration
+- `services/core/api/middleware/static.go` — static file serving + SPA fallback
+- `services/core/internal/cli/serve.go` — single consumer of `web.StaticFS`
+- `services/core/web/admin/composables/usePresetScreens.ts` — dynamic-import pattern reused by Option 2
+- `services/core/application/preset_registry.go` — existing preset contract (for comparison with the slot registration Option 2 would add)
+- `services/ic-crm/web/admin/src/README.md` — the "blocked" note this ADR unblocks
+- [Nuxt Layers documentation](https://nuxt.com/docs/getting-started/layers) — the mechanism Option 1 depends on

--- a/docs/decisions/admin-index-override.md
+++ b/docs/decisions/admin-index-override.md
@@ -21,7 +21,7 @@ We need a way for a host binary to replace the admin's index without dragging in
 
 ### Why each naive approach fails
 
-- **Edit `services/core/web/admin/pages/index.vue` directly from ic-crm.** Requires ic-crm to touch `services/core`'s working tree at build time, which means every thin-wrap build dirties a different repo. Concurrent branch work in core is at risk and any Makefile failure mid-build leaves core in a modified state.
+- **Edit `web/admin/pages/index.vue` in this repo directly from ic-crm.** Requires ic-crm to touch this repo's working tree at build time, which means every thin-wrap build dirties a different repo. Concurrent branch work in core is at risk and any Makefile failure mid-build leaves core in a modified state.
 - **Swap only `dist/index.html` at serve time.** Nuxt's generated `index.html` is a 1-KB shell that imports hashed `_nuxt/*.js` chunks; the index route's component lives inside one of those chunks, not in the HTML. Swapping `index.html` alone does not change what renders at `/`.
 - **Fork the admin SPA into the thin-wrap.** Defeats the point of the thin-wrap pattern. Every admin-side improvement in core would then need to be manually reconciled in every product.
 
@@ -41,7 +41,7 @@ Verified during exploration. Any option must respect these.
 - **`api/middleware/static.go:73-81`** — SPA fallback: for any path that isn't `/api/*` and doesn't match a real file, the middleware rewrites the URL to `/` and serves `index.html` from the FS. This means any override mechanism that replaces the FS must ship a complete SPA tree (including `index.html` and the `_nuxt/` chunks).
 - **`web/admin/composables/usePresetScreens.ts:99-102`** — existing preset-screen dynamic-import pattern is Blob-URL + `import()` of a module fetched from an API endpoint. Already-proven in-tree.
 - **Preset `.mjs` files are hand-maintained** in Options API + string-template format. There is no Vite/SFC build in the education preset today (confirmed in `presets/weos-private-presets/education/screens/src/README.md`).
-- **`services/core/web/admin/nuxt.config.ts`** — no `extends` / layers config today; Nuxt layers are a greenfield option.
+- **`web/admin/nuxt.config.ts`** — no `extends` / layers config today; Nuxt layers are a greenfield option.
 
 ## Options
 
@@ -52,7 +52,7 @@ Verified during exploration. Any option must respect these.
 Expose the admin's static FS as a settable value on the `web` package. A host binary provides its own `fs.FS` at startup; the static middleware reads through it.
 
 **Core change (~5-10 LOC):**
-- `services/core/web/embed.go`: change the package-level var to an `fs.FS` typed accessor, and add a setter:
+- `web/embed.go`: change the package-level var to an `fs.FS` typed accessor, and add a setter:
   ```go
   var embeddedFS embed.FS // the //go:embed target
 
@@ -66,7 +66,7 @@ Expose the admin's static FS as a settable value on the `web` package. A host bi
   // Must be called before the serve command constructs the HTTP stack.
   func SetStaticFS(fsys fs.FS) { staticFS = fsys }
   ```
-- `services/core/internal/cli/serve.go:148`: read via `web.StaticFS()`.
+- `internal/cli/serve.go:148`: read via `web.StaticFS()`.
 - No middleware changes — `StaticConfig.Filesystem` is already `fs.FS`.
 
 **Host binary responsibilities:**
@@ -102,7 +102,7 @@ Keep the admin SPA single-sourced in core. Add a registration point for a single
 **Core change (~60-80 LOC across Go + Vue + TS):**
 - Registration point: `application.SetIndexComponent(fs.FS, filename string)` (or a method on a dedicated registry).
 - New handler `GET /api/admin/index-component` that serves the registered `.mjs` (404 if none).
-- Rewrite `services/core/web/admin/pages/index.vue`:
+- Rewrite `web/admin/pages/index.vue`:
   - Extract today's resource-types grid into a new `components/DefaultResourceGrid.vue`.
   - On mount, `$fetch('/api/admin/index-component')`. If a body comes back, Blob-URL + `import()` (copy the pattern from `usePresetScreens.ts:99-102`). Render the imported component via `<component :is="...">`.
   - If 404, render `<DefaultResourceGrid />`.
@@ -164,13 +164,13 @@ Included so the ADR records explicitly why "just overlay the files" doesn't work
 
 ### Option 4 — No core change; dirty overlay in the host build
 
-Host `make build` target copies its `Dashboard.vue` over `services/core/web/admin/pages/index.vue`, runs `nuxt generate` inside `services/core`, runs `go build` of the host, then reverts the core file.
+Host `make build` target copies its `Dashboard.vue` over this repo's `web/admin/pages/index.vue`, runs `nuxt generate` in this repo, runs `go build` of the host, then reverts the file.
 
 **Pros:**
 - Zero upstream change.
 
 **Cons:**
-- **Dirties `services/core`'s working tree on every host build.** Any concurrent branch work in core is at risk.
+- **Dirties this repo's working tree on every host build.** Any concurrent branch work in core is at risk.
 - **Fails open on Makefile errors.** If `nuxt generate` or `go build` fails between the copy and the revert, core is left in a modified state.
 - **Each host binary reinvents this dance.** Not one upstream mechanism but N brittle host-side scripts.
 - **Blocks sharing the admin among multiple products running in the same workspace.** Two wrappers trying to build concurrently race on core's `pages/index.vue`.
@@ -188,7 +188,7 @@ Included so the ADR records explicitly why "do nothing upstream" is not an optio
 | **Host needs Node/Nuxt build** | Yes (minimal — 1 layer project) | No | Yes (see Cons) | Yes (in core's tree) |
 | **Keeps `.vue` SFC authoring for the override** | Yes | No (Options API + string template) | Yes | Yes |
 | **Generalizes to N overridden pages** | Yes (just add more files to host layer) | No (one slot per rewrite) | N/A (doesn't work) | Yes (but with worse tradeoffs per page) |
-| **Touches `services/core`'s working tree at build time** | No | No | No | Yes — the core concern |
+| **Touches this repo's working tree at build time** | No | No | No | Yes — the core concern |
 | **Fetch-at-mount latency for `/`** | None (static) | Extra round-trip | None | None |
 | **Preserves thin-wrap boundary** | Yes | Yes | Yes | No |
 | **Idiomatic to the ecosystem** | Yes (Nuxt layers are the intended extension model) | Reinvents what layers already do | No | No |
@@ -223,10 +223,10 @@ The consequences depend on which option is chosen. Written conditionally so the 
 
 ## References
 
-- `services/core/web/embed.go` — current static FS declaration
-- `services/core/api/middleware/static.go` — static file serving + SPA fallback
-- `services/core/internal/cli/serve.go` — single consumer of `web.StaticFS`
-- `services/core/web/admin/composables/usePresetScreens.ts` — dynamic-import pattern reused by Option 2
-- `services/core/application/preset_registry.go` — existing preset contract (for comparison with the slot registration Option 2 would add)
+- `web/embed.go` — current static FS declaration
+- `api/middleware/static.go` — static file serving + SPA fallback
+- `internal/cli/serve.go` — single consumer of `web.StaticFS`
+- `web/admin/composables/usePresetScreens.ts` — dynamic-import pattern reused by Option 2
+- `application/preset_registry.go` — existing preset contract (for comparison with the slot registration Option 2 would add)
 - `services/ic-crm/web/admin/src/README.md` — the "blocked" note this ADR unblocks
 - [Nuxt Layers documentation](https://nuxt.com/docs/getting-started/layers) — the mechanism Option 1 depends on

--- a/docs/decisions/admin-index-override.md
+++ b/docs/decisions/admin-index-override.md
@@ -29,11 +29,11 @@ We need a way for a host binary to replace the admin's index without dragging in
 
 Verified during exploration. Any option must respect these.
 
-- **`web/embed.go:21`** — `var StaticFS embed.FS` is today a concrete `embed.FS`. Read from exactly one place.
-- **`internal/cli/serve.go:147-150`** — the single consumer:
+- **`web/embed.go`** — the web package exposes the admin asset filesystem via `StaticFS()` / `SetStaticFS` (after this ADR's implementation; the pre-implementation form was a directly-read `var StaticFS embed.FS`). The effective FS is still read from exactly one place.
+- **`internal/cli/serve.go`** — the single consumer reads that FS through the getter at config time:
   ```go
   e.Use(apimw.Static(apimw.StaticConfig{
-      Filesystem: web.StaticFS,
+      Filesystem: web.StaticFS(),
       Root:       "dist",
   }))
   ```

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -15,3 +15,4 @@ Architecture Decision Records (ADRs) capture significant technical decisions mad
 | [Transaction ID and Projection Consolidation]({% link decisions/transaction-id-and-projection-consolidation.md %}) | Accepted (Implemented) | 2026-04-04 |
 | [Injecting Services into ResourceBehavior]({% link decisions/behavior-service-injection.md %}) | Accepted (Implemented) | 2026-04-07 |
 | [Cross-Resource Writes from ResourceBehavior Hooks]({% link decisions/behavior-resource-writer.md %}) | Accepted (Implemented) | 2026-04-07 |
+| [Admin Index Override for Thin-Wrap Binaries]({% link decisions/admin-index-override.md %}) | Proposed | 2026-04-14 |

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -145,7 +145,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	e.HideBanner = true
 
 	e.Use(apimw.Static(apimw.StaticConfig{
-		Filesystem: web.StaticFS,
+		Filesystem: web.StaticFS(),
 		Root:       "dist",
 	}))
 

--- a/web/embed.go
+++ b/web/embed.go
@@ -18,6 +18,7 @@ package web
 import (
 	"embed"
 	"io/fs"
+	"reflect"
 )
 
 // embeddedAdmin holds the compiled admin SPA. Don't read this var
@@ -42,23 +43,45 @@ func StaticFS() fs.FS { return staticFS }
 //
 // Intended use: a thin-wrap host binary (e.g. services/ic-crm) embeds
 // its own Nuxt-layer dist and calls SetStaticFS in main() before
-// invoking the serve command. The replacement FS must be rooted to
-// expose `dist/` (matching the embedded layout and the StaticConfig.Root
-// the serve command passes to the middleware).
+// invoking the serve command. The replacement FS must contain a
+// `dist/` directory whose contents mirror the embedded admin layout
+// (serve.go passes `Root: "dist"` to the static middleware, which
+// calls `fs.Sub(fsys, "dist")` — so `dist/index.html` must be
+// readable under the FS root).
 //
 // Must be called before the serve command constructs the HTTP stack.
 // Once the static middleware is wired, it captures the FS at config
 // time — later SetStaticFS calls cannot reach already-running handlers.
 //
-// Panics if fsys is nil. A nil FS would crash the static middleware
-// with a less actionable error during request serving; failing fast
-// at the setter call site (in main()) gives a clear stack trace at
-// the point of the bug.
+// Panics if fsys is nil (bare-nil interface value, or a typed-nil
+// pointer/map/slice/chan/func stored in the fs.FS interface). A nil
+// FS would crash the static middleware with a less actionable error
+// during request serving; failing fast at the setter call site (in
+// main()) gives a clear stack trace at the point of the bug.
 //
 // See docs/decisions/admin-index-override.md for the design rationale.
 func SetStaticFS(fsys fs.FS) {
-	if fsys == nil {
-		panic("web.SetStaticFS: fsys is nil; pass a non-nil fs.FS rooted at dist/")
+	if isNilFS(fsys) {
+		panic("web.SetStaticFS: fsys is nil; pass a non-nil fs.FS containing a dist/ directory")
 	}
 	staticFS = fsys
+}
+
+// isNilFS reports whether fsys is untyped nil or a typed-nil value
+// stored in the fs.FS interface. Go's `x == nil` test on an interface
+// variable is false when the interface holds a typed nil pointer, map,
+// slice, chan, or func — so `fsys == nil` alone would let e.g.
+// `var p *myFS; SetStaticFS(p)` through even though p is nil and
+// would crash on first read. Reflection handles the typed-nil case.
+func isNilFS(fsys fs.FS) bool {
+	if fsys == nil {
+		return true
+	}
+	v := reflect.ValueOf(fsys)
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func, reflect.Interface:
+		return v.IsNil()
+	default:
+		return false
+	}
 }

--- a/web/embed.go
+++ b/web/embed.go
@@ -15,7 +15,50 @@
 
 package web
 
-import "embed"
+import (
+	"embed"
+	"io/fs"
+)
 
+// embeddedAdmin holds the compiled admin SPA. Don't read this var
+// directly — go through StaticFS() so a host binary's SetStaticFS
+// replacement takes effect.
+//
 //go:embed all:dist
-var StaticFS embed.FS
+var embeddedAdmin embed.FS
+
+// staticFS is the FS the static middleware actually reads from.
+// Defaults to the embedded admin; thin-wrap host binaries can replace
+// it via SetStaticFS before the serve command builds the HTTP stack.
+var staticFS fs.FS = embeddedAdmin
+
+// StaticFS returns the active admin static filesystem. Consumers
+// (notably the serve command's static middleware wiring) must call
+// this rather than reading a package-level value, so a host binary's
+// SetStaticFS replacement takes effect.
+func StaticFS() fs.FS { return staticFS }
+
+// SetStaticFS replaces the admin static filesystem.
+//
+// Intended use: a thin-wrap host binary (e.g. services/ic-crm) embeds
+// its own Nuxt-layer dist and calls SetStaticFS in main() before
+// invoking the serve command. The replacement FS must be rooted to
+// expose `dist/` (matching the embedded layout and the StaticConfig.Root
+// the serve command passes to the middleware).
+//
+// Must be called before the serve command constructs the HTTP stack.
+// Once the static middleware is wired, it captures the FS at config
+// time — later SetStaticFS calls cannot reach already-running handlers.
+//
+// Panics if fsys is nil. A nil FS would crash the static middleware
+// with a less actionable error during request serving; failing fast
+// at the setter call site (in main()) gives a clear stack trace at
+// the point of the bug.
+//
+// See docs/decisions/admin-index-override.md for the design rationale.
+func SetStaticFS(fsys fs.FS) {
+	if fsys == nil {
+		panic("web.SetStaticFS: fsys is nil; pass a non-nil fs.FS rooted at dist/")
+	}
+	staticFS = fsys
+}

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -1,0 +1,180 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package web_test
+
+import (
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	apimw "weos/api/middleware"
+	"weos/web"
+
+	"github.com/labstack/echo/v4"
+)
+
+// TestStaticFS_DefaultEmbed pins that the default StaticFS() (backed by
+// the //go:embed all:dist directive on embeddedAdmin) exposes
+// dist/index.html. Guards against a refactor that drops the embed
+// directive, narrows the embed pattern, or re-points staticFS to an
+// FS that doesn't include the admin shell — any of which would only
+// surface at runtime when serving /.
+func TestStaticFS_DefaultEmbed(t *testing.T) {
+	t.Parallel()
+	if _, err := fs.Stat(web.StaticFS(), "dist/index.html"); err != nil {
+		t.Fatalf("default StaticFS() should expose dist/index.html: %v", err)
+	}
+}
+
+// TestSetStaticFS_RoundTripsToServedContent is the end-to-end smoke test
+// for the swap mechanism a thin-wrap host binary will rely on. It pins
+// the read-through path from SetStaticFS through StaticFS() into the
+// static middleware. A regression where StaticFS() stops reading
+// staticFS (e.g. a refactor that returns embeddedAdmin directly from
+// the accessor) would break the override contract and surface here.
+//
+// Note: the static middleware legitimately captures the FS at config
+// time, so this test calls SetStaticFS *before* wiring the middleware,
+// matching the documented contract on SetStaticFS.
+func TestSetStaticFS_RoundTripsToServedContent(t *testing.T) {
+	// MUST NOT be converted to t.Parallel — SetStaticFS mutates a
+	// package-level variable with no synchronization (the documented
+	// contract is "call once from main() before serve"), so a parallel
+	// run would race under -race and produce flaky failures.
+
+	const sentinel = "HOST_OVERRIDE_SENTINEL"
+
+	orig := web.StaticFS()
+	t.Cleanup(func() { web.SetStaticFS(orig) })
+
+	hostFS := fstest.MapFS{
+		"dist/index.html": &fstest.MapFile{
+			Data: []byte("<html><body>" + sentinel + "</body></html>"),
+		},
+	}
+	web.SetStaticFS(hostFS)
+
+	// Wire the Static middleware the same way internal/cli/serve.go
+	// does: read web.StaticFS(), pass "dist" as Root.
+	e := echo.New()
+	e.Use(apimw.Static(apimw.StaticConfig{
+		Filesystem: web.StaticFS(),
+		Root:       "dist",
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /: status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), sentinel) {
+		t.Fatalf("GET / body did not contain host sentinel %q; got: %q",
+			sentinel, rec.Body.String())
+	}
+}
+
+// TestSetStaticFS_LastWriteWins pins the idempotence semantics — the
+// most recent SetStaticFS call wins. Cheap to maintain; prevents a
+// future maintainer from "fixing" the setter to reject second calls
+// (e.g., interpreting it as initialization-only).
+func TestSetStaticFS_LastWriteWins(t *testing.T) {
+	// MUST NOT be converted to t.Parallel — see TestSetStaticFS_RoundTripsToServedContent.
+
+	orig := web.StaticFS()
+	t.Cleanup(func() { web.SetStaticFS(orig) })
+
+	first := fstest.MapFS{"dist/marker.txt": &fstest.MapFile{Data: []byte("first")}}
+	second := fstest.MapFS{"dist/marker.txt": &fstest.MapFile{Data: []byte("second")}}
+
+	web.SetStaticFS(first)
+	web.SetStaticFS(second)
+
+	got, err := fs.ReadFile(web.StaticFS(), "dist/marker.txt")
+	if err != nil {
+		t.Fatalf("read marker after two SetStaticFS calls: %v", err)
+	}
+	if string(got) != "second" {
+		t.Errorf("StaticFS() after two SetStaticFS calls returned %q; want %q (last-write-wins)",
+			string(got), "second")
+	}
+}
+
+// TestSetStaticFS_Nil pins the nil-handling contract: SetStaticFS panics
+// at the call site rather than letting the nil propagate to the static
+// middleware (which would then panic with a less actionable error
+// during request serving). A host binary that hits this gets a clean
+// stack trace at the bug — the SetStaticFS call in main().
+func TestSetStaticFS_Nil(t *testing.T) {
+	// MUST NOT be converted to t.Parallel — see TestSetStaticFS_RoundTripsToServedContent.
+	// (No cleanup needed; the panic prevents the assignment.)
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("SetStaticFS(nil) should panic, but returned normally")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("panic value should be a string with a clear message; got %T: %v", r, r)
+		}
+		if !strings.Contains(msg, "nil") {
+			t.Errorf("panic message should mention nil; got %q", msg)
+		}
+	}()
+
+	web.SetStaticFS(nil)
+}
+
+// TestSetStaticFS_CleanupRestoresOriginal pins the t.Cleanup pattern
+// used by the swap test: capturing the original FS, swapping, and
+// restoring works end-to-end. If StaticFS() ever stopped read-through
+// (e.g. cached the embed at first call), restoration would silently
+// fail and other tests in this package would observe a swapped FS.
+//
+// Uses behavioral assertions (a sentinel file present only in the
+// swapped FS) rather than identity comparison, since fstest.MapFS is
+// a map type and not == comparable.
+func TestSetStaticFS_CleanupRestoresOriginal(t *testing.T) {
+	// MUST NOT be converted to t.Parallel — see TestSetStaticFS_RoundTripsToServedContent.
+
+	orig := web.StaticFS()
+	const sentinelPath = "dist/swap-only-sentinel.txt"
+	swapped := fstest.MapFS{
+		sentinelPath: &fstest.MapFile{Data: []byte("swapped")},
+	}
+
+	// Sanity: the original embed must NOT contain the sentinel — the
+	// behavioral check below depends on this. If a future change adds
+	// such a file under dist/, pick a different name.
+	if _, err := fs.Stat(orig, sentinelPath); err == nil {
+		t.Fatalf("test setup invalid: %s exists in original FS; pick another name", sentinelPath)
+	}
+
+	web.SetStaticFS(swapped)
+	if _, err := fs.Stat(web.StaticFS(), sentinelPath); err != nil {
+		t.Fatalf("after SetStaticFS(swapped), sentinel should be readable: %v", err)
+	}
+
+	web.SetStaticFS(orig)
+	if _, err := fs.Stat(web.StaticFS(), sentinelPath); err == nil {
+		t.Fatal("after SetStaticFS(orig), sentinel should be gone — restoration leaked the swapped FS")
+	}
+}

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -35,8 +35,11 @@ import (
 // directive, narrows the embed pattern, or re-points staticFS to an
 // FS that doesn't include the admin shell — any of which would only
 // surface at runtime when serving /.
+//
+// Not parallel: other tests in this file mutate the package-level
+// staticFS via SetStaticFS. Marking this test parallel would create
+// a read/write race on staticFS under -race.
 func TestStaticFS_DefaultEmbed(t *testing.T) {
-	t.Parallel()
 	if _, err := fs.Stat(web.StaticFS(), "dist/index.html"); err != nil {
 		t.Fatalf("default StaticFS() should expose dist/index.html: %v", err)
 	}

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -125,25 +125,46 @@ func TestSetStaticFS_LastWriteWins(t *testing.T) {
 // middleware (which would then panic with a less actionable error
 // during request serving). A host binary that hits this gets a clean
 // stack trace at the bug — the SetStaticFS call in main().
+//
+// Covers both bare-nil (literal `nil` passed via the fs.FS interface)
+// and typed-nil (a concrete nil pointer assigned to the fs.FS
+// interface variable — Go's `x == nil` on the interface is false in
+// this case, so the setter needs a reflection-based check).
 func TestSetStaticFS_Nil(t *testing.T) {
 	// MUST NOT be converted to t.Parallel — see TestSetStaticFS_RoundTripsToServedContent.
 	// (No cleanup needed; the panic prevents the assignment.)
 
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatal("SetStaticFS(nil) should panic, but returned normally")
-		}
-		msg, ok := r.(string)
-		if !ok {
-			t.Fatalf("panic value should be a string with a clear message; got %T: %v", r, r)
-		}
-		if !strings.Contains(msg, "nil") {
-			t.Errorf("panic message should mention nil; got %q", msg)
-		}
-	}()
+	assertPanics := func(t *testing.T, name string, call func()) {
+		t.Helper()
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatalf("%s: expected panic, returned normally", name)
+			}
+			msg, ok := r.(string)
+			if !ok {
+				t.Fatalf("%s: panic value should be a string; got %T: %v", name, r, r)
+			}
+			if !strings.Contains(msg, "nil") {
+				t.Errorf("%s: panic message should mention nil; got %q", name, msg)
+			}
+		}()
+		call()
+	}
 
-	web.SetStaticFS(nil)
+	t.Run("bare nil", func(t *testing.T) {
+		assertPanics(t, "SetStaticFS(nil)", func() { web.SetStaticFS(nil) })
+	})
+
+	t.Run("typed-nil pointer", func(t *testing.T) {
+		var p *fstest.MapFS // nil pointer to a concrete fs.FS implementer
+		assertPanics(t, "SetStaticFS(typed-nil *fstest.MapFS)", func() { web.SetStaticFS(p) })
+	})
+
+	t.Run("typed-nil map", func(t *testing.T) {
+		var m fstest.MapFS // nil map; fstest.MapFS is a map type
+		assertPanics(t, "SetStaticFS(typed-nil fstest.MapFS)", func() { web.SetStaticFS(m) })
+	})
 }
 
 // TestSetStaticFS_CleanupRestoresOriginal pins the t.Cleanup pattern


### PR DESCRIPTION
## Summary

Implements [Option 1 of the Admin Index Override ADR](docs/decisions/admin-index-override.md): turn `web.StaticFS` from a `var embed.FS` into a `StaticFS()` getter and a `SetStaticFS(fs.FS)` setter so a thin-wrap host binary (e.g. `services/ic-crm`) can replace the admin SPA at startup with its own Nuxt-layer dist — without forking the admin and without touching `services/core`'s tree at build time.

The static middleware (`api/middleware/static.go`) already accepts `fs.FS`, so no middleware change is needed; `internal/cli/serve.go:148` just reads through `web.StaticFS()` at config time.

`SetStaticFS(nil)` panics at the call site for a clear stack trace, instead of letting the `nil` propagate to a less actionable middleware crash during request serving.

## Changes

- `web/embed.go` — replace `var StaticFS embed.FS` with private `embeddedAdmin` + `StaticFS() fs.FS` getter + `SetStaticFS(fs.FS)` setter (panics on `nil`)
- `internal/cli/serve.go:148` — read through `web.StaticFS()` instead of the variable
- `web/embed_test.go` — **new file**, 5 tests:
  - `TestStaticFS_DefaultEmbed` — pins that the default `StaticFS()` exposes `dist/index.html`
  - `TestSetStaticFS_RoundTripsToServedContent` — end-to-end: `SetStaticFS` → static middleware → served body contains a sentinel
  - `TestSetStaticFS_LastWriteWins` — pins idempotence semantics
  - `TestSetStaticFS_Nil` — pins the panic-on-nil contract
  - `TestSetStaticFS_CleanupRestoresOriginal` — pins the cleanup pattern used by the swap test
- `docs/decisions/admin-index-override.md` — the ADR being implemented
- `docs/decisions/index.md` — registry entry
- `docs/_tutorials/customizing-the-ui.md` — updated 'Static Asset Embedding' section to match the new API + link to the ADR

## Test plan

- [x] `go test -race ./web/...` — all 5 new tests pass
- [x] `go test ./...` — full suite green (e2e included)
- [x] `golangci-lint run ./web/... ./internal/cli/...` — 0 issues
- [x] `make build` clean
- [ ] Manual smoke: `make run`, open `http://localhost:8080/`, confirm the embedded admin renders by default (no host binary involved)

## Out of scope (follow-ups)

These land in separate branches, per the ADR's Consequences §1 and the user-chosen scope for this PR:

- `services/ic-crm` Nuxt-layer wiring (`nuxt.config.ts` extending core, `pages/index.vue` from existing `Dashboard.vue`, `Makefile` step for `nuxt generate`, `main.go` calling `web.SetStaticFS`)
- `services/ic-crm/CLAUDE.md` "drop the frontend stage" note revision
- Flipping the ADR's `## Decision` from "Proposed" to "Accepted: Option 1" — bundled with the ic-crm change since that's where the consequences materialize

Sibling services `weos-finance` and `finexity` have their own `web/embed.go` and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)