### PR TITLE
feat(presets): declare cross-type links outside resource schemas (#328)

### DIFF
--- a/application/builtin_resource_types.go
+++ b/application/builtin_resource_types.go
@@ -17,6 +17,7 @@ package application
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/wepala/weos/v3/domain/entities"
 
@@ -25,12 +26,15 @@ import (
 
 // ensureBuiltInResourceTypes installs all presets marked as AutoInstall at
 // startup, creating resource types and seeding fixture data if they don't
-// already exist.
+// already exist. After every auto-install finishes, a single LinkActivator
+// reconcile runs so cross-preset links whose endpoints are now both present
+// activate at startup regardless of preset install order.
 func ensureBuiltInResourceTypes(params struct {
 	fx.In
-	Registry *PresetRegistry
-	TypeSvc  ResourceTypeService
-	Logger   entities.Logger
+	Registry      *PresetRegistry
+	TypeSvc       ResourceTypeService
+	Logger        entities.Logger
+	LinkActivator *LinkActivator `optional:"true"`
 }) error {
 	ctx := context.Background()
 	for _, preset := range params.Registry.List() {
@@ -54,6 +58,23 @@ func ensureBuiltInResourceTypes(params struct {
 			}
 			params.Logger.Info(ctx, "seeded built-in fixture data",
 				"slug", slug, "count", count)
+		}
+	}
+	// InstallPreset already reconciles after each install, but presets install
+	// one at a time in the loop above — if preset B depends on preset A's
+	// types, the activation during A's install won't know B exists yet. A
+	// single terminal reconcile catches any link whose endpoints ended up
+	// both installed across the whole auto-install sequence.
+	//
+	// A reconcile error is returned so Fx's invoke machinery fails startup.
+	// Link activation is load-bearing for correct FK columns; booting a
+	// service with a silently-broken link graph is worse than refusing to
+	// start, since clients would see missing display values and write paths
+	// would skip triple creation for affected references.
+	if params.LinkActivator != nil {
+		if err := params.LinkActivator.Reconcile(ctx); err != nil {
+			params.Logger.Error(ctx, "terminal link reconcile failed", "error", err)
+			return fmt.Errorf("terminal link reconcile: %w", err)
 		}
 	}
 	return nil

--- a/application/builtin_resource_types.go
+++ b/application/builtin_resource_types.go
@@ -67,10 +67,11 @@ func ensureBuiltInResourceTypes(params struct {
 	// both installed across the whole auto-install sequence.
 	//
 	// A reconcile error is returned so Fx's invoke machinery fails startup.
-	// Link activation is load-bearing for correct FK columns; booting a
-	// service with a silently-broken link graph is worse than refusing to
-	// start, since clients would see missing display values and write paths
-	// would skip triple creation for affected references.
+	// Link activation is load-bearing for correct FK/projection columns;
+	// booting a service with a silently-broken link graph is worse than
+	// refusing to start, since clients would see missing display values and
+	// other denormalized link projections even though triple extraction/linking
+	// can still occur for affected references.
 	if params.LinkActivator != nil {
 		if err := params.LinkActivator.Reconcile(ctx); err != nil {
 			params.Logger.Error(ctx, "terminal link reconcile failed", "error", err)

--- a/application/event_handlers_test.go
+++ b/application/event_handlers_test.go
@@ -57,6 +57,10 @@ func (s *stubProjMgr) AncestorSlugs(slug string) []string {
 
 func (s *stubProjMgr) HasColumn(_, _ string) bool { return false }
 
+func (s *stubProjMgr) RegisterLink(_ context.Context, _ repositories.LinkReference) error {
+	return nil
+}
+
 func makeRT(slug, ctxJSON string) *entities.ResourceType {
 	rt := &entities.ResourceType{}
 	_ = rt.Restore("id-"+slug, slug, slug, "desc", "active",

--- a/application/install_preset_test.go
+++ b/application/install_preset_test.go
@@ -48,7 +48,13 @@ func (r *installTestTypeRepo) FindByID(_ context.Context, id string) (*entities.
 func (r *installTestTypeRepo) FindAll(
 	_ context.Context, _ string, _ int,
 ) (repositories.PaginatedResponse[*entities.ResourceType], error) {
-	return repositories.PaginatedResponse[*entities.ResourceType]{}, nil
+	items := make([]*entities.ResourceType, 0, len(r.types))
+	for _, rt := range r.types {
+		items = append(items, rt)
+	}
+	return repositories.PaginatedResponse[*entities.ResourceType]{
+		Data: items, HasMore: false,
+	}, nil
 }
 
 func (r *installTestTypeRepo) Update(_ context.Context, _ *entities.ResourceType) error { return nil }
@@ -351,3 +357,173 @@ func (r *failingTypeRepo) FindAll(
 }
 func (r *failingTypeRepo) Update(context.Context, *entities.ResourceType) error { return nil }
 func (r *failingTypeRepo) Delete(context.Context, string) error                 { return nil }
+
+// End-to-end: a preset declaring both Types and Links → InstallPreset
+// creates the types, then the LinkActivator reconciles and asks the
+// ProjectionManager to RegisterLink for any link whose endpoints are both
+// installed. Covers the "finance-education integration" use case from #328.
+func TestInstallPreset_ActivatesCrossPresetLinkViaActivator(t *testing.T) {
+	t.Parallel()
+	// Two separate presets — one per type — plus a third "integration" preset
+	// that declares the link between them. Exactly the decoupling the issue
+	// describes: neither finance nor education knows about the other, and the
+	// link lives in a package that depends on both.
+	financePreset := PresetDefinition{
+		Name: "finance",
+		Types: []PresetResourceType{
+			{
+				Name: "Invoice", Slug: "invoice",
+				Context: json.RawMessage(`{"@vocab":"https://schema.org/"}`),
+				Schema:  json.RawMessage(`{"type":"object","properties":{"amount":{"type":"number"}}}`),
+			},
+		},
+	}
+	educationPreset := PresetDefinition{
+		Name: "education",
+		Types: []PresetResourceType{
+			{
+				Name: "Guardian", Slug: "guardian",
+				Context: json.RawMessage(`{"@vocab":"https://schema.org/"}`),
+				Schema:  json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`),
+			},
+		},
+	}
+	integrationPreset := PresetDefinition{
+		Name:  "finance-education",
+		Types: nil, // no types of its own — only the link.
+		Links: []PresetLinkDefinition{
+			{
+				Name: "invoice-guardian", SourceType: "invoice", TargetType: "guardian",
+				PropertyName: "guardian", DisplayProperty: "name",
+			},
+		},
+	}
+
+	registry := NewPresetRegistry()
+	registry.MustAdd(financePreset)
+	registry.MustAdd(educationPreset)
+	registry.MustAdd(integrationPreset)
+
+	// Build a link registry seeded from the presets — mirrors buildLinkRegistry.
+	links := NewLinkRegistry()
+	for _, def := range registry.List() {
+		for _, l := range def.Links {
+			if err := links.Add(l); err != nil {
+				t.Fatalf("Add link: %v", err)
+			}
+		}
+	}
+
+	repo := newInstallTestTypeRepo()
+	pm := &recordingProjMgr{}
+	activator, err := NewLinkActivator(links, pm, repo, noopLogger{})
+	if err != nil {
+		t.Fatalf("NewLinkActivator: %v", err)
+	}
+
+	// Helper builds a resourceTypeService wired with the activator and a
+	// dispatcher that projects Save events back into repo.
+	makeSvc := func() ResourceTypeService {
+		es := &stubEventStore{}
+		d := domain.NewEventDispatcher()
+		projMgrStub := &stubProjMgr{}
+		if err := SubscribeResourceTypeHandlers(d, repo, projMgrStub, noopLogger{}); err != nil {
+			t.Fatalf("SubscribeResourceTypeHandlers: %v", err)
+		}
+		return &resourceTypeService{
+			repo: repo, projMgr: projMgrStub, eventStore: es, dispatcher: d,
+			registry: registry, logger: noopLogger{}, resourceSvc: newFakeResourceSvc(),
+			linkActivator: activator,
+		}
+	}
+
+	ctx := context.Background()
+
+	// Install finance first — guardian isn't installed yet, so the link stays
+	// dormant even though finance's install triggers a reconcile.
+	svc := makeSvc()
+	if _, err := svc.InstallPreset(ctx, "finance", false); err != nil {
+		t.Fatalf("install finance: %v", err)
+	}
+	if pm.callCount() != 0 {
+		t.Fatalf("expected dormant link after finance only, got %d RegisterLink calls", pm.callCount())
+	}
+
+	// Installing education completes both endpoints — the reconcile during
+	// education's install should activate the invoice→guardian link.
+	if _, err := svc.InstallPreset(ctx, "education", false); err != nil {
+		t.Fatalf("install education: %v", err)
+	}
+	if pm.callCount() != 1 {
+		t.Fatalf("expected 1 RegisterLink call after both presets installed, got %d", pm.callCount())
+	}
+	call := pm.calls[0]
+	if call.SourceSlug != "invoice" || call.TargetSlug != "guardian" ||
+		call.PropertyName != "guardian" || call.DisplayProperty != "name" {
+		t.Errorf("unexpected link call: %+v", call)
+	}
+
+	// Installing the integration preset (which adds zero new types) runs a
+	// reconcile that finds the link already active; RegisterLink is called
+	// again but the ProjectionManager side dedups — covered elsewhere.
+	if _, err := svc.InstallPreset(ctx, "finance-education", false); err != nil {
+		t.Fatalf("install finance-education: %v", err)
+	}
+}
+
+// Reconcile failures inside InstallPreset must not be silently swallowed —
+// they surface on the result's Warnings slice so API/CLI callers can tell
+// the admin the install was partial.
+func TestInstallPreset_ReconcileFailureSurfacesAsWarning(t *testing.T) {
+	t.Parallel()
+	registry := NewPresetRegistry()
+	registry.MustAdd(PresetDefinition{
+		Name: "finance",
+		Types: []PresetResourceType{{
+			Name: "Invoice", Slug: "invoice",
+			Context: json.RawMessage(`{"@vocab":"https://schema.org/"}`),
+			Schema:  json.RawMessage(`{"type":"object","properties":{"amount":{"type":"number"}}}`),
+		}},
+		Links: []PresetLinkDefinition{{
+			SourceType: "invoice", TargetType: "invoice",
+			PropertyName: "parent", DisplayProperty: "name",
+		}},
+	})
+	links := NewLinkRegistry()
+	for _, def := range registry.List() {
+		for _, l := range def.Links {
+			_ = links.Add(l)
+		}
+	}
+
+	repo := newInstallTestTypeRepo()
+	// Force every RegisterLink call to fail.
+	pm := &recordingProjMgr{errors: map[string]error{"invoice": errors.New("boom")}}
+	activator, err := NewLinkActivator(links, pm, repo, noopLogger{})
+	if err != nil {
+		t.Fatalf("NewLinkActivator: %v", err)
+	}
+
+	es := &stubEventStore{}
+	d := domain.NewEventDispatcher()
+	projMgrStub := &stubProjMgr{}
+	if err := SubscribeResourceTypeHandlers(d, repo, projMgrStub, noopLogger{}); err != nil {
+		t.Fatalf("SubscribeResourceTypeHandlers: %v", err)
+	}
+	svc := &resourceTypeService{
+		repo: repo, projMgr: projMgrStub, eventStore: es, dispatcher: d,
+		registry: registry, logger: noopLogger{}, resourceSvc: newFakeResourceSvc(),
+		linkActivator: activator,
+	}
+
+	result, err := svc.InstallPreset(context.Background(), "finance", false)
+	if err != nil {
+		t.Fatalf("InstallPreset itself should not error: %v", err)
+	}
+	if len(result.Warnings) == 0 {
+		t.Fatalf("expected reconcile failure to surface as a warning, got none")
+	}
+	if len(result.Created) != 1 {
+		t.Errorf("expected the type to still be created, got %+v", result.Created)
+	}
+}

--- a/application/link_activation.go
+++ b/application/link_activation.go
@@ -17,6 +17,7 @@ package application
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/wepala/weos/v3/domain/entities"
@@ -77,10 +78,13 @@ func NewLinkActivator(
 // ProjectionManager.RegisterLink; they'll activate on a subsequent call
 // after the source is installed.
 //
-// Individual RegisterLink failures are logged and counted but don't stop
-// the pass — one bad link shouldn't block siblings. A final aggregate error
-// surfaces to the caller so InstallPreset / startup can escalate; per-link
-// errors are also available in logs for operator diagnosis.
+// Individual RegisterLink failures are logged and collected but don't stop
+// the pass — one bad link shouldn't block siblings. The returned error is
+// the errors.Join of every per-link failure, each wrapped with the
+// (source, target, property) triple so API/CLI callers reading
+// InstallPresetResult.Warnings can identify which link(s) failed without
+// needing log access. A Go 1.20+ errors.Is walk still finds the underlying
+// cause for each branch.
 func (a *LinkActivator) Reconcile(ctx context.Context) error {
 	installed, err := a.loadInstalledSlugs(ctx)
 	if err != nil {
@@ -88,7 +92,7 @@ func (a *LinkActivator) Reconcile(ctx context.Context) error {
 	}
 
 	active := a.registry.ActiveFor(installed)
-	var failed int
+	var failures []error
 	for _, link := range active {
 		err := a.projMgr.RegisterLink(ctx, repositories.LinkReference{
 			SourceSlug:      link.SourceType,
@@ -97,7 +101,11 @@ func (a *LinkActivator) Reconcile(ctx context.Context) error {
 			DisplayProperty: link.DisplayProperty,
 		})
 		if err != nil {
-			failed++
+			wrapped := fmt.Errorf(
+				"link activation failed (source=%q target=%q property=%q): %w",
+				link.SourceType, link.TargetType, link.PropertyName, err,
+			)
+			failures = append(failures, wrapped)
 			a.logger.Error(ctx, "link activation failed",
 				"source", link.SourceType, "target", link.TargetType,
 				"property", link.PropertyName, "error", err)
@@ -107,8 +115,11 @@ func (a *LinkActivator) Reconcile(ctx context.Context) error {
 			"source", link.SourceType, "target", link.TargetType,
 			"property", link.PropertyName)
 	}
-	if failed > 0 {
-		return fmt.Errorf("link activation: %d of %d links failed", failed, len(active))
+	if len(failures) > 0 {
+		return fmt.Errorf(
+			"link activation: %d of %d links failed: %w",
+			len(failures), len(active), errors.Join(failures...),
+		)
 	}
 	return nil
 }

--- a/application/link_activation.go
+++ b/application/link_activation.go
@@ -1,0 +1,138 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
+)
+
+// LinkActivator walks the LinkRegistry and activates any link whose source
+// and target resource types are both installed. Activation means asking the
+// ProjectionManager to add the FK + display columns and record forward/reverse
+// reference entries — the same effects schema-declared x-resource-type
+// properties produce.
+//
+// Reconcile is idempotent and safe to call repeatedly. It's the single entry
+// point used from both startup (builtin_resource_types.go after AutoInstall)
+// and InstallPreset, so any path that adds a resource type re-evaluates every
+// previously-dormant link.
+type LinkActivator struct {
+	registry *LinkRegistry
+	projMgr  repositories.ProjectionManager
+	typeRepo repositories.ResourceTypeRepository
+	logger   entities.Logger
+}
+
+// NewLinkActivator constructs a LinkActivator, validating that every
+// dependency is present. Moving the nil-check to construction time keeps
+// Reconcile's hot path honest: a running activator is guaranteed to have
+// a working registry, projection manager, repo, and logger. Returns an
+// error (rather than panicking) so Fx surfaces wiring mistakes cleanly.
+func NewLinkActivator(
+	registry *LinkRegistry,
+	projMgr repositories.ProjectionManager,
+	typeRepo repositories.ResourceTypeRepository,
+	logger entities.Logger,
+) (*LinkActivator, error) {
+	if registry == nil {
+		return nil, fmt.Errorf("NewLinkActivator: registry is required")
+	}
+	if projMgr == nil {
+		return nil, fmt.Errorf("NewLinkActivator: projMgr is required")
+	}
+	if typeRepo == nil {
+		return nil, fmt.Errorf("NewLinkActivator: typeRepo is required")
+	}
+	if logger == nil {
+		return nil, fmt.Errorf("NewLinkActivator: logger is required")
+	}
+	return &LinkActivator{
+		registry: registry,
+		projMgr:  projMgr,
+		typeRepo: typeRepo,
+		logger:   logger,
+	}, nil
+}
+
+// Reconcile loads the set of installed resource-type slugs and activates
+// every link in the registry whose endpoints are both present. Links whose
+// source type lacks a projection table are skipped silently by
+// ProjectionManager.RegisterLink; they'll activate on a subsequent call
+// after the source is installed.
+//
+// Individual RegisterLink failures are logged and counted but don't stop
+// the pass — one bad link shouldn't block siblings. A final aggregate error
+// surfaces to the caller so InstallPreset / startup can escalate; per-link
+// errors are also available in logs for operator diagnosis.
+func (a *LinkActivator) Reconcile(ctx context.Context) error {
+	installed, err := a.loadInstalledSlugs(ctx)
+	if err != nil {
+		return fmt.Errorf("LinkActivator: load installed types: %w", err)
+	}
+
+	active := a.registry.ActiveFor(installed)
+	var failed int
+	for _, link := range active {
+		err := a.projMgr.RegisterLink(ctx, repositories.LinkReference{
+			SourceSlug:      link.SourceType,
+			PropertyName:    link.PropertyName,
+			TargetSlug:      link.TargetType,
+			DisplayProperty: link.DisplayProperty,
+		})
+		if err != nil {
+			failed++
+			a.logger.Error(ctx, "link activation failed",
+				"source", link.SourceType, "target", link.TargetType,
+				"property", link.PropertyName, "error", err)
+			continue
+		}
+		a.logger.Info(ctx, "link activated",
+			"source", link.SourceType, "target", link.TargetType,
+			"property", link.PropertyName)
+	}
+	if failed > 0 {
+		return fmt.Errorf("link activation: %d of %d links failed", failed, len(active))
+	}
+	return nil
+}
+
+// loadInstalledSlugs paginates through every installed resource type and
+// returns a set of slugs. A chunked cursor pagination (500 per page) avoids
+// pulling the full resource-type table into memory in one query, even though
+// in practice the count is small.
+func (a *LinkActivator) loadInstalledSlugs(ctx context.Context) (map[string]bool, error) {
+	installed := make(map[string]bool)
+	cursor := ""
+	const pageSize = 500
+	for {
+		page, err := a.typeRepo.FindAll(ctx, cursor, pageSize)
+		if err != nil {
+			return nil, err
+		}
+		for _, rt := range page.Data {
+			installed[rt.Slug()] = true
+		}
+		if !page.HasMore || page.Cursor == "" {
+			break
+		}
+		cursor = page.Cursor
+	}
+	return installed, nil
+}

--- a/application/link_activation_test.go
+++ b/application/link_activation_test.go
@@ -1,0 +1,262 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
+)
+
+// listingTypeRepo is a stubTypeRepo-like minimal fake that returns a
+// predictable slice from FindAll. The existing stubTypeRepo.FindAll returns
+// an empty page, which isn't useful for activation tests.
+type listingTypeRepo struct {
+	slugs []string
+}
+
+func (r *listingTypeRepo) Save(context.Context, *entities.ResourceType) error { return nil }
+func (r *listingTypeRepo) FindByID(context.Context, string) (*entities.ResourceType, error) {
+	return nil, repositories.ErrNotFound
+}
+func (r *listingTypeRepo) FindBySlug(_ context.Context, slug string) (*entities.ResourceType, error) {
+	for _, s := range r.slugs {
+		if s == slug {
+			return fakeResourceType(s), nil
+		}
+	}
+	return nil, repositories.ErrNotFound
+}
+func (r *listingTypeRepo) FindAll(
+	_ context.Context, _ string, _ int,
+) (repositories.PaginatedResponse[*entities.ResourceType], error) {
+	items := make([]*entities.ResourceType, 0, len(r.slugs))
+	for _, s := range r.slugs {
+		items = append(items, fakeResourceType(s))
+	}
+	return repositories.PaginatedResponse[*entities.ResourceType]{
+		Data: items, HasMore: false,
+	}, nil
+}
+func (r *listingTypeRepo) Update(context.Context, *entities.ResourceType) error { return nil }
+func (r *listingTypeRepo) Delete(context.Context, string) error                 { return nil }
+
+func fakeResourceType(slug string) *entities.ResourceType {
+	rt := &entities.ResourceType{}
+	_ = rt.Restore("id-"+slug, slug, slug, "", "active",
+		json.RawMessage(`{}`), json.RawMessage(`{}`), time.Now(), 1)
+	return rt
+}
+
+// recordingProjMgr captures RegisterLink calls so tests can assert activation
+// behavior without a real DB. A per-call error override (keyed on source slug)
+// lets tests exercise the failure branch without swapping the whole fake.
+type recordingProjMgr struct {
+	mu     sync.Mutex
+	calls  []repositories.LinkReference
+	errors map[string]error // source slug → error to return
+	stubProjMgr
+}
+
+func (r *recordingProjMgr) RegisterLink(_ context.Context, ref repositories.LinkReference) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, ref)
+	if r.errors != nil {
+		if err, ok := r.errors[ref.SourceSlug]; ok {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *recordingProjMgr) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.calls)
+}
+
+// newTestLinkActivator panics on construction errors so test call sites stay
+// readable — production wiring uses NewLinkActivator directly.
+func newTestLinkActivator(
+	t *testing.T, registry *LinkRegistry, pm repositories.ProjectionManager,
+	repo repositories.ResourceTypeRepository,
+) *LinkActivator {
+	t.Helper()
+	a, err := NewLinkActivator(registry, pm, repo, noopLogger{})
+	if err != nil {
+		t.Fatalf("NewLinkActivator: %v", err)
+	}
+	return a
+}
+
+func TestLinkActivator_ActivatesWhenBothEndpointsInstalled(t *testing.T) {
+	t.Parallel()
+	registry := NewLinkRegistry()
+	_ = registry.Add(PresetLinkDefinition{
+		SourceType: "invoice", TargetType: "guardian",
+		PropertyName: "guardian", DisplayProperty: "name",
+	})
+	pm := &recordingProjMgr{}
+	repo := &listingTypeRepo{slugs: []string{"invoice", "guardian"}}
+	act := newTestLinkActivator(t, registry, pm, repo)
+
+	if err := act.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if pm.callCount() != 1 {
+		t.Fatalf("expected 1 RegisterLink call, got %d", pm.callCount())
+	}
+	got := pm.calls[0]
+	if got.SourceSlug != "invoice" || got.TargetSlug != "guardian" ||
+		got.PropertyName != "guardian" || got.DisplayProperty != "name" {
+		t.Errorf("unexpected call args: %+v", got)
+	}
+}
+
+func TestLinkActivator_SkipsWhenEndpointMissing(t *testing.T) {
+	t.Parallel()
+	registry := NewLinkRegistry()
+	_ = registry.Add(PresetLinkDefinition{
+		SourceType: "invoice", TargetType: "guardian", PropertyName: "guardian",
+	})
+	pm := &recordingProjMgr{}
+	// Only one side installed — link must stay dormant.
+	repo := &listingTypeRepo{slugs: []string{"invoice"}}
+	act := newTestLinkActivator(t, registry, pm, repo)
+
+	if err := act.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if pm.callCount() != 0 {
+		t.Errorf("expected 0 RegisterLink calls with missing endpoint, got %d", pm.callCount())
+	}
+}
+
+func TestLinkActivator_ActivatesLateInstalledTarget(t *testing.T) {
+	t.Parallel()
+	registry := NewLinkRegistry()
+	_ = registry.Add(PresetLinkDefinition{
+		SourceType: "invoice", TargetType: "guardian", PropertyName: "guardian",
+	})
+	pm := &recordingProjMgr{}
+	repo := &listingTypeRepo{slugs: []string{"invoice"}} // target missing
+	act := newTestLinkActivator(t, registry, pm, repo)
+
+	// First reconcile: dormant.
+	_ = act.Reconcile(context.Background())
+	if pm.callCount() != 0 {
+		t.Fatalf("expected dormant, got %d calls", pm.callCount())
+	}
+
+	// Target installed — reconcile again.
+	repo.slugs = append(repo.slugs, "guardian")
+	if err := act.Reconcile(context.Background()); err != nil {
+		t.Fatalf("second Reconcile: %v", err)
+	}
+	if pm.callCount() != 1 {
+		t.Errorf("expected 1 activation after late install, got %d", pm.callCount())
+	}
+}
+
+func TestLinkActivator_ReconcileIsSafeToRepeat(t *testing.T) {
+	t.Parallel()
+	registry := NewLinkRegistry()
+	_ = registry.Add(PresetLinkDefinition{
+		SourceType: "invoice", TargetType: "guardian", PropertyName: "guardian",
+	})
+	pm := &recordingProjMgr{}
+	repo := &listingTypeRepo{slugs: []string{"invoice", "guardian"}}
+	act := newTestLinkActivator(t, registry, pm, repo)
+
+	// Each reconcile calls RegisterLink; the underlying ProjectionManager is
+	// what dedups — LinkActivator doesn't need to track prior activations.
+	// Dedup correctness is covered by TestRegisterLink_Idempotent in the
+	// projection_manager_test.go suite.
+	if err := act.Reconcile(context.Background()); err != nil {
+		t.Fatalf("first Reconcile: %v", err)
+	}
+	if err := act.Reconcile(context.Background()); err != nil {
+		t.Fatalf("second Reconcile: %v", err)
+	}
+	if pm.callCount() != 2 {
+		t.Errorf("expected 2 calls (one per reconcile), got %d", pm.callCount())
+	}
+}
+
+// Per-link RegisterLink failures must be logged, counted, and not stop
+// subsequent links from being attempted. Reconcile returns an aggregate
+// error so callers can escalate; siblings still get a chance to activate.
+func TestLinkActivator_PerLinkErrorIsSurfacedAndSiblingsProceed(t *testing.T) {
+	t.Parallel()
+	registry := NewLinkRegistry()
+	_ = registry.Add(PresetLinkDefinition{
+		SourceType: "bad", TargetType: "guardian", PropertyName: "guardian",
+	})
+	_ = registry.Add(PresetLinkDefinition{
+		SourceType: "good", TargetType: "guardian", PropertyName: "guardian",
+	})
+
+	pm := &recordingProjMgr{errors: map[string]error{
+		"bad": errors.New("alter table failed"),
+	}}
+	repo := &listingTypeRepo{slugs: []string{"bad", "good", "guardian"}}
+	act := newTestLinkActivator(t, registry, pm, repo)
+
+	err := act.Reconcile(context.Background())
+	if err == nil {
+		t.Fatalf("expected aggregate error when a link fails, got nil")
+	}
+	// Sibling activation still attempted: both links were dispatched to the
+	// projection manager.
+	if pm.callCount() != 2 {
+		t.Errorf("expected 2 RegisterLink attempts despite failure, got %d", pm.callCount())
+	}
+}
+
+func TestNewLinkActivator_RejectsMissingDependencies(t *testing.T) {
+	t.Parallel()
+	registry := NewLinkRegistry()
+	pm := &recordingProjMgr{}
+	repo := &listingTypeRepo{}
+	logger := noopLogger{}
+
+	cases := []struct {
+		name string
+		r    *LinkRegistry
+		p    repositories.ProjectionManager
+		t    repositories.ResourceTypeRepository
+		l    entities.Logger
+	}{
+		{"nil registry", nil, pm, repo, logger},
+		{"nil projection manager", registry, nil, repo, logger},
+		{"nil type repo", registry, pm, nil, logger},
+		{"nil logger", registry, pm, repo, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewLinkActivator(tc.r, tc.p, tc.t, tc.l); err == nil {
+				t.Errorf("%s: expected error, got nil", tc.name)
+			}
+		})
+	}
+}

--- a/application/link_registry.go
+++ b/application/link_registry.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/wepala/weos/v3/domain/repositories"
+	"github.com/wepala/weos/v3/pkg/utils"
 )
 
 // PresetLinkDefinition declares a relationship between two resource types that
@@ -177,7 +178,7 @@ func (r *LinkRegistry) ByTarget(slug string) []PresetLinkDefinition {
 func (r *LinkRegistry) LinkReferencesForSource(sourceSlug string) []repositories.LinkReference {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	var out []repositories.LinkReference
+	out := []repositories.LinkReference{}
 	for _, l := range r.links {
 		if l.SourceType != sourceSlug {
 			continue
@@ -228,18 +229,33 @@ var linkSlugPattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 // the projection table's standard columns — an ALTER TABLE ADD COLUMN for
 // any of these would fail at reconcile time. Rejecting at Add() surfaces the
 // mistake at registration instead of burying it in a log entry later.
+//
+// Both the raw PropertyName and its snake_case projection (the actual column
+// name) are checked, so "typeSlug", "type_slug", "createdAt", and "created_at"
+// all get rejected. JSON-LD reserved keys (@id, @type, @context) are also
+// rejected because they have special meaning in the serialized resource.
 var linkReservedPropertyNames = map[string]bool{
-	"id":         true,
-	"type":       true,
-	"typeSlug":   true,
-	"data":       true,
-	"status":     true,
-	"createdBy":  true,
-	"accountId":  true,
-	"sequenceNo": true,
-	"createdAt":  true,
-	"updatedAt":  true,
-	"deletedAt":  true,
+	"@id":         true,
+	"@type":       true,
+	"@context":    true,
+	"id":          true,
+	"type":        true,
+	"typeSlug":    true,
+	"type_slug":   true,
+	"data":        true,
+	"status":      true,
+	"createdBy":   true,
+	"created_by":  true,
+	"accountId":   true,
+	"account_id":  true,
+	"sequenceNo":  true,
+	"sequence_no": true,
+	"createdAt":   true,
+	"created_at":  true,
+	"updatedAt":   true,
+	"updated_at":  true,
+	"deletedAt":   true,
+	"deleted_at":  true,
 }
 
 func validateLinkDefinition(def PresetLinkDefinition) error {
@@ -258,7 +274,8 @@ func validateLinkDefinition(def PresetLinkDefinition) error {
 	if !linkSlugPattern.MatchString(def.TargetType) {
 		return fmt.Errorf("link definition: TargetType %q must be lowercase kebab-case", def.TargetType)
 	}
-	if linkReservedPropertyNames[def.PropertyName] {
+	if linkReservedPropertyNames[def.PropertyName] ||
+		linkReservedPropertyNames[utils.CamelToSnake(def.PropertyName)] {
 		return fmt.Errorf("link definition: PropertyName %q collides with a standard projection column", def.PropertyName)
 	}
 	return nil

--- a/application/link_registry.go
+++ b/application/link_registry.go
@@ -76,15 +76,19 @@ func NewLinkRegistry() *LinkRegistry {
 	}
 }
 
-// Add registers a link definition. If the (SourceType, PropertyName) pair is
-// already present, the new definition replaces the old one — last-writer-wins,
-// so a package-init RegisterLink that overrides a preset-declared link takes
-// effect without the caller needing to unregister first.
+// Add registers a link definition. If another definition already maps to
+// the same source type and derived FK column — i.e. the same
+// (SourceType, CamelToSnake(PropertyName)) pair — the new definition
+// replaces the old one (last-writer-wins), so a package-init RegisterLink
+// that overrides a preset-declared link takes effect without the caller
+// needing to unregister first. Keying on the snake_case form (not the raw
+// PropertyName) catches ambiguous camelCase spellings like "guardianId"
+// vs "guardianID" that both project to the same "guardian_id" column.
 func (r *LinkRegistry) Add(def PresetLinkDefinition) error {
 	if err := validateLinkDefinition(def); err != nil {
 		return err
 	}
-	key := def.SourceType + "|" + def.PropertyName
+	key := def.SourceType + "|" + utils.CamelToSnake(def.PropertyName)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if idx, ok := r.index[key]; ok {

--- a/application/link_registry.go
+++ b/application/link_registry.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
-	"strings"
 	"sync"
 
 	"github.com/wepala/weos/v3/domain/repositories"
@@ -227,6 +226,14 @@ func DefaultLinkRegistry() *LinkRegistry {
 // mismatch would silently leave the link dormant forever.
 var linkSlugPattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 
+// linkPropertyNamePattern enforces lowerCamelCase for PropertyName: first
+// rune must be a lowercase letter, remaining runes are letters/digits only.
+// Without this a link could register "Guardian" while another registered
+// "guardian" — both CamelToSnake to "guardian" and silently collide in the
+// projection column. Underscores, hyphens, leading uppercase, and leading
+// digits are all rejected.
+var linkPropertyNamePattern = regexp.MustCompile(`^[a-z][a-zA-Z0-9]*$`)
+
 // linkReservedPropertyNames rejects property names that would collide with
 // the projection table's standard columns — an ALTER TABLE ADD COLUMN for
 // any of these would fail at reconcile time. Rejecting at Add() surfaces the
@@ -270,14 +277,15 @@ func validateLinkDefinition(def PresetLinkDefinition) error {
 	if def.PropertyName == "" {
 		return fmt.Errorf("link definition: PropertyName is required")
 	}
-	if strings.ContainsRune(def.PropertyName, '_') {
-		// Two links like "guardianId" and "guardian_id" would dedup to different
-		// registry keys but share the same snake_case FK column, causing a
-		// silent ALTER TABLE collision later. Reject underscores so camelCase
-		// is the only accepted form and the (SourceType, PropertyName) registry
-		// key matches DB column uniqueness one-to-one.
+	if !linkPropertyNamePattern.MatchString(def.PropertyName) {
+		// Enforce lowerCamelCase end-to-end. Two links like "guardianId" and
+		// "guardian_id" — or "Guardian" and "guardian" — would dedup to
+		// different registry keys but share the same snake_case FK column,
+		// causing a silent ALTER TABLE collision later. Requiring a lowercase
+		// first rune and alphanumeric tail keeps the (SourceType, PropertyName)
+		// registry key one-to-one with the derived DB column name.
 		return fmt.Errorf(
-			"link definition: PropertyName %q must be camelCase (no underscores)",
+			"link definition: PropertyName %q must be lowerCamelCase (first rune lowercase letter, alphanumeric only)",
 			def.PropertyName,
 		)
 	}

--- a/application/link_registry.go
+++ b/application/link_registry.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/wepala/weos/v3/domain/repositories"
@@ -268,6 +269,17 @@ func validateLinkDefinition(def PresetLinkDefinition) error {
 	}
 	if def.PropertyName == "" {
 		return fmt.Errorf("link definition: PropertyName is required")
+	}
+	if strings.ContainsRune(def.PropertyName, '_') {
+		// Two links like "guardianId" and "guardian_id" would dedup to different
+		// registry keys but share the same snake_case FK column, causing a
+		// silent ALTER TABLE collision later. Reject underscores so camelCase
+		// is the only accepted form and the (SourceType, PropertyName) registry
+		// key matches DB column uniqueness one-to-one.
+		return fmt.Errorf(
+			"link definition: PropertyName %q must be camelCase (no underscores)",
+			def.PropertyName,
+		)
 	}
 	if !linkSlugPattern.MatchString(def.SourceType) {
 		return fmt.Errorf("link definition: SourceType %q must be lowercase kebab-case", def.SourceType)

--- a/application/link_registry.go
+++ b/application/link_registry.go
@@ -41,9 +41,10 @@ import (
 //   - PropertyName is the attribute name on the source resource that carries
 //     the reference (e.g. "guardian"). This drives the FK column name and the
 //     predicate IRI derivation.
-//   - PredicateIRI, if empty, is resolved at activation time from the source
-//     type's @vocab + PropertyName via jsonld.ResolvePredicateIRI — the same
-//     rule used for schema-derived x-resource-type properties.
+//   - PredicateIRI, if empty, is derived later from the source type's JSON-LD
+//     context and PropertyName using the same rule as schema-derived
+//     x-resource-type properties; activation itself does not resolve or
+//     validate it.
 //   - DisplayProperty defaults to "name" when empty; it names the property on
 //     the target whose value is denormalized into <prop>_display.
 type PresetLinkDefinition struct {

--- a/application/link_registry.go
+++ b/application/link_registry.go
@@ -1,0 +1,265 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"sync"
+
+	"github.com/wepala/weos/v3/domain/repositories"
+)
+
+// PresetLinkDefinition declares a relationship between two resource types that
+// lives outside either type's schema. Unlike x-resource-type properties baked
+// into a schema, link definitions can be registered by a third package so
+// neither the source nor target type needs to know about the other.
+//
+// A link activates the first time both SourceType and TargetType exist as
+// installed resource types; until then it remains dormant. Activation is
+// idempotent.
+//
+// Fields:
+//   - Name is a human-readable identifier ("invoice-guardian"). Used in logs
+//     and for disambiguation; not persisted.
+//   - SourceType and TargetType are resource type slugs.
+//   - PropertyName is the attribute name on the source resource that carries
+//     the reference (e.g. "guardian"). This drives the FK column name and the
+//     predicate IRI derivation.
+//   - PredicateIRI, if empty, is resolved at activation time from the source
+//     type's @vocab + PropertyName via jsonld.ResolvePredicateIRI — the same
+//     rule used for schema-derived x-resource-type properties.
+//   - DisplayProperty defaults to "name" when empty; it names the property on
+//     the target whose value is denormalized into <prop>_display.
+type PresetLinkDefinition struct {
+	Name            string
+	SourceType      string
+	TargetType      string
+	PropertyName    string
+	PredicateIRI    string
+	DisplayProperty string
+}
+
+// LinkRegistry holds cross-type link definitions contributed by presets and by
+// packages that call application.RegisterLink at startup. Definitions are
+// declarative code: "pending vs active" is a runtime view computed by
+// ActiveFor given the set of installed type slugs, not a stored state.
+type LinkRegistry struct {
+	mu    sync.RWMutex
+	links []PresetLinkDefinition
+	// index prevents duplicate (SourceType, PropertyName) entries. The key is
+	// what's unique in the database — multiple links could legitimately target
+	// the same type, but only one can occupy a given property on a source.
+	index map[string]int // "source|property" -> index into links
+}
+
+// NewLinkRegistry creates an empty registry.
+func NewLinkRegistry() *LinkRegistry {
+	return &LinkRegistry{
+		index: make(map[string]int),
+	}
+}
+
+// Add registers a link definition. If the (SourceType, PropertyName) pair is
+// already present, the new definition replaces the old one — last-writer-wins,
+// so a package-init RegisterLink that overrides a preset-declared link takes
+// effect without the caller needing to unregister first.
+func (r *LinkRegistry) Add(def PresetLinkDefinition) error {
+	if err := validateLinkDefinition(def); err != nil {
+		return err
+	}
+	key := def.SourceType + "|" + def.PropertyName
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if idx, ok := r.index[key]; ok {
+		r.links[idx] = def
+		return nil
+	}
+	r.index[key] = len(r.links)
+	r.links = append(r.links, def)
+	return nil
+}
+
+// MustAdd is the panicking form of Add for init-time registration of
+// known-good link definitions.
+func (r *LinkRegistry) MustAdd(def PresetLinkDefinition) {
+	if err := r.Add(def); err != nil {
+		panic(fmt.Sprintf("link registration failed: %v", err))
+	}
+}
+
+// All returns a copy of every registered link definition, sorted by
+// (SourceType, PropertyName) for deterministic iteration.
+func (r *LinkRegistry) All() []PresetLinkDefinition {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]PresetLinkDefinition, len(r.links))
+	copy(out, r.links)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].SourceType != out[j].SourceType {
+			return out[i].SourceType < out[j].SourceType
+		}
+		return out[i].PropertyName < out[j].PropertyName
+	})
+	return out
+}
+
+// ActiveFor returns the subset of links whose SourceType and TargetType both
+// appear as keys in installed. The caller supplies the installed set rather
+// than having the registry query a repository, so the registry stays
+// dependency-free and trivially testable.
+func (r *LinkRegistry) ActiveFor(installed map[string]bool) []PresetLinkDefinition {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var out []PresetLinkDefinition
+	for _, l := range r.links {
+		if installed[l.SourceType] && installed[l.TargetType] {
+			out = append(out, l)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].SourceType != out[j].SourceType {
+			return out[i].SourceType < out[j].SourceType
+		}
+		return out[i].PropertyName < out[j].PropertyName
+	})
+	return out
+}
+
+// BySource returns every link whose SourceType matches slug. Used by the
+// resource write path to merge link-derived reference properties with the
+// schema-derived x-resource-type properties for triple extraction.
+func (r *LinkRegistry) BySource(slug string) []PresetLinkDefinition {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var out []PresetLinkDefinition
+	for _, l := range r.links {
+		if l.SourceType == slug {
+			out = append(out, l)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].PropertyName < out[j].PropertyName })
+	return out
+}
+
+// ByTarget returns every link whose TargetType matches slug.
+func (r *LinkRegistry) ByTarget(slug string) []PresetLinkDefinition {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var out []PresetLinkDefinition
+	for _, l := range r.links {
+		if l.TargetType == slug {
+			out = append(out, l)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].PropertyName < out[j].PropertyName })
+	return out
+}
+
+// LinkReferencesForSource implements repositories.LinkSource so the projection
+// manager can replay link-declared refs after a schema re-parse clears its
+// forward/reverse maps. Returns an empty slice (not nil) for unknown slugs
+// so callers can range over the result without a nil check.
+func (r *LinkRegistry) LinkReferencesForSource(sourceSlug string) []repositories.LinkReference {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var out []repositories.LinkReference
+	for _, l := range r.links {
+		if l.SourceType != sourceSlug {
+			continue
+		}
+		out = append(out, repositories.LinkReference{
+			SourceSlug:      l.SourceType,
+			PropertyName:    l.PropertyName,
+			TargetSlug:      l.TargetType,
+			DisplayProperty: l.DisplayProperty,
+		})
+	}
+	return out
+}
+
+// defaultLinkRegistry is the process-wide registry that package-init
+// RegisterLink calls populate. application.Module seeds its Fx-provided
+// LinkRegistry from this value so package-init registrations are visible
+// to the running service.
+var defaultLinkRegistry = NewLinkRegistry()
+
+// RegisterLink appends a link definition to the process-wide default
+// registry. Intended for package init() of integration packages that don't
+// carry a full PresetDefinition but still want to declare a cross-preset
+// link — e.g. a lightweight "finance-education" integration package that
+// connects Invoice to Guardian without either preset depending on the other.
+//
+// Links declared inside a PresetDefinition.Links slice are merged into the
+// same registry via presets.RegisterAll, so the two entry points share one
+// source of truth.
+func RegisterLink(def PresetLinkDefinition) error {
+	return defaultLinkRegistry.Add(def)
+}
+
+// DefaultLinkRegistry returns the process-wide registry seeded by
+// package-init RegisterLink calls. Exported for the DI layer to use as the
+// seed for the Fx-provided *LinkRegistry.
+func DefaultLinkRegistry() *LinkRegistry {
+	return defaultLinkRegistry
+}
+
+// linkSlugPattern mirrors validateSlug's regex (resource_type_service.go):
+// lowercase kebab-case, digits allowed. Catches typos like "Invoice" or
+// "invoice_id" at registration time rather than at reconcile, where the
+// mismatch would silently leave the link dormant forever.
+var linkSlugPattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// linkReservedPropertyNames rejects property names that would collide with
+// the projection table's standard columns — an ALTER TABLE ADD COLUMN for
+// any of these would fail at reconcile time. Rejecting at Add() surfaces the
+// mistake at registration instead of burying it in a log entry later.
+var linkReservedPropertyNames = map[string]bool{
+	"id":         true,
+	"type":       true,
+	"typeSlug":   true,
+	"data":       true,
+	"status":     true,
+	"createdBy":  true,
+	"accountId":  true,
+	"sequenceNo": true,
+	"createdAt":  true,
+	"updatedAt":  true,
+	"deletedAt":  true,
+}
+
+func validateLinkDefinition(def PresetLinkDefinition) error {
+	if def.SourceType == "" {
+		return fmt.Errorf("link definition: SourceType is required")
+	}
+	if def.TargetType == "" {
+		return fmt.Errorf("link definition: TargetType is required")
+	}
+	if def.PropertyName == "" {
+		return fmt.Errorf("link definition: PropertyName is required")
+	}
+	if !linkSlugPattern.MatchString(def.SourceType) {
+		return fmt.Errorf("link definition: SourceType %q must be lowercase kebab-case", def.SourceType)
+	}
+	if !linkSlugPattern.MatchString(def.TargetType) {
+		return fmt.Errorf("link definition: TargetType %q must be lowercase kebab-case", def.TargetType)
+	}
+	if linkReservedPropertyNames[def.PropertyName] {
+		return fmt.Errorf("link definition: PropertyName %q collides with a standard projection column", def.PropertyName)
+	}
+	return nil
+}

--- a/application/link_registry.go
+++ b/application/link_registry.go
@@ -63,10 +63,11 @@ type PresetLinkDefinition struct {
 type LinkRegistry struct {
 	mu    sync.RWMutex
 	links []PresetLinkDefinition
-	// index prevents duplicate (SourceType, PropertyName) entries. The key is
-	// what's unique in the database — multiple links could legitimately target
-	// the same type, but only one can occupy a given property on a source.
-	index map[string]int // "source|property" -> index into links
+	// index prevents duplicate (SourceType, CamelToSnake(PropertyName))
+	// entries. The key is what's unique in the database — multiple links
+	// could legitimately target the same type, but only one can occupy a
+	// given derived snake_case property/column on a source.
+	index map[string]int // "source|snake_property" -> index into links
 }
 
 // NewLinkRegistry creates an empty registry.
@@ -210,9 +211,10 @@ var defaultLinkRegistry = NewLinkRegistry()
 // link — e.g. a lightweight "finance-education" integration package that
 // connects Invoice to Guardian without either preset depending on the other.
 //
-// Links declared inside a PresetDefinition.Links slice are merged into the
-// same registry via presets.RegisterAll, so the two entry points share one
-// source of truth.
+// Links declared inside a PresetDefinition.Links slice are collected through
+// preset registration separately; the runtime *LinkRegistry seen by the
+// application is assembled later by the DI wiring from both PresetRegistry
+// and DefaultLinkRegistry().
 func RegisterLink(def PresetLinkDefinition) error {
 	return defaultLinkRegistry.Add(def)
 }

--- a/application/link_registry_test.go
+++ b/application/link_registry_test.go
@@ -1,0 +1,230 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestLinkRegistry_AddValidation(t *testing.T) {
+	t.Parallel()
+	r := NewLinkRegistry()
+
+	cases := []struct {
+		name    string
+		def     PresetLinkDefinition
+		wantErr bool
+	}{
+		{"missing source", PresetLinkDefinition{TargetType: "g", PropertyName: "g"}, true},
+		{"missing target", PresetLinkDefinition{SourceType: "i", PropertyName: "g"}, true},
+		{"missing property", PresetLinkDefinition{SourceType: "i", TargetType: "g"}, true},
+		{"valid", PresetLinkDefinition{SourceType: "i", TargetType: "g", PropertyName: "guardian"}, false},
+		{"valid kebab source", PresetLinkDefinition{
+			SourceType: "invoice-line", TargetType: "guardian", PropertyName: "guardian",
+		}, false},
+		{"uppercase source rejected", PresetLinkDefinition{
+			SourceType: "Invoice", TargetType: "guardian", PropertyName: "guardian",
+		}, true},
+		{"snake_case source rejected", PresetLinkDefinition{
+			SourceType: "invoice_line", TargetType: "guardian", PropertyName: "guardian",
+		}, true},
+		{"uppercase target rejected", PresetLinkDefinition{
+			SourceType: "invoice", TargetType: "Guardian", PropertyName: "guardian",
+		}, true},
+		{"reserved property rejected", PresetLinkDefinition{
+			SourceType: "invoice", TargetType: "guardian", PropertyName: "id",
+		}, true},
+		{"reserved property typeSlug", PresetLinkDefinition{
+			SourceType: "invoice", TargetType: "guardian", PropertyName: "typeSlug",
+		}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := r.Add(tc.def)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestLinkRegistry_DedupesOnSourceAndProperty(t *testing.T) {
+	t.Parallel()
+	r := NewLinkRegistry()
+	first := PresetLinkDefinition{
+		Name: "first", SourceType: "invoice", TargetType: "guardian",
+		PropertyName: "guardian", DisplayProperty: "name",
+	}
+	second := PresetLinkDefinition{
+		Name: "second", SourceType: "invoice", TargetType: "guardian",
+		PropertyName: "guardian", DisplayProperty: "fullName",
+	}
+	if err := r.Add(first); err != nil {
+		t.Fatalf("Add first: %v", err)
+	}
+	if err := r.Add(second); err != nil {
+		t.Fatalf("Add second: %v", err)
+	}
+
+	all := r.All()
+	if len(all) != 1 {
+		t.Fatalf("expected 1 entry after dedup, got %d: %+v", len(all), all)
+	}
+	if all[0].DisplayProperty != "fullName" {
+		t.Errorf("expected second def to overwrite first, got %+v", all[0])
+	}
+}
+
+func TestLinkRegistry_DifferentPropertiesCoexist(t *testing.T) {
+	t.Parallel()
+	r := NewLinkRegistry()
+	_ = r.Add(PresetLinkDefinition{
+		SourceType: "invoice", TargetType: "guardian", PropertyName: "guardian",
+	})
+	_ = r.Add(PresetLinkDefinition{
+		SourceType: "invoice", TargetType: "student", PropertyName: "student",
+	})
+	if got := len(r.All()); got != 2 {
+		t.Errorf("expected 2 entries, got %d", got)
+	}
+}
+
+func TestLinkRegistry_ActiveForRequiresBothEndpoints(t *testing.T) {
+	t.Parallel()
+	r := NewLinkRegistry()
+	_ = r.Add(PresetLinkDefinition{
+		SourceType: "invoice", TargetType: "guardian", PropertyName: "guardian",
+	})
+	_ = r.Add(PresetLinkDefinition{
+		SourceType: "task", TargetType: "project", PropertyName: "project",
+	})
+
+	// Only finance side installed — no links active.
+	active := r.ActiveFor(map[string]bool{"invoice": true})
+	if len(active) != 0 {
+		t.Errorf("expected 0 active links with only source installed, got %+v", active)
+	}
+
+	// Only education side installed — still no links active.
+	active = r.ActiveFor(map[string]bool{"guardian": true})
+	if len(active) != 0 {
+		t.Errorf("expected 0 active links with only target installed, got %+v", active)
+	}
+
+	// Both endpoints of one link installed.
+	active = r.ActiveFor(map[string]bool{"invoice": true, "guardian": true})
+	if len(active) != 1 || active[0].SourceType != "invoice" {
+		t.Errorf("expected 1 active link (invoice→guardian), got %+v", active)
+	}
+
+	// Both links activatable.
+	active = r.ActiveFor(map[string]bool{
+		"invoice": true, "guardian": true, "task": true, "project": true,
+	})
+	if len(active) != 2 {
+		t.Errorf("expected 2 active links, got %+v", active)
+	}
+}
+
+func TestLinkRegistry_BySourceAndByTarget(t *testing.T) {
+	t.Parallel()
+	r := NewLinkRegistry()
+	_ = r.Add(PresetLinkDefinition{
+		SourceType: "invoice", TargetType: "guardian", PropertyName: "guardian",
+	})
+	_ = r.Add(PresetLinkDefinition{
+		SourceType: "invoice", TargetType: "student", PropertyName: "student",
+	})
+	_ = r.Add(PresetLinkDefinition{
+		SourceType: "payment", TargetType: "guardian", PropertyName: "guardian",
+	})
+
+	if got := len(r.BySource("invoice")); got != 2 {
+		t.Errorf("BySource(invoice): expected 2, got %d", got)
+	}
+	if got := len(r.BySource("payment")); got != 1 {
+		t.Errorf("BySource(payment): expected 1, got %d", got)
+	}
+	if got := len(r.BySource("unknown")); got != 0 {
+		t.Errorf("BySource(unknown): expected 0, got %d", got)
+	}
+	if got := len(r.ByTarget("guardian")); got != 2 {
+		t.Errorf("ByTarget(guardian): expected 2, got %d", got)
+	}
+	if got := len(r.ByTarget("student")); got != 1 {
+		t.Errorf("ByTarget(student): expected 1, got %d", got)
+	}
+}
+
+func TestLinkRegistry_ConcurrentAdd(t *testing.T) {
+	t.Parallel()
+	r := NewLinkRegistry()
+
+	// Race detector flags any map/slice write without lock protection.
+	var wg sync.WaitGroup
+	const goroutines = 50
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			_ = r.Add(PresetLinkDefinition{
+				SourceType:   "src",
+				TargetType:   "tgt",
+				PropertyName: propName(i),
+			})
+		}(i)
+	}
+	wg.Wait()
+
+	if got := len(r.All()); got != goroutines {
+		t.Errorf("expected %d entries, got %d", goroutines, got)
+	}
+}
+
+func propName(i int) string {
+	// Avoid fmt to keep the hot loop allocation-free — any stable unique string works.
+	const chars = "abcdefghijklmnopqrstuvwxyz"
+	hi, lo := i/len(chars), i%len(chars)
+	return string([]byte{chars[hi%len(chars)], chars[lo]})
+}
+
+func TestRegisterLink_WritesToDefaultRegistry(t *testing.T) {
+	// Intentionally not t.Parallel(): this test mutates package-global state.
+	before := len(defaultLinkRegistry.All())
+	defer func() {
+		// Reset to avoid leaking into other tests. There's no public Remove
+		// helper so replace the default registry for the duration of the test
+		// process — safe here because nothing else runs in parallel with this.
+		defaultLinkRegistry = NewLinkRegistry()
+	}()
+
+	def := PresetLinkDefinition{
+		Name: "test-link", SourceType: "a", TargetType: "b", PropertyName: "b",
+	}
+	if err := RegisterLink(def); err != nil {
+		t.Fatalf("RegisterLink: %v", err)
+	}
+	if got := len(defaultLinkRegistry.All()); got != before+1 {
+		t.Errorf("expected registry to grow by 1 (was %d, now %d)", before, got)
+	}
+	if got := DefaultLinkRegistry(); got != defaultLinkRegistry {
+		t.Errorf("DefaultLinkRegistry returned a different registry than the package-global")
+	}
+}

--- a/application/module.go
+++ b/application/module.go
@@ -121,6 +121,16 @@ func Module(cfg config.Config, registry *PresetRegistry) fx.Option {
 		// Email sender
 		fx.Provide(email.ProvideEmailSender),
 
+		// LinkRegistry seeded from preset.Links + package-init RegisterLink calls.
+		// Both entry points converge here so the service wiring sees one
+		// authoritative registry. Also exposed as a repositories.LinkSource so
+		// the projection manager can replay link refs after schema re-parse.
+		fx.Provide(func(r *PresetRegistry, logger entities.Logger) *LinkRegistry {
+			return buildLinkRegistry(r, logger)
+		}),
+		fx.Provide(func(r *LinkRegistry) repositories.LinkSource { return r }),
+		fx.Provide(ProvideLinkActivator),
+
 		// Service providers
 		fx.Provide(ProvideResourceTypeService),
 		fx.Provide(ProvideResourceService),
@@ -146,4 +156,54 @@ func ensureProjectionTables(params struct {
 	ProjMgr repositories.ProjectionManager
 }) error {
 	return params.ProjMgr.EnsureExistingTables(context.Background())
+}
+
+// buildLinkRegistry seeds a process-local LinkRegistry from two sources:
+// every link declared in a registered preset's PresetDefinition.Links slice,
+// and every link added to DefaultLinkRegistry() via application.RegisterLink
+// before the Fx container starts up. The same (SourceType, PropertyName)
+// key dedups within the registry — last write wins — so a preset-declared
+// link is effectively replaced if a package-init RegisterLink for the same
+// key runs later.
+func buildLinkRegistry(registry *PresetRegistry, logger entities.Logger) *LinkRegistry {
+	out := NewLinkRegistry()
+	if registry != nil {
+		for _, def := range registry.List() {
+			for _, link := range def.Links {
+				if err := out.Add(link); err != nil {
+					if logger != nil {
+						logger.Error(context.Background(),
+							"invalid preset link definition ignored",
+							"preset", def.Name, "error", err)
+					}
+				}
+			}
+		}
+	}
+	for _, link := range DefaultLinkRegistry().All() {
+		if err := out.Add(link); err != nil {
+			if logger != nil {
+				logger.Error(context.Background(),
+					"invalid RegisterLink definition ignored",
+					"error", err)
+			}
+		}
+	}
+	return out
+}
+
+// ProvideLinkActivator constructs the activator used to reconcile link
+// definitions after resource types are installed. It depends on the
+// ProjectionManager and the ResourceTypeRepository because activation needs
+// to know which types are installed (repo) and where to add FK columns
+// (projection manager). Returns an error (surfaced by Fx) if any dependency
+// is missing — preferable to a runtime panic in Reconcile.
+func ProvideLinkActivator(params struct {
+	fx.In
+	Registry *LinkRegistry
+	ProjMgr  repositories.ProjectionManager
+	TypeRepo repositories.ResourceTypeRepository
+	Logger   entities.Logger
+}) (*LinkActivator, error) {
+	return NewLinkActivator(params.Registry, params.ProjMgr, params.TypeRepo, params.Logger)
 }

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -71,15 +71,27 @@ type PresetDefinition struct {
 	Screens      fs.FS                            // optional embedded screen components
 	Sidebar      *PresetSidebarConfig             // optional sidebar defaults
 	Handlers     []PresetHTTPHandler              // optional HTTP routes mounted under /api
-	AutoInstall  bool                             // if true, types are auto-created at startup
+	// Links declares cross-type relationships that live outside any resource
+	// type's schema. Each link activates when both SourceType and TargetType
+	// are installed — enabling a "finance-education" integration preset to
+	// link Invoice and Guardian without either preset depending on the other.
+	// See PresetLinkDefinition for semantics.
+	Links       []PresetLinkDefinition
+	AutoInstall bool // if true, types are auto-created at startup
 }
 
 // InstallPresetResult reports which types were created, updated, or skipped.
+// Warnings carries non-fatal issues encountered during install — primarily
+// link-activation failures, which don't prevent types from being created
+// but do mean link-declared FK columns are missing until the next
+// successful reconcile. Callers that want strict behavior can inspect this
+// field and escalate.
 type InstallPresetResult struct {
-	Created []string       `json:"created"`
-	Updated []string       `json:"updated,omitempty"`
-	Skipped []string       `json:"skipped"`
-	Seeded  map[string]int `json:"seeded,omitempty"` // slug -> count of fixtures created
+	Created  []string       `json:"created"`
+	Updated  []string       `json:"updated,omitempty"`
+	Skipped  []string       `json:"skipped"`
+	Seeded   map[string]int `json:"seeded,omitempty"` // slug -> count of fixtures created
+	Warnings []string       `json:"warnings,omitempty"`
 }
 
 // PresetRegistry holds all registered presets. Preset packages call Add() to register.
@@ -117,9 +129,37 @@ func (r *PresetRegistry) Add(def PresetDefinition) error {
 	if err := validateHandlers(def); err != nil {
 		return err
 	}
+	if err := validatePresetLinks(def); err != nil {
+		return err
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.presets[def.Name] = def
+	return nil
+}
+
+// validatePresetLinks enforces per-preset invariants on Links: each entry
+// must declare SourceType, TargetType, and PropertyName, and no two entries
+// within the same preset may share (SourceType, PropertyName) since that's
+// the uniqueness key the LinkRegistry dedups on.
+func validatePresetLinks(def PresetDefinition) error {
+	if len(def.Links) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(def.Links))
+	for i, l := range def.Links {
+		if err := validateLinkDefinition(l); err != nil {
+			return fmt.Errorf("preset %q: links[%d]: %w", def.Name, i, err)
+		}
+		key := l.SourceType + "|" + l.PropertyName
+		if _, dup := seen[key]; dup {
+			return fmt.Errorf(
+				"preset %q: links[%d] duplicates (source=%q, property=%q) within the preset",
+				def.Name, i, l.SourceType, l.PropertyName,
+			)
+		}
+		seen[key] = struct{}{}
+	}
 	return nil
 }
 
@@ -193,6 +233,11 @@ func (d PresetDefinition) clone() PresetDefinition {
 		handlers := make([]PresetHTTPHandler, len(d.Handlers))
 		copy(handlers, d.Handlers)
 		d.Handlers = handlers
+	}
+	if d.Links != nil {
+		links := make([]PresetLinkDefinition, len(d.Links))
+		copy(links, d.Links)
+		d.Links = links
 	}
 	if d.Sidebar != nil {
 		s := *d.Sidebar

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 
 	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/pkg/utils"
 )
 
 // PresetResourceType defines a single resource type within a preset.
@@ -140,8 +141,12 @@ func (r *PresetRegistry) Add(def PresetDefinition) error {
 
 // validatePresetLinks enforces per-preset invariants on Links: each entry
 // must declare SourceType, TargetType, and PropertyName, and no two entries
-// within the same preset may share (SourceType, PropertyName) since that's
-// the uniqueness key the LinkRegistry dedups on.
+// within the same preset may share (SourceType, CamelToSnake(PropertyName))
+// since that's the actual DB column uniqueness key. validateLinkDefinition
+// already rejects underscores so raw PropertyName collisions and snake_case
+// column collisions can't diverge, but keying on the snake_case form here
+// keeps the dedup aligned with the DDL invariant even if that upstream rule
+// changes.
 func validatePresetLinks(def PresetDefinition) error {
 	if len(def.Links) == 0 {
 		return nil
@@ -151,7 +156,7 @@ func validatePresetLinks(def PresetDefinition) error {
 		if err := validateLinkDefinition(l); err != nil {
 			return fmt.Errorf("preset %q: links[%d]: %w", def.Name, i, err)
 		}
-		key := l.SourceType + "|" + l.PropertyName
+		key := l.SourceType + "|" + utils.CamelToSnake(l.PropertyName)
 		if _, dup := seen[key]; dup {
 			return fmt.Errorf(
 				"preset %q: links[%d] duplicates (source=%q, property=%q) within the preset",

--- a/application/resource_service.go
+++ b/application/resource_service.go
@@ -60,9 +60,11 @@ type resourceService struct {
 
 // referencePropsFor returns the merged list of schema-declared and
 // link-declared reference properties for the given resource type. Centralized
-// so Create/Update use the same rules — schema-declared refs always appear;
-// link-declared refs appear only if the registry has entries for this source
-// type (dormant links won't surface references the DB can't honor yet).
+// so Create/Update use the same rules. Every link registered against this
+// source slug is surfaced — including dormant ones whose target isn't
+// installed yet — so triple extraction is consistent regardless of install
+// order. The FK/display columns added by LinkActivator are a separate concern;
+// until they exist, only the triple is recorded.
 func (s *resourceService) referencePropsFor(rt *entities.ResourceType) []ReferencePropertyDef {
 	var links []PresetLinkDefinition
 	if s.linkRegistry != nil {

--- a/application/resource_service.go
+++ b/application/resource_service.go
@@ -55,6 +55,20 @@ type resourceService struct {
 	behaviors        ResourceBehaviorRegistry
 	behaviorMeta     BehaviorMetaRegistry
 	behaviorSettings repositories.BehaviorSettingsRepository
+	linkRegistry     *LinkRegistry
+}
+
+// referencePropsFor returns the merged list of schema-declared and
+// link-declared reference properties for the given resource type. Centralized
+// so Create/Update use the same rules — schema-declared refs always appear;
+// link-declared refs appear only if the registry has entries for this source
+// type (dormant links won't surface references the DB can't honor yet).
+func (s *resourceService) referencePropsFor(rt *entities.ResourceType) []ReferencePropertyDef {
+	var links []PresetLinkDefinition
+	if s.linkRegistry != nil {
+		links = s.linkRegistry.BySource(rt.Slug())
+	}
+	return ExtractReferencePropertiesWithLinks(rt.Schema(), rt.Context(), links)
 }
 
 // maxBehaviorRecursionDepth caps how deep a behavior cascade can go. Behaviors
@@ -191,6 +205,7 @@ func ProvideResourceService(params struct {
 	Behaviors        ResourceBehaviorRegistry
 	BehaviorMeta     BehaviorMetaRegistry
 	BehaviorSettings repositories.BehaviorSettingsRepository
+	LinkRegistry     *LinkRegistry `optional:"true"`
 }) ResourceService {
 	return &resourceService{
 		repo:             params.Repo,
@@ -204,6 +219,7 @@ func ProvideResourceService(params struct {
 		behaviors:        params.Behaviors,
 		behaviorMeta:     params.BehaviorMeta,
 		behaviorSettings: params.BehaviorSettings,
+		linkRegistry:     params.LinkRegistry,
 	}
 }
 
@@ -240,7 +256,7 @@ func (s *resourceService) Create(
 	}
 
 	entityID := identity.NewResource(cmd.TypeSlug)
-	refProps := ExtractReferenceProperties(rt.Schema(), rt.Context())
+	refProps := s.referencePropsFor(rt)
 
 	// Extract reference triples for atomic UoW commit alongside the entity.
 	// BuildResourceGraph below consumes the original data (refs intact), so
@@ -442,7 +458,7 @@ func (s *resourceService) Update(
 		return nil, fmt.Errorf("schema validation failed: %w", err)
 	}
 
-	refProps := ExtractReferenceProperties(rt.Schema(), rt.Context())
+	refProps := s.referencePropsFor(rt)
 
 	// Extract reference triples for atomic UoW commit alongside the entity.
 	// BuildResourceGraph below consumes the original data (refs intact), so

--- a/application/resource_service_test.go
+++ b/application/resource_service_test.go
@@ -17,8 +17,11 @@ package application
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/wepala/weos/v3/domain/entities"
 )
 
 // TestEnterResourceCall_IncrementsBelowLimit verifies the happy path: depths
@@ -159,6 +162,74 @@ func TestResourceService_UpdateEnforcesDepthGuard(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "recursion depth") {
 		t.Errorf("Update error = %q, want contains 'recursion depth' (guard did not fire)", err.Error())
+	}
+}
+
+// TestResourceService_ReferencePropsFor_MergesLinkRegistry is the load-bearing
+// regression guard for the #328 feature: resourceService.Create and Update
+// call referencePropsFor(rt) to get the merged list of schema-declared and
+// link-declared refs, which downstream builds the @graph edges node and
+// extracts Triple.Created events. If this method stopped consulting
+// linkRegistry (e.g. a refactor that accidentally dropped the field from
+// Fx params), link-declared references would silently stop producing triples
+// — and end-to-end tests with real dispatchers would be the first to notice.
+//
+// Verifying the merge here pins the contract without needing the full
+// UnitOfWork/event-dispatch machinery. BuildResourceGraph +
+// ExtractReferenceTriples are already tested in triple_extraction_test.go
+// against the same []ReferencePropertyDef, so this test plus those form the
+// full chain.
+func TestResourceService_ReferencePropsFor_MergesLinkRegistry(t *testing.T) {
+	t.Parallel()
+	registry := NewLinkRegistry()
+	if err := registry.Add(PresetLinkDefinition{
+		SourceType: "invoice", TargetType: "guardian",
+		PropertyName: "guardian", DisplayProperty: "name",
+	}); err != nil {
+		t.Fatalf("Add link: %v", err)
+	}
+
+	rt := &entities.ResourceType{}
+	_ = rt.Restore("id-invoice", "Invoice", "invoice", "", "active",
+		json.RawMessage(`{"@vocab":"https://schema.org/"}`),
+		json.RawMessage(`{"type":"object","properties":{"amount":{"type":"number"}}}`),
+		rt.CreatedAt(), 1)
+
+	svc := &resourceService{linkRegistry: registry}
+	refs := svc.referencePropsFor(rt)
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 link-derived reference, got %d: %+v", len(refs), refs)
+	}
+	got := refs[0]
+	if got.PropertyName != "guardian" || got.TargetType != "guardian" ||
+		got.DisplayProperty != "name" {
+		t.Errorf("unexpected ref: %+v", got)
+	}
+	if got.PredicateIRI != "https://schema.org/guardian" {
+		t.Errorf("expected predicate resolved via @vocab, got %q", got.PredicateIRI)
+	}
+}
+
+// When linkRegistry is nil (test paths that don't wire it), referencePropsFor
+// must still return schema-declared refs — no panic, no regression in the
+// pre-existing x-resource-type path.
+func TestResourceService_ReferencePropsFor_NilRegistryFallsBackToSchema(t *testing.T) {
+	t.Parallel()
+	rt := &entities.ResourceType{}
+	_ = rt.Restore("id-task", "Task", "task", "", "active",
+		json.RawMessage(`{"@vocab":"https://schema.org/"}`),
+		json.RawMessage(`{
+			"type":"object",
+			"properties":{
+				"project":{"type":"string","x-resource-type":"project"}
+			}
+		}`),
+		rt.CreatedAt(), 1)
+
+	svc := &resourceService{linkRegistry: nil}
+	refs := svc.referencePropsFor(rt)
+	if len(refs) != 1 || refs[0].PropertyName != "project" {
+		t.Errorf("expected schema-derived ref to survive nil registry, got %+v", refs)
 	}
 }
 

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -117,6 +117,7 @@ type resourceTypeService struct {
 	behaviorMeta     BehaviorMetaRegistry
 	behaviorSettings repositories.BehaviorSettingsRepository
 	accountRepo      authrepos.AccountRepository
+	linkActivator    *LinkActivator
 }
 
 func ProvideResourceTypeService(params struct {
@@ -132,6 +133,7 @@ func ProvideResourceTypeService(params struct {
 	BehaviorMeta     BehaviorMetaRegistry
 	BehaviorSettings repositories.BehaviorSettingsRepository
 	AccountRepo      authrepos.AccountRepository
+	LinkActivator    *LinkActivator `optional:"true"`
 }) ResourceTypeService {
 	return &resourceTypeService{
 		repo:             params.Repo,
@@ -145,6 +147,7 @@ func ProvideResourceTypeService(params struct {
 		behaviorMeta:     params.BehaviorMeta,
 		behaviorSettings: params.BehaviorSettings,
 		accountRepo:      params.AccountRepo,
+		linkActivator:    params.LinkActivator,
 	}
 }
 
@@ -287,6 +290,24 @@ func (s *resourceTypeService) InstallPreset(
 			s.seedFixtures(ctx, pt, result)
 		default:
 			return result, fmt.Errorf("failed to look up resource type %q: %w", pt.Slug, err)
+		}
+	}
+	// Reconcile any link definitions whose endpoints are now both present. This
+	// runs unconditionally because a newly installed type in *this* preset may
+	// also complete a link declared by a *different* preset (e.g. installing
+	// `education` can activate a finance→education link declared by a third
+	// integration package).
+	//
+	// A reconcile error doesn't roll back the install — the resource types are
+	// already persisted — but it does mean link-declared FK columns are
+	// missing. Record it on the result so API/CLI callers can surface the
+	// partial success instead of claiming the install is fully green.
+	if s.linkActivator != nil {
+		if rErr := s.linkActivator.Reconcile(ctx); rErr != nil {
+			s.logger.Error(ctx, "link reconciliation after InstallPreset failed",
+				"preset", presetName, "error", rErr)
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("link reconciliation failed: %s", rErr.Error()))
 		}
 	}
 	return result, nil

--- a/application/triple_extraction.go
+++ b/application/triple_extraction.go
@@ -17,44 +17,92 @@ type ReferencePropertyDef struct {
 	DisplayProperty string // e.g. "name" — property on the target resource shown in lists
 }
 
-// ExtractReferenceProperties parses a JSON Schema and JSON-LD context to find properties
-// that reference other resources (marked with x-resource-type) and their predicate IRIs.
+// ExtractReferenceProperties parses a JSON Schema and JSON-LD context to find
+// properties that reference other resources (marked with x-resource-type).
+// Schema-only form: use when no LinkRegistry is available (pure parsers,
+// static analyzers). Call sites inside ResourceService go through
+// ExtractReferencePropertiesWithLinks so cross-preset links participate.
 func ExtractReferenceProperties(
 	schema json.RawMessage, ldContext json.RawMessage,
 ) []ReferencePropertyDef {
-	if len(schema) == 0 {
-		return nil
-	}
+	return ExtractReferencePropertiesWithLinks(schema, ldContext, nil)
+}
 
-	var s struct {
-		Properties map[string]struct {
-			XResourceType    string `json:"x-resource-type"`
-			XDisplayProperty string `json:"x-display-property"`
-		} `json:"properties"`
-	}
-	if json.Unmarshal(schema, &s) != nil || len(s.Properties) == 0 {
-		return nil
-	}
-
-	// Parse @context to resolve predicate IRIs.
+// ExtractReferencePropertiesWithLinks combines schema-declared x-resource-type
+// references with link-declared references from external PresetLinkDefinitions.
+// Both contribute to the same []ReferencePropertyDef downstream, so the write
+// path (BuildResourceGraph, ExtractReferenceTriples, projection FK/display
+// population) treats them identically.
+//
+// Merge rule: when both the schema and a link define a reference on the same
+// PropertyName, the schema wins. Schemas are closer to the type definition
+// and already validated by existing tests; a conflicting external link is
+// almost certainly a mistake, so we keep the predictable (schema) behavior.
+// Callers with a *LinkRegistry typically pass registry.BySource(typeSlug) as
+// externalLinks.
+func ExtractReferencePropertiesWithLinks(
+	schema, ldContext json.RawMessage,
+	externalLinks []PresetLinkDefinition,
+) []ReferencePropertyDef {
 	vocab, contextMap := jsonld.ParseContext(ldContext)
 
+	seen := make(map[string]struct{})
 	var defs []ReferencePropertyDef
-	for propName, prop := range s.Properties {
-		if prop.XResourceType == "" {
+
+	if len(schema) > 0 {
+		var s struct {
+			Properties map[string]struct {
+				XResourceType    string `json:"x-resource-type"`
+				XDisplayProperty string `json:"x-display-property"`
+			} `json:"properties"`
+		}
+		if json.Unmarshal(schema, &s) == nil {
+			for propName, prop := range s.Properties {
+				if prop.XResourceType == "" {
+					continue
+				}
+				displayProp := prop.XDisplayProperty
+				if displayProp == "" {
+					displayProp = "name"
+				}
+				defs = append(defs, ReferencePropertyDef{
+					PropertyName:    propName,
+					PredicateIRI:    jsonld.ResolvePredicateIRI(propName, vocab, contextMap),
+					TargetType:      prop.XResourceType,
+					DisplayProperty: displayProp,
+				})
+				seen[propName] = struct{}{}
+			}
+		}
+	}
+
+	for _, link := range externalLinks {
+		if link.PropertyName == "" || link.TargetType == "" {
 			continue
 		}
-		displayProp := prop.XDisplayProperty
+		if _, dup := seen[link.PropertyName]; dup {
+			// Schema already declares this property — schema wins.
+			continue
+		}
+		displayProp := link.DisplayProperty
 		if displayProp == "" {
 			displayProp = "name"
 		}
-		predicateIRI := jsonld.ResolvePredicateIRI(propName, vocab, contextMap)
+		predicateIRI := link.PredicateIRI
+		if predicateIRI == "" {
+			predicateIRI = jsonld.ResolvePredicateIRI(link.PropertyName, vocab, contextMap)
+		}
 		defs = append(defs, ReferencePropertyDef{
-			PropertyName:    propName,
+			PropertyName:    link.PropertyName,
 			PredicateIRI:    predicateIRI,
-			TargetType:      prop.XResourceType,
+			TargetType:      link.TargetType,
 			DisplayProperty: displayProp,
 		})
+		seen[link.PropertyName] = struct{}{}
+	}
+
+	if len(defs) == 0 {
+		return nil
 	}
 	return defs
 }

--- a/application/triple_extraction.go
+++ b/application/triple_extraction.go
@@ -35,16 +35,28 @@ func ExtractReferenceProperties(
 // population) treats them identically.
 //
 // Merge rule: when both the schema and a link define a reference on the same
-// PropertyName, the schema wins. Schemas are closer to the type definition
-// and already validated by existing tests; a conflicting external link is
-// almost certainly a mistake, so we keep the predictable (schema) behavior.
+// PropertyName, the schema wins and the conflicting link is silently dropped.
+// The function returns no signal for the drop — callers that need to surface
+// conflicts should inspect the registry against the schema before calling.
 // Callers with a *LinkRegistry typically pass registry.BySource(typeSlug) as
 // externalLinks.
 func ExtractReferencePropertiesWithLinks(
 	schema, ldContext json.RawMessage,
 	externalLinks []PresetLinkDefinition,
 ) []ReferencePropertyDef {
-	vocab, contextMap := jsonld.ParseContext(ldContext)
+	// ParseContext unmarshals the entire @context — skip it when no
+	// references need predicate resolution. resolveVocab caches the lazy
+	// parse so a second reference doesn't re-parse.
+	var vocab string
+	var contextMap map[string]string
+	var contextParsed bool
+	resolveVocab := func() (string, map[string]string) {
+		if !contextParsed {
+			vocab, contextMap = jsonld.ParseContext(ldContext)
+			contextParsed = true
+		}
+		return vocab, contextMap
+	}
 
 	seen := make(map[string]struct{})
 	var defs []ReferencePropertyDef
@@ -65,9 +77,10 @@ func ExtractReferencePropertiesWithLinks(
 				if displayProp == "" {
 					displayProp = "name"
 				}
+				v, cm := resolveVocab()
 				defs = append(defs, ReferencePropertyDef{
 					PropertyName:    propName,
-					PredicateIRI:    jsonld.ResolvePredicateIRI(propName, vocab, contextMap),
+					PredicateIRI:    jsonld.ResolvePredicateIRI(propName, v, cm),
 					TargetType:      prop.XResourceType,
 					DisplayProperty: displayProp,
 				})
@@ -90,7 +103,8 @@ func ExtractReferencePropertiesWithLinks(
 		}
 		predicateIRI := link.PredicateIRI
 		if predicateIRI == "" {
-			predicateIRI = jsonld.ResolvePredicateIRI(link.PropertyName, vocab, contextMap)
+			v, cm := resolveVocab()
+			predicateIRI = jsonld.ResolvePredicateIRI(link.PropertyName, v, cm)
 		}
 		defs = append(defs, ReferencePropertyDef{
 			PropertyName:    link.PropertyName,

--- a/application/triple_extraction_test.go
+++ b/application/triple_extraction_test.go
@@ -557,3 +557,106 @@ func TestBuildResourceGraph_FlattenGraph_RoundTrip(t *testing.T) {
 		}
 	}
 }
+
+// Schema-declared x-resource-type properties and external link definitions
+// should merge into a single []ReferencePropertyDef with schema winning on
+// conflicts.
+func TestExtractReferencePropertiesWithLinks_MergesSchemaAndExternal(t *testing.T) {
+	t.Parallel()
+	schema := json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"name":{"type":"string"},
+			"project":{"type":"string","x-resource-type":"project","x-display-property":"name"}
+		}
+	}`)
+	ctx := json.RawMessage(`{"@vocab":"https://schema.org/"}`)
+	external := []PresetLinkDefinition{
+		{
+			SourceType: "task", TargetType: "user",
+			PropertyName: "assignee", DisplayProperty: "givenName",
+		},
+	}
+
+	defs := ExtractReferencePropertiesWithLinks(schema, ctx, external)
+	if len(defs) != 2 {
+		t.Fatalf("expected 2 defs (schema + link), got %d: %+v", len(defs), defs)
+	}
+	byProp := map[string]ReferencePropertyDef{}
+	for _, d := range defs {
+		byProp[d.PropertyName] = d
+	}
+	if byProp["project"].TargetType != "project" || byProp["project"].DisplayProperty != "name" {
+		t.Errorf("schema-derived def unexpected: %+v", byProp["project"])
+	}
+	if byProp["assignee"].TargetType != "user" || byProp["assignee"].DisplayProperty != "givenName" {
+		t.Errorf("link-derived def unexpected: %+v", byProp["assignee"])
+	}
+	if byProp["assignee"].PredicateIRI != "https://schema.org/assignee" {
+		t.Errorf("expected predicate resolved via @vocab, got %q", byProp["assignee"].PredicateIRI)
+	}
+}
+
+func TestExtractReferencePropertiesWithLinks_SchemaWinsOnConflict(t *testing.T) {
+	t.Parallel()
+	schema := json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"project":{"type":"string","x-resource-type":"project","x-display-property":"name"}
+		}
+	}`)
+	// External link redefines "project" to point at a different target.
+	external := []PresetLinkDefinition{
+		{
+			SourceType: "task", TargetType: "wrong-target",
+			PropertyName: "project", DisplayProperty: "title",
+		},
+	}
+	defs := ExtractReferencePropertiesWithLinks(schema, nil, external)
+	if len(defs) != 1 {
+		t.Fatalf("expected 1 def after dedup, got %d: %+v", len(defs), defs)
+	}
+	if defs[0].TargetType != "project" {
+		t.Errorf("expected schema to win (project), got %+v", defs[0])
+	}
+}
+
+func TestExtractReferencePropertiesWithLinks_NilSchemaReturnsExternalOnly(t *testing.T) {
+	t.Parallel()
+	ctx := json.RawMessage(`{"@vocab":"https://schema.org/"}`)
+	external := []PresetLinkDefinition{
+		{SourceType: "invoice", TargetType: "guardian", PropertyName: "guardian"},
+	}
+	defs := ExtractReferencePropertiesWithLinks(nil, ctx, external)
+	if len(defs) != 1 || defs[0].TargetType != "guardian" {
+		t.Errorf("expected single link-only def, got %+v", defs)
+	}
+}
+
+func TestExtractReferencePropertiesWithLinks_LinkHonorsExplicitPredicate(t *testing.T) {
+	t.Parallel()
+	external := []PresetLinkDefinition{
+		{
+			SourceType: "invoice", TargetType: "guardian", PropertyName: "guardian",
+			PredicateIRI: "https://example.org/parent-of",
+		},
+	}
+	defs := ExtractReferencePropertiesWithLinks(nil, nil, external)
+	if len(defs) != 1 || defs[0].PredicateIRI != "https://example.org/parent-of" {
+		t.Errorf("expected explicit predicate preserved, got %+v", defs)
+	}
+}
+
+func TestExtractReferenceProperties_StillWorksWithoutLinks(t *testing.T) {
+	t.Parallel()
+	schema := json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"project":{"type":"string","x-resource-type":"project"}
+		}
+	}`)
+	defs := ExtractReferenceProperties(schema, nil)
+	if len(defs) != 1 || defs[0].TargetType != "project" {
+		t.Errorf("back-compat broken: %+v", defs)
+	}
+}

--- a/docs/_explanation/atomic-models-and-triples.md
+++ b/docs/_explanation/atomic-models-and-triples.md
@@ -112,6 +112,57 @@ The `x-display-property` extension specifies which property of the referenced ty
 
 This creates columns `project` (stores the project URN) and `project_display` (stores the project's name). When the project's name changes, the display value propagates automatically to all referencing resources.
 
+## Cross-Preset Links — Relationships Outside the Schema
+
+`x-resource-type` is convenient when both types live in the same preset (e.g. Task and Project in `tasks`). Across presets it creates a problem: if an Invoice schema embeds `guardianId` with `x-resource-type: guardian`, the `finance` preset now depends on the `education` preset even though neither should know about the other.
+
+**Link definitions** solve this by declaring relationships *outside* either type's schema:
+
+```go
+registry.MustAdd(application.PresetDefinition{
+    Name: "finance-education",
+    // No new types — this preset only contributes a link.
+    Links: []application.PresetLinkDefinition{
+        {
+            Name:            "invoice-guardian",
+            SourceType:      "invoice",
+            TargetType:      "guardian",
+            PropertyName:    "guardian",
+            DisplayProperty: "name",
+        },
+    },
+})
+```
+
+Packages that are not full presets can register link definitions the same way:
+
+```go
+func init() {
+    _ = application.RegisterLink(application.PresetLinkDefinition{
+        SourceType:   "invoice",
+        TargetType:   "guardian",
+        PropertyName: "guardian",
+    })
+}
+```
+
+### Activation semantics
+
+A link is **dormant** until both `SourceType` and `TargetType` exist as installed resource types. On every preset install — and once at startup — the `LinkActivator` reconciles the link registry against the installed set and activates any link whose endpoints are both present. Activation:
+
+1. Adds the FK column (`guardian TEXT`) and display column (`guardian_display VARCHAR(512)`) to the source type's projection table.
+2. Registers forward/reverse references so display-value propagation and triple extraction treat link-declared references identically to schema-declared ones.
+3. Is idempotent — repeated reconciles are safe.
+
+If only the `finance` preset is installed, the Invoice→Guardian link stays dormant and the Invoice projection table has no `guardian` column. Installing `education` later completes the pair and the columns appear on the next reconcile.
+
+### When to use which
+
+- **`x-resource-type` in the schema** — when source and target live in the same preset (or in a preset that explicitly owns both, like `tasks` owning Task and Project).
+- **`Links` / `RegisterLink`** — when the relationship spans presets, or when a third package wants to connect two existing presets without modifying either.
+
+Both mechanisms produce the same projection columns, the same triple events, and the same UI behavior — they differ only in where the relationship is declared.
+
 ## The Resource.Published Signal
 
 Because entity creation involves multiple events (Resource.Created + Triple.Created), event handlers that need the complete picture wait for the `Resource.Published` signal. This event fires after all creation events are committed, indicating that the resource's data and relationships are fully available.

--- a/docs/_tutorials/creating-a-preset.md
+++ b/docs/_tutorials/creating-a-preset.md
@@ -166,6 +166,46 @@ Create a menu and a menu item:
   --data '{"name": "Grilled Salmon", "price": 24.99, "category": "main", "menu": "MENU_ID"}'
 ```
 
+## Linking to Types from Other Presets
+
+The `menu` property above uses `x-resource-type` — the right choice here because both `menu` and `menu-item` live inside this preset. When you need to link to a type that lives in *another* preset, embedding `x-resource-type` in your schema would force your preset to depend on theirs.
+
+For those cross-preset cases, declare the relationship as a **link definition** instead. Link definitions live outside any resource type's schema, so neither preset needs to know about the other:
+
+```go
+registry.MustAdd(application.PresetDefinition{
+    Name: "restaurant-payments",
+    // No types of its own — this preset's only job is to connect
+    // the `menu-item` type (from the restaurant preset) to the
+    // `invoice-line` type (from some billing preset).
+    Links: []application.PresetLinkDefinition{
+        {
+            Name:            "invoice-line-menu-item",
+            SourceType:      "invoice-line",
+            TargetType:      "menu-item",
+            PropertyName:    "menuItem",
+            DisplayProperty: "name",
+        },
+    },
+})
+```
+
+A link stays **dormant** until both `SourceType` and `TargetType` exist as installed resource types. Install one side alone and nothing happens; install both and the FK + `_display` columns appear on the source's projection table automatically.
+
+Any Go package can also register a link at init time without being a full preset:
+
+```go
+func init() {
+    _ = application.RegisterLink(application.PresetLinkDefinition{
+        SourceType:   "invoice-line",
+        TargetType:   "menu-item",
+        PropertyName: "menuItem",
+    })
+}
+```
+
+Use `x-resource-type` inside a preset; use `Links` / `RegisterLink` across presets. See [Atomic Models and Triples]({% link _explanation/atomic-models-and-triples.md %}#cross-preset-links--relationships-outside-the-schema) for the full story.
+
 ## What Happens Behind the Scenes
 
 When you install a preset, WeOS:

--- a/docs/decisions/cross-preset-link-definitions.md
+++ b/docs/decisions/cross-preset-link-definitions.md
@@ -1,0 +1,115 @@
+---
+title: "ADR: Cross-Preset Link Definitions"
+parent: Architecture Decision Records
+layout: default
+nav_order: 6
+---
+
+# ADR: Declaring Cross-Type Relationships Outside Resource Type Schemas
+
+**Status:** Accepted — Implemented
+**Date:** 2026-04-19
+**Issue:** [#328 — Find another way to define foreign key relationships in resource type schema](https://github.com/wepala/weos/issues/328)
+
+## Problem
+
+Cross-type relationships in WeOS were declared by embedding an `x-resource-type` extension on a property in the source type's JSON Schema:
+
+```json
+{
+  "properties": {
+    "guardianId": {
+      "type": "string",
+      "x-resource-type": "guardian",
+      "x-display-property": "name"
+    }
+  }
+}
+```
+
+This works well when both types live in the same preset, but it creates a one-way coupling across presets: for a `finance` preset's `Invoice` to reference an `education` preset's `Guardian`, `Invoice`'s schema must name `Guardian` explicitly. The parent preset ends up with "knowledge of other presets" even though the two are conceptually independent. A third integration package that wants to connect two existing presets cannot express a link between them without modifying one of their schemas.
+
+The issue also asked that cross-preset links **only form when both sides are installed** — installing `finance` alone should not leave a dangling `guardian` column on the Invoice projection table.
+
+## Design Goals
+
+1. Resource type schemas stay atomic — only their own properties.
+2. A link between two types can be declared by a *third* package without either endpoint preset knowing about it.
+3. Links activate only when both source and target resource types are installed.
+4. The existing `x-resource-type` mechanism keeps working unchanged (backward compatibility).
+5. Downstream systems (triple extraction, projection FK columns, display propagation, UI rendering) treat schema-declared and link-declared references identically.
+
+## Decision
+
+Introduce a **link registry** populated from two ergonomic entry points, reconciled against installed types by a dedicated activator.
+
+### Data model
+
+```go
+// PresetLinkDefinition lives alongside PresetResourceType, not inside a schema.
+type PresetLinkDefinition struct {
+    Name            string
+    SourceType      string // slug of source resource type
+    TargetType      string // slug of target resource type
+    PropertyName    string // attribute on source (drives FK column name)
+    PredicateIRI    string // optional; resolved from @vocab if empty
+    DisplayProperty string // defaults to "name"
+    Multi           bool
+}
+
+// Links inside a preset — natural packaging for a "finance-education" integration preset.
+type PresetDefinition struct {
+    // ... existing fields ...
+    Links []PresetLinkDefinition
+}
+
+// Or at package init — for integration packages that don't ship a full preset.
+func RegisterLink(def PresetLinkDefinition) error
+```
+
+Both feed one `LinkRegistry`, deduped on `(SourceType, PropertyName)` — the database uniqueness key for a FK column on a source type.
+
+### Activation
+
+A `LinkActivator.Reconcile(ctx)` pass runs:
+- After every `InstallPreset` call (including the per-preset ones inside `ensureBuiltInResourceTypes`).
+- Once more at startup, after the auto-install loop finishes — this catches links whose endpoints arrived from two different presets and would otherwise only see each other after the next manual install.
+
+Reconcile loads installed type slugs from the repository, asks the registry `ActiveFor(installed)` for links whose source **and** target are both present, and calls `ProjectionManager.RegisterLink` for each. `RegisterLink` adds the FK column + display column via `ALTER TABLE` (idempotent via `addMissingColumns`) and records the same forward/reverse reference entries that schema-declared `x-resource-type` produces.
+
+### Triple extraction
+
+`ExtractReferencePropertiesWithLinks(schema, ldContext, externalLinks)` merges schema-derived refs with link-derived refs into one `[]ReferencePropertyDef`. The write path (`BuildResourceGraph`, `ExtractReferenceTriples`, projection FK/display population) consumes this list unchanged, so link-declared references produce the same triples and the same `@graph` edges node as schema-declared ones.
+
+When both mechanisms declare the same `PropertyName`, **schema wins** (link is dropped with a warning). Schemas are closer to the type definition, so a conflicting external link is almost always a mistake.
+
+## Consequences
+
+### Good
+
+- Cross-preset coupling is gone. A `finance-education` integration preset (or any package) can connect Invoice and Guardian without either preset depending on the other.
+- Activation is conditional and idempotent — installing only one side leaves the schema clean; installing the other side later adds the columns on the next reconcile.
+- The existing `x-resource-type` mechanism continues to work, so no presets in the repo need to migrate.
+- Downstream consumers (UI forms, triple projections, display propagation) see one uniform list of references regardless of where each reference was declared.
+
+### Neutral
+
+- Link definitions are declarative Go code, not persisted domain entities. "Dormant vs active" is a runtime view computed from `(link, installed slugs)` rather than a stored state — simpler, and sync bugs between registry and DB are impossible by construction. The trade-off: we never record *when* a link was activated, but the triples it produces carry that history already.
+- Always materializes FK + display columns when a link activates. Chosen over a "triples-only" opt-out because list query performance parity with `x-resource-type` was prioritized; the issue's "atomic schema" goal is already satisfied by keeping the *source schema* untouched.
+
+### Risks
+
+- **Late activation and historical rows.** Rows written before a link activates won't have `<prop>_display` populated. v1 ships with this limitation; a backfill job is a follow-up, mirroring how resource renames propagate today via `UpdateColumnByFK`.
+- **Type deletion while linked.** Not addressed in v1. Follow-up should block deletion of a resource type when any active link references it.
+- **Predicate collision with schemas.** Dedup on `PropertyName` with schema winning prevents silent data loss; a warning surfaces the conflict.
+
+## Alternatives Considered
+
+1. **Persist `LinkDefinition` as a domain entity with events.** Rejected as sync-prone: the preset code is already the source of truth for link definitions, and persisting them creates two authorities for the same fact.
+2. **Triples-only links with no projection columns.** Rejected for v1: list queries that already rely on FK columns would need JOIN rewrites across the codebase, and there is no opt-in complexity budget for a mechanism that users should adopt by default.
+3. **Replace `x-resource-type` entirely and migrate all presets.** Rejected as unnecessary churn — intra-preset references are unambiguous and the schema is already the right place to declare them.
+
+## Further Reading
+
+- [Atomic Models and Triples]({% link _explanation/atomic-models-and-triples.md %}) — the triple-based relationship model the link mechanism plugs into.
+- [Creating a Preset]({% link _tutorials/creating-a-preset.md %}) — how to use `Links` and `RegisterLink` from a preset.

--- a/docs/decisions/cross-preset-link-definitions.md
+++ b/docs/decisions/cross-preset-link-definitions.md
@@ -54,7 +54,6 @@ type PresetLinkDefinition struct {
     PropertyName    string // attribute on source (drives FK column name)
     PredicateIRI    string // optional; resolved from @vocab if empty
     DisplayProperty string // defaults to "name"
-    Multi           bool
 }
 
 // Links inside a preset — natural packaging for a "finance-education" integration preset.

--- a/docs/decisions/cross-preset-link-definitions.md
+++ b/docs/decisions/cross-preset-link-definitions.md
@@ -100,7 +100,7 @@ When both mechanisms declare the same `PropertyName`, **schema wins** — the co
 
 - **Late activation and historical rows.** Rows written before a link activates won't have `<prop>_display` populated. v1 ships with this limitation; a backfill job is a follow-up, mirroring how resource renames propagate today via `UpdateColumnByFK`.
 - **Type deletion while linked.** Not addressed in v1. Follow-up should block deletion of a resource type when any active link references it.
-- **Predicate collision with schemas.** Dedup on `PropertyName` with schema winning prevents silent data loss; a warning surfaces the conflict.
+- **Predicate collision with schemas.** Dedup on `PropertyName` is schema-first: when a schema property and a cross-preset link definition collide, the schema definition wins and the link definition is silently dropped.
 
 ## Alternatives Considered
 

--- a/docs/decisions/cross-preset-link-definitions.md
+++ b/docs/decisions/cross-preset-link-definitions.md
@@ -80,7 +80,7 @@ Reconcile loads installed type slugs from the repository, asks the registry `Act
 
 `ExtractReferencePropertiesWithLinks(schema, ldContext, externalLinks)` merges schema-derived refs with link-derived refs into one `[]ReferencePropertyDef`. The write path (`BuildResourceGraph`, `ExtractReferenceTriples`, projection FK/display population) consumes this list unchanged, so link-declared references produce the same triples and the same `@graph` edges node as schema-declared ones.
 
-When both mechanisms declare the same `PropertyName`, **schema wins** (link is dropped with a warning). Schemas are closer to the type definition, so a conflicting external link is almost always a mistake.
+When both mechanisms declare the same `PropertyName`, **schema wins** — the conflicting link is silently dropped from the merged list and from the `registerReverseReferences` replay. Schemas are closer to the type definition, so a conflicting external link is almost always a mistake; callers that need to surface the conflict can inspect the registry and compare against the schema before merging.
 
 ## Consequences
 

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -16,3 +16,4 @@ Architecture Decision Records (ADRs) capture significant technical decisions mad
 | [Injecting Services into ResourceBehavior]({% link decisions/behavior-service-injection.md %}) | Accepted (Implemented) | 2026-04-07 |
 | [Cross-Resource Writes from ResourceBehavior Hooks]({% link decisions/behavior-resource-writer.md %}) | Accepted (Implemented) | 2026-04-07 |
 | [Admin Index Override for Thin-Wrap Binaries]({% link decisions/admin-index-override.md %}) | Proposed | 2026-04-14 |
+| [Cross-Preset Link Definitions]({% link decisions/cross-preset-link-definitions.md %}) | Accepted (Implemented) | 2026-04-19 |

--- a/domain/repositories/projection_manager.go
+++ b/domain/repositories/projection_manager.go
@@ -69,6 +69,43 @@ type ProjectionManager interface {
 	// For "loan" with subClassOf "financial-instrument", returns ["financial-instrument"].
 	// Returns nil for types with no parent. Circular references are safely broken.
 	AncestorSlugs(slug string) []string
+
+	// RegisterLink activates a cross-type link declared outside a source type's
+	// schema (see application.PresetLinkDefinition). It adds the <PropertyName>
+	// FK column and sibling <PropertyName>_display column to the source type's
+	// projection table, then records the same ForwardReference/ReverseReference
+	// entries that x-resource-type properties produce — so downstream display
+	// propagation and triple extraction treat link-declared references
+	// identically to schema-declared ones.
+	//
+	// Idempotent: calling RegisterLink twice with the same LinkReference is a
+	// no-op after the first call (column exists + maps dedup on conflict).
+	// Returns an error only if the ALTER TABLE fails; callers that discover
+	// the source type doesn't exist yet (no projection table) should skip
+	// activation and retry after the source type is installed.
+	RegisterLink(ctx context.Context, ref LinkReference) error
+}
+
+// LinkReference is the cross-type-link equivalent of a ForwardReference,
+// carried into ProjectionManager.RegisterLink as a single value so callers
+// can't accidentally swap source and target slugs (both are strings, both
+// were positional in an earlier API). Empty DisplayProperty is treated as
+// "name" by the implementation.
+type LinkReference struct {
+	SourceSlug      string
+	PropertyName    string
+	TargetSlug      string
+	DisplayProperty string
+}
+
+// LinkSource lets ProjectionManager re-apply link-declared references whenever
+// it re-parses a source type's schema. A schema edit triggers EnsureTable,
+// which clears the slug's forward/reverse refs to drop stale entries — without
+// a LinkSource, link-declared refs would be wiped on every schema edit and
+// only restored on the next LinkActivator.Reconcile. Implemented by the
+// application's LinkRegistry; optional for the projection manager.
+type LinkSource interface {
+	LinkReferencesForSource(sourceSlug string) []LinkReference
 }
 
 // ReverseReference describes a resource type that references another via a FK column.

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -74,6 +74,10 @@ type projectionManager struct {
 	forwardRe   sync.Map   // referencingTypeSlug → []repositories.ForwardReference
 	reverseReMu sync.Mutex // guards reverseRe AND forwardRe writes (symmetric)
 	parentOf    sync.Map   // slug → parentSlug (from rdfs:subClassOf, for ancestor chain)
+	// linkSource replays link-declared refs after registerReverseReferences
+	// clears a slug's entries. Optional — nil means link refs are only set by
+	// RegisterLink and will be wiped on schema re-parse.
+	linkSource repositories.LinkSource
 }
 
 type ProjectionManagerResult struct {
@@ -83,13 +87,15 @@ type ProjectionManagerResult struct {
 
 func ProvideProjectionManager(params struct {
 	fx.In
-	DB     *gorm.DB
-	Logger entities.Logger
+	DB         *gorm.DB
+	Logger     entities.Logger
+	LinkSource repositories.LinkSource `optional:"true"`
 }) ProjectionManagerResult {
 	return ProjectionManagerResult{
 		ProjectionManager: &projectionManager{
-			db:     params.DB,
-			logger: params.Logger,
+			db:         params.DB,
+			logger:     params.Logger,
+			linkSource: params.LinkSource,
 		},
 	}
 }
@@ -313,22 +319,48 @@ func (pm *projectionManager) registerReverseReferences(slug string, schema json.
 		if displayProp == "" {
 			displayProp = "name"
 		}
-		colName := utils.CamelToSnake(propName)
-		reverseRef := repositories.ReverseReference{
-			ReferencingTypeSlug: slug,
-			FKColumn:            colName,
-			DisplayColumn:       colName + "_display",
-			DisplayProperty:     displayProp,
-		}
-		forwardRef := repositories.ForwardReference{
-			FKColumn:        colName,
-			DisplayColumn:   colName + "_display",
-			TargetTypeSlug:  prop.XResourceType,
-			DisplayProperty: displayProp,
-		}
-		pm.appendReverseRefLocked(prop.XResourceType, reverseRef)
-		pm.appendForwardRefLocked(slug, forwardRef)
+		pm.registerRefLocked(slug, propName, prop.XResourceType, displayProp)
 	}
+
+	// Replay link-declared refs. Without this, any schema re-parse (EnsureTable
+	// via ResourceType.Updated, or the lazy HasProjectionTable path) would wipe
+	// refs set by RegisterLink and the next Reconcile wouldn't run until the
+	// next InstallPreset or restart — display propagation for link-declared
+	// references would silently stop in the meantime.
+	if pm.linkSource != nil {
+		for _, ref := range pm.linkSource.LinkReferencesForSource(slug) {
+			displayProp := ref.DisplayProperty
+			if displayProp == "" {
+				displayProp = "name"
+			}
+			pm.registerRefLocked(slug, ref.PropertyName, ref.TargetSlug, displayProp)
+		}
+	}
+}
+
+// registerRefLocked records one forward + one reverse reference entry for a
+// reference from sourceSlug.<propertyName> → targetSlug. Shared by
+// registerReverseReferences (schema-derived x-resource-type) and RegisterLink
+// (link-registry-derived) so both paths funnel through the same dedup
+// semantics. Caller must hold reverseReMu.
+func (pm *projectionManager) registerRefLocked(
+	sourceSlug, propertyName, targetSlug, displayProperty string,
+) {
+	colName := utils.CamelToSnake(propertyName)
+	reverseRef := repositories.ReverseReference{
+		ReferencingTypeSlug: sourceSlug,
+		FKColumn:            colName,
+		DisplayColumn:       colName + "_display",
+		DisplayProperty:     displayProperty,
+	}
+	forwardRef := repositories.ForwardReference{
+		FKColumn:        colName,
+		DisplayColumn:   colName + "_display",
+		TargetTypeSlug:  targetSlug,
+		DisplayProperty: displayProperty,
+	}
+	pm.appendReverseRefLocked(targetSlug, reverseRef)
+	pm.appendForwardRefLocked(sourceSlug, forwardRef)
 }
 
 // clearReferencesForSlugLocked removes every reference entry that names slug
@@ -419,6 +451,59 @@ func (pm *projectionManager) appendForwardRefLocked(
 	}
 	updated = append(updated, ref)
 	pm.forwardRe.Store(referencingSlug, updated)
+}
+
+// RegisterLink activates a cross-type link declared outside the source type's
+// schema. See the ProjectionManager interface docstring for semantics.
+//
+// Implementation: the method adds the FK + display columns via the existing
+// addMissingColumns path (idempotent — skips columns that already exist),
+// then records symmetric forward/reverse reference entries through the same
+// helpers used by x-resource-type schema parsing. This keeps schema-declared
+// and link-declared references indistinguishable to the rest of the system
+// (display propagation, triple extraction, UI rendering).
+//
+// If the source type has no projection table yet (RegisterLink called before
+// EnsureTable), the method returns nil and skips silently — the caller
+// (LinkActivator) re-runs the pass after each preset install, and the link
+// will activate the next time around when the source table exists.
+func (pm *projectionManager) RegisterLink(ctx context.Context, ref repositories.LinkReference) error {
+	if ref.SourceSlug == "" || ref.PropertyName == "" || ref.TargetSlug == "" {
+		return fmt.Errorf("RegisterLink: SourceSlug, PropertyName, TargetSlug are required")
+	}
+	displayProperty := ref.DisplayProperty
+	if displayProperty == "" {
+		displayProperty = "name"
+	}
+	if !pm.HasProjectionTable(ref.SourceSlug) {
+		// Source type not yet installed — activation deferred to next reconcile.
+		return nil
+	}
+	tableName := pm.TableName(ref.SourceSlug)
+	colName := utils.CamelToSnake(ref.PropertyName)
+	cols := []columnDef{
+		{Name: colName, SQLType: "TEXT"},
+		{Name: colName + "_display", SQLType: "VARCHAR(512)"},
+	}
+	if err := pm.addMissingColumns(ctx, tableName, cols); err != nil {
+		return fmt.Errorf("RegisterLink: add columns to %q: %w", tableName, err)
+	}
+	// Refresh cached column set so HasColumn reflects the ALTER TABLE.
+	if v, ok := pm.tables.Load(ref.SourceSlug); ok {
+		if info, ok := v.(tableInfo); ok {
+			if info.columns == nil {
+				info.columns = make(map[string]bool)
+			}
+			for _, col := range cols {
+				info.columns[col.Name] = true
+			}
+			pm.tables.Store(ref.SourceSlug, info)
+		}
+	}
+	pm.reverseReMu.Lock()
+	pm.registerRefLocked(ref.SourceSlug, ref.PropertyName, ref.TargetSlug, displayProperty)
+	pm.reverseReMu.Unlock()
+	return nil
 }
 
 func (pm *projectionManager) EnsureExistingTables(ctx context.Context) error {

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -488,15 +488,20 @@ func (pm *projectionManager) RegisterLink(ctx context.Context, ref repositories.
 	if err := pm.addMissingColumns(ctx, tableName, cols); err != nil {
 		return fmt.Errorf("RegisterLink: add columns to %q: %w", tableName, err)
 	}
-	// Refresh cached column set so HasColumn reflects the ALTER TABLE.
+	// Refresh cached column set so HasColumn reflects the ALTER TABLE. The
+	// columns map is read without a lock by HasColumn, so we copy-on-write
+	// into a fresh map and Store the new tableInfo rather than mutating the
+	// existing map in place (maps are not safe for concurrent read/write).
 	if v, ok := pm.tables.Load(ref.SourceSlug); ok {
 		if info, ok := v.(tableInfo); ok {
-			if info.columns == nil {
-				info.columns = make(map[string]bool)
+			updatedColumns := make(map[string]bool, len(info.columns)+len(cols))
+			for name, exists := range info.columns {
+				updatedColumns[name] = exists
 			}
 			for _, col := range cols {
-				info.columns[col.Name] = true
+				updatedColumns[col.Name] = true
 			}
+			info.columns = updatedColumns
 			pm.tables.Store(ref.SourceSlug, info)
 		}
 	}

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -316,6 +316,13 @@ func (pm *projectionManager) registerReverseReferences(slug string, schema json.
 	// Clear any prior entries that name this slug — schema may have changed.
 	pm.clearReferencesForSlugLocked(slug)
 
+	// Track schema-declared refs by both PropertyName and derived FK column
+	// name so the link replay can skip any entry that would override either
+	// (schema wins on conflict). Keying on both catches a link that spells
+	// the property differently but derives to the same column.
+	schemaProps := make(map[string]bool)
+	schemaCols := make(map[string]bool)
+
 	if len(schema) > 0 {
 		var s struct {
 			Properties map[string]struct {
@@ -333,6 +340,8 @@ func (pm *projectionManager) registerReverseReferences(slug string, schema json.
 					displayProp = "name"
 				}
 				pm.registerRefLocked(slug, propName, prop.XResourceType, displayProp)
+				schemaProps[propName] = true
+				schemaCols[utils.CamelToSnake(propName)] = true
 			}
 		}
 	}
@@ -342,9 +351,14 @@ func (pm *projectionManager) registerReverseReferences(slug string, schema json.
 	// since they come from a separate source of truth. Any schema re-parse
 	// (EnsureTable via ResourceType.Updated, or the lazy HasProjectionTable
 	// path) would otherwise leave display propagation silently broken until
-	// the next Reconcile.
+	// the next Reconcile. Conflicting entries (same property or same derived
+	// column) are skipped — schema wins, matching the documented merge rule
+	// in ExtractReferencePropertiesWithLinks.
 	if pm.linkSource != nil {
 		for _, ref := range pm.linkSource.LinkReferencesForSource(slug) {
+			if schemaProps[ref.PropertyName] || schemaCols[utils.CamelToSnake(ref.PropertyName)] {
+				continue
+			}
 			displayProp := ref.DisplayProperty
 			if displayProp == "" {
 				displayProp = "name"

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -124,6 +124,24 @@ func (pm *projectionManager) EnsureTable(
 	for _, col := range columns {
 		colSet[col.Name] = true
 	}
+	// Re-add previously activated link columns so a schema re-parse doesn't
+	// silently drop them from the cache. Schema-derived columns alone won't
+	// include RegisterLink-added FK/_display columns, but they still exist in
+	// the DB — only add what the migrator confirms, so we don't claim cached
+	// presence for a link that hasn't been activated yet.
+	if pm.linkSource != nil {
+		migrator := pm.db.Migrator()
+		for _, ref := range pm.linkSource.LinkReferencesForSource(slug) {
+			colName := utils.CamelToSnake(ref.PropertyName)
+			displayCol := colName + "_display"
+			if migrator.HasColumn(tableName, colName) {
+				colSet[colName] = true
+			}
+			if migrator.HasColumn(tableName, displayCol) {
+				colSet[displayCol] = true
+			}
+		}
+	}
 	pm.tables.Store(slug, tableInfo{name: tableName, context: ldContext, columns: colSet})
 	if parentSlug := jsonld.SubClassOf(ldContext); parentSlug != "" {
 		pm.parentOf.Store(slug, parentSlug)

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -316,35 +316,33 @@ func (pm *projectionManager) registerReverseReferences(slug string, schema json.
 	// Clear any prior entries that name this slug — schema may have changed.
 	pm.clearReferencesForSlugLocked(slug)
 
-	if len(schema) == 0 {
-		return
-	}
-	var s struct {
-		Properties map[string]struct {
-			XResourceType    string `json:"x-resource-type"`
-			XDisplayProperty string `json:"x-display-property"`
-		} `json:"properties"`
-	}
-	if json.Unmarshal(schema, &s) != nil {
-		return
+	if len(schema) > 0 {
+		var s struct {
+			Properties map[string]struct {
+				XResourceType    string `json:"x-resource-type"`
+				XDisplayProperty string `json:"x-display-property"`
+			} `json:"properties"`
+		}
+		if json.Unmarshal(schema, &s) == nil {
+			for propName, prop := range s.Properties {
+				if prop.XResourceType == "" {
+					continue
+				}
+				displayProp := prop.XDisplayProperty
+				if displayProp == "" {
+					displayProp = "name"
+				}
+				pm.registerRefLocked(slug, propName, prop.XResourceType, displayProp)
+			}
+		}
 	}
 
-	for propName, prop := range s.Properties {
-		if prop.XResourceType == "" {
-			continue
-		}
-		displayProp := prop.XDisplayProperty
-		if displayProp == "" {
-			displayProp = "name"
-		}
-		pm.registerRefLocked(slug, propName, prop.XResourceType, displayProp)
-	}
-
-	// Replay link-declared refs. Without this, any schema re-parse (EnsureTable
-	// via ResourceType.Updated, or the lazy HasProjectionTable path) would wipe
-	// refs set by RegisterLink and the next Reconcile wouldn't run until the
-	// next InstallPreset or restart — display propagation for link-declared
-	// references would silently stop in the meantime.
+	// Replay link-declared refs unconditionally — a re-parse with empty or
+	// unparseable schema must not silently wipe RegisterLink-declared refs,
+	// since they come from a separate source of truth. Any schema re-parse
+	// (EnsureTable via ResourceType.Updated, or the lazy HasProjectionTable
+	// path) would otherwise leave display propagation silently broken until
+	// the next Reconcile.
 	if pm.linkSource != nil {
 		for _, ref := range pm.linkSource.LinkReferencesForSource(slug) {
 			displayProp := ref.DisplayProperty

--- a/infrastructure/database/gorm/projection_manager_test.go
+++ b/infrastructure/database/gorm/projection_manager_test.go
@@ -638,3 +638,300 @@ func TestForwardReferences_NoXResourceTypeReturnsNil(t *testing.T) {
 		t.Errorf("expected nil forward refs for schema without x-resource-type, got %+v", fwd)
 	}
 }
+
+func TestRegisterLink_AddsColumnsAndRefs(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	// Both sides installed, no schema-declared link between them.
+	invoiceSchema := json.RawMessage(`{"type":"object","properties":{"amount":{"type":"number"}}}`)
+	guardianSchema := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`)
+	if err := pm.EnsureTable(ctx, "invoice", invoiceSchema, nil); err != nil {
+		t.Fatalf("EnsureTable(invoice): %v", err)
+	}
+	if err := pm.EnsureTable(ctx, "guardian", guardianSchema, nil); err != nil {
+		t.Fatalf("EnsureTable(guardian): %v", err)
+	}
+
+	if err := pm.RegisterLink(ctx, repositories.LinkReference{
+		SourceSlug: "invoice", PropertyName: "guardian",
+		TargetSlug: "guardian", DisplayProperty: "name",
+	}); err != nil {
+		t.Fatalf("RegisterLink: %v", err)
+	}
+
+	// Columns added via ALTER TABLE.
+	if !db.Migrator().HasColumn("invoices", "guardian") {
+		t.Error("expected invoices.guardian column to exist after RegisterLink")
+	}
+	if !db.Migrator().HasColumn("invoices", "guardian_display") {
+		t.Error("expected invoices.guardian_display column to exist after RegisterLink")
+	}
+	// Cached column set reflects the ALTER TABLE so subsequent writers via
+	// HasColumn see the new columns without hitting the migrator again.
+	if !pm.HasColumn("invoice", "guardian") {
+		t.Error("expected pm.HasColumn(invoice, guardian) after RegisterLink")
+	}
+
+	// Forward + reverse references recorded.
+	fwd := pm.ForwardReferences("invoice")
+	if len(fwd) != 1 || fwd[0].FKColumn != "guardian" || fwd[0].TargetTypeSlug != "guardian" {
+		t.Errorf("forward refs: got %+v", fwd)
+	}
+	rev := pm.ReverseReferences("guardian")
+	if len(rev) != 1 || rev[0].ReferencingTypeSlug != "invoice" {
+		t.Errorf("reverse refs: got %+v", rev)
+	}
+}
+
+func TestRegisterLink_Idempotent(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	if err := pm.EnsureTable(ctx, "invoice",
+		json.RawMessage(`{"type":"object","properties":{"amount":{"type":"number"}}}`), nil); err != nil {
+		t.Fatalf("EnsureTable(invoice): %v", err)
+	}
+	if err := pm.EnsureTable(ctx, "guardian",
+		json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`), nil); err != nil {
+		t.Fatalf("EnsureTable(guardian): %v", err)
+	}
+
+	ref := repositories.LinkReference{
+		SourceSlug: "invoice", PropertyName: "guardian",
+		TargetSlug: "guardian", DisplayProperty: "name",
+	}
+	// Call twice — simulates a startup reconcile after a previous reconcile
+	// already activated the same link.
+	if err := pm.RegisterLink(ctx, ref); err != nil {
+		t.Fatalf("first RegisterLink: %v", err)
+	}
+	if err := pm.RegisterLink(ctx, ref); err != nil {
+		t.Fatalf("second RegisterLink: %v", err)
+	}
+
+	if got := len(pm.ForwardReferences("invoice")); got != 1 {
+		t.Errorf("expected 1 forward ref after idempotent calls, got %d", got)
+	}
+	if got := len(pm.ReverseReferences("guardian")); got != 1 {
+		t.Errorf("expected 1 reverse ref after idempotent calls, got %d", got)
+	}
+}
+
+func TestRegisterLink_SkipsWhenSourceNotInstalled(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	// Invoice type not installed — source table missing. RegisterLink must
+	// return nil (not error) so callers can safely run reconcile passes before
+	// all endpoints are installed.
+	if err := pm.RegisterLink(ctx, repositories.LinkReference{
+		SourceSlug: "invoice", PropertyName: "guardian",
+		TargetSlug: "guardian", DisplayProperty: "name",
+	}); err != nil {
+		t.Fatalf("RegisterLink should succeed silently when source missing, got: %v", err)
+	}
+	if got := pm.ForwardReferences("invoice"); got != nil {
+		t.Errorf("expected no forward refs when source missing, got %+v", got)
+	}
+}
+
+func TestRegisterLink_DefaultsDisplayPropertyToName(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	if err := pm.EnsureTable(ctx, "invoice",
+		json.RawMessage(`{"type":"object","properties":{"amount":{"type":"number"}}}`), nil); err != nil {
+		t.Fatalf("EnsureTable(invoice): %v", err)
+	}
+	if err := pm.EnsureTable(ctx, "guardian",
+		json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`), nil); err != nil {
+		t.Fatalf("EnsureTable(guardian): %v", err)
+	}
+
+	// Pass empty displayProperty — defaults to "name" to match x-resource-type.
+	if err := pm.RegisterLink(ctx, repositories.LinkReference{
+		SourceSlug: "invoice", PropertyName: "guardian", TargetSlug: "guardian",
+	}); err != nil {
+		t.Fatalf("RegisterLink: %v", err)
+	}
+	fwd := pm.ForwardReferences("invoice")
+	if len(fwd) != 1 || fwd[0].DisplayProperty != "name" {
+		t.Errorf("expected default DisplayProperty=name, got %+v", fwd)
+	}
+}
+
+// TestRegisterLink_DisplayValuePropagatesViaReverseRef verifies the full
+// propagation contract: once a link is active, ReverseReferences on the
+// target returns an entry that would normally drive UpdateColumnByFK to
+// write the target's display property into the source's <prop>_display
+// column. The test uses UpdateColumnByFK directly — the ResourceService
+// handler that normally triggers it already exists and isn't this test's
+// responsibility — to pin that the underlying SQL path works end-to-end
+// for link-declared refs, not just schema-declared ones.
+func TestRegisterLink_DisplayValuePropagatesViaReverseRef(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	invoiceSchema := json.RawMessage(`{"type":"object","properties":{"amount":{"type":"number"}}}`)
+	guardianSchema := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`)
+	if err := pm.EnsureTable(ctx, "invoice", invoiceSchema, nil); err != nil {
+		t.Fatalf("EnsureTable(invoice): %v", err)
+	}
+	if err := pm.EnsureTable(ctx, "guardian", guardianSchema, nil); err != nil {
+		t.Fatalf("EnsureTable(guardian): %v", err)
+	}
+	if err := pm.RegisterLink(ctx, repositories.LinkReference{
+		SourceSlug: "invoice", PropertyName: "guardian",
+		TargetSlug: "guardian", DisplayProperty: "name",
+	}); err != nil {
+		t.Fatalf("RegisterLink: %v", err)
+	}
+
+	// Seed an invoice row whose `guardian` FK points at a guardian URN.
+	if err := db.Exec(
+		`INSERT INTO invoices (id, type_slug, status, amount, guardian) VALUES (?, 'invoice', 'active', 100, ?)`,
+		"urn:invoice:1", "urn:guardian:42",
+	).Error; err != nil {
+		t.Fatalf("seed invoice: %v", err)
+	}
+
+	// Reverse ref drives the SQL UPDATE. This is the path taken when the
+	// target's display property changes — handler loops over
+	// ReverseReferences("guardian") and issues UpdateColumnByFK for each.
+	revs := pm.ReverseReferences("guardian")
+	if len(revs) != 1 {
+		t.Fatalf("expected 1 reverse ref, got %d", len(revs))
+	}
+	rev := revs[0]
+	if err := pm.UpdateColumnByFK(ctx, rev.ReferencingTypeSlug,
+		rev.FKColumn, "urn:guardian:42", rev.DisplayColumn, "Alice Bellamy"); err != nil {
+		t.Fatalf("UpdateColumnByFK: %v", err)
+	}
+
+	var got string
+	if err := db.Raw(
+		`SELECT guardian_display FROM invoices WHERE id = ?`, "urn:invoice:1",
+	).Scan(&got).Error; err != nil {
+		t.Fatalf("read guardian_display: %v", err)
+	}
+	if got != "Alice Bellamy" {
+		t.Errorf("expected guardian_display = 'Alice Bellamy', got %q", got)
+	}
+}
+
+// stubLinkSource implements repositories.LinkSource for tests. Matches by
+// source slug and returns the preloaded refs so we can verify replay.
+type stubLinkSource struct {
+	bySource map[string][]repositories.LinkReference
+}
+
+func (s *stubLinkSource) LinkReferencesForSource(slug string) []repositories.LinkReference {
+	return s.bySource[slug]
+}
+
+// Regression guard: calling EnsureTable a second time after RegisterLink has
+// run must not wipe link-declared refs. Before the linkSource replay was
+// added, a schema edit (ResourceType.Updated) or a lazy EnsureTable would
+// clear forward/reverse maps and drop the link ref silently.
+func TestEnsureTable_ReplaysLinkRefsAfterClear(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	src := &stubLinkSource{bySource: map[string][]repositories.LinkReference{
+		"invoice": {{
+			SourceSlug: "invoice", PropertyName: "guardian",
+			TargetSlug: "guardian", DisplayProperty: "name",
+		}},
+	}}
+	pm := &projectionManager{db: db, logger: &testLogger{}, linkSource: src}
+	ctx := context.Background()
+
+	invoiceSchema := json.RawMessage(`{"type":"object","properties":{"amount":{"type":"number"}}}`)
+	guardianSchema := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`)
+	if err := pm.EnsureTable(ctx, "invoice", invoiceSchema, nil); err != nil {
+		t.Fatalf("EnsureTable(invoice) #1: %v", err)
+	}
+	if err := pm.EnsureTable(ctx, "guardian", guardianSchema, nil); err != nil {
+		t.Fatalf("EnsureTable(guardian): %v", err)
+	}
+	if err := pm.RegisterLink(ctx, repositories.LinkReference{
+		SourceSlug: "invoice", PropertyName: "guardian",
+		TargetSlug: "guardian", DisplayProperty: "name",
+	}); err != nil {
+		t.Fatalf("RegisterLink: %v", err)
+	}
+	if got := len(pm.ForwardReferences("invoice")); got != 1 {
+		t.Fatalf("pre-condition: expected 1 forward ref after RegisterLink, got %d", got)
+	}
+
+	// Simulate a schema edit (or a lazy EnsureTable) on invoice. Prior to the
+	// linkSource replay this was the bug: forwardRe[invoice] would be wiped.
+	if err := pm.EnsureTable(ctx, "invoice", invoiceSchema, nil); err != nil {
+		t.Fatalf("EnsureTable(invoice) #2: %v", err)
+	}
+	fwd := pm.ForwardReferences("invoice")
+	if len(fwd) != 1 || fwd[0].TargetTypeSlug != "guardian" {
+		t.Errorf("expected link-declared forward ref to survive re-EnsureTable, got %+v", fwd)
+	}
+	rev := pm.ReverseReferences("guardian")
+	if len(rev) != 1 || rev[0].ReferencingTypeSlug != "invoice" {
+		t.Errorf("expected link-declared reverse ref to survive re-EnsureTable, got %+v", rev)
+	}
+}
+
+func TestRegisterLink_CoexistsWithSchemaReference(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	// Task has a schema-declared x-resource-type reference to project.
+	taskSchema := json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"name":{"type":"string"},
+			"project":{"type":"string","x-resource-type":"project"}
+		}
+	}`)
+	if err := pm.EnsureTable(ctx, "task", taskSchema, nil); err != nil {
+		t.Fatalf("EnsureTable(task): %v", err)
+	}
+	if err := pm.EnsureTable(ctx, "project",
+		json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`), nil); err != nil {
+		t.Fatalf("EnsureTable(project): %v", err)
+	}
+	if err := pm.EnsureTable(ctx, "user",
+		json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`), nil); err != nil {
+		t.Fatalf("EnsureTable(user): %v", err)
+	}
+
+	// External link adds a second reference on task.
+	if err := pm.RegisterLink(ctx, repositories.LinkReference{
+		SourceSlug: "task", PropertyName: "assignee",
+		TargetSlug: "user", DisplayProperty: "name",
+	}); err != nil {
+		t.Fatalf("RegisterLink: %v", err)
+	}
+
+	fwd := pm.ForwardReferences("task")
+	if len(fwd) != 2 {
+		t.Fatalf("expected 2 forward refs (schema + link), got %d: %+v", len(fwd), fwd)
+	}
+	targets := make(map[string]bool, len(fwd))
+	for _, f := range fwd {
+		targets[f.TargetTypeSlug] = true
+	}
+	if !targets["project"] || !targets["user"] {
+		t.Errorf("expected targets {project, user}, got %+v", targets)
+	}
+}


### PR DESCRIPTION
## Summary

- Introduces a declarative link mechanism (`PresetLinkDefinition`, `LinkRegistry`, `LinkActivator`) so cross-preset relationships can be declared outside any resource type's JSON Schema — e.g. a `finance-education` integration preset can link `Invoice`→`Guardian` without either endpoint preset depending on the other.
- Links stay **dormant** until both source and target resource types are installed; activation adds FK + `_display` columns and registers forward/reverse refs identically to schema-declared `x-resource-type` properties.
- Existing `x-resource-type` declarations keep working unchanged — the new mechanism is additive.

Closes #328.

## How it works

- Add `Links []PresetLinkDefinition` to `PresetDefinition`, plus `application.RegisterLink(def)` for packages that aren't full presets. Both feed one process-wide `LinkRegistry`, deduped on `(SourceType, PropertyName)`.
- `LinkActivator.Reconcile(ctx)` runs after every `InstallPreset` and once more at startup after `ensureBuiltInResourceTypes`. It loads installed slugs, filters the registry to active links, and calls `ProjectionManager.RegisterLink(ctx, repositories.LinkReference{...})` for each.
- `repositories.LinkSource` (implemented by `LinkRegistry`) lets the projection manager replay link-declared refs after a schema re-parse, so a `ResourceType.Updated` event or a lazy `EnsureTable` can't silently wipe them.
- Triple extraction (`ExtractReferencePropertiesWithLinks`) merges schema-declared and link-declared refs; schema wins on conflict.
- `ProjectionManager.RegisterLink` takes a `LinkReference` struct rather than four positional strings so source/target can't accidentally swap.
- Reconcile failures surface: `InstallPresetResult.Warnings []string` carries the error for API/CLI callers; the startup terminal reconcile returns its error so Fx fails boot on broken activation.

## Docs

- `docs/_explanation/atomic-models-and-triples.md` — new "Cross-Preset Links" section contrasting `x-resource-type` with `Links`/`RegisterLink`.
- `docs/_tutorials/creating-a-preset.md` — new section showing a cross-preset integration preset.
- `docs/decisions/cross-preset-link-definitions.md` — ADR capturing goals, decision, consequences, and alternatives.

## Test plan

- [x] `make test` — all packages pass (unit, integration, e2e).
- [x] `make vet` — clean.
- [x] `make lint` — 0 issues.
- [x] `TestEnsureTable_ReplaysLinkRefsAfterClear` — regression guard against the ref-wipe bug caught in review.
- [x] `TestResourceService_ReferencePropsFor_MergesLinkRegistry` — load-bearing guard that `ResourceService.Create/Update` actually consults the registry.
- [x] `TestLinkActivator_PerLinkErrorIsSurfacedAndSiblingsProceed` — one bad link doesn't block activation of siblings, and Reconcile returns an aggregate error.
- [x] `TestInstallPreset_ReconcileFailureSurfacesAsWarning` — reconcile failures flow through `InstallPresetResult.Warnings` instead of being swallowed.
- [x] `TestRegisterLink_DisplayValuePropagatesViaReverseRef` — the SQL `UpdateColumnByFK` propagation path works for link-declared refs, not just schema-declared ones.
- [x] Link-registry validation covers: missing fields, non-kebab slugs, reserved property names (`id`, `typeSlug`, etc.), dedup on `(Source, Property)`, and concurrent `Add`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)