### PR TITLE
ResourceHandler: map schema-validation errors to 400, not 500

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,79 @@
+# Copilot Code Review Instructions — WeOS Core
+
+## How to review
+
+You are reviewing PRs for a Go service that maintainers ship daily. **Comment only when you have HIGH confidence (>80%) that a real issue exists.** A wrong nit costs more than a missed nit — silence is acceptable, noise is not.
+
+Each comment must follow this shape:
+1. One sentence stating the problem.
+2. *(Optional, only if non-obvious)* One sentence on why it matters.
+3. A concrete fix — code snippet or specific action.
+
+If you cannot meet that bar, do not comment. Do not produce summaries, praise, or "consider"-style musings.
+
+## Project context
+
+- **Language / runtime:** Go 1.24+ (CI builds on 1.25), single binary at `cmd/weos/main.go` (CLI + HTTP + MCP).
+- **Architecture:** Event Sourcing / CQRS via pericarp (`BaseEntity`, `EventDispatcher`, `UnitOfWork`, `EventStore`); DI via Uber Fx; Echo v4 HTTP; GORM (auto-detects SQLite/Postgres); Cobra CLI; Zap logging; Gorilla Sessions; KSUID identifiers.
+- **Domain model:** Content is modeled as `ResourceType` + `Resource`. Creating a `ResourceType` auto-generates a projection table via `ProjectionManager`. The `data` column always holds the full JSON-LD blob; typed columns are query-optimization mirrors. Auth entities (User/Role/Account) stay in pericarp — they are **not** resource types.
+- **Layering:** API → Application → Domain ← Infrastructure. Dependencies point inward.
+- **Identity:** URNs — `urn:type:<slug>` for ResourceType, `urn:<typeSlug>:<ksuid>` for Resource.
+- **CI already runs:** `go build`, `go test -race -coverprofile`, `golangci-lint` (gofmt, goimports, errcheck, govet, ineffassign, staticcheck, unused, misspell). **Do not re-flag anything CI catches.**
+
+## What to flag (high priority)
+
+**Security & safety**
+- Secrets, tokens, JWTs, passwords, or session IDs logged or returned in responses.
+- Missing or weakened auth/authz on new endpoints; routes added outside the protected `/api` group without justification.
+- Cookies missing `Secure`, `HttpOnly`, or `SameSite` where the existing code sets them; hardcoded session/cookie defaults that should be config-driven (see `SESSION_SECRET`, OAuth provider config patterns).
+- Missing input validation at HTTP boundaries (request body, query, path params); SQL string concatenation outside GORM; path traversal in file/upload handlers.
+- Casbin policy / ODRL action IRI mismatches — actions enforced in code must match the seeded policies.
+- Trusting client-supplied IPs without `RealIP` middleware where rate limiting / auditing depends on it.
+
+**Correctness**
+- Persisting domain entities without `UnitOfWork` (violates "never persist entities directly").
+- Mutating events after creation, or event handlers that aren't idempotent under replay.
+- Goroutines / channels with leaked references, missing `ctx` cancellation, or race conditions (CI runs `-race` — only flag races CI cannot detect statically).
+- `nil` dereferences after type assertions or map lookups; ignored `error` returns on calls that can fail meaningfully (CI's errcheck catches most — only flag when errcheck is suppressed or the error is silently swallowed inside a wrapper).
+- Off-by-one or boundary errors in pagination (cursor handling in `domain/repositories/pagination.go`), slug derivation (hyphens→underscores, pluralization), or KSUID/URN parsing.
+- Dynamic projection-table SQL where column names are not safely quoted/whitelisted.
+
+**Architecture & conventions**
+- HTTP handlers returning raw `c.JSON(...)` instead of the envelope helpers in `api/handlers/response.go` (`respond`, `respondPaginated`, `respondError`, `respondRaw`, `respondForbidden`). The `/health` endpoint is the only documented exception.
+- Pre-serialized JSON-LD sent through `respond` (causes double-encoding) instead of `respondRaw`.
+- `respondError` callers stuffing the error into the `messages` array — that array is for context-accumulated warnings only.
+- Logger calls that don't use the `entities.Logger` variadic key-value form (`logger.Info(ctx, "msg", "key", val)`).
+- New repositories / services not registered in `application/module.go`, or providers that don't follow the `fx.In`/`fx.Out` pattern in `application/providers.go`.
+- New routes registered outside the `/api` group in `internal/cli/serve.go`.
+- Auth entities (User, Role, Account, etc.) modeled as resource types instead of staying in pericarp.
+
+**Linting limits worth flagging in review** (golangci-lint enforces these but reviewers should still call them out when intent matters):
+- Line length > 120, function > 100 lines / 50 statements, cyclomatic complexity > 15. If a function is at the limit *and* the logic is genuinely tangled, suggest a split — otherwise leave it.
+
+**Tests**
+- New exported behavior with no test in `*_test.go` (unit), `tests/integration/`, or `tests/e2e/`.
+- Tests that assert on log output instead of behavior, or tests that don't use `t.Helper()` / `t.Cleanup` where appropriate.
+- Mocks regenerated by hand instead of via `make mocks` (moqup).
+
+## What NOT to flag
+
+- Style, formatting, import ordering, naming nits — `gofmt`/`goimports`/golangci-lint own these.
+- Anything `staticcheck`, `govet`, `ineffassign`, `unused`, `errcheck`, `misspell` already report.
+- Missing AGPL license header on **test** files (intentionally not required) or on files where it already exists.
+- Suggestions to add comments / docstrings unless an exported symbol is genuinely ambiguous.
+- Refactoring suggestions without a concrete bug or architectural violation behind them.
+- "Consider extracting…" / "you could also…" — speculative cleanup is out of scope.
+- Pluralization or wording quibbles in user-facing strings unless they cause confusion.
+- Coverage percentage commentary — Codecov reports it.
+- Performance suggestions without a measurable hot path or benchmark to back them.
+- Dependency / `go.mod` churn when `go mod tidy` produced it.
+
+## Response format examples
+
+> The `register` handler returns the user's password hash in the JSON body. Drop `PasswordHash` from `authSuccessResponse` or use a sanitized DTO.
+
+> `ResourceRepository.Save` writes directly via GORM instead of going through `UnitOfWork`, so events aren't persisted on commit. Wrap the entity with `uow.Track(entity)` and call `uow.Commit(ctx)`.
+
+> The new `/admin/...` route is registered outside the `/api` group in `serve.go`, so the auth middleware doesn't apply. Move the route inside the `apiGroup` block or attach the middleware explicitly.
+
+If a finding does not fit that shape with that level of specificity, it isn't ready to post.

--- a/api/handlers/resource_handler.go
+++ b/api/handlers/resource_handler.go
@@ -76,6 +76,9 @@ func (h *ResourceHandler) Create(c echo.Context) error {
 		if errors.Is(err, entities.ErrAccessDenied) {
 			return respondForbidden(c)
 		}
+		if errors.Is(err, application.ErrValidation) {
+			return respondError(c, http.StatusBadRequest, err.Error())
+		}
 		return respondError(c, http.StatusInternalServerError, err.Error())
 	}
 	return respondWithResource(c, http.StatusCreated, entity)
@@ -287,6 +290,9 @@ func (h *ResourceHandler) Update(c echo.Context) error {
 	if err != nil {
 		if errors.Is(err, entities.ErrAccessDenied) {
 			return respondForbidden(c)
+		}
+		if errors.Is(err, application.ErrValidation) {
+			return respondError(c, http.StatusBadRequest, err.Error())
 		}
 		return respondError(c, http.StatusInternalServerError, err.Error())
 	}

--- a/api/handlers/resource_handler_test.go
+++ b/api/handlers/resource_handler_test.go
@@ -19,8 +19,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -46,6 +48,12 @@ type stubResourceSvc struct {
 	byIDEntity *entities.Resource
 	byIDErr    error
 	byIDHit    int
+
+	createEntity *entities.Resource
+	createErr    error
+
+	updateEntity *entities.Resource
+	updateErr    error
 }
 
 func (s *stubResourceSvc) GetFlat(_ context.Context, _, _ string) (map[string]any, error) {
@@ -56,6 +64,14 @@ func (s *stubResourceSvc) GetFlat(_ context.Context, _, _ string) (map[string]an
 func (s *stubResourceSvc) GetByID(_ context.Context, _ string) (*entities.Resource, error) {
 	s.byIDHit++
 	return s.byIDEntity, s.byIDErr
+}
+
+func (s *stubResourceSvc) Create(_ context.Context, _ application.CreateResourceCommand) (*entities.Resource, error) {
+	return s.createEntity, s.createErr
+}
+
+func (s *stubResourceSvc) Update(_ context.Context, _ application.UpdateResourceCommand) (*entities.Resource, error) {
+	return s.updateEntity, s.updateErr
 }
 
 // stubTypeSvc returns a fixed resource type from GetBySlug and panics on
@@ -377,5 +393,87 @@ func TestResourceHandler_Get_JSONLD_TypeSlugMismatchReturns404(t *testing.T) {
 	}
 	if svc.flatHit != 0 {
 		t.Errorf("flatHit = %d, want 0 (JSON-LD requests must not call GetFlat)", svc.flatHit)
+	}
+}
+
+func newPostRequest(t *testing.T, body string) (echo.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/resources/course", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("typeSlug")
+	c.SetParamValues("course")
+	return c, rec
+}
+
+func newPutRequest(t *testing.T, body string) (echo.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPut, "/api/resources/course/urn:course:abc", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("typeSlug", "id")
+	c.SetParamValues("course", "urn:course:abc")
+	return c, rec
+}
+
+// TestResourceHandler_Create_ValidationErrorReturns400 verifies that a schema
+// validation failure surfaced from the resource service is mapped to 400, not
+// 500. The 500-default branch only fires for genuinely unexpected errors —
+// malformed user input must surface as a client error so callers (and CI
+// assertions in downstream services) can distinguish "you sent bad data" from
+// "the server crashed".
+func TestResourceHandler_Create_ValidationErrorReturns400(t *testing.T) {
+	svc := &stubResourceSvc{
+		createErr: fmt.Errorf("schema validation failed: missing property 'actorId': %w", application.ErrValidation),
+	}
+	h := newHandler(t, svc)
+
+	c, rec := newPostRequest(t, `{"theme":"dark"}`)
+	if err := h.Create(c); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 (validation errors must be 4xx, not 500)", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "actorId") {
+		t.Fatalf("body = %q, want underlying validation message preserved", rec.Body.String())
+	}
+}
+
+// TestResourceHandler_Create_UnexpectedErrorReturns500 verifies the default
+// branch — a non-validation, non-AccessDenied error still maps to 500 so
+// genuine server faults aren't reclassified as client errors.
+func TestResourceHandler_Create_UnexpectedErrorReturns500(t *testing.T) {
+	svc := &stubResourceSvc{createErr: errors.New("database is on fire")}
+	h := newHandler(t, svc)
+
+	c, rec := newPostRequest(t, `{"name":"x"}`)
+	if err := h.Create(c); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("code = %d, want 500", rec.Code)
+	}
+}
+
+func TestResourceHandler_Update_ValidationErrorReturns400(t *testing.T) {
+	svc := &stubResourceSvc{
+		updateErr: fmt.Errorf("schema validation failed: theme must be one of [light dark system]: %w", application.ErrValidation),
+	}
+	h := newHandler(t, svc)
+
+	c, rec := newPutRequest(t, `{"theme":"blue"}`)
+	if err := h.Update(c); err != nil {
+		t.Fatalf("Update returned error: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "theme") {
+		t.Fatalf("body = %q, want underlying validation message preserved", rec.Body.String())
 	}
 }

--- a/application/resource_service.go
+++ b/application/resource_service.go
@@ -641,7 +641,10 @@ func validateAgainstSchema(schema, data json.RawMessage) error {
 
 	var v any
 	if err := json.Unmarshal(data, &v); err != nil {
-		return fmt.Errorf("invalid JSON data: %w", err)
+		return fmt.Errorf("invalid JSON data: %v: %w", err, ErrValidation)
 	}
-	return sch.Validate(v)
+	if err := sch.Validate(v); err != nil {
+		return fmt.Errorf("%v: %w", err, ErrValidation)
+	}
+	return nil
 }

--- a/application/resource_service.go
+++ b/application/resource_service.go
@@ -3,6 +3,7 @@ package application
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/wepala/weos/v3/domain/entities"
@@ -641,10 +642,10 @@ func validateAgainstSchema(schema, data json.RawMessage) error {
 
 	var v any
 	if err := json.Unmarshal(data, &v); err != nil {
-		return fmt.Errorf("invalid JSON data: %v: %w", err, ErrValidation)
+		return errors.Join(ErrValidation, fmt.Errorf("invalid JSON data: %w", err))
 	}
 	if err := sch.Validate(v); err != nil {
-		return fmt.Errorf("%v: %w", err, ErrValidation)
+		return errors.Join(ErrValidation, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- `ResourceHandler.Create` and `Update` previously turned any non-`ErrAccessDenied` error into a 500, including JSON-Schema validation failures from `validateAgainstSchema`. A bad-body POST got a 500, masking a client error as a server error.
- Wrap the two user-data error paths inside `validateAgainstSchema` with the existing `application.ErrValidation` sentinel; schema-compilation errors keep their plain wrap and stay 500 (server-config issue, not user input).
- In `Create` / `Update`, add an `errors.Is(err, application.ErrValidation)` branch that returns 400 with the underlying detail preserved.
- Discovered via crossdeck's e2e suite (`TestCreateSettings_MissingActorId`, `TestCreateSettings_InvalidTheme`), which tightened its assertions to 4xx specifically to catch this class of bug.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes across the whole weos repo
- [x] New handler tests cover Create→400 (validation), Create→500 (unexpected error), Update→400 (validation)
- [x] Crossdeck's previously-failing e2e tests pass against this branch

## Follow-up (not in this PR)
`person_handler.go` and `organization_handler.go` have the same 500-default pattern over `resourceService.Create/Update`. They aren't routed by the crossdeck failing tests, so leaving them for a follow-up to keep this PR scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)