### PR TITLE
fix(events): align BigQuery schema with pericarp writer

### DIFF
--- a/application/module.go
+++ b/application/module.go
@@ -62,7 +62,7 @@ func Module(cfg config.Config, registry *PresetRegistry) fx.Option {
 			lc.Append(fx.Hook{OnStop: func(_ context.Context) error { return bqStore.Close() }})
 			logger.Info(context.Background(), "BigQuery dual-write enabled",
 				"project", cfg.BigQueryProjectID, "dataset", cfg.BigQueryDatasetID)
-			return events.NewDualWriteEventStore(primary, bqStore)
+			return events.NewDualWriteEventStore(primary, bqStore, logger)
 		}),
 
 		// Session store provider (for pericarp auth integration)

--- a/infrastructure/events/bigquery_batch_insert.go
+++ b/infrastructure/events/bigquery_batch_insert.go
@@ -67,7 +67,7 @@ func BatchInsertEvents(
 		tsP := fmt.Sprintf("ts_%d", i)
 
 		valuePlaceholders = append(valuePlaceholders,
-			fmt.Sprintf("(@%s, @%s, @%s, @%s, @%s, PARSE_JSON(@%s), PARSE_JSON(@%s), @%s)",
+			fmt.Sprintf("(@%s, @%s, @%s, @%s, @%s, @%s, @%s, @%s)",
 				idP, aggP, typeP, seqP, txP, payP, metaP, tsP))
 
 		params = append(params,

--- a/infrastructure/events/dual_write_store.go
+++ b/infrastructure/events/dual_write_store.go
@@ -2,9 +2,10 @@ package events
 
 import (
 	"context"
-	"log"
 
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
+
+	"github.com/wepala/weos/v3/domain/entities"
 )
 
 // DualWriteEventStore writes events to both a primary and secondary event store.
@@ -14,10 +15,11 @@ import (
 type DualWriteEventStore struct {
 	primary   domain.EventStore
 	secondary domain.EventStore
+	logger    entities.Logger
 }
 
-func NewDualWriteEventStore(primary, secondary domain.EventStore) *DualWriteEventStore {
-	return &DualWriteEventStore{primary: primary, secondary: secondary}
+func NewDualWriteEventStore(primary, secondary domain.EventStore, logger entities.Logger) *DualWriteEventStore {
+	return &DualWriteEventStore{primary: primary, secondary: secondary, logger: logger}
 }
 
 func (s *DualWriteEventStore) Append(
@@ -29,7 +31,8 @@ func (s *DualWriteEventStore) Append(
 	}
 	// Write to secondary with no version check (-1) since primary is the source of truth.
 	if err := s.secondary.Append(ctx, aggregateID, -1, events...); err != nil {
-		log.Printf("WARNING: BigQuery dual-write failed for %s: %v", aggregateID, err)
+		s.logger.Warn(ctx, "BigQuery dual-write failed",
+			"aggregateID", aggregateID, "eventCount", len(events), "error", err)
 	}
 	return nil
 }

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -61,15 +61,15 @@ resource "google_bigquery_table" "events" {
     },
     {
       name        = "payload"
-      type        = "JSON"
+      type        = "STRING"
       mode        = "NULLABLE"
-      description = "Event payload"
+      description = "Event payload (JSON-encoded string; use PARSE_JSON(payload) or JSON_VALUE for analytics)"
     },
     {
       name        = "metadata"
-      type        = "JSON"
+      type        = "STRING"
       mode        = "NULLABLE"
-      description = "Event metadata"
+      description = "Event metadata (JSON-encoded string; use PARSE_JSON(metadata) or JSON_VALUE for analytics)"
     },
     {
       name        = "created_at"


### PR DESCRIPTION
## Summary
Follow-up to #338. BigQuery dual-writes still failed after adding the `transaction_id` column:

> `googleapi: Error 400: Value has type STRING which cannot be inserted into column payload, which has type JSON`

Pericarp's `BigQueryEventStore.buildInsertQuery` passes `payload` and `metadata` as plain STRING parameters (no `PARSE_JSON` wrapping). Its own test schema (`bigquery_store_test.go:104-105`) uses `StringFieldType` for both, confirming STRING is the intended column type. Our Terraform had declared them as JSON, so every write rejected.

Changes:
- **`terraform/bigquery.tf`** — `payload` and `metadata` changed from `JSON` to `STRING NULLABLE`. Column descriptions note that analytics should use `PARSE_JSON(payload)` or `JSON_VALUE(payload, '$.field')` at query time.
- **`infrastructure/events/bigquery_batch_insert.go`** — removed the `PARSE_JSON(@pay)` / `PARSE_JSON(@meta)` wrapping from `BatchInsertEvents` (used by `weos events sync-bigquery`) so it matches the new STRING columns and pericarp's write path.
- **`infrastructure/events/dual_write_store.go`** — `DualWriteEventStore` now takes the structured `entities.Logger` and emits BigQuery failures via `logger.Warn(...)` with `aggregateID`, `eventCount`, and `error` fields instead of `log.Printf`. Operators can filter/correlate the warnings in Cloud Logging like any other app log.
- **`application/module.go`** — passes the logger through when constructing the dual-write store.

## Migration runbook
BigQuery does **not** support `ALTER TABLE ... ALTER COLUMN SET DATA TYPE` from JSON to STRING — the `events` table must be recreated.

1. Confirm the existing table is empty (or export what's there). Since every dual-write has been failing since pericarp's `transaction_id` upgrade, in most environments the table will already be empty.
2. In the environment's Terraform, temporarily set `deletion_protection = false` on `google_bigquery_table.events` (or `terraform state rm` + `terraform import` if you prefer). Apply.
3. `terraform apply` — Terraform will drop and recreate the `events` table with the STRING payload/metadata columns.
4. Set `deletion_protection = true` back on (the value in this repo) and apply once more.

## Verification
- [ ] `terraform apply` succeeds and the recreated BigQuery `events` table shows payload/metadata as STRING.
- [ ] Create a resource (e.g. a resource type) and confirm no `BigQuery dual-write failed ...` warnings appear in the logs.
- [ ] `SELECT JSON_VALUE(payload, '$.type_slug'), transaction_id FROM events LIMIT 5` returns populated values.
- [ ] `weos events sync-bigquery --before=<future-ts>` runs cleanly against a dev dataset.

## Review scope
Did a broader pass while I was in here. Items **not** changed but worth noting for future work:
- Clustering is still `[aggregate_id, event_type]`; `GetEventsByTransactionID` scans the whole partition. Adding `transaction_id` to clustering requires a table recreate — left for a follow-up.
- Pericarp's `appendWithVersionCheck` uses read-then-write (documented race). Our `DualWriteEventStore` calls the secondary with `-1`, so we're unaffected.
- No unit tests for `BatchInsertEvents` / `DualWriteEventStore` — worth adding in a dedicated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)