### PR TITLE
feat(auth): NetSuite OAuth, password endpoints, logout cookie cleanup

### DIFF
--- a/api/handlers/password_auth_handler.go
+++ b/api/handlers/password_auth_handler.go
@@ -40,7 +40,12 @@ type PasswordAuthHandlerConfig struct {
 	SessionDuration time.Duration
 	JWTCookieName   string
 	JWTCookieMaxAge int
-	Logger          entities.Logger
+	// SecureCookies controls the Secure flag on the JWT cookie. Must match
+	// the session manager's setting (false in plain-HTTP local dev, true
+	// otherwise) — a mismatch means the browser drops one of the two
+	// cookies and auth never sticks.
+	SecureCookies bool
+	Logger        entities.Logger
 }
 
 type PasswordAuthHandler struct {
@@ -54,11 +59,10 @@ func NewPasswordAuthHandler(cfg PasswordAuthHandlerConfig) *PasswordAuthHandler 
 	if cfg.JWTCookieName == "" {
 		cfg.JWTCookieName = "pericarp_token"
 	}
-	// Cookie outlives the JWT's exp claim on purpose: BearerOrSession
-	// falls back to the gorilla session when the JWT is stale, so as long
-	// as the cookie is sent the browser still talks to a valid session
-	// for the full SessionDuration. A 15-min cookie would force a
-	// silent re-login on every page that takes longer than that.
+	// Keep the JWT cookie alive for the full session window so the browser
+	// keeps sending it during that period. Whether an expired JWT can fall
+	// back to a valid gorilla session is a property of the auth middleware
+	// on each route, not of this cookie's max age.
 	if cfg.JWTCookieMaxAge == 0 {
 		cfg.JWTCookieMaxAge = int(cfg.SessionDuration.Seconds())
 	}
@@ -162,10 +166,10 @@ func (h *PasswordAuthHandler) Login(c echo.Context) error {
 }
 
 // Logout clears both the gorilla session cookie (delegated to pericarp's
-// Logout handler) and the JWT cookie set by completeAuth. Without
-// explicitly expiring the JWT cookie, BearerOrSession would keep
-// accepting it until its MaxAge elapses — so a sign-out endpoint that
-// only invalidates the session leaves an authenticated cookie pair.
+// Logout handler) and the JWT cookie set by completeAuth. The JWT cookie
+// is currently informational on the server side (no middleware reads it)
+// but a SPA may attach it as a Bearer token, so an endpoint that only
+// invalidates the session would leave a still-presentable JWT.
 func (h *PasswordAuthHandler) Logout(c echo.Context, oauthLogout http.HandlerFunc) error {
 	w := c.Response().Writer
 	http.SetCookie(w, &http.Cookie{
@@ -174,7 +178,7 @@ func (h *PasswordAuthHandler) Logout(c echo.Context, oauthLogout http.HandlerFun
 		Path:     "/",
 		MaxAge:   -1,
 		HttpOnly: true,
-		Secure:   true,
+		Secure:   h.cfg.SecureCookies,
 		SameSite: http.SameSiteLaxMode,
 	})
 	oauthLogout(w, c.Request())
@@ -230,7 +234,7 @@ func (h *PasswordAuthHandler) completeAuth(
 			Path:     "/",
 			MaxAge:   h.cfg.JWTCookieMaxAge,
 			HttpOnly: true,
-			Secure:   true,
+			Secure:   h.cfg.SecureCookies,
 			SameSite: http.SameSiteLaxMode,
 		})
 	}

--- a/api/handlers/password_auth_handler.go
+++ b/api/handlers/password_auth_handler.go
@@ -1,0 +1,243 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package handlers
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/wepala/weos/v3/domain/entities"
+
+	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
+	authentities "github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+	"github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/session"
+	"github.com/labstack/echo/v4"
+)
+
+// PasswordAuthHandlerConfig wires the dependencies used by the password
+// register/login HTTP handlers. The same SessionManager and AuthService
+// instances powering the OAuth flows are reused so password sessions and
+// OAuth sessions share a single cookie and JWT lifecycle.
+type PasswordAuthHandlerConfig struct {
+	AuthService     authapp.AuthenticationService
+	SessionManager  session.SessionManager
+	SessionDuration time.Duration
+	JWTCookieName   string
+	JWTCookieMaxAge int
+	Logger          entities.Logger
+}
+
+type PasswordAuthHandler struct {
+	cfg PasswordAuthHandlerConfig
+}
+
+func NewPasswordAuthHandler(cfg PasswordAuthHandlerConfig) *PasswordAuthHandler {
+	if cfg.SessionDuration == 0 {
+		cfg.SessionDuration = 24 * time.Hour
+	}
+	if cfg.JWTCookieName == "" {
+		cfg.JWTCookieName = "pericarp_token"
+	}
+	if cfg.JWTCookieMaxAge == 0 {
+		cfg.JWTCookieMaxAge = 900
+	}
+	return &PasswordAuthHandler{cfg: cfg}
+}
+
+type registerRequest struct {
+	Email       string `json:"email"`
+	Password    string `json:"password"`
+	DisplayName string `json:"display_name"`
+}
+
+type loginRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type authSuccessResponse struct {
+	Agent     authAgentResponse    `json:"agent"`
+	Account   *authAccountResponse `json:"account,omitempty"`
+	Token     string               `json:"token,omitempty"`
+	ExpiresAt time.Time            `json:"expires_at"`
+}
+
+type authAgentResponse struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+type authAccountResponse struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// Register handles POST /api/auth/register. Mirrors the success branch of
+// pericarp's OAuth Callback: register → create auth session → set HTTP
+// session cookie → issue JWT cookie.
+func (h *PasswordAuthHandler) Register(c echo.Context) error {
+	var req registerRequest
+	if err := c.Bind(&req); err != nil {
+		return respondError(c, http.StatusBadRequest, "invalid request body")
+	}
+	email := strings.TrimSpace(req.Email)
+	if email == "" || req.Password == "" {
+		return respondError(c, http.StatusBadRequest, "email and password are required")
+	}
+	displayName := strings.TrimSpace(req.DisplayName)
+	if displayName == "" {
+		// Fall back to the local-part of the email so the agent has a name
+		// even when the client doesn't supply one. RegisterPassword needs
+		// a non-empty display name to build the personal-account name.
+		if at := strings.Index(email, "@"); at > 0 {
+			displayName = email[:at]
+		} else {
+			displayName = email
+		}
+	}
+
+	ctx := c.Request().Context()
+	agent, credential, account, err := h.cfg.AuthService.RegisterPassword(ctx, email, displayName, req.Password)
+	if err != nil {
+		switch {
+		case errors.Is(err, authapp.ErrEmailAlreadyTaken):
+			return respondError(c, http.StatusConflict, "email already registered")
+		case errors.Is(err, authapp.ErrPasswordSupportNotConfigured):
+			h.cfg.Logger.Error(ctx, "password support not configured")
+			return respondError(c, http.StatusServiceUnavailable, "password registration unavailable")
+		default:
+			h.cfg.Logger.Error(ctx, "register password failed", "error", err)
+			return respondError(c, http.StatusInternalServerError, "failed to register account")
+		}
+	}
+
+	return h.completeAuth(c, agent, credential, account, email)
+}
+
+// Login handles POST /api/auth/password-login. Issues the same session/JWT
+// cookies as Register so a freshly-signed-up client and a returning client
+// look identical to downstream middleware.
+func (h *PasswordAuthHandler) Login(c echo.Context) error {
+	var req loginRequest
+	if err := c.Bind(&req); err != nil {
+		return respondError(c, http.StatusBadRequest, "invalid request body")
+	}
+	email := strings.TrimSpace(req.Email)
+	if email == "" || req.Password == "" {
+		return respondError(c, http.StatusBadRequest, "email and password are required")
+	}
+
+	ctx := c.Request().Context()
+	agent, credential, account, err := h.cfg.AuthService.VerifyPassword(ctx, email, req.Password)
+	if err != nil {
+		switch {
+		case errors.Is(err, authapp.ErrInvalidPassword):
+			return respondError(c, http.StatusUnauthorized, "invalid email or password")
+		case errors.Is(err, authapp.ErrPasswordSupportNotConfigured):
+			h.cfg.Logger.Error(ctx, "password support not configured")
+			return respondError(c, http.StatusServiceUnavailable, "password login unavailable")
+		default:
+			h.cfg.Logger.Error(ctx, "verify password failed", "error", err)
+			return respondError(c, http.StatusInternalServerError, "failed to log in")
+		}
+	}
+
+	return h.completeAuth(c, agent, credential, account, email)
+}
+
+func (h *PasswordAuthHandler) completeAuth(
+	c echo.Context,
+	agent *authentities.Agent,
+	credential *authentities.Credential,
+	account *authentities.Account,
+	email string,
+) error {
+	ctx := c.Request().Context()
+	r := c.Request()
+	w := c.Response().Writer
+
+	authSession, err := h.cfg.AuthService.CreateSession(
+		ctx, agent.GetID(), credential.GetID(),
+		clientIP(r), r.UserAgent(), h.cfg.SessionDuration,
+	)
+	if err != nil {
+		h.cfg.Logger.Error(ctx, "password auth: session creation failed", "error", err)
+		return respondError(c, http.StatusInternalServerError, "failed to create session")
+	}
+
+	sessionData := session.SessionData{
+		SessionID: authSession.GetID(),
+		AgentID:   agent.GetID(),
+		CreatedAt: time.Now(),
+		ExpiresAt: authSession.ExpiresAt(),
+	}
+	var accountResp *authAccountResponse
+	activeAccountID := ""
+	if account != nil {
+		sessionData.AccountID = account.GetID()
+		activeAccountID = account.GetID()
+		accountResp = &authAccountResponse{ID: account.GetID(), Name: account.Name()}
+	}
+	if err := h.cfg.SessionManager.CreateHTTPSession(w, r, sessionData); err != nil {
+		h.cfg.Logger.Error(ctx, "password auth: HTTP session creation failed", "error", err)
+		return respondError(c, http.StatusInternalServerError, "failed to create session")
+	}
+
+	// IssueIdentityToken is best-effort; an outage here must not block login.
+	tokenString, issueErr := h.cfg.AuthService.IssueIdentityToken(ctx, agent, activeAccountID)
+	if issueErr != nil {
+		h.cfg.Logger.Warn(ctx, "password auth: failed to issue identity token", "error", issueErr)
+	} else if tokenString != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     h.cfg.JWTCookieName,
+			Value:    tokenString,
+			Path:     "/",
+			MaxAge:   h.cfg.JWTCookieMaxAge,
+			HttpOnly: true,
+			Secure:   true,
+			SameSite: http.SameSiteLaxMode,
+		})
+	}
+
+	return respond(c, http.StatusOK, authSuccessResponse{
+		Agent: authAgentResponse{
+			ID:    agent.GetID(),
+			Name:  agent.Name(),
+			Email: email,
+		},
+		Account:   accountResp,
+		Token:     tokenString,
+		ExpiresAt: authSession.ExpiresAt(),
+	})
+}
+
+func clientIP(r *http.Request) string {
+	if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
+		if comma := strings.Index(fwd, ","); comma >= 0 {
+			return strings.TrimSpace(fwd[:comma])
+		}
+		return strings.TrimSpace(fwd)
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/api/handlers/password_auth_handler.go
+++ b/api/handlers/password_auth_handler.go
@@ -17,7 +17,6 @@ package handlers
 
 import (
 	"errors"
-	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -198,7 +197,7 @@ func (h *PasswordAuthHandler) completeAuth(
 
 	authSession, err := h.cfg.AuthService.CreateSession(
 		ctx, agent.GetID(), credential.GetID(),
-		clientIP(r), r.UserAgent(), h.cfg.SessionDuration,
+		c.RealIP(), r.UserAgent(), h.cfg.SessionDuration,
 	)
 	if err != nil {
 		h.cfg.Logger.Error(ctx, "password auth: session creation failed", "error", err)
@@ -251,14 +250,3 @@ func (h *PasswordAuthHandler) completeAuth(
 	})
 }
 
-func clientIP(r *http.Request) string {
-	if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
-		first, _, _ := strings.Cut(fwd, ",")
-		return strings.TrimSpace(first)
-	}
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
-	}
-	return host
-}

--- a/api/handlers/password_auth_handler.go
+++ b/api/handlers/password_auth_handler.go
@@ -223,9 +223,13 @@ func (h *PasswordAuthHandler) completeAuth(
 	}
 
 	// IssueIdentityToken is best-effort; an outage here must not block login.
+	// On error, drop the token entirely so the client doesn't see a JWT in
+	// the response body that has no matching cookie — that mismatch makes
+	// "logged in but no cookie" states harder to reason about.
 	tokenString, issueErr := h.cfg.AuthService.IssueIdentityToken(ctx, agent, activeAccountID)
 	if issueErr != nil {
 		h.cfg.Logger.Warn(ctx, "password auth: failed to issue identity token", "error", issueErr)
+		tokenString = ""
 	} else if tokenString != "" {
 		http.SetCookie(w, &http.Cookie{
 			Name:     h.cfg.JWTCookieName,

--- a/api/handlers/password_auth_handler.go
+++ b/api/handlers/password_auth_handler.go
@@ -30,10 +30,10 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// PasswordAuthHandlerConfig wires the dependencies used by the password
-// register/login HTTP handlers. The same SessionManager and AuthService
-// instances powering the OAuth flows are reused so password sessions and
-// OAuth sessions share a single cookie and JWT lifecycle.
+// PasswordAuthHandlerConfig wires dependencies for the password
+// register/login endpoints. SessionManager and AuthService are shared
+// with the OAuth flow so a password-authed and an OAuth-authed request
+// are indistinguishable to downstream middleware.
 type PasswordAuthHandlerConfig struct {
 	AuthService     authapp.AuthenticationService
 	SessionManager  session.SessionManager
@@ -54,8 +54,13 @@ func NewPasswordAuthHandler(cfg PasswordAuthHandlerConfig) *PasswordAuthHandler 
 	if cfg.JWTCookieName == "" {
 		cfg.JWTCookieName = "pericarp_token"
 	}
+	// Cookie outlives the JWT's exp claim on purpose: BearerOrSession
+	// falls back to the gorilla session when the JWT is stale, so as long
+	// as the cookie is sent the browser still talks to a valid session
+	// for the full SessionDuration. A 15-min cookie would force a
+	// silent re-login on every page that takes longer than that.
 	if cfg.JWTCookieMaxAge == 0 {
-		cfg.JWTCookieMaxAge = 900
+		cfg.JWTCookieMaxAge = int(cfg.SessionDuration.Seconds())
 	}
 	return &PasswordAuthHandler{cfg: cfg}
 }
@@ -89,9 +94,6 @@ type authAccountResponse struct {
 	Name string `json:"name"`
 }
 
-// Register handles POST /api/auth/register. Mirrors the success branch of
-// pericarp's OAuth Callback: register → create auth session → set HTTP
-// session cookie → issue JWT cookie.
 func (h *PasswordAuthHandler) Register(c echo.Context) error {
 	var req registerRequest
 	if err := c.Bind(&req); err != nil {
@@ -103,11 +105,11 @@ func (h *PasswordAuthHandler) Register(c echo.Context) error {
 	}
 	displayName := strings.TrimSpace(req.DisplayName)
 	if displayName == "" {
-		// Fall back to the local-part of the email so the agent has a name
-		// even when the client doesn't supply one. RegisterPassword needs
-		// a non-empty display name to build the personal-account name.
-		if at := strings.Index(email, "@"); at > 0 {
-			displayName = email[:at]
+		// RegisterPassword requires a non-empty display name (it's used to
+		// build the personal-account name); the email's local-part is the
+		// least surprising default.
+		if local, _, ok := strings.Cut(email, "@"); ok && local != "" {
+			displayName = local
 		} else {
 			displayName = email
 		}
@@ -131,9 +133,6 @@ func (h *PasswordAuthHandler) Register(c echo.Context) error {
 	return h.completeAuth(c, agent, credential, account, email)
 }
 
-// Login handles POST /api/auth/password-login. Issues the same session/JWT
-// cookies as Register so a freshly-signed-up client and a returning client
-// look identical to downstream middleware.
 func (h *PasswordAuthHandler) Login(c echo.Context) error {
 	var req loginRequest
 	if err := c.Bind(&req); err != nil {
@@ -160,6 +159,26 @@ func (h *PasswordAuthHandler) Login(c echo.Context) error {
 	}
 
 	return h.completeAuth(c, agent, credential, account, email)
+}
+
+// Logout clears both the gorilla session cookie (delegated to pericarp's
+// Logout handler) and the JWT cookie set by completeAuth. Without
+// explicitly expiring the JWT cookie, BearerOrSession would keep
+// accepting it until its MaxAge elapses — so a sign-out endpoint that
+// only invalidates the session leaves an authenticated cookie pair.
+func (h *PasswordAuthHandler) Logout(c echo.Context, oauthLogout http.HandlerFunc) error {
+	w := c.Response().Writer
+	http.SetCookie(w, &http.Cookie{
+		Name:     h.cfg.JWTCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
+	oauthLogout(w, c.Request())
+	return nil
 }
 
 func (h *PasswordAuthHandler) completeAuth(
@@ -230,10 +249,8 @@ func (h *PasswordAuthHandler) completeAuth(
 
 func clientIP(r *http.Request) string {
 	if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
-		if comma := strings.Index(fwd, ","); comma >= 0 {
-			return strings.TrimSpace(fwd[:comma])
-		}
-		return strings.TrimSpace(fwd)
+		first, _, _ := strings.Cut(fwd, ",")
+		return strings.TrimSpace(first)
 	}
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {

--- a/api/handlers/password_auth_handler_test.go
+++ b/api/handlers/password_auth_handler_test.go
@@ -1,0 +1,388 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wepala/weos/v3/api/handlers"
+
+	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
+	authentities "github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+	"github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/session"
+	"github.com/labstack/echo/v4"
+)
+
+// fakeAuthService embeds the AuthenticationService interface so unimplemented
+// methods stay nil-pointer-panicking — only the calls the handler makes need
+// real bodies, which keeps the fake small.
+type fakeAuthService struct {
+	authapp.AuthenticationService
+
+	registerAgent   *authentities.Agent
+	registerCred    *authentities.Credential
+	registerAccount *authentities.Account
+	registerErr     error
+
+	verifyAgent   *authentities.Agent
+	verifyCred    *authentities.Credential
+	verifyAccount *authentities.Account
+	verifyErr     error
+
+	sessionResult *authentities.AuthSession
+	sessionErr    error
+
+	tokenString string
+	tokenErr    error
+
+	gotEmail       string
+	gotDisplayName string
+	gotPassword    string
+}
+
+func (f *fakeAuthService) RegisterPassword(_ context.Context, email, displayName, plaintext string) (
+	*authentities.Agent, *authentities.Credential, *authentities.Account, error,
+) {
+	f.gotEmail = email
+	f.gotDisplayName = displayName
+	f.gotPassword = plaintext
+	return f.registerAgent, f.registerCred, f.registerAccount, f.registerErr
+}
+
+func (f *fakeAuthService) VerifyPassword(_ context.Context, email, plaintext string) (
+	*authentities.Agent, *authentities.Credential, *authentities.Account, error,
+) {
+	f.gotEmail = email
+	f.gotPassword = plaintext
+	return f.verifyAgent, f.verifyCred, f.verifyAccount, f.verifyErr
+}
+
+func (f *fakeAuthService) CreateSession(
+	_ context.Context, _, _, _, _ string, _ time.Duration,
+) (*authentities.AuthSession, error) {
+	return f.sessionResult, f.sessionErr
+}
+
+func (f *fakeAuthService) IssueIdentityToken(
+	_ context.Context, _ *authentities.Agent, _ string,
+) (string, error) {
+	return f.tokenString, f.tokenErr
+}
+
+type fakeSessionManager struct {
+	session.SessionManager
+
+	createCalls int
+	createErr   error
+	gotData     session.SessionData
+}
+
+func (f *fakeSessionManager) CreateHTTPSession(_ http.ResponseWriter, _ *http.Request, data session.SessionData) error {
+	f.createCalls++
+	f.gotData = data
+	return f.createErr
+}
+
+func newAgent(t *testing.T, id, name string) *authentities.Agent {
+	t.Helper()
+	a, err := (&authentities.Agent{}).With(id, name, authentities.AgentTypePerson)
+	if err != nil {
+		t.Fatalf("build agent: %v", err)
+	}
+	return a
+}
+
+func newCredential(t *testing.T) *authentities.Credential {
+	t.Helper()
+	c, err := (&authentities.Credential{}).With(
+		"cred-1", "agent-1", "password", "user@example.com", "user@example.com", "alice",
+	)
+	if err != nil {
+		t.Fatalf("build credential: %v", err)
+	}
+	return c
+}
+
+func newAccount(t *testing.T, id, name string) *authentities.Account {
+	t.Helper()
+	a, err := (&authentities.Account{}).With(id, name, authentities.AccountTypePersonal)
+	if err != nil {
+		t.Fatalf("build account: %v", err)
+	}
+	return a
+}
+
+func newAuthSession(t *testing.T) *authentities.AuthSession {
+	t.Helper()
+	s, err := (&authentities.AuthSession{}).With(
+		"sess-1", "agent-1", "cred-1", "127.0.0.1", "go-test", time.Now().Add(time.Hour),
+	)
+	if err != nil {
+		t.Fatalf("build auth session: %v", err)
+	}
+	return s
+}
+
+func newJSONRequest(method, path, body string) *http.Request {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func TestPasswordAuthHandler_Register_MissingFields(t *testing.T) {
+	h := handlers.NewPasswordAuthHandler(handlers.PasswordAuthHandlerConfig{
+		AuthService:    &fakeAuthService{},
+		SessionManager: &fakeSessionManager{},
+		Logger:         nopLogger{},
+	})
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"empty body", `{}`},
+		{"missing password", `{"email":"u@example.com"}`},
+		{"missing email", `{"password":"pw"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c := echo.New().NewContext(newJSONRequest(http.MethodPost, "/api/auth/register", tc.body), rec)
+			if err := h.Register(c); err != nil {
+				t.Fatalf("Register: %v", err)
+			}
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+			}
+		})
+	}
+}
+
+func TestPasswordAuthHandler_Register_DefaultsDisplayNameToLocalPart(t *testing.T) {
+	auth := &fakeAuthService{
+		registerAgent:   newAgent(t, "agent-1", "alice"),
+		registerCred:    newCredential(t),
+		registerAccount: newAccount(t, "acct-1", "alice"),
+		sessionResult:   newAuthSession(t),
+	}
+	sm := &fakeSessionManager{}
+	h := handlers.NewPasswordAuthHandler(handlers.PasswordAuthHandlerConfig{
+		AuthService:    auth,
+		SessionManager: sm,
+		Logger:         nopLogger{},
+	})
+
+	rec := httptest.NewRecorder()
+	req := newJSONRequest(http.MethodPost, "/api/auth/register", `{"email":"alice@example.com","password":"pw"}`)
+	c := echo.New().NewContext(req, rec)
+
+	if err := h.Register(c); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body=%s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if auth.gotDisplayName != "alice" {
+		t.Errorf("display name = %q, want %q (should default to email local-part)", auth.gotDisplayName, "alice")
+	}
+}
+
+func TestPasswordAuthHandler_Register_ErrorMapping(t *testing.T) {
+	cases := []struct {
+		name      string
+		regErr    error
+		wantCode  int
+		wantError string
+	}{
+		{"email taken", authapp.ErrEmailAlreadyTaken, http.StatusConflict, "email already registered"},
+		{"password support missing", authapp.ErrPasswordSupportNotConfigured, http.StatusServiceUnavailable, "password registration unavailable"},
+		{"unknown error", errors.New("boom"), http.StatusInternalServerError, "failed to register account"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := handlers.NewPasswordAuthHandler(handlers.PasswordAuthHandlerConfig{
+				AuthService:    &fakeAuthService{registerErr: tc.regErr},
+				SessionManager: &fakeSessionManager{},
+				Logger:         nopLogger{},
+			})
+
+			rec := httptest.NewRecorder()
+			req := newJSONRequest(http.MethodPost, "/api/auth/register",
+				`{"email":"u@example.com","password":"pw","display_name":"u"}`)
+			c := echo.New().NewContext(req, rec)
+			if err := h.Register(c); err != nil {
+				t.Fatalf("Register: %v", err)
+			}
+			if rec.Code != tc.wantCode {
+				t.Errorf("status = %d, want %d", rec.Code, tc.wantCode)
+			}
+			var env struct {
+				Error string `json:"error"`
+			}
+			_ = json.Unmarshal(rec.Body.Bytes(), &env)
+			if env.Error != tc.wantError {
+				t.Errorf("error = %q, want %q", env.Error, tc.wantError)
+			}
+		})
+	}
+}
+
+func TestPasswordAuthHandler_Login_InvalidPassword(t *testing.T) {
+	h := handlers.NewPasswordAuthHandler(handlers.PasswordAuthHandlerConfig{
+		AuthService:    &fakeAuthService{verifyErr: authapp.ErrInvalidPassword},
+		SessionManager: &fakeSessionManager{},
+		Logger:         nopLogger{},
+	})
+
+	rec := httptest.NewRecorder()
+	req := newJSONRequest(http.MethodPost, "/api/auth/password-login",
+		`{"email":"u@example.com","password":"wrong"}`)
+	c := echo.New().NewContext(req, rec)
+	if err := h.Login(c); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestPasswordAuthHandler_Login_SetsSessionAndJWTCookie(t *testing.T) {
+	auth := &fakeAuthService{
+		verifyAgent:   newAgent(t, "agent-1", "alice"),
+		verifyCred:    newCredential(t),
+		verifyAccount: newAccount(t, "acct-1", "alice"),
+		sessionResult: newAuthSession(t),
+		tokenString:   "the.jwt.token",
+	}
+	sm := &fakeSessionManager{}
+	h := handlers.NewPasswordAuthHandler(handlers.PasswordAuthHandlerConfig{
+		AuthService:    auth,
+		SessionManager: sm,
+		Logger:         nopLogger{},
+		// SecureCookies left false — the test runs over plain HTTP and the
+		// Set-Cookie header should reflect that without forcing Secure.
+	})
+
+	rec := httptest.NewRecorder()
+	req := newJSONRequest(http.MethodPost, "/api/auth/password-login",
+		`{"email":"alice@example.com","password":"pw"}`)
+	c := echo.New().NewContext(req, rec)
+	if err := h.Login(c); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body=%s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if sm.createCalls != 1 {
+		t.Errorf("CreateHTTPSession calls = %d, want 1", sm.createCalls)
+	}
+	if sm.gotData.AccountID != "acct-1" {
+		t.Errorf("session AccountID = %q, want %q", sm.gotData.AccountID, "acct-1")
+	}
+
+	cookie := findCookie(rec.Result().Cookies(), "pericarp_token")
+	if cookie == nil {
+		t.Fatal("missing JWT cookie on successful login")
+	}
+	if cookie.Value != "the.jwt.token" {
+		t.Errorf("cookie value = %q, want %q", cookie.Value, "the.jwt.token")
+	}
+	if cookie.Secure {
+		t.Error("cookie Secure = true, want false (SecureCookies not configured)")
+	}
+	if !cookie.HttpOnly {
+		t.Error("cookie HttpOnly = false, want true")
+	}
+	if cookie.MaxAge <= 0 {
+		t.Errorf("cookie MaxAge = %d, want >0", cookie.MaxAge)
+	}
+}
+
+func TestPasswordAuthHandler_Login_TokenIssuanceFailureStillSucceeds(t *testing.T) {
+	auth := &fakeAuthService{
+		verifyAgent:   newAgent(t, "agent-1", "alice"),
+		verifyCred:    newCredential(t),
+		sessionResult: newAuthSession(t),
+		tokenErr:      errors.New("jwt down"),
+	}
+	h := handlers.NewPasswordAuthHandler(handlers.PasswordAuthHandlerConfig{
+		AuthService:    auth,
+		SessionManager: &fakeSessionManager{},
+		Logger:         nopLogger{},
+	})
+
+	rec := httptest.NewRecorder()
+	req := newJSONRequest(http.MethodPost, "/api/auth/password-login",
+		`{"email":"u@example.com","password":"pw"}`)
+	c := echo.New().NewContext(req, rec)
+	if err := h.Login(c); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d — JWT outage must not block login", rec.Code, http.StatusOK)
+	}
+	if cookie := findCookie(rec.Result().Cookies(), "pericarp_token"); cookie != nil && cookie.Value != "" {
+		t.Errorf("JWT cookie unexpectedly set: %q", cookie.Value)
+	}
+}
+
+func TestPasswordAuthHandler_Logout_ClearsJWTCookie(t *testing.T) {
+	h := handlers.NewPasswordAuthHandler(handlers.PasswordAuthHandlerConfig{
+		AuthService:    &fakeAuthService{},
+		SessionManager: &fakeSessionManager{},
+		Logger:         nopLogger{},
+		SecureCookies:  true,
+	})
+
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil), rec)
+	oauthCalls := 0
+	oauthLogout := func(http.ResponseWriter, *http.Request) { oauthCalls++ }
+
+	if err := h.Logout(c, oauthLogout); err != nil {
+		t.Fatalf("Logout: %v", err)
+	}
+	if oauthCalls != 1 {
+		t.Errorf("oauth logout calls = %d, want 1", oauthCalls)
+	}
+
+	cookie := findCookie(rec.Result().Cookies(), "pericarp_token")
+	if cookie == nil {
+		t.Fatal("expected expired JWT cookie in response")
+	}
+	if cookie.MaxAge >= 0 {
+		t.Errorf("cookie MaxAge = %d, want negative (cookie cleared)", cookie.MaxAge)
+	}
+	if !cookie.Secure {
+		t.Error("cookie Secure = false, want true (SecureCookies configured)")
+	}
+}
+
+func findCookie(cookies []*http.Cookie, name string) *http.Cookie {
+	for _, c := range cookies {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}

--- a/api/handlers/password_auth_handler_test.go
+++ b/api/handlers/password_auth_handler_test.go
@@ -323,7 +323,11 @@ func TestPasswordAuthHandler_Login_TokenIssuanceFailureStillSucceeds(t *testing.
 		verifyAgent:   newAgent(t, "agent-1", "alice"),
 		verifyCred:    newCredential(t),
 		sessionResult: newAuthSession(t),
-		tokenErr:      errors.New("jwt down"),
+		// Pericarp may still hand back a token alongside an error; the
+		// handler should drop both the cookie *and* the body token so the
+		// client doesn't see a JWT it can't actually use.
+		tokenString: "leaked.jwt.token",
+		tokenErr:    errors.New("jwt down"),
 	}
 	h := handlers.NewPasswordAuthHandler(handlers.PasswordAuthHandlerConfig{
 		AuthService:    auth,
@@ -343,6 +347,18 @@ func TestPasswordAuthHandler_Login_TokenIssuanceFailureStillSucceeds(t *testing.
 	}
 	if cookie := findCookie(rec.Result().Cookies(), "pericarp_token"); cookie != nil && cookie.Value != "" {
 		t.Errorf("JWT cookie unexpectedly set: %q", cookie.Value)
+	}
+
+	var env struct {
+		Data struct {
+			Token string `json:"token"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if env.Data.Token != "" {
+		t.Errorf("response token = %q, want empty when issuance fails", env.Data.Token)
 	}
 }
 

--- a/application/auth_providers.go
+++ b/application/auth_providers.go
@@ -22,12 +22,23 @@ func ProvideOAuthProviderRegistry(params struct {
 	Config config.Config
 }) authapp.OAuthProviderRegistry {
 	registry := make(authapp.OAuthProviderRegistry)
-	if params.Config.OAuthEnabled() {
-		google := providers.NewGoogle(providers.GoogleConfig{
-			ClientID:     params.Config.OAuth.GoogleClientID,
-			ClientSecret: params.Config.OAuth.GoogleClientSecret,
+	if !params.Config.OAuthEnabled() {
+		return registry
+	}
+	cfg := params.Config.OAuth
+	if cfg.GoogleClientID != "" && cfg.GoogleClientSecret != "" {
+		registry["google"] = providers.NewGoogle(providers.GoogleConfig{
+			ClientID:     cfg.GoogleClientID,
+			ClientSecret: cfg.GoogleClientSecret,
 		})
-		registry["google"] = google
+	}
+	if cfg.NetSuiteClientID != "" && cfg.NetSuiteClientSecret != "" && cfg.NetSuiteAccountID != "" {
+		registry["netsuite"] = providers.NewNetSuite(providers.NetSuiteConfig{
+			ClientID:     cfg.NetSuiteClientID,
+			ClientSecret: cfg.NetSuiteClientSecret,
+			AccountID:    cfg.NetSuiteAccountID,
+			Scopes:       cfg.NetSuiteScopes,
+		})
 	}
 	return registry
 }

--- a/application/auth_providers.go
+++ b/application/auth_providers.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -11,6 +12,7 @@ import (
 	authcasbin "github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/casbin"
 	"github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/providers"
 	"github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/session"
+	esdomain "github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
 	gormadapter "github.com/casbin/gorm-adapter/v3"
 	"github.com/gorilla/sessions"
 	"go.uber.org/fx"
@@ -33,14 +35,52 @@ func ProvideOAuthProviderRegistry(params struct {
 		})
 	}
 	if cfg.NetSuiteClientID != "" && cfg.NetSuiteClientSecret != "" && cfg.NetSuiteAccountID != "" {
-		registry["netsuite"] = providers.NewNetSuite(providers.NetSuiteConfig{
+		registry["netsuite"] = &displayNameFallback{OAuthProvider: providers.NewNetSuite(providers.NetSuiteConfig{
 			ClientID:     cfg.NetSuiteClientID,
 			ClientSecret: cfg.NetSuiteClientSecret,
 			AccountID:    cfg.NetSuiteAccountID,
 			Scopes:       cfg.NetSuiteScopes,
-		})
+		})}
 	}
 	return registry
+}
+
+// displayNameFallback wraps an OAuthProvider so that UserInfo.DisplayName is
+// never empty when it reaches FindOrCreateAgent. NetSuite's userinfo response
+// frequently omits both `name` and `preferred_username`, leaving DisplayName
+// empty — and pericarp's agent.With rejects empty names with
+// "agent name cannot be empty", which surfaces to the browser as the opaque
+// "failed to find or create agent". Falling back to Email then ProviderUserID
+// is enough to unblock first login; admins can rename the user afterwards.
+type displayNameFallback struct {
+	authapp.OAuthProvider
+}
+
+func (w *displayNameFallback) Exchange(ctx context.Context, code, codeVerifier, redirectURI string) (*authapp.AuthResult, error) {
+	res, err := w.OAuthProvider.Exchange(ctx, code, codeVerifier, redirectURI)
+	if res != nil {
+		fillDisplayName(&res.UserInfo)
+	}
+	return res, err
+}
+
+func (w *displayNameFallback) RefreshToken(ctx context.Context, refreshToken string) (*authapp.AuthResult, error) {
+	res, err := w.OAuthProvider.RefreshToken(ctx, refreshToken)
+	if res != nil {
+		fillDisplayName(&res.UserInfo)
+	}
+	return res, err
+}
+
+func fillDisplayName(ui *authapp.UserInfo) {
+	if ui.DisplayName != "" {
+		return
+	}
+	if ui.Email != "" {
+		ui.DisplayName = ui.Email
+		return
+	}
+	ui.DisplayName = ui.ProviderUserID
 }
 
 func ProvideAuthorizationChecker(db *gorm.DB) (*authcasbin.CasbinAuthorizationChecker, error) {
@@ -60,7 +100,9 @@ func ProvideAuthenticationService(params struct {
 	Accounts            authrepos.AccountRepository
 	PasswordCredentials authrepos.PasswordCredentialRepository
 	AuthzChecker        *authcasbin.CasbinAuthorizationChecker
-	JWTService          authapp.JWTService `optional:"true"`
+	EventStore          esdomain.EventStore         `optional:"true"`
+	EventDispatcher     *esdomain.EventDispatcher   `optional:"true"`
+	JWTService          authapp.JWTService          `optional:"true"`
 }) authapp.AuthenticationService {
 	opts := []authapp.AuthServiceOption{
 		authapp.WithAuthorizationChecker(params.AuthzChecker),
@@ -68,6 +110,16 @@ func ProvideAuthenticationService(params struct {
 	}
 	if params.JWTService != nil {
 		opts = append(opts, authapp.WithJWTService(params.JWTService))
+	}
+	// Wiring both lets pericarp's auth aggregates persist their events
+	// AND broadcast them to subscribers (e.g. kulr's AgentCreated listener).
+	// WithEventDispatcher is a no-op inside pericarp unless WithEventStore
+	// is also set, so they're conditionally paired.
+	if params.EventStore != nil {
+		opts = append(opts, authapp.WithEventStore(params.EventStore))
+		if params.EventDispatcher != nil {
+			opts = append(opts, authapp.WithEventDispatcher(params.EventDispatcher))
+		}
 	}
 	return authapp.NewDefaultAuthenticationService(
 		params.Registry,

--- a/application/auth_providers.go
+++ b/application/auth_providers.go
@@ -42,20 +42,29 @@ func ProvideAuthorizationChecker(db *gorm.DB) (*authcasbin.CasbinAuthorizationCh
 
 func ProvideAuthenticationService(params struct {
 	fx.In
-	Registry     authapp.OAuthProviderRegistry
-	Agents       authrepos.AgentRepository
-	Credentials  authrepos.CredentialRepository
-	Sessions     authrepos.AuthSessionRepository
-	Accounts     authrepos.AccountRepository
-	AuthzChecker *authcasbin.CasbinAuthorizationChecker
+	Registry            authapp.OAuthProviderRegistry
+	Agents              authrepos.AgentRepository
+	Credentials         authrepos.CredentialRepository
+	Sessions            authrepos.AuthSessionRepository
+	Accounts            authrepos.AccountRepository
+	PasswordCredentials authrepos.PasswordCredentialRepository
+	AuthzChecker        *authcasbin.CasbinAuthorizationChecker
+	JWTService          authapp.JWTService `optional:"true"`
 }) authapp.AuthenticationService {
+	opts := []authapp.AuthServiceOption{
+		authapp.WithAuthorizationChecker(params.AuthzChecker),
+		authapp.WithPasswordCredentialRepository(params.PasswordCredentials),
+	}
+	if params.JWTService != nil {
+		opts = append(opts, authapp.WithJWTService(params.JWTService))
+	}
 	return authapp.NewDefaultAuthenticationService(
 		params.Registry,
 		params.Agents,
 		params.Credentials,
 		params.Sessions,
 		params.Accounts,
-		authapp.WithAuthorizationChecker(params.AuthzChecker),
+		opts...,
 	)
 }
 

--- a/application/module.go
+++ b/application/module.go
@@ -88,6 +88,9 @@ func Module(cfg config.Config, registry *PresetRegistry) fx.Option {
 		}),
 		fx.Provide(func(db *gormdb.DB) authrepos.AccountRepository { return authgorm.NewAccountRepository(db) }),
 		fx.Provide(func(db *gormdb.DB) authrepos.InviteRepository { return authgorm.NewInviteRepository(db) }),
+		fx.Provide(func(db *gormdb.DB) authrepos.PasswordCredentialRepository {
+			return authgorm.NewPasswordCredentialRepository(db)
+		}),
 
 		// Auth infrastructure
 		fx.Provide(ProvideOAuthProviderRegistry),

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,16 @@
 module github.com/wepala/weos/v3
 
-go 1.25.0
+go 1.25.4
 
 require (
 	cloud.google.com/go/bigquery v1.74.0
 	cloud.google.com/go/storage v1.62.0
-	github.com/akeemphilbert/pericarp v0.0.0-20260404155656-110ff0f74cd7
+	github.com/akeemphilbert/pericarp v0.0.0-20260425205456-1a6eea6982e8
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
 	github.com/casbin/gorm-adapter/v3 v3.41.0
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/gorilla/sessions v1.4.0
 	github.com/jinzhu/inflection v1.0.0
 	github.com/joho/godotenv v1.5.1
@@ -19,6 +20,7 @@ require (
 	github.com/segmentio/ksuid v1.0.4
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.21.0
+	github.com/wepala/weos-private-presets v0.1.1
 	go.uber.org/fx v1.23.0
 	go.uber.org/zap v1.27.0
 	google.golang.org/adk v0.6.0
@@ -80,7 +82,6 @@ require (
 	github.com/go-sql-driver/mysql v1.9.3 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
-	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/google/flatbuffers v23.5.26+incompatible // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.4
 require (
 	cloud.google.com/go/bigquery v1.74.0
 	cloud.google.com/go/storage v1.62.0
-	github.com/akeemphilbert/pericarp v0.0.0-20260425205456-1a6eea6982e8
+	github.com/akeemphilbert/pericarp v0.0.0-20260430232129-e6b927b11fb7
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/segmentio/ksuid v1.0.4
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.21.0
-	github.com/wepala/weos-private-presets v0.1.1
 	go.uber.org/fx v1.23.0
 	go.uber.org/zap v1.27.0
 	google.golang.org/adk v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/akeemphilbert/pericarp v0.0.0-20260425205456-1a6eea6982e8 h1:GYSU2q0j6KSrmb6lVMlgxhqGO04DgSJP6LRAL6gLr3M=
 github.com/akeemphilbert/pericarp v0.0.0-20260425205456-1a6eea6982e8/go.mod h1:XhYByCcu7T7RUjhCS5Avpcqr3YQpmEh041+tfGpEsoY=
+github.com/akeemphilbert/pericarp v0.0.0-20260430232129-e6b927b11fb7 h1:3P91h74hxw8jPSI7KA4hsijXpDdEKoTVyvxE8TPec4A=
+github.com/akeemphilbert/pericarp v0.0.0-20260430232129-e6b927b11fb7/go.mod h1:XhYByCcu7T7RUjhCS5Avpcqr3YQpmEh041+tfGpEsoY=
 github.com/apache/arrow/go/v15 v15.0.2 h1:60IliRbiyTWCWjERBCkO1W4Qun9svcYoZrSLcyOsMLE=
 github.com/apache/arrow/go/v15 v15.0.2/go.mod h1:DGXsR3ajT524njufqf95822i+KTh+yea1jass9YXgjA=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/akeemphilbert/pericarp v0.0.0-20260404155656-110ff0f74cd7 h1:9BdBZryhsbijTYL161bZOm1SjjipekUsFpcld6WR7hY=
-github.com/akeemphilbert/pericarp v0.0.0-20260404155656-110ff0f74cd7/go.mod h1:WwG0D5gqfFnh3I8HvJTbKqQkfyJsCoLQMPoD3y02oCU=
+github.com/akeemphilbert/pericarp v0.0.0-20260425205456-1a6eea6982e8 h1:GYSU2q0j6KSrmb6lVMlgxhqGO04DgSJP6LRAL6gLr3M=
+github.com/akeemphilbert/pericarp v0.0.0-20260425205456-1a6eea6982e8/go.mod h1:XhYByCcu7T7RUjhCS5Avpcqr3YQpmEh041+tfGpEsoY=
 github.com/apache/arrow/go/v15 v15.0.2 h1:60IliRbiyTWCWjERBCkO1W4Qun9svcYoZrSLcyOsMLE=
 github.com/apache/arrow/go/v15 v15.0.2/go.mod h1:DGXsR3ajT524njufqf95822i+KTh+yea1jass9YXgjA=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
@@ -404,6 +404,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
+github.com/wepala/weos-private-presets v0.1.1 h1:evksmoDFj173Rxo8hTO3gqPhwABEceCmzk6GNO79iDc=
+github.com/wepala/weos-private-presets v0.1.1/go.mod h1:v0lGI//8zM0PWEQIas8vktULlbfWq18jo81WdvJyoVg=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,6 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/akeemphilbert/pericarp v0.0.0-20260425205456-1a6eea6982e8 h1:GYSU2q0j6KSrmb6lVMlgxhqGO04DgSJP6LRAL6gLr3M=
-github.com/akeemphilbert/pericarp v0.0.0-20260425205456-1a6eea6982e8/go.mod h1:XhYByCcu7T7RUjhCS5Avpcqr3YQpmEh041+tfGpEsoY=
 github.com/akeemphilbert/pericarp v0.0.0-20260430232129-e6b927b11fb7 h1:3P91h74hxw8jPSI7KA4hsijXpDdEKoTVyvxE8TPec4A=
 github.com/akeemphilbert/pericarp v0.0.0-20260430232129-e6b927b11fb7/go.mod h1:XhYByCcu7T7RUjhCS5Avpcqr3YQpmEh041+tfGpEsoY=
 github.com/apache/arrow/go/v15 v15.0.2 h1:60IliRbiyTWCWjERBCkO1W4Qun9svcYoZrSLcyOsMLE=
@@ -406,8 +404,6 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
-github.com/wepala/weos-private-presets v0.1.1 h1:evksmoDFj173Rxo8hTO3gqPhwABEceCmzk6GNO79iDc=
-github.com/wepala/weos-private-presets v0.1.1/go.mod h1:v0lGI//8zM0PWEQIas8vktULlbfWq18jo81WdvJyoVg=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -54,6 +54,19 @@ import (
 
 var serveViper = viper.New()
 
+// customFxOptions are extra fx options merged into the serve command's fx graph.
+// Downstream binaries (e.g. weos-kulr) call RegisterFxOptions before Execute()
+// to plug in app-specific providers, invokes, or modules without forking
+// serve.go. Mirrors the process-global registration pattern used for presets.
+var customFxOptions []fx.Option
+
+// RegisterFxOptions appends fx options to be merged into the serve command's
+// fx graph. Must be called before Execute(). Reachable from downstream binaries
+// via the public re-export in pkg/cli.
+func RegisterFxOptions(opts ...fx.Option) {
+	customFxOptions = append(customFxOptions, opts...)
+}
+
 var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Start the API server",
@@ -97,7 +110,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	registry := presets.NewDefaultRegistry()
 
-	app := fx.New(
+	fxOpts := []fx.Option{
 		fx.NopLogger,
 		application.Module(appCfg, registry),
 		fx.Provide(weosoauth.ProvideJWTService),
@@ -121,7 +134,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 		fx.Populate(&inviteRepo),
 		fx.Populate(&db),
 		fx.Populate(&presetHandlers),
-	)
+	}
+	fxOpts = append(fxOpts, customFxOptions...)
+	app := fx.New(fxOpts...)
 
 	startCtx, startCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
 	defer startCancel()

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -199,13 +199,20 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 	// Email + password account flow. Public routes — must reach the handler
 	// even when no session exists yet, so they sit outside the protected group.
+	// Mirror the SessionManager's dev-default Secure flag (Secure=false when
+	// SESSION_SECRET is unset) so the JWT cookie is accepted in plain-HTTP
+	// local dev and stays Secure in any real deployment.
+	secureCookies := appCfg.SessionSecret != "change-me-in-production"
 	passwordAuthHandlers := handlers.NewPasswordAuthHandler(handlers.PasswordAuthHandlerConfig{
 		AuthService:    authService,
 		SessionManager: sessionManager,
+		SecureCookies:  secureCookies,
 		Logger:         logger,
 	})
-	api.POST("/auth/register", passwordAuthHandlers.Register)
-	api.POST("/auth/password-login", passwordAuthHandlers.Login)
+	if appCfg.PasswordAuthEnabled {
+		api.POST("/auth/register", passwordAuthHandlers.Register)
+		api.POST("/auth/password-login", passwordAuthHandlers.Login)
+	}
 
 	// Logout must clear BOTH the gorilla session (pericarp Logout) AND the
 	// JWT cookie issued by the password and OAuth flows. Routing through
@@ -266,9 +273,13 @@ func runServe(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	// Protected API group — apply auth middleware when OAuth is configured
+	// Protected API group — apply real auth middleware when any
+	// authentication mechanism (OAuth or password) is configured. Falling
+	// back to SoftAuth only in fully-unconfigured dev mode keeps a password
+	// deployment from looking authenticated while protected routes remain
+	// effectively open.
 	protected := api.Group("")
-	if appCfg.OAuthEnabled() {
+	if appCfg.AuthEnabled() {
 		protected.Use(echo.WrapMiddleware(authhttp.RequireAuth(sessionManager, authService)))
 		protected.Use(apimw.Impersonation(sessionStore, accountRepo, logger))
 		protected.Use(apimw.AuthorizeResource(authzChecker, accountRepo, logger))

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -192,7 +192,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	api.GET("/auth/login", echo.WrapHandler(http.HandlerFunc(authHandlers.Login)))
 	api.GET("/auth/callback", echo.WrapHandler(http.HandlerFunc(authHandlers.Callback)))
-	if appCfg.OAuthEnabled() {
+	if appCfg.AuthEnabled() {
 		api.GET("/auth/me", impersonationHandler.Me(authHandlers))
 	} else {
 		api.GET("/auth/me", handlers.DevMe(credentialRepo, agentRepo, accountRepo, logger))

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -178,7 +178,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		RedirectURI: authhttp.RedirectURIConfig{
 			CallbackPath: "/api/auth/callback",
 		},
-		DefaultProvider: "google",
+		DefaultProvider: appCfg.DefaultOAuthProvider(),
 		FrontendURL:     appCfg.OAuth.FrontendURL,
 		Logger:          logger,
 	})

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -184,6 +184,16 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 	api.POST("/auth/logout", echo.WrapHandler(http.HandlerFunc(authHandlers.Logout)))
 
+	// Email + password account flow. Public routes — must reach the handler
+	// even when no session exists yet, so they sit outside the protected group.
+	passwordAuthHandlers := handlers.NewPasswordAuthHandler(handlers.PasswordAuthHandlerConfig{
+		AuthService:    authService,
+		SessionManager: sessionManager,
+		Logger:         logger,
+	})
+	api.POST("/auth/register", passwordAuthHandlers.Register)
+	api.POST("/auth/password-login", passwordAuthHandlers.Login)
+
 	// Derive a public base URL for OAuth metadata, JWT issuer, and bearer auth.
 	baseURL := strings.TrimRight(appCfg.OAuth.BaseURL, "/")
 	if baseURL == "" {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -182,8 +182,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 	} else {
 		api.GET("/auth/me", handlers.DevMe(credentialRepo, agentRepo, accountRepo, logger))
 	}
-	api.POST("/auth/logout", echo.WrapHandler(http.HandlerFunc(authHandlers.Logout)))
-
 	// Email + password account flow. Public routes — must reach the handler
 	// even when no session exists yet, so they sit outside the protected group.
 	passwordAuthHandlers := handlers.NewPasswordAuthHandler(handlers.PasswordAuthHandlerConfig{
@@ -193,6 +191,13 @@ func runServe(cmd *cobra.Command, args []string) error {
 	})
 	api.POST("/auth/register", passwordAuthHandlers.Register)
 	api.POST("/auth/password-login", passwordAuthHandlers.Login)
+
+	// Logout must clear BOTH the gorilla session (pericarp Logout) AND the
+	// JWT cookie issued by the password and OAuth flows. Routing through
+	// the password handler so a single endpoint is correct for both flows.
+	api.POST("/auth/logout", func(c echo.Context) error {
+		return passwordAuthHandlers.Logout(c, authHandlers.Logout)
+	})
 
 	// Derive a public base URL for OAuth metadata, JWT issuer, and bearer auth.
 	baseURL := strings.TrimRight(appCfg.OAuth.BaseURL, "/")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,9 +84,10 @@ type Config struct {
 	SessionSecret string
 
 	// PasswordAuthEnabled toggles the email + password register/login
-	// endpoints. Off by default — enabling it without a real SessionSecret
-	// is a footgun (sessions become forgeable), so the SessionSecret check
-	// in AuthEnabled keeps dev defaults in dev mode.
+	// endpoints. Off by default — enabling it without a non-default
+	// SessionSecret is a footgun because sessions become forgeable.
+	// Callers should ensure SessionSecret is set to a production-safe
+	// value before enabling password authentication.
 	PasswordAuthEnabled bool
 
 	// LLM holds configuration for LLM integrations.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,12 +18,32 @@ package config
 import (
 	"os"
 	"strconv"
+	"strings"
 )
 
 // OAuthConfig holds configuration for OAuth authentication.
+//
+// Provider credentials are independent — set whichever providers you
+// want available to the auth registry. OAuthEnabled returns true if at
+// least one provider is fully configured.
 type OAuthConfig struct {
-	GoogleClientID      string
-	GoogleClientSecret  string
+	GoogleClientID     string
+	GoogleClientSecret string
+
+	// NetSuite OAuth 2.0 (SuiteTalk REST). AccountID accepts the bare
+	// account number for production (e.g. "1234567") or the underscore
+	// suffix for sandboxes (e.g. "1234567_SB1") — pericarp derives the
+	// auth/token endpoints from it.
+	NetSuiteClientID     string
+	NetSuiteClientSecret string
+	NetSuiteAccountID    string
+	// NetSuiteScopes overrides pericarp's default scope list. Leave nil/empty
+	// to fall back to ["rest_webservices"]. Include "openid" when the binary
+	// needs to call NetSuite's userinfo endpoint — without it, the token
+	// exchange succeeds but the userinfo fetch returns 400 "Unable to
+	// authenticate", because NetSuite's userinfo is gated behind OIDC.
+	NetSuiteScopes []string
+
 	FrontendURL         string
 	BaseURL             string // Public URL for OAuth metadata/endpoints (e.g. https://example.com)
 	JWTSigningKey       string // PEM-encoded RSA private key, or "auto" to generate ephemeral key
@@ -107,9 +127,17 @@ type StorageConfig struct {
 	MaxUploadBytes int64
 }
 
-// OAuthEnabled returns true when Google OAuth credentials are configured.
+// OAuthEnabled returns true when at least one OAuth provider is fully
+// configured. The auth registry is gated on this so a binary without
+// any provider creds doesn't expose half-wired login routes.
 func (c *Config) OAuthEnabled() bool {
-	return c.OAuth.GoogleClientID != "" && c.OAuth.GoogleClientSecret != ""
+	if c.OAuth.GoogleClientID != "" && c.OAuth.GoogleClientSecret != "" {
+		return true
+	}
+	if c.OAuth.NetSuiteClientID != "" && c.OAuth.NetSuiteClientSecret != "" && c.OAuth.NetSuiteAccountID != "" {
+		return true
+	}
+	return false
 }
 
 // LLMConfig holds configuration for LLM providers.
@@ -218,6 +246,24 @@ func (c *Config) LoadFromEnvironment() {
 
 	if clientSecret := os.Getenv("GOOGLE_CLIENT_SECRET"); clientSecret != "" {
 		c.OAuth.GoogleClientSecret = clientSecret
+	}
+
+	if clientID := os.Getenv("NETSUITE_CLIENT_ID"); clientID != "" {
+		c.OAuth.NetSuiteClientID = clientID
+	}
+
+	if clientSecret := os.Getenv("NETSUITE_CLIENT_SECRET"); clientSecret != "" {
+		c.OAuth.NetSuiteClientSecret = clientSecret
+	}
+
+	if accountID := os.Getenv("NETSUITE_ACCOUNT_ID"); accountID != "" {
+		c.OAuth.NetSuiteAccountID = accountID
+	}
+
+	if scopes := os.Getenv("NETSUITE_SCOPES"); scopes != "" {
+		c.OAuth.NetSuiteScopes = strings.FieldsFunc(scopes, func(r rune) bool {
+			return r == ',' || r == ' ' || r == '\t'
+		})
 	}
 
 	if frontendURL := os.Getenv("FRONTEND_URL"); frontendURL != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,6 +83,12 @@ type Config struct {
 	// SessionSecret is the secret key for session cookies.
 	SessionSecret string
 
+	// PasswordAuthEnabled toggles the email + password register/login
+	// endpoints. Off by default — enabling it without a real SessionSecret
+	// is a footgun (sessions become forgeable), so the SessionSecret check
+	// in AuthEnabled keeps dev defaults in dev mode.
+	PasswordAuthEnabled bool
+
 	// LLM holds configuration for LLM integrations.
 	LLM LLMConfig
 
@@ -138,6 +144,15 @@ func (c *Config) OAuthEnabled() bool {
 		return true
 	}
 	return false
+}
+
+// AuthEnabled returns true when any real authentication mechanism is
+// configured (OAuth provider or password endpoints). Drives whether the
+// API is mounted with RequireAuth or the dev-mode SoftAuth fallback —
+// without this, a password-only deployment would mount login endpoints
+// on top of routes that were still effectively unauthenticated.
+func (c *Config) AuthEnabled() bool {
+	return c.OAuthEnabled() || c.PasswordAuthEnabled
 }
 
 // LLMConfig holds configuration for LLM providers.
@@ -230,6 +245,12 @@ func (c *Config) LoadFromEnvironment() {
 
 	if secret := os.Getenv("SESSION_SECRET"); secret != "" {
 		c.SessionSecret = secret
+	}
+
+	if v := os.Getenv("PASSWORD_AUTH_ENABLED"); v != "" {
+		if enabled, err := strconv.ParseBool(v); err == nil {
+			c.PasswordAuthEnabled = enabled
+		}
 	}
 
 	if apiKey := os.Getenv("GEMINI_API_KEY"); apiKey != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -282,10 +282,16 @@ func (c *Config) LoadFromEnvironment() {
 		c.OAuth.NetSuiteAccountID = accountID
 	}
 
-	if scopes := os.Getenv("NETSUITE_SCOPES"); scopes != "" {
-		c.OAuth.NetSuiteScopes = strings.FieldsFunc(scopes, func(r rune) bool {
+	if scopes := os.Getenv("NETSUITE_SCOPES"); strings.TrimSpace(scopes) != "" {
+		parsed := strings.FieldsFunc(scopes, func(r rune) bool {
 			return r == ',' || r == ' ' || r == '\t'
 		})
+		// Only override pericarp's default scope list if parsing actually
+		// produced something — a whitespace-only override (common in
+		// templated env files) would otherwise wipe the defaults.
+		if len(parsed) > 0 {
+			c.OAuth.NetSuiteScopes = parsed
+		}
 	}
 
 	if frontendURL := os.Getenv("FRONTEND_URL"); frontendURL != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,12 @@ type OAuthConfig struct {
 	BaseURL             string // Public URL for OAuth metadata/endpoints (e.g. https://example.com)
 	JWTSigningKey       string // PEM-encoded RSA private key, or "auto" to generate ephemeral key
 	DynamicRegistration bool   // Enable OAuth Dynamic Client Registration (RFC 7591)
+
+	// DefaultProvider is the provider used by /api/auth/login when the
+	// caller doesn't pass a provider query param (the admin SPA does
+	// this). Empty means "auto-pick from the configured registry" —
+	// see DefaultOAuthProvider below.
+	DefaultProvider string
 }
 
 // SMTPConfig holds configuration for outbound email via SMTP.
@@ -154,6 +160,25 @@ func (c *Config) OAuthEnabled() bool {
 // on top of routes that were still effectively unauthenticated.
 func (c *Config) AuthEnabled() bool {
 	return c.OAuthEnabled() || c.PasswordAuthEnabled
+}
+
+// DefaultOAuthProvider returns the provider name to use when the caller
+// of /api/auth/login doesn't pass a `provider` query param (the admin
+// SPA does this). Honors OAUTH_DEFAULT_PROVIDER when set, otherwise
+// auto-picks from the configured registry — preferring google for
+// backward-compat, then netsuite. Falls back to "google" so the
+// behavior is unchanged when nothing is configured.
+func (c *Config) DefaultOAuthProvider() string {
+	if c.OAuth.DefaultProvider != "" {
+		return c.OAuth.DefaultProvider
+	}
+	if c.OAuth.GoogleClientID != "" && c.OAuth.GoogleClientSecret != "" {
+		return "google"
+	}
+	if c.OAuth.NetSuiteClientID != "" && c.OAuth.NetSuiteClientSecret != "" && c.OAuth.NetSuiteAccountID != "" {
+		return "netsuite"
+	}
+	return "google"
 }
 
 // LLMConfig holds configuration for LLM providers.
@@ -310,6 +335,10 @@ func (c *Config) LoadFromEnvironment() {
 		if enabled, err := strconv.ParseBool(dynReg); err == nil {
 			c.OAuth.DynamicRegistration = enabled
 		}
+	}
+
+	if provider := os.Getenv("OAUTH_DEFAULT_PROVIDER"); provider != "" {
+		c.OAuth.DefaultProvider = provider
 	}
 
 	if bqProject := os.Getenv("BIGQUERY_PROJECT_ID"); bqProject != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,3 +74,19 @@ func TestLoadFromEnvironment_NetSuiteScopes_NotSet(t *testing.T) {
 		t.Fatalf("expected nil NetSuiteScopes when env not set, got %#v", cfg.OAuth.NetSuiteScopes)
 	}
 }
+
+// A whitespace-only override (common in templated env files) must not
+// wipe pericarp's default scope list — empty parsing keeps Scopes nil
+// so the default kicks in downstream.
+func TestLoadFromEnvironment_NetSuiteScopes_WhitespaceOnly(t *testing.T) {
+	for _, value := range []string{" ", "\t", " , \t , ", ",,"} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv("NETSUITE_SCOPES", value)
+			cfg := Default()
+			cfg.LoadFromEnvironment()
+			if cfg.OAuth.NetSuiteScopes != nil {
+				t.Fatalf("expected nil NetSuiteScopes for whitespace-only env, got %#v", cfg.OAuth.NetSuiteScopes)
+			}
+		})
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -75,6 +75,67 @@ func TestLoadFromEnvironment_NetSuiteScopes_NotSet(t *testing.T) {
 	}
 }
 
+func TestDefaultOAuthProvider(t *testing.T) {
+	tests := []struct {
+		name string
+		mut  func(*Config)
+		want string
+	}{
+		{
+			name: "explicit override wins",
+			mut: func(c *Config) {
+				c.OAuth.DefaultProvider = "netsuite"
+				c.OAuth.GoogleClientID = "g"
+				c.OAuth.GoogleClientSecret = "s"
+			},
+			want: "netsuite",
+		},
+		{
+			name: "google preferred when configured",
+			mut: func(c *Config) {
+				c.OAuth.GoogleClientID = "g"
+				c.OAuth.GoogleClientSecret = "s"
+				c.OAuth.NetSuiteClientID = "n"
+				c.OAuth.NetSuiteClientSecret = "ns"
+				c.OAuth.NetSuiteAccountID = "1234567"
+			},
+			want: "google",
+		},
+		{
+			name: "netsuite-only deployment",
+			mut: func(c *Config) {
+				c.OAuth.NetSuiteClientID = "n"
+				c.OAuth.NetSuiteClientSecret = "ns"
+				c.OAuth.NetSuiteAccountID = "1234567"
+			},
+			want: "netsuite",
+		},
+		{
+			name: "fallback when nothing configured",
+			mut:  func(*Config) {},
+			want: "google",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Default()
+			tc.mut(&cfg)
+			if got := cfg.DefaultOAuthProvider(); got != tc.want {
+				t.Fatalf("DefaultOAuthProvider() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadFromEnvironment_DefaultOAuthProvider(t *testing.T) {
+	t.Setenv("OAUTH_DEFAULT_PROVIDER", "netsuite")
+	cfg := Default()
+	cfg.LoadFromEnvironment()
+	if cfg.OAuth.DefaultProvider != "netsuite" {
+		t.Fatalf("DefaultProvider = %q, want %q", cfg.OAuth.DefaultProvider, "netsuite")
+	}
+}
+
 // A whitespace-only override (common in templated env files) must not
 // wipe pericarp's default scope list — empty parsing keeps Scopes nil
 // so the default kicks in downstream.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,9 @@
 package config
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestLoadFromEnvironment_SMTP(t *testing.T) {
 	t.Setenv("SMTP_HOST", "mail.example.com")
@@ -38,5 +41,36 @@ func TestLoadFromEnvironment_SMTP_NotSet(t *testing.T) {
 	}
 	if cfg.SMTP.Port != "" {
 		t.Fatalf("expected empty Port, got %s", cfg.SMTP.Port)
+	}
+}
+
+func TestLoadFromEnvironment_NetSuiteScopes(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want []string
+	}{
+		{"comma-separated", "rest_webservices,openid", []string{"rest_webservices", "openid"}},
+		{"space-separated", "rest_webservices openid", []string{"rest_webservices", "openid"}},
+		{"mixed with whitespace", " rest_webservices ,  openid\trestlets ", []string{"rest_webservices", "openid", "restlets"}},
+		{"single scope", "openid", []string{"openid"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("NETSUITE_SCOPES", tc.env)
+			cfg := Default()
+			cfg.LoadFromEnvironment()
+			if !reflect.DeepEqual(cfg.OAuth.NetSuiteScopes, tc.want) {
+				t.Fatalf("NetSuiteScopes = %#v, want %#v", cfg.OAuth.NetSuiteScopes, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadFromEnvironment_NetSuiteScopes_NotSet(t *testing.T) {
+	cfg := Default()
+	cfg.LoadFromEnvironment()
+	if cfg.OAuth.NetSuiteScopes != nil {
+		t.Fatalf("expected nil NetSuiteScopes when env not set, got %#v", cfg.OAuth.NetSuiteScopes)
 	}
 }

--- a/internal/oauth/token.go
+++ b/internal/oauth/token.go
@@ -191,7 +191,7 @@ func handleAuthCodeGrant(
 	}
 
 	accessToken, err := jwtService.IssueToken(
-		ctx, agent, accounts, authCode.AccountID)
+		ctx, agent, accounts, authCode.AccountID, nil)
 	if err != nil {
 		logger.Error(ctx, "oauth token: JWT issuance failed", "error", err)
 		return c.JSON(http.StatusInternalServerError, tokenErrorResponse{
@@ -311,7 +311,7 @@ func handleRefreshGrant(
 	}
 
 	accessToken, err := jwtService.IssueToken(
-		ctx, agent, accounts, stored.AccountID)
+		ctx, agent, accounts, stored.AccountID, nil)
 	if err != nil {
 		logger.Error(ctx, "oauth refresh: JWT issuance failed", "error", err)
 		return c.JSON(http.StatusInternalServerError, tokenErrorResponse{

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -22,7 +22,10 @@
 // public entry point.
 package cli
 
-import internalcli "github.com/wepala/weos/v3/internal/cli"
+import (
+	internalcli "github.com/wepala/weos/v3/internal/cli"
+	"go.uber.org/fx"
+)
 
 // Execute runs the weos CLI root command.
 //
@@ -31,4 +34,12 @@ import internalcli "github.com/wepala/weos/v3/internal/cli"
 // custom presets they want to plug into the default registry.
 func Execute() error {
 	return internalcli.Execute()
+}
+
+// RegisterFxOptions appends fx options to be merged into the serve command's
+// fx graph. Use this from a downstream binary's main() to plug in app-specific
+// providers, invokes, or modules without forking serve.go. Must be called
+// before Execute().
+func RegisterFxOptions(opts ...fx.Option) {
+	internalcli.RegisterFxOptions(opts...)
 }


### PR DESCRIPTION
## Summary
- Add NetSuite OAuth provider with custom-scope support, plus a display-name fallback (Email → ProviderUserID) so first login doesn't fail when NetSuite's userinfo omits `name`/`preferred_username`.
- Add password register/login HTTP endpoints.
- Clear the JWT cookie on logout and align cookie lifetime to the session.
- Wire `EventStore`/`EventDispatcher` into `AuthenticationService` so auth aggregates persist events and broadcast to subscribers.
- Expose `RegisterFxOptions` (via `pkg/cli`) so downstream binaries can plug providers/invokes into the serve fx graph without forking `serve.go`.
- Bump pericarp to `20260430232129-e6b927b11fb7`.

## Test plan
- [ ] `make test`
- [ ] `make lint`
- [ ] Manual: NetSuite OAuth login completes end-to-end and creates an agent with a non-empty DisplayName when userinfo omits `name`.
- [ ] Manual: password register + login flows return expected envelopes.
- [ ] Manual: logout clears the JWT cookie and ends the session.
- [ ] Downstream binary can call `cli.RegisterFxOptions(...)` before `cli.Execute()` and see its providers in the serve graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)