### PR TITLE
feat: let presets contribute HTTP routes via PresetDefinition

### DIFF
--- a/application/module.go
+++ b/application/module.go
@@ -115,6 +115,7 @@ func Module(cfg config.Config, registry *PresetRegistry) fx.Option {
 		fx.Provide(newLazyResourceWriter),
 		fx.Provide(ProvideResourceBehaviorRegistry),
 		fx.Provide(ProvideBehaviorMetaRegistry),
+		fx.Provide(ProvidePresetHTTPHandlers),
 		fx.Provide(gorm.ProvideBehaviorSettingsRepository),
 
 		// Email sender

--- a/application/preset_http_handlers.go
+++ b/application/preset_http_handlers.go
@@ -1,0 +1,76 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"context"
+	"fmt"
+
+	"weos/domain/entities"
+	"weos/domain/repositories"
+)
+
+// PresetHTTPHandlers is a distinct nominal type for the Fx-provided list of
+// resolved preset routes — keeps it from being confused with any other
+// []MountedHandler that might enter the graph later.
+type PresetHTTPHandlers []MountedHandler
+
+// ProvidePresetHTTPHandlers resolves preset-contributed HTTP routes against
+// the same BehaviorServices that behavior factories receive, so handlers and
+// behaviors share a single application-services view.
+func ProvidePresetHTTPHandlers(
+	registry *PresetRegistry,
+	resources repositories.ResourceRepository,
+	triples repositories.TripleRepository,
+	resourceTypes repositories.ResourceTypeRepository,
+	logger entities.Logger,
+	writer *lazyResourceWriter,
+) (PresetHTTPHandlers, error) {
+	if registry == nil {
+		return nil, fmt.Errorf("ProvidePresetHTTPHandlers: nil PresetRegistry")
+	}
+	if isNilInterface(resources) {
+		return nil, fmt.Errorf("ProvidePresetHTTPHandlers: nil Resources")
+	}
+	if isNilInterface(triples) {
+		return nil, fmt.Errorf("ProvidePresetHTTPHandlers: nil Triples")
+	}
+	if isNilInterface(resourceTypes) {
+		return nil, fmt.Errorf("ProvidePresetHTTPHandlers: nil ResourceTypes")
+	}
+	if isNilInterface(logger) {
+		return nil, fmt.Errorf("ProvidePresetHTTPHandlers: nil Logger")
+	}
+	if writer == nil {
+		return nil, fmt.Errorf("ProvidePresetHTTPHandlers: nil lazyResourceWriter")
+	}
+	services := BehaviorServices{
+		Resources:     resources,
+		Triples:       triples,
+		ResourceTypes: resourceTypes,
+		Logger:        logger,
+		Writer:        writer,
+	}
+	mounted, err := registry.Handlers(services)
+	if err != nil {
+		return nil, err
+	}
+	if len(mounted) > 0 {
+		logger.Info(context.Background(), "preset HTTP handlers registered",
+			"count", len(mounted))
+	}
+	return mounted, nil
+}

--- a/application/preset_http_handlers_test.go
+++ b/application/preset_http_handlers_test.go
@@ -1,0 +1,183 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestProvidePresetHTTPHandlers_RejectsNilDeps(t *testing.T) {
+	t.Parallel()
+	registry := NewPresetRegistry()
+	writer := newLazyResourceWriter()
+	cases := []struct {
+		name    string
+		invoke  func() error
+		wantSub string
+	}{
+		{"nil registry", func() error {
+			_, err := ProvidePresetHTTPHandlers(
+				nil, &stubResourceRepo{}, &stubTripleRepo{}, &stubTypeRepo{}, noopLogger{}, writer,
+			)
+			return err
+		}, "PresetRegistry"},
+		{"nil resources", func() error {
+			_, err := ProvidePresetHTTPHandlers(
+				registry, nil, &stubTripleRepo{}, &stubTypeRepo{}, noopLogger{}, writer,
+			)
+			return err
+		}, "Resources"},
+		{"nil triples", func() error {
+			_, err := ProvidePresetHTTPHandlers(
+				registry, &stubResourceRepo{}, nil, &stubTypeRepo{}, noopLogger{}, writer,
+			)
+			return err
+		}, "Triples"},
+		{"nil resourceTypes", func() error {
+			_, err := ProvidePresetHTTPHandlers(
+				registry, &stubResourceRepo{}, &stubTripleRepo{}, nil, noopLogger{}, writer,
+			)
+			return err
+		}, "ResourceTypes"},
+		{"nil logger", func() error {
+			_, err := ProvidePresetHTTPHandlers(
+				registry, &stubResourceRepo{}, &stubTripleRepo{}, &stubTypeRepo{}, nil, writer,
+			)
+			return err
+		}, "Logger"},
+		{"nil writer", func() error {
+			_, err := ProvidePresetHTTPHandlers(
+				registry, &stubResourceRepo{}, &stubTripleRepo{}, &stubTypeRepo{}, noopLogger{}, nil,
+			)
+			return err
+		}, "lazyResourceWriter"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.invoke()
+			if err == nil {
+				t.Fatalf("expected error for %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error %q does not name dependency %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestProvidePresetHTTPHandlers_RejectsTypedNilDeps(t *testing.T) {
+	t.Parallel()
+	registry := NewPresetRegistry()
+	writer := newLazyResourceWriter()
+	var typedNilResources *stubResourceRepo
+	var typedNilTriples *stubTripleRepo
+	var typedNilTypes *stubTypeRepo
+	if _, err := ProvidePresetHTTPHandlers(
+		registry, typedNilResources, &stubTripleRepo{}, &stubTypeRepo{}, noopLogger{}, writer,
+	); err == nil {
+		t.Error("expected error for typed-nil Resources")
+	}
+	if _, err := ProvidePresetHTTPHandlers(
+		registry, &stubResourceRepo{}, typedNilTriples, &stubTypeRepo{}, noopLogger{}, writer,
+	); err == nil {
+		t.Error("expected error for typed-nil Triples")
+	}
+	if _, err := ProvidePresetHTTPHandlers(
+		registry, &stubResourceRepo{}, &stubTripleRepo{}, typedNilTypes, noopLogger{}, writer,
+	); err == nil {
+		t.Error("expected error for typed-nil ResourceTypes")
+	}
+}
+
+func TestProvidePresetHTTPHandlers_PropagatesRegistryError(t *testing.T) {
+	t.Parallel()
+	registry := NewPresetRegistry()
+	registry.MustAdd(PresetDefinition{
+		Name:     "first",
+		Handlers: []PresetHTTPHandler{{Method: http.MethodPost, Path: "/x", Factory: okHandler}},
+	})
+	registry.MustAdd(PresetDefinition{
+		Name:     "second",
+		Handlers: []PresetHTTPHandler{{Method: http.MethodPost, Path: "/x", Factory: okHandler}},
+	})
+	_, err := ProvidePresetHTTPHandlers(
+		registry, &stubResourceRepo{}, &stubTripleRepo{}, &stubTypeRepo{},
+		noopLogger{}, newLazyResourceWriter(),
+	)
+	if err == nil || !strings.Contains(err.Error(), "POST /x") {
+		t.Fatalf("expected collision error from registry, got %v", err)
+	}
+}
+
+func TestProvidePresetHTTPHandlers_BuildsBehaviorServicesCorrectly(t *testing.T) {
+	t.Parallel()
+	resources := &stubResourceRepo{}
+	triples := &stubTripleRepo{}
+	types := &stubTypeRepo{}
+	logger := noopLogger{}
+	writer := newLazyResourceWriter()
+
+	registry := NewPresetRegistry()
+	var seen BehaviorServices
+	registry.MustAdd(PresetDefinition{
+		Name: "p",
+		Handlers: []PresetHTTPHandler{{
+			Method: http.MethodGet, Path: "/x",
+			Factory: func(s BehaviorServices) http.HandlerFunc {
+				seen = s
+				return func(http.ResponseWriter, *http.Request) {}
+			},
+		}},
+	})
+
+	if _, err := ProvidePresetHTTPHandlers(registry, resources, triples, types, logger, writer); err != nil {
+		t.Fatalf("ProvidePresetHTTPHandlers: %v", err)
+	}
+	// Each field must come from the matching argument — guards against future
+	// refactors that drop or substitute values inside the BehaviorServices literal.
+	if seen.Resources != resources {
+		t.Errorf("Resources misrouted")
+	}
+	if seen.Triples != triples {
+		t.Errorf("Triples misrouted")
+	}
+	if seen.ResourceTypes != types {
+		t.Errorf("ResourceTypes misrouted")
+	}
+	if seen.Logger != logger {
+		t.Errorf("Logger misrouted")
+	}
+	if seen.Writer != writer {
+		t.Errorf("Writer misrouted")
+	}
+}
+
+func TestProvidePresetHTTPHandlers_EmptyRegistryReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	registry := NewPresetRegistry()
+	mounted, err := ProvidePresetHTTPHandlers(
+		registry, &stubResourceRepo{}, &stubTripleRepo{}, &stubTypeRepo{},
+		noopLogger{}, newLazyResourceWriter(),
+	)
+	if err != nil {
+		t.Fatalf("empty registry should not error: %v", err)
+	}
+	if len(mounted) != 0 {
+		t.Errorf("expected empty mounted list, got %d", len(mounted))
+	}
+}

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"net/http"
 	"path"
 	"sort"
 	"strings"
@@ -44,8 +45,23 @@ type PresetSidebarConfig struct {
 	MenuGroups  map[string]string // slug -> parent slug for sidebar nesting
 }
 
+// PresetHTTPHandler describes one HTTP route contributed by a preset. The
+// Factory is invoked once at server start with the same BehaviorServices that
+// behavior factories receive, so handlers can close over real repositories
+// without depending on Fx directly.
+//
+// Path is relative to /api: a preset declaring Path "/leads/upload" mounts at
+// /api/leads/upload. Protected selects the auth-gated group; public handlers
+// land on the bare /api group and run without auth middleware.
+type PresetHTTPHandler struct {
+	Method    string // GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD
+	Path      string // relative to /api, e.g. "/leads/upload"
+	Factory   func(BehaviorServices) http.HandlerFunc
+	Protected bool // true => mount behind auth middleware
+}
+
 // PresetDefinition defines a named preset package that bundles resource types,
-// behaviors, screen components, and sidebar configuration.
+// behaviors, screen components, sidebar configuration, and HTTP routes.
 type PresetDefinition struct {
 	Name         string
 	Description  string
@@ -54,6 +70,7 @@ type PresetDefinition struct {
 	BehaviorMeta map[string]entities.BehaviorMeta // slug -> metadata for UI/config
 	Screens      fs.FS                            // optional embedded screen components
 	Sidebar      *PresetSidebarConfig             // optional sidebar defaults
+	Handlers     []PresetHTTPHandler              // optional HTTP routes mounted under /api
 	AutoInstall  bool                             // if true, types are auto-created at startup
 }
 
@@ -96,6 +113,9 @@ func (r *PresetRegistry) Add(def PresetDefinition) error {
 		if factory == nil {
 			return fmt.Errorf("preset %q: behavior factory for slug %q is nil", def.Name, slug)
 		}
+	}
+	if err := validateHandlers(def); err != nil {
+		return err
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -168,6 +188,11 @@ func (d PresetDefinition) clone() PresetDefinition {
 			meta[k] = v
 		}
 		d.BehaviorMeta = meta
+	}
+	if d.Handlers != nil {
+		handlers := make([]PresetHTTPHandler, len(d.Handlers))
+		copy(handlers, d.Handlers)
+		d.Handlers = handlers
 	}
 	if d.Sidebar != nil {
 		s := *d.Sidebar
@@ -277,6 +302,114 @@ func (r *PresetRegistry) Behaviors(services BehaviorServices) (ResourceBehaviorR
 		}
 	}
 	return behaviors, nil
+}
+
+// MountedHandler is a fully-resolved preset HTTP route, ready to mount on the
+// HTTP router. Source names the preset that contributed it, surfaced in
+// collision errors and startup logs.
+type MountedHandler struct {
+	Method    string
+	Path      string
+	Protected bool
+	Handler   http.HandlerFunc
+	Source    string
+}
+
+// validHTTPMethods is the allowlist for PresetHTTPHandler.Method. Uppercase
+// only — matches the constants in net/http. CONNECT and TRACE are omitted by
+// design: preset endpoints have no legitimate use for them.
+var validHTTPMethods = map[string]struct{}{
+	http.MethodGet:     {},
+	http.MethodPost:    {},
+	http.MethodPut:     {},
+	http.MethodPatch:   {},
+	http.MethodDelete:  {},
+	http.MethodOptions: {},
+	http.MethodHead:    {},
+}
+
+// validateHandlers enforces the per-preset invariants on PresetDefinition.Handlers:
+// non-empty path, known HTTP verb, non-nil factory, and no intra-preset duplicates
+// of "METHOD /path". Cross-preset collisions are detected later in Handlers().
+func validateHandlers(def PresetDefinition) error {
+	if len(def.Handlers) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(def.Handlers))
+	for i, h := range def.Handlers {
+		if h.Path == "" {
+			return fmt.Errorf("preset %q: handler[%d] path is empty", def.Name, i)
+		}
+		// A path without a leading slash silently produces a wrong route once
+		// concatenated with the /api group prefix (e.g. "leads" -> "/apileads").
+		if !strings.HasPrefix(h.Path, "/") {
+			return fmt.Errorf("preset %q: handler[%d] path %q must start with %q",
+				def.Name, i, h.Path, "/")
+		}
+		if _, ok := validHTTPMethods[h.Method]; !ok {
+			return fmt.Errorf("preset %q: handler[%d] method %q is not a known HTTP verb", def.Name, i, h.Method)
+		}
+		if h.Factory == nil {
+			return fmt.Errorf("preset %q: handler[%d] factory is nil", def.Name, i)
+		}
+		key := h.Method + " " + h.Path
+		if _, dup := seen[key]; dup {
+			return fmt.Errorf("preset %q: handler[%d] duplicates %q within the same preset", def.Name, i, key)
+		}
+		seen[key] = struct{}{}
+	}
+	return nil
+}
+
+// Handlers returns all preset-contributed HTTP routes, with each Factory
+// invoked once with the supplied services. Ordering is alphabetical by preset
+// name, preserving each preset's declared handler order. Returns an error if
+// any factory is nil or returns nil, or if two presets declare the same
+// "METHOD /path" — startup fails so the conflict can't go unnoticed.
+func (r *PresetRegistry) Handlers(services BehaviorServices) ([]MountedHandler, error) {
+	r.mu.RLock()
+	names := make([]string, 0, len(r.presets))
+	snapshot := make(map[string][]PresetHTTPHandler, len(r.presets))
+	for name, def := range r.presets {
+		names = append(names, name)
+		if len(def.Handlers) == 0 {
+			continue
+		}
+		copied := make([]PresetHTTPHandler, len(def.Handlers))
+		copy(copied, def.Handlers)
+		snapshot[name] = copied
+	}
+	r.mu.RUnlock()
+
+	sort.Strings(names)
+
+	var mounted []MountedHandler
+	source := make(map[string]string) // "METHOD /path" -> preset name
+	for _, name := range names {
+		for i, h := range snapshot[name] {
+			if h.Factory == nil {
+				return nil, fmt.Errorf("preset %q: handler[%d] factory is nil", name, i)
+			}
+			key := h.Method + " " + h.Path
+			if prev, ok := source[key]; ok {
+				return nil, fmt.Errorf("preset %q and preset %q both declare handler %q",
+					prev, name, key)
+			}
+			fn := h.Factory(services)
+			if fn == nil {
+				return nil, fmt.Errorf("preset %q: handler[%d] factory returned nil", name, i)
+			}
+			source[key] = name
+			mounted = append(mounted, MountedHandler{
+				Method:    h.Method,
+				Path:      h.Path,
+				Protected: h.Protected,
+				Handler:   fn,
+				Source:    name,
+			})
+		}
+	}
+	return mounted, nil
 }
 
 // validateFixtures checks that fixture data is well-formed at registration time.

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -346,6 +346,13 @@ func validateHandlers(def PresetDefinition) error {
 			return fmt.Errorf("preset %q: handler[%d] path %q must start with %q",
 				def.Name, i, h.Path, "/")
 		}
+		// Handler paths are documented as relative to the /api router group,
+		// so an already-prefixed "/api/leads" would mount at "/api/api/leads".
+		// Reject such paths so the runtime matches the documented contract.
+		if h.Path == "/api" || strings.HasPrefix(h.Path, "/api/") {
+			return fmt.Errorf("preset %q: handler[%d] path %q must be relative to %q, not include it",
+				def.Name, i, h.Path, "/api")
+		}
 		if _, ok := validHTTPMethods[h.Method]; !ok {
 			return fmt.Errorf("preset %q: handler[%d] method %q is not a known HTTP verb", def.Name, i, h.Method)
 		}

--- a/application/preset_registry_test.go
+++ b/application/preset_registry_test.go
@@ -1,0 +1,346 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func okHandler(BehaviorServices) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func TestPresetRegistry_AddRejectsHandlerWithEmptyPath(t *testing.T) {
+	t.Parallel()
+	r := NewPresetRegistry()
+	err := r.Add(PresetDefinition{
+		Name: "p",
+		Handlers: []PresetHTTPHandler{
+			{Method: http.MethodGet, Path: "", Factory: okHandler},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "path is empty") {
+		t.Fatalf("expected empty-path error, got %v", err)
+	}
+}
+
+func TestPresetRegistry_AddRejectsHandlerWithoutLeadingSlash(t *testing.T) {
+	t.Parallel()
+	r := NewPresetRegistry()
+	err := r.Add(PresetDefinition{
+		Name: "p",
+		Handlers: []PresetHTTPHandler{
+			{Method: http.MethodGet, Path: "leads/upload", Factory: okHandler},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), `must start with "/"`) {
+		t.Fatalf("expected leading-slash error, got %v", err)
+	}
+}
+
+func TestPresetRegistry_AddRejectsHandlerWithUnknownMethod(t *testing.T) {
+	t.Parallel()
+	r := NewPresetRegistry()
+	err := r.Add(PresetDefinition{
+		Name: "p",
+		Handlers: []PresetHTTPHandler{
+			{Method: "GIT", Path: "/x", Factory: okHandler},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "not a known HTTP verb") {
+		t.Fatalf("expected unknown-method error, got %v", err)
+	}
+}
+
+func TestPresetRegistry_AddRejectsLowercaseMethod(t *testing.T) {
+	t.Parallel()
+	r := NewPresetRegistry()
+	err := r.Add(PresetDefinition{
+		Name: "p",
+		Handlers: []PresetHTTPHandler{
+			{Method: "get", Path: "/x", Factory: okHandler},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected lowercase method to be rejected (allowlist is uppercase only)")
+	}
+}
+
+func TestPresetRegistry_AddRejectsNilHandlerFactory(t *testing.T) {
+	t.Parallel()
+	r := NewPresetRegistry()
+	err := r.Add(PresetDefinition{
+		Name: "p",
+		Handlers: []PresetHTTPHandler{
+			{Method: http.MethodGet, Path: "/x", Factory: nil},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "factory is nil") {
+		t.Fatalf("expected nil-factory error, got %v", err)
+	}
+}
+
+func TestPresetRegistry_AddRejectsIntraPresetDuplicateRoute(t *testing.T) {
+	t.Parallel()
+	r := NewPresetRegistry()
+	err := r.Add(PresetDefinition{
+		Name: "p",
+		Handlers: []PresetHTTPHandler{
+			{Method: http.MethodGet, Path: "/x", Factory: okHandler},
+			{Method: http.MethodGet, Path: "/x", Factory: okHandler},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "duplicates") {
+		t.Fatalf("expected duplicate-route error, got %v", err)
+	}
+}
+
+func TestPresetRegistry_AddAcceptsAllStandardMethods(t *testing.T) {
+	t.Parallel()
+	for _, m := range []string{
+		http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch,
+		http.MethodDelete, http.MethodOptions, http.MethodHead,
+	} {
+		r := NewPresetRegistry()
+		err := r.Add(PresetDefinition{
+			Name:     "p-" + m,
+			Handlers: []PresetHTTPHandler{{Method: m, Path: "/x", Factory: okHandler}},
+		})
+		if err != nil {
+			t.Errorf("method %q should be accepted, got %v", m, err)
+		}
+	}
+}
+
+func TestPresetRegistry_HandlersCloneIsolatesCallerMutations(t *testing.T) {
+	t.Parallel()
+	r := NewPresetRegistry()
+	r.MustAdd(PresetDefinition{
+		Name: "p",
+		Handlers: []PresetHTTPHandler{
+			{Method: http.MethodGet, Path: "/x", Factory: okHandler, Protected: true},
+		},
+	})
+	got, ok := r.Get("p")
+	if !ok {
+		t.Fatal("expected to find preset 'p'")
+	}
+	got.Handlers[0].Path = "/mutated"
+	got.Handlers = append(got.Handlers, PresetHTTPHandler{
+		Method: http.MethodPost, Path: "/extra", Factory: okHandler,
+	})
+
+	again, _ := r.Get("p")
+	if len(again.Handlers) != 1 {
+		t.Fatalf("clone mutation leaked: registry has %d handlers, want 1", len(again.Handlers))
+	}
+	if again.Handlers[0].Path != "/x" {
+		t.Fatalf("clone mutation leaked: path is %q, want %q", again.Handlers[0].Path, "/x")
+	}
+}
+
+func TestPresetRegistry_HandlersAggregatorReturnsAllRoutes(t *testing.T) {
+	t.Parallel()
+	r := NewPresetRegistry()
+	r.MustAdd(PresetDefinition{
+		Name: "alpha",
+		Handlers: []PresetHTTPHandler{
+			{Method: http.MethodGet, Path: "/a", Factory: okHandler, Protected: false},
+			{Method: http.MethodPost, Path: "/a", Factory: okHandler, Protected: true},
+		},
+	})
+	r.MustAdd(PresetDefinition{
+		Name: "beta",
+		Handlers: []PresetHTTPHandler{
+			{Method: http.MethodGet, Path: "/b", Factory: okHandler, Protected: true},
+		},
+	})
+
+	mounted, err := r.Handlers(BehaviorServices{})
+	if err != nil {
+		t.Fatalf("Handlers() returned error: %v", err)
+	}
+	if len(mounted) != 3 {
+		t.Fatalf("expected 3 mounted handlers, got %d", len(mounted))
+	}
+	// Alphabetical by source: alpha first (in declared order), then beta.
+	want := []struct{ src, method, path string }{
+		{"alpha", http.MethodGet, "/a"},
+		{"alpha", http.MethodPost, "/a"},
+		{"beta", http.MethodGet, "/b"},
+	}
+	for i, w := range want {
+		if mounted[i].Source != w.src ||
+			mounted[i].Method != w.method ||
+			mounted[i].Path != w.path {
+			t.Errorf("mounted[%d] = {%s %s %s}, want {%s %s %s}",
+				i, mounted[i].Source, mounted[i].Method, mounted[i].Path,
+				w.src, w.method, w.path)
+		}
+		if mounted[i].Handler == nil {
+			t.Errorf("mounted[%d].Handler is nil", i)
+		}
+	}
+}
+
+func TestPresetRegistry_HandlersDetectsCrossPresetCollision(t *testing.T) {
+	t.Parallel()
+	r := NewPresetRegistry()
+	r.MustAdd(PresetDefinition{
+		Name:     "first",
+		Handlers: []PresetHTTPHandler{{Method: http.MethodPost, Path: "/x", Factory: okHandler}},
+	})
+	r.MustAdd(PresetDefinition{
+		Name:     "second",
+		Handlers: []PresetHTTPHandler{{Method: http.MethodPost, Path: "/x", Factory: okHandler}},
+	})
+
+	_, err := r.Handlers(BehaviorServices{})
+	if err == nil {
+		t.Fatal("expected cross-preset collision error")
+	}
+	if !strings.Contains(err.Error(), "POST /x") {
+		t.Errorf("error should name the colliding route, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "first") || !strings.Contains(err.Error(), "second") {
+		t.Errorf("error should name both colliding presets, got %v", err)
+	}
+}
+
+func TestPresetRegistry_HandlersAllowsSamePathDifferentMethodsAcrossPresets(t *testing.T) {
+	t.Parallel()
+	r := NewPresetRegistry()
+	r.MustAdd(PresetDefinition{
+		Name:     "alpha",
+		Handlers: []PresetHTTPHandler{{Method: http.MethodGet, Path: "/x", Factory: okHandler}},
+	})
+	r.MustAdd(PresetDefinition{
+		Name:     "beta",
+		Handlers: []PresetHTTPHandler{{Method: http.MethodPost, Path: "/x", Factory: okHandler}},
+	})
+	mounted, err := r.Handlers(BehaviorServices{})
+	if err != nil {
+		t.Fatalf("same-path different-method should not collide: %v", err)
+	}
+	if len(mounted) != 2 {
+		t.Fatalf("expected 2 mounted handlers, got %d", len(mounted))
+	}
+}
+
+func TestPresetRegistry_HandlersRejectsNilReturningFactory(t *testing.T) {
+	t.Parallel()
+	r := NewPresetRegistry()
+	r.MustAdd(PresetDefinition{
+		Name: "p",
+		Handlers: []PresetHTTPHandler{{
+			Method: http.MethodGet, Path: "/x",
+			Factory: func(BehaviorServices) http.HandlerFunc { return nil },
+		}},
+	})
+	_, err := r.Handlers(BehaviorServices{})
+	if err == nil || !strings.Contains(err.Error(), "returned nil") {
+		t.Fatalf("expected nil-return error, got %v", err)
+	}
+}
+
+func TestPresetRegistry_HandlersFactoryInvokedOncePerHandler(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	r := NewPresetRegistry()
+	r.MustAdd(PresetDefinition{
+		Name: "p",
+		Handlers: []PresetHTTPHandler{
+			{
+				Method: http.MethodGet, Path: "/x",
+				Factory: func(BehaviorServices) http.HandlerFunc {
+					calls++
+					return func(http.ResponseWriter, *http.Request) {}
+				},
+			},
+			{
+				Method: http.MethodPost, Path: "/y",
+				Factory: func(BehaviorServices) http.HandlerFunc {
+					calls++
+					return func(http.ResponseWriter, *http.Request) {}
+				},
+			},
+		},
+	})
+	if _, err := r.Handlers(BehaviorServices{}); err != nil {
+		t.Fatalf("Handlers() returned error: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected each factory invoked once (2 total), got %d", calls)
+	}
+}
+
+func TestPresetRegistry_HandlersInjectsServices(t *testing.T) {
+	t.Parallel()
+	r := NewPresetRegistry()
+	var got BehaviorServices
+	r.MustAdd(PresetDefinition{
+		Name: "p",
+		Handlers: []PresetHTTPHandler{{
+			Method: http.MethodGet, Path: "/x",
+			Factory: func(s BehaviorServices) http.HandlerFunc {
+				got = s
+				return func(http.ResponseWriter, *http.Request) {}
+			},
+		}},
+	})
+	want := BehaviorServices{
+		Resources:     &stubResourceRepo{},
+		Triples:       &stubTripleRepo{},
+		ResourceTypes: &stubTypeRepo{},
+		Logger:        noopLogger{},
+		Writer:        newLazyResourceWriter(),
+	}
+	if _, err := r.Handlers(want); err != nil {
+		t.Fatalf("Handlers() returned error: %v", err)
+	}
+	if got.Resources != want.Resources {
+		t.Errorf("Resources not propagated")
+	}
+	if got.Triples != want.Triples {
+		t.Errorf("Triples not propagated")
+	}
+	if got.ResourceTypes != want.ResourceTypes {
+		t.Errorf("ResourceTypes not propagated")
+	}
+	if got.Logger != want.Logger {
+		t.Errorf("Logger not propagated")
+	}
+	if got.Writer != want.Writer {
+		t.Errorf("Writer not propagated")
+	}
+}
+
+func TestPresetRegistry_HandlersReturnsEmptyForRegistryWithNoHandlers(t *testing.T) {
+	t.Parallel()
+	r := NewPresetRegistry()
+	r.MustAdd(PresetDefinition{Name: "p"})
+	mounted, err := r.Handlers(BehaviorServices{})
+	if err != nil {
+		t.Fatalf("Handlers() returned error: %v", err)
+	}
+	if len(mounted) != 0 {
+		t.Fatalf("expected 0 mounted handlers, got %d", len(mounted))
+	}
+}

--- a/application/preset_registry_test.go
+++ b/application/preset_registry_test.go
@@ -55,6 +55,30 @@ func TestPresetRegistry_AddRejectsHandlerWithoutLeadingSlash(t *testing.T) {
 	}
 }
 
+func TestPresetRegistry_AddRejectsHandlerPathWithAPIPrefix(t *testing.T) {
+	t.Parallel()
+	// Preset paths are documented as relative to the /api group. A preset
+	// that prefixes its path with "/api/" would silently mount at
+	// "/api/api/..." — reject it up front so the failure is loud.
+	cases := []string{"/api", "/api/", "/api/leads", "/api/leads/upload"}
+	for _, p := range cases {
+		p := p
+		t.Run(p, func(t *testing.T) {
+			t.Parallel()
+			r := NewPresetRegistry()
+			err := r.Add(PresetDefinition{
+				Name: "p",
+				Handlers: []PresetHTTPHandler{
+					{Method: http.MethodGet, Path: p, Factory: okHandler},
+				},
+			})
+			if err == nil || !strings.Contains(err.Error(), `must be relative to "/api"`) {
+				t.Fatalf("expected /api-prefix error for %q, got %v", p, err)
+			}
+		})
+	}
+}
+
 func TestPresetRegistry_AddRejectsHandlerWithUnknownMethod(t *testing.T) {
 	t.Parallel()
 	r := NewPresetRegistry()

--- a/internal/cli/preset_handlers.go
+++ b/internal/cli/preset_handlers.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package cli
+
+import (
+	"context"
+
+	"weos/application"
+	"weos/domain/entities"
+
+	"github.com/labstack/echo/v4"
+)
+
+// mountPresetHandlers attaches each MountedHandler to the appropriate Echo
+// group: Protected handlers go on `protected` (full auth chain), public
+// handlers go on `api` (Messages middleware only).
+func mountPresetHandlers(api, protected *echo.Group, mounted application.PresetHTTPHandlers, logger entities.Logger) {
+	for _, mh := range mounted {
+		group := api
+		if mh.Protected {
+			group = protected
+		}
+		group.Add(mh.Method, mh.Path, echo.WrapHandler(mh.Handler))
+		logger.Info(context.Background(), "mounted preset handler",
+			"method", mh.Method, "path", mh.Path,
+			"protected", mh.Protected, "preset", mh.Source)
+	}
+}

--- a/internal/cli/preset_handlers_test.go
+++ b/internal/cli/preset_handlers_test.go
@@ -1,0 +1,243 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package cli
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"weos/application"
+
+	"github.com/labstack/echo/v4"
+)
+
+type silentLogger struct{}
+
+func (silentLogger) Info(context.Context, string, ...any)  {}
+func (silentLogger) Warn(context.Context, string, ...any)  {}
+func (silentLogger) Error(context.Context, string, ...any) {}
+
+// fakeAuth stands in for the protected group's auth middleware. It only
+// inspects the Authorization header (sessions are out of scope here); the
+// goal is to prove that protected preset handlers run behind some 401 gate.
+func fakeAuth(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		if c.Request().Header.Get("Authorization") == "" {
+			return c.NoContent(http.StatusUnauthorized)
+		}
+		return next(c)
+	}
+}
+
+// buildTestServer wires a minimal Echo router that mirrors the structure of
+// serve.go: an /api group plus a /api `protected` subgroup with auth applied.
+// Then it mounts the supplied preset handlers via the same helper serve.go uses.
+func buildTestServer(t *testing.T, registry *application.PresetRegistry) *echo.Echo {
+	t.Helper()
+	mounted, err := registry.Handlers(application.BehaviorServices{})
+	if err != nil {
+		t.Fatalf("registry.Handlers: %v", err)
+	}
+	e := echo.New()
+	api := e.Group("/api")
+	protected := api.Group("")
+	protected.Use(fakeAuth)
+	mountPresetHandlers(api, protected, mounted, silentLogger{})
+	return e
+}
+
+func TestServe_MountsPublicPresetHandlerWithoutAuth(t *testing.T) {
+	t.Parallel()
+	registry := application.NewPresetRegistry()
+	registry.MustAdd(application.PresetDefinition{
+		Name: "p",
+		Handlers: []application.PresetHTTPHandler{{
+			Method: http.MethodGet, Path: "/test/ping", Protected: false,
+			Factory: func(application.BehaviorServices) http.HandlerFunc {
+				return func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("pong"))
+				}
+			},
+		}},
+	})
+	srv := buildTestServer(t, registry)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test/ping", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("public handler: got %d, want 200", rec.Code)
+	}
+	if rec.Body.String() != "pong" {
+		t.Errorf("public handler body: got %q, want %q", rec.Body.String(), "pong")
+	}
+}
+
+func TestServe_ProtectedPresetHandlerRejectsUnauthenticated(t *testing.T) {
+	t.Parallel()
+	registry := application.NewPresetRegistry()
+	registry.MustAdd(application.PresetDefinition{
+		Name: "p",
+		Handlers: []application.PresetHTTPHandler{{
+			Method: http.MethodPost, Path: "/test/secure", Protected: true,
+			Factory: func(application.BehaviorServices) http.HandlerFunc {
+				return func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusCreated)
+				}
+			},
+		}},
+	})
+	srv := buildTestServer(t, registry)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/test/secure", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("protected handler without auth: got %d, want 401", rec.Code)
+	}
+}
+
+func TestServe_ProtectedPresetHandlerRunsWhenAuthenticated(t *testing.T) {
+	t.Parallel()
+	registry := application.NewPresetRegistry()
+	registry.MustAdd(application.PresetDefinition{
+		Name: "p",
+		Handlers: []application.PresetHTTPHandler{{
+			Method: http.MethodPost, Path: "/test/secure", Protected: true,
+			Factory: func(application.BehaviorServices) http.HandlerFunc {
+				return func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusCreated)
+				}
+			},
+		}},
+	})
+	srv := buildTestServer(t, registry)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/test/secure", nil)
+	req.Header.Set("Authorization", "Bearer token")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("protected handler with auth: got %d, want 201", rec.Code)
+	}
+}
+
+func TestServe_MountsHandlersFromMultiplePresets(t *testing.T) {
+	t.Parallel()
+	registry := application.NewPresetRegistry()
+	// Public handler from one preset; protected handler from another. This
+	// exercises both group-selection branches AND multi-preset aggregation in
+	// a single test, so a regression that only mounts the first preset (or
+	// only one group) shows up here.
+	registry.MustAdd(application.PresetDefinition{
+		Name: "alpha",
+		Handlers: []application.PresetHTTPHandler{{
+			Method: http.MethodGet, Path: "/alpha", Protected: false,
+			Factory: func(application.BehaviorServices) http.HandlerFunc {
+				return func(w http.ResponseWriter, _ *http.Request) {
+					_, _ = w.Write([]byte("a"))
+				}
+			},
+		}},
+	})
+	registry.MustAdd(application.PresetDefinition{
+		Name: "beta",
+		Handlers: []application.PresetHTTPHandler{{
+			Method: http.MethodGet, Path: "/beta", Protected: true,
+			Factory: func(application.BehaviorServices) http.HandlerFunc {
+				return func(w http.ResponseWriter, _ *http.Request) {
+					_, _ = w.Write([]byte("b"))
+				}
+			},
+		}},
+	})
+	srv := buildTestServer(t, registry)
+
+	tests := []struct {
+		name, path, body, authHeader string
+		wantCode                     int
+	}{
+		{"public alpha no auth", "/api/alpha", "a", "", http.StatusOK},
+		{"protected beta no auth", "/api/beta", "", "", http.StatusUnauthorized},
+		{"protected beta with auth", "/api/beta", "b", "Bearer t", http.StatusOK},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+			rec := httptest.NewRecorder()
+			srv.ServeHTTP(rec, req)
+			if rec.Code != tc.wantCode {
+				t.Errorf("%s: got %d, want %d", tc.path, rec.Code, tc.wantCode)
+			}
+			if tc.body != "" && rec.Body.String() != tc.body {
+				t.Errorf("%s body: got %q, want %q", tc.path, rec.Body.String(), tc.body)
+			}
+		})
+	}
+}
+
+// TestServe_PresetHandlerNotShadowedByDynamicResourceRoute locks in the
+// architectural invariant called out in serve.go: preset handlers must mount
+// before the dynamic /:typeSlug catch-all. If a future change reorders
+// registration, the catch-all silently swallows preset POSTs.
+func TestServe_PresetHandlerNotShadowedByDynamicResourceRoute(t *testing.T) {
+	t.Parallel()
+	registry := application.NewPresetRegistry()
+	registry.MustAdd(application.PresetDefinition{
+		Name: "p",
+		Handlers: []application.PresetHTTPHandler{{
+			Method: http.MethodPost, Path: "/leads", Protected: true,
+			Factory: func(application.BehaviorServices) http.HandlerFunc {
+				return func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusCreated)
+					_, _ = w.Write([]byte("preset"))
+				}
+			},
+		}},
+	})
+	mounted, err := registry.Handlers(application.BehaviorServices{})
+	if err != nil {
+		t.Fatalf("registry.Handlers: %v", err)
+	}
+	e := echo.New()
+	api := e.Group("/api")
+	protected := api.Group("")
+	protected.Use(fakeAuth)
+	// Mount the preset routes FIRST, then the catch-all — same order as serve.go.
+	mountPresetHandlers(api, protected, mounted, silentLogger{})
+	protected.POST("/:typeSlug", func(c echo.Context) error {
+		return c.String(http.StatusOK, "catchall:"+c.Param("typeSlug"))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/leads", nil)
+	req.Header.Set("Authorization", "Bearer t")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated || rec.Body.String() != "preset" {
+		t.Fatalf("preset handler was shadowed by catch-all: got status=%d body=%q, want 201 \"preset\"",
+			rec.Code, rec.Body.String())
+	}
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -93,6 +93,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	var inviteService *authapp.InviteService
 	var inviteRepo authrepos.InviteRepository
 	var db *gormlib.DB
+	var presetHandlers application.PresetHTTPHandlers
 
 	registry := presets.NewDefaultRegistry()
 
@@ -119,6 +120,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		fx.Populate(&inviteService),
 		fx.Populate(&inviteRepo),
 		fx.Populate(&db),
+		fx.Populate(&presetHandlers),
 	)
 
 	startCtx, startCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
@@ -388,6 +390,10 @@ func runServe(cmd *cobra.Command, args []string) error {
 	protected.POST("/:typeSlug/:id/permissions", permHandler.Grant)
 	protected.GET("/:typeSlug/:id/permissions", permHandler.List)
 	protected.DELETE("/:typeSlug/:id/permissions/:agentId", permHandler.Revoke)
+
+	// Preset-contributed HTTP handlers. Registered before the dynamic /:typeSlug
+	// catch-all so preset routes aren't shadowed by it.
+	mountPresetHandlers(api, protected, presetHandlers, logger)
 
 	// Dynamic resource routes — MUST be registered after ALL static routes
 	resourceHandler := handlers.NewResourceHandler(resourceService, resourceTypeService, logger)


### PR DESCRIPTION
## Summary
- Adds `Handlers []PresetHTTPHandler` to `PresetDefinition` so preset packages can declare HTTP routes (`Method`, `Path`, `Factory`, `Protected`) instead of shipping loose `http.HandlerFunc` values that downstream binaries mount out-of-band.
- Validation at `PresetRegistry.Add` time: empty path, missing leading slash, unknown HTTP verb, nil factory, intra-preset duplicates.
- New `PresetRegistry.Handlers(services)` aggregator: invokes each factory once with `BehaviorServices`, detects cross-preset `METHOD /path` collisions, returns deterministic ordering (alphabetical by preset, then declared order).
- New Fx provider `ProvidePresetHTTPHandlers` mirrors the `ProvideResourceBehaviorRegistry` pattern.
- New `mountPresetHandlers` helper in `internal/cli` selects the auth-protected vs. public Echo group based on the `Protected` flag and mounts before the dynamic `/:typeSlug` catch-all so preset routes aren't shadowed.

Resolves #333.

## Out of scope (follow-ups)
- Built-in route collision detection (preset vs. existing routes like `/persons`, `/uploads`).
- Typed `HTTPMethod` enum for compile-time method validation.
- Migrating existing preset packages to use the `Handlers` field.

## Test plan
- [x] `make test` — all packages pass
- [x] `make lint` — 0 issues
- [x] `make vet` — clean
- [x] `make build` — clean
- [x] Unit tests cover: every validation rejection path, clone isolation, aggregator ordering, cross-preset collision (asserts both preset names in error), same-path-different-method does NOT collide, factory-invoked-once, all 5 `BehaviorServices` fields propagate, empty-registry path
- [x] Fx provider tests cover: 6 nil-dep guards (untyped + typed), registry error propagation, argument routing into `BehaviorServices`, empty-registry path
- [x] Integration tests cover: public mount without auth, protected mount rejects unauthenticated, protected runs when authenticated, multiple presets with mixed protected/public, route-shadowing invariant (preset POST `/leads` wins over `protected.POST("/:typeSlug")`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)