### PR TITLE
fix(auth): align AuthorizeResource action IRI with seeded Casbin policies

### DIFF
--- a/api/middleware/authorize_resource.go
+++ b/api/middleware/authorize_resource.go
@@ -22,18 +22,23 @@ import (
 	"github.com/wepala/weos/v3/domain/entities"
 
 	"github.com/akeemphilbert/pericarp/pkg/auth"
+	authentities "github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
 	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
 	authcasbin "github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/casbin"
 	"github.com/labstack/echo/v4"
 )
 
-// methodToAction maps HTTP methods to ODRL action IRIs.
+// methodToAction maps HTTP methods to ODRL action identifiers. The values must
+// match the strings stored in Casbin policies (see SeedAdminPolicies and
+// SyncAccessMapToCasbin, both of which use authentities.Action*). Using the
+// literal full IRI here silently breaks admin/owner access because Casbin's
+// matcher compares action strings byte-for-byte.
 var methodToAction = map[string]string{
-	"GET":    "http://www.w3.org/ns/odrl/2/read",
-	"POST":   "http://www.w3.org/ns/odrl/2/modify",
-	"PUT":    "http://www.w3.org/ns/odrl/2/modify",
-	"PATCH":  "http://www.w3.org/ns/odrl/2/modify",
-	"DELETE": "http://www.w3.org/ns/odrl/2/delete",
+	"GET":    authentities.ActionRead,
+	"POST":   authentities.ActionModify,
+	"PUT":    authentities.ActionModify,
+	"PATCH":  authentities.ActionModify,
+	"DELETE": authentities.ActionDelete,
 }
 
 // AuthorizeResource returns Echo middleware that checks Casbin policies for
@@ -115,7 +120,7 @@ func AuthorizeResource(
 						"error", permErr, "role", role)
 					return c.JSON(http.StatusInternalServerError, map[string]string{"error": "authorization check failed"})
 				}
-				isRead := action == "http://www.w3.org/ns/odrl/2/read"
+				isRead := action == authentities.ActionRead
 				if len(perms) == 0 && isRead {
 					logger.Warn(ctx, "authorization: allowing unconfigured role read access",
 						"role", role, "action", action, "resource", typeSlug)

--- a/docs/_tutorials/auth-roles-and-access.md
+++ b/docs/_tutorials/auth-roles-and-access.md
@@ -25,10 +25,12 @@ Access control is enforced at two levels:
 1. **Role-based policies** — which resource types a role can read, modify, or delete
 2. **Resource-level permissions** — per-resource grants for specific users (ownership model)
 
-Actions use ODRL IRIs:
-- `http://www.w3.org/ns/odrl/2/read` — view resources
-- `http://www.w3.org/ns/odrl/2/modify` — create and update resources
-- `http://www.w3.org/ns/odrl/2/delete` — delete resources
+Actions use the ODRL compact CURIE form:
+- `odrl:read` — view resources
+- `odrl:modify` — create and update resources
+- `odrl:delete` — delete resources
+
+These match the strings stored in Casbin policies, so use the same form in role-access requests.
 
 ## Step 1: Seed Users and Roles
 
@@ -68,24 +70,24 @@ The response shows a map of roles to their permitted actions per resource type:
   "roles": {
     "admin": {
       "project": [
-        "http://www.w3.org/ns/odrl/2/read",
-        "http://www.w3.org/ns/odrl/2/modify",
-        "http://www.w3.org/ns/odrl/2/delete"
+        "odrl:read",
+        "odrl:modify",
+        "odrl:delete"
       ],
       "task": [
-        "http://www.w3.org/ns/odrl/2/read",
-        "http://www.w3.org/ns/odrl/2/modify",
-        "http://www.w3.org/ns/odrl/2/delete"
+        "odrl:read",
+        "odrl:modify",
+        "odrl:delete"
       ]
     },
     "editor": {
       "project": [
-        "http://www.w3.org/ns/odrl/2/read",
-        "http://www.w3.org/ns/odrl/2/modify"
+        "odrl:read",
+        "odrl:modify"
       ],
       "task": [
-        "http://www.w3.org/ns/odrl/2/read",
-        "http://www.w3.org/ns/odrl/2/modify"
+        "odrl:read",
+        "odrl:modify"
       ]
     }
   }
@@ -100,12 +102,12 @@ curl -X PUT http://localhost:8080/api/settings/role-access \
   -d '{
     "roles": {
       "admin": {
-        "project": ["http://www.w3.org/ns/odrl/2/read", "http://www.w3.org/ns/odrl/2/modify", "http://www.w3.org/ns/odrl/2/delete"],
-        "task": ["http://www.w3.org/ns/odrl/2/read", "http://www.w3.org/ns/odrl/2/modify", "http://www.w3.org/ns/odrl/2/delete"]
+        "project": ["odrl:read", "odrl:modify", "odrl:delete"],
+        "task": ["odrl:read", "odrl:modify", "odrl:delete"]
       },
       "viewer": {
-        "project": ["http://www.w3.org/ns/odrl/2/read"],
-        "task": ["http://www.w3.org/ns/odrl/2/read"]
+        "project": ["odrl:read"],
+        "task": ["odrl:read"]
       }
     }
   }'
@@ -149,7 +151,7 @@ curl -X POST http://localhost:8080/api/resources/PROJECT_ID/permissions \
   -H "Content-Type: application/json" \
   -d '{
     "agent_id": "USER_AGENT_ID",
-    "actions": ["http://www.w3.org/ns/odrl/2/read"]
+    "actions": ["odrl:read"]
   }'
 
 # List permissions on a resource


### PR DESCRIPTION
## Summary
- `AuthorizeResource` middleware built its Casbin action from the full ODRL IRI (`http://www.w3.org/ns/odrl/2/read|modify|delete`), but `SeedAdminPolicies` and `SyncAccessMapToCasbin` store policies using `authentities.Action*` (`odrl:read|modify|delete`).
- Casbin's matcher compares action strings byte-for-byte, so admin/owner users silently failed every resource-route authorization check — `GET /api/line-of-business`, `/api/student`, etc. returned 403 despite the seeded wildcard policies being present.
- Switched `methodToAction` and the `isRead` comparison to use the pericarp constants, and updated the auth tutorial to show the compact CURIE form that is actually stored.

## Test plan
- [ ] `go build ./...` and `go vet ./api/...` pass (verified locally).
- [ ] Against a dev instance where `casbin_rule` already contains `(p,admin,*,odrl:read,*,allow)` etc. and the user has `role_id='admin'` in `account_members`, a `GET /api/line-of-business` returns 200 (previously 403).
- [ ] `IsAuthorizedInAccount` path behaves the same — an account-scoped `AssignAccountRole` + `odrl:read` policy still authorizes.
- [ ] Manual confirm that `PUT /api/settings/role-access` with `"odrl:read"` values round-trips as expected (docs updated accordingly).