### PR TITLE
fix(events): add transaction_id column to BigQuery events schema

### DIFF
--- a/docs/decisions/transaction-id-and-projection-consolidation.md
+++ b/docs/decisions/transaction-id-and-projection-consolidation.md
@@ -16,7 +16,7 @@ nav_order: 2
 The final pericarp implementation (`v0.0.0-20260404155656-110ff0f74cd7`) went with the **first-class `TransactionID` field** on `EventEnvelope` — the alternative considered below — rather than the Metadata JSONB approach this ADR proposed. Consequences:
 
 - `EventEnvelope.TransactionID string` is a real struct field, serialized to JSON as `transaction_id`.
-- The GORM `events` table has a `transaction_id` column with an index (`gorm_model.go:47`).
+- The GORM `events` table has a `transaction_id` column with an index defined in the pericarp GORM model.
 - The BigQuery event store INSERTs and SELECTs include `transaction_id` as a dedicated column.
 - **WeOS consumers of pericarp must ensure their BigQuery event table schema includes `transaction_id STRING NULLABLE`** — otherwise dual-writes fail with `Column transaction_id is not present in table ...`. The Terraform schema in `terraform/bigquery.tf` has been updated accordingly.
 - Handlers read the ID via `env.TransactionID` directly — not `env.Metadata["transaction_id"]` as written below.

--- a/docs/decisions/transaction-id-and-projection-consolidation.md
+++ b/docs/decisions/transaction-id-and-projection-consolidation.md
@@ -7,9 +7,21 @@ nav_order: 2
 
 # ADR: Transaction ID on Events and Consolidated Projection Writes
 
-**Status:** Accepted — Implemented (fully consolidated: TripleService removed, all mutations through UoW + Resource.Published)  
+**Status:** Accepted — Implemented, **but implementation diverged from proposal** (see Implementation Note below)  
 **Date:** 2026-04-04  
 **Follows from:** [Event Handler Data Availability](event-handler-data-availability.md) (Accepted — Option 5)
+
+## Implementation Note (2026-04-19)
+
+The final pericarp implementation (`v0.0.0-20260404155656-110ff0f74cd7`) went with the **first-class `TransactionID` field** on `EventEnvelope` — the alternative considered below — rather than the Metadata JSONB approach this ADR proposed. Consequences:
+
+- `EventEnvelope.TransactionID string` is a real struct field, serialized to JSON as `transaction_id`.
+- The GORM `events` table has a `transaction_id` column with an index (`gorm_model.go:47`).
+- The BigQuery event store INSERTs and SELECTs include `transaction_id` as a dedicated column.
+- **WeOS consumers of pericarp must ensure their BigQuery event table schema includes `transaction_id STRING NULLABLE`** — otherwise dual-writes fail with `Column transaction_id is not present in table ...`. The Terraform schema in `terraform/bigquery.tf` has been updated accordingly.
+- Handlers read the ID via `env.TransactionID` directly — not `env.Metadata["transaction_id"]` as written below.
+
+The rest of this ADR (consolidated projection writes in `Resource.Published`) was implemented as proposed.
 
 ## Problem
 

--- a/infrastructure/events/bigquery_batch_insert.go
+++ b/infrastructure/events/bigquery_batch_insert.go
@@ -28,6 +28,10 @@ import (
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
 )
 
+func nullableString(s string) bigquery.NullString {
+	return bigquery.NullString{StringVal: s, Valid: s != ""}
+}
+
 func fullTableID(projectID, datasetID, tableID string) string {
 	return fmt.Sprintf("`%s.%s.%s`", projectID, datasetID, tableID)
 }
@@ -57,19 +61,21 @@ func BatchInsertEvents(
 		aggP := fmt.Sprintf("agg_%d", i)
 		typeP := fmt.Sprintf("type_%d", i)
 		seqP := fmt.Sprintf("seq_%d", i)
+		txP := fmt.Sprintf("tx_%d", i)
 		payP := fmt.Sprintf("pay_%d", i)
 		metaP := fmt.Sprintf("meta_%d", i)
 		tsP := fmt.Sprintf("ts_%d", i)
 
 		valuePlaceholders = append(valuePlaceholders,
-			fmt.Sprintf("(@%s, @%s, @%s, @%s, PARSE_JSON(@%s), PARSE_JSON(@%s), @%s)",
-				idP, aggP, typeP, seqP, payP, metaP, tsP))
+			fmt.Sprintf("(@%s, @%s, @%s, @%s, @%s, PARSE_JSON(@%s), PARSE_JSON(@%s), @%s)",
+				idP, aggP, typeP, seqP, txP, payP, metaP, tsP))
 
 		params = append(params,
 			bigquery.QueryParameter{Name: idP, Value: event.ID},
 			bigquery.QueryParameter{Name: aggP, Value: event.AggregateID},
 			bigquery.QueryParameter{Name: typeP, Value: event.EventType},
 			bigquery.QueryParameter{Name: seqP, Value: event.SequenceNo},
+			bigquery.QueryParameter{Name: txP, Value: nullableString(event.TransactionID)},
 			bigquery.QueryParameter{Name: payP, Value: payloadJSON},
 			bigquery.QueryParameter{Name: metaP, Value: metadataJSON},
 			bigquery.QueryParameter{Name: tsP, Value: event.Created.UTC()},
@@ -77,7 +83,7 @@ func BatchInsertEvents(
 	}
 
 	querySQL := fmt.Sprintf(
-		"INSERT INTO %s (id, aggregate_id, event_type, sequence_no, payload, metadata, created_at) VALUES %s",
+		"INSERT INTO %s (id, aggregate_id, event_type, sequence_no, transaction_id, payload, metadata, created_at) VALUES %s",
 		fullTableID(projectID, datasetID, tableID),
 		strings.Join(valuePlaceholders, ", "),
 	)

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -54,6 +54,12 @@ resource "google_bigquery_table" "events" {
       description = "Sequence number within the aggregate event stream"
     },
     {
+      name        = "transaction_id"
+      type        = "STRING"
+      mode        = "NULLABLE"
+      description = "Correlates events committed in the same UnitOfWork"
+    },
+    {
       name        = "payload"
       type        = "JSON"
       mode        = "NULLABLE"


### PR DESCRIPTION
## Summary
- Pericarp (`v0.0.0-20260404155656`) promoted `TransactionID` to a first-class `EventEnvelope` field backed by a dedicated `transaction_id` column on both GORM and BigQuery, but our Terraform schema was never updated — every BigQuery dual-write was failing with `Column transaction_id is not present in table ...`.
- Adds `transaction_id STRING NULLABLE` to the `events` table in `terraform/bigquery.tf` and propagates the column through the custom `BatchInsertEvents` used by `weos events sync`.
- Adds an Implementation Note to the ADR flagging that pericarp shipped the first-class-field alternative rather than the Metadata-JSONB approach the ADR proposed, so future readers don't follow stale guidance.

## Test plan
- [ ] `terraform apply` against each environment to add the NULLABLE column (non-destructive, no table recreate).
- [ ] Trigger a write that produces events (e.g. create a resource type) and confirm no more `BigQuery dual-write failed ... Column transaction_id is not present` warnings in logs.
- [ ] Query the BigQuery `events` table and verify `transaction_id` is populated for new events and NULL for older rows.
- [ ] Run `weos events sync` end-to-end against a dev BigQuery dataset to confirm the updated `BatchInsertEvents` query is accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)