### PR TITLE
fix(web/admin): anchor layer paths via createResolver

### DIFF
--- a/web/admin/nuxt.config.ts
+++ b/web/admin/nuxt.config.ts
@@ -13,15 +13,26 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import { createResolver } from '@nuxt/kit'
+
+// `~/` in a Nuxt layer's config resolves against the *consumer's* rootDir,
+// not the layer's own rootDir. So `~/components` and `~/assets/...` quietly
+// point at the consumer's project when this layer is fetched via giget or
+// listed under `extends`, which means none of the layer's own components
+// get auto-imported and the layer's CSS fails to load. Anchor every
+// layer-local path to this file's directory instead so the layer works
+// both standalone and as a dependency. Closes wepala/weos#337.
+const { resolve } = createResolver(import.meta.url)
+
 export default defineNuxtConfig({
   ssr: false,
   // Preset screens (.mjs) use string templates — requires the runtime compiler.
   vue: { runtimeCompiler: true },
   modules: ['@ant-design-vue/nuxt'],
   components: [
-    { path: '~/components', pathPrefix: false },
+    { path: resolve('./components'), pathPrefix: false },
   ],
-  css: ['~/assets/css/main.css'],
+  css: [resolve('./assets/css/main.css')],
   devtools: { enabled: false },
   devServer: {
     port: 3000,


### PR DESCRIPTION
## Summary
- Replaces `~/components` and `~/assets/css/main.css` in `web/admin/nuxt.config.ts` with paths built from `createResolver(import.meta.url)`.
- `~/` in a layer's config resolves against the *consumer's* rootDir, not the layer's, so when `web/admin` is consumed as a giget layer (e.g. by `services/ic-crm`) Nuxt scans the consumer's `components/` dir only and misses every layer-local component. Result: all 49 resource-type menu items render as unresolved `<SidebarMenuItem>` tags, and the sidebar appears empty.
- Same quirk breaks the layer's CSS import; the consumer currently works around it by symlinking the fetched layer's `assets/` into its own rootDir (see `services/ic-crm/Makefile`).

Closes #337.

## Test plan
- [x] `npx nuxt prepare` in `services/core/web/admin` (standalone) still generates `components.d.ts` with `SidebarMenuItem` imported.
- [x] Pointing `services/ic-crm`'s `nuxt.config` at the local core layer (with this fix applied) causes `SidebarMenuItem` — and the rest of the layer's components — to show up in the consumer's `components.d.ts`, which is what was missing before.
- [ ] Once merged, bump the giget ref in `services/ic-crm/web/admin/nuxt.config.ts` to the new SHA; rebuild the embedded SPA and confirm the sidebar renders resource-type entries against a populated DB.
- [ ] Drop the `assets/` symlink block from `services/ic-crm/Makefile` (follow-up).