### PR TITLE
fix(mcp): make stdio transport protocol-clean and shut down gracefully (#374)

### DIFF
--- a/docs/_tutorials/connecting-mcp-to-llm.md
+++ b/docs/_tutorials/connecting-mcp-to-llm.md
@@ -21,11 +21,12 @@ In this tutorial you'll start the MCP server, connect it to Claude Desktop, and 
 
 WeOS's MCP server uses **stdio transport** — it communicates via standard input/output. The LLM client launches the `weos mcp` process and communicates with it through stdin/stdout.
 
-The server exposes four tool groups:
+The server exposes five tool groups:
 - **person** — create, get, list, update, delete persons
 - **organization** — create, get, list, update, delete organizations
-- **resource-type** — create, get, list, update, delete resource types; list and install presets
+- **resource-type** — create, get, list, update, delete resource types; list and install presets; list and set behaviors
 - **resource** — create, get, list, update, delete resources of any type
+- **knowledge-graph** — search entities, describe classes, expand entities, find paths, run SPARQL queries (registered only when a knowledge-graph store is configured)
 
 You can enable only specific tool groups:
 
@@ -180,11 +181,21 @@ You can also set this via the `MCP_SERVICES` environment variable:
 | `resource_type_delete` | id | Delete a resource type |
 | `resource_type_preset_list` | (none) | List available presets |
 | `resource_type_preset_install` | name, update? | Install a preset |
+| `resource_type_behavior_list` | type_slug | List a resource type's behaviors and their enabled state |
+| `resource_type_behavior_set` | type_slug, slugs | Set which behaviors are enabled for a resource type |
 | `resource_create` | type_slug, data | Create a resource |
 | `resource_get` | id | Get a resource |
 | `resource_list` | type_slug, cursor?, limit?, sort_by?, sort_order? | List resources |
 | `resource_update` | id, data | Update a resource |
 | `resource_delete` | id | Delete a resource |
+| `kg_search_entities` | q, class_iri?, limit? | Search knowledge-graph entities by label/name |
+| `kg_list_classes` | (none) | List classes in the knowledge graph |
+| `kg_describe_class` | class_iri, sample_instances? | Describe a class: its predicates and example instances |
+| `kg_expand_entity` | iri, depth? | Expand an entity's relationships |
+| `kg_find_path` | from, to, max_hops? | Find a path between two entities |
+| `kg_sparql_query` | query | Run a SPARQL 1.1 query |
+
+Knowledge-graph tools are registered only when a knowledge-graph store (e.g. Oxigraph) is configured.
 
 See [MCP Tools Reference]({% link _reference/mcp-tools.md %}) for complete input/output schemas.
 

--- a/docs/_tutorials/connecting-mcp-to-llm.md
+++ b/docs/_tutorials/connecting-mcp-to-llm.md
@@ -26,7 +26,7 @@ The server exposes five tool groups:
 - **organization** — create, get, list, update, delete organizations
 - **resource-type** — create, get, list, update, delete resource types; list and install presets; list and set behaviors
 - **resource** — create, get, list, update, delete resources of any type
-- **knowledge-graph** — search entities, describe classes, expand entities, find paths, run SPARQL queries (registered only when a knowledge-graph store is configured)
+- **knowledge-graph** — search entities, describe classes, expand entities, find paths, run SPARQL queries (the tools are always available; if no knowledge-graph store is configured, each call returns a "knowledge graph not configured" error)
 
 You can enable only specific tool groups:
 
@@ -195,7 +195,7 @@ You can also set this via the `MCP_SERVICES` environment variable:
 | `kg_find_path` | from, to, max_hops? | Find a path between two entities |
 | `kg_sparql_query` | query | Run a SPARQL 1.1 query |
 
-Knowledge-graph tools are registered only when a knowledge-graph store (e.g. Oxigraph) is configured.
+Knowledge-graph tools are always registered. When no knowledge-graph store (e.g. Oxigraph) is configured, each call returns a "knowledge graph not configured" error instead of the tools being absent.
 
 See [MCP Tools Reference]({% link _reference/mcp-tools.md %}) for complete input/output schemas.
 

--- a/infrastructure/database/gorm/provider.go
+++ b/infrastructure/database/gorm/provider.go
@@ -18,7 +18,10 @@ package gorm
 import (
 	"database/sql"
 	"fmt"
+	"log"
+	"os"
 	"strings"
+	"time"
 
 	weosmodels "github.com/wepala/weos/v3/infrastructure/models"
 	"github.com/wepala/weos/v3/internal/config"
@@ -29,7 +32,28 @@ import (
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
 )
+
+// gormConfig returns the shared GORM config. The logger writes to stderr, never
+// stdout: the `weos mcp` stdio transport speaks JSON-RPC over stdout, and any
+// stray write there corrupts the protocol stream. (GORM's default logger logs
+// to stdout — which silently breaks stdio MCP clients.) RecordNotFound is
+// ignored because the repositories map it to a domain not-found error as normal
+// control flow, so it is not worth logging.
+func gormConfig() *gorm.Config {
+	return &gorm.Config{
+		Logger: gormlogger.New(
+			log.New(os.Stderr, "\r\n", log.LstdFlags),
+			gormlogger.Config{
+				SlowThreshold:             200 * time.Millisecond,
+				LogLevel:                  gormlogger.Warn,
+				IgnoreRecordNotFoundError: true,
+				Colorful:                  false,
+			},
+		),
+	}
+}
 
 // GormDBResult holds the GORM database connection results.
 type GormDBResult struct {
@@ -53,12 +77,12 @@ func ProvideGormDB(params struct {
 	// PostgreSQL DSNs typically start with "host=" or contain "postgres://"
 	// SQLite DSNs are file paths or "file:" URIs
 	if strings.HasPrefix(dsn, "host=") || strings.Contains(dsn, "postgres://") || strings.Contains(dsn, "postgresql://") {
-		db, err = gorm.Open(postgres.Open(dsn), &gorm.Config{})
+		db, err = gorm.Open(postgres.Open(dsn), gormConfig())
 		if err != nil {
 			return GormDBResult{}, fmt.Errorf("failed to connect to PostgreSQL database: %w", err)
 		}
 	} else {
-		db, err = gorm.Open(sqlite.Open(sqliteDSNWithWorkerPragmas(dsn)), &gorm.Config{})
+		db, err = gorm.Open(sqlite.Open(sqliteDSNWithWorkerPragmas(dsn)), gormConfig())
 		if err != nil {
 			return GormDBResult{}, fmt.Errorf("failed to connect to SQLite database: %w", err)
 		}

--- a/infrastructure/database/gorm/provider.go
+++ b/infrastructure/database/gorm/provider.go
@@ -44,7 +44,9 @@ import (
 func gormConfig() *gorm.Config {
 	return &gorm.Config{
 		Logger: gormlogger.New(
-			log.New(os.Stderr, "\r\n", log.LstdFlags),
+			// No "\r\n" prefix (GORM's default uses one, which prepends a blank
+			// line to every entry) — keep stderr log lines clean.
+			log.New(os.Stderr, "", log.LstdFlags),
 			gormlogger.Config{
 				SlowThreshold:             200 * time.Millisecond,
 				LogLevel:                  gormlogger.Warn,

--- a/infrastructure/database/gorm/provider_logger_test.go
+++ b/infrastructure/database/gorm/provider_logger_test.go
@@ -54,8 +54,8 @@ func TestGormConfig_LogsToStderrNotStdout(t *testing.T) {
 		t.Fatalf("open: %v", err)
 	}
 	// A query against a missing table is a real error GORM logs at Error level
-	// (unlike RecordNotFound, which gormConfig ignores). This is the kind of
-	// write that would otherwise land on stdout.
+	// (unlike RecordNotFound, which gormConfig ignores) — forcing the logger to
+	// emit so we can see which stream it writes to.
 	_ = db.Exec("SELECT * FROM table_that_does_not_exist").Error
 
 	restore()
@@ -64,8 +64,14 @@ func TestGormConfig_LogsToStderrNotStdout(t *testing.T) {
 	outBytes, _ := io.ReadAll(outR)
 	errBytes, _ := io.ReadAll(errR)
 
+	// Two complementary regressions are covered:
+	//   - The stderr assertion fires if gormConfig were reverted to the bare
+	//     &gorm.Config{}: GORM's default logger captured the real os.Stdout at
+	//     package init (before this swap), so nothing reaches the piped stderr.
+	//   - The stdout assertion fires if gormConfig itself were changed to build
+	//     its logger over os.Stdout: it captures the swapped stdout at call time.
 	if len(outBytes) != 0 {
-		t.Errorf("GORM wrote to stdout (corrupts stdio MCP protocol):\n%s", outBytes)
+		t.Errorf("GORM logger wrote to stdout (corrupts stdio MCP protocol):\n%s", outBytes)
 	}
 	if !strings.Contains(string(errBytes), "table_that_does_not_exist") {
 		t.Errorf("expected the GORM error log on stderr, got: %q", errBytes)

--- a/infrastructure/database/gorm/provider_logger_test.go
+++ b/infrastructure/database/gorm/provider_logger_test.go
@@ -1,0 +1,73 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package gorm
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestGormConfig_LogsToStderrNotStdout guards the `weos mcp` stdio transport:
+// it speaks JSON-RPC over stdout, so ANY byte GORM writes to stdout corrupts
+// the protocol stream and breaks the MCP client. GORM's default logger logs to
+// stdout; gormConfig must redirect it to stderr.
+//
+// Deliberately NOT parallel: it swaps the os.Stdout/os.Stderr globals, and
+// serial tests run to completion before any t.Parallel() test in the package
+// resumes, so there is no interference.
+func TestGormConfig_LogsToStderrNotStdout(t *testing.T) {
+	origOut, origErr := os.Stdout, os.Stderr
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	errR, errW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	// Swap BEFORE building the config: log.New captures os.Stderr by value.
+	os.Stdout, os.Stderr = outW, errW
+	restore := func() { os.Stdout, os.Stderr = origOut, origErr }
+	defer restore()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), gormConfig())
+	if err != nil {
+		restore()
+		t.Fatalf("open: %v", err)
+	}
+	// A query against a missing table is a real error GORM logs at Error level
+	// (unlike RecordNotFound, which gormConfig ignores). This is the kind of
+	// write that would otherwise land on stdout.
+	_ = db.Exec("SELECT * FROM table_that_does_not_exist").Error
+
+	restore()
+	_ = outW.Close()
+	_ = errW.Close()
+	outBytes, _ := io.ReadAll(outR)
+	errBytes, _ := io.ReadAll(errR)
+
+	if len(outBytes) != 0 {
+		t.Errorf("GORM wrote to stdout (corrupts stdio MCP protocol):\n%s", outBytes)
+	}
+	if !strings.Contains(string(errBytes), "table_that_does_not_exist") {
+		t.Errorf("expected the GORM error log on stderr, got: %q", errBytes)
+	}
+}

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -42,7 +42,11 @@ Examples:
   weos mcp --services website --services page # same, repeated flag syntax
   MCP_SERVICES=organization weos mcp         # env var override`,
 		strings.Join(mcpserver.ValidServiceNames(), ", ")),
-	RunE: runMCP,
+	// This command is a long-running stdio server, not an interactive CLI. On a
+	// runtime error, printing the full usage/help text would be noise on the
+	// client's stderr and misleading, so suppress it and surface only the error.
+	SilenceUsage: true,
+	RunE:         runMCP,
 }
 
 func init() {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -190,12 +190,24 @@ func Run(enabledServices []string) error {
 }
 
 // isCleanShutdown reports whether err is the normal end of a stdio MCP session
-// rather than a real failure. A desktop client ends the session by closing the
-// server's stdin (surfaces as io.EOF) or by signaling the process
-// (SIGINT/SIGTERM, which cancels ctx). The SDK reports a closed stdin as an
-// "...server is closing: EOF" error whose cause is joined with %v, so io.EOF is
-// not in the chain — fall back to matching that message for the case where EOF
-// arrives mid-handshake.
+// rather than a real failure, so the caller can exit 0 instead of surfacing it.
+// Two signals count as clean:
+//
+//   - ctx was canceled — the process got SIGINT/SIGTERM and server.Run returned
+//     ctx.Err(). This is the common interactive-shutdown path.
+//   - the client closed stdin mid-handshake — the SDK returns an error whose
+//     message is "server is closing: EOF". The EOF cause is joined with %v (not
+//     %w), so errors.Is(err, io.EOF) can't see it; we match the message but also
+//     require the EOF cause, so a non-EOF transport failure wrapped in the same
+//     "server is closing" prefix (e.g. a broken pipe) still propagates as a real
+//     error rather than being mistaken for a clean exit.
+//
+// Note: a clean stdin EOF on an already-established session does NOT reach here.
+// The SDK's jsonrpc2 wait() swallows a bare io.EOF read error and server.Run
+// returns nil, which the caller treats as success before calling this. The
+// errors.Is(io.EOF) check below is only defensive cover for wrapped-EOF variants.
+//
+// Verified against modelcontextprotocol/go-sdk v1.4.1.
 func isCleanShutdown(ctx context.Context, err error) bool {
 	if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
 		return true
@@ -203,7 +215,8 @@ func isCleanShutdown(ctx context.Context, err error) bool {
 	if errors.Is(err, io.EOF) {
 		return true
 	}
-	return strings.Contains(err.Error(), "server is closing")
+	msg := err.Error()
+	return strings.Contains(msg, "server is closing") && strings.Contains(msg, "EOF")
 }
 
 // isNilInterface returns true if v is nil or a typed-nil (interface wrapping a nil pointer).

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -2,7 +2,9 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"reflect"
@@ -181,7 +183,27 @@ func Run(enabledServices []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	return server.Run(ctx, &mcp.StdioTransport{})
+	if err := server.Run(ctx, &mcp.StdioTransport{}); err != nil && !isCleanShutdown(ctx, err) {
+		return err
+	}
+	return nil
+}
+
+// isCleanShutdown reports whether err is the normal end of a stdio MCP session
+// rather than a real failure. A desktop client ends the session by closing the
+// server's stdin (surfaces as io.EOF) or by signaling the process
+// (SIGINT/SIGTERM, which cancels ctx). The SDK reports a closed stdin as an
+// "...server is closing: EOF" error whose cause is joined with %v, so io.EOF is
+// not in the chain — fall back to matching that message for the case where EOF
+// arrives mid-handshake.
+func isCleanShutdown(ctx context.Context, err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+		return true
+	}
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+	return strings.Contains(err.Error(), "server is closing")
 }
 
 // isNilInterface returns true if v is nil or a typed-nil (interface wrapping a nil pointer).

--- a/internal/mcp/shutdown_test.go
+++ b/internal/mcp/shutdown_test.go
@@ -1,0 +1,56 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+)
+
+// A stdio MCP session ends normally when the client closes stdin (io.EOF) or
+// signals the process (ctx canceled). Those must read as clean shutdowns so
+// `weos mcp` exits 0; a genuine failure must still propagate.
+func TestIsCleanShutdown(t *testing.T) {
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	live := context.Background()
+
+	cases := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want bool
+	}{
+		{"context canceled via ctx", canceled, errors.New("anything"), true},
+		{"context canceled via err", live, context.Canceled, true},
+		{"plain io.EOF", live, io.EOF, true},
+		{"wrapped io.EOF", live, fmt.Errorf("read: %w", io.EOF), true},
+		// The SDK joins the EOF cause with %v, so io.EOF is not in the chain —
+		// the "server is closing" message is the only signal.
+		{"server is closing: EOF (%v-joined)", live, errors.New("server is closing: EOF"), true},
+		{"real failure", live, errors.New("database is locked"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isCleanShutdown(tc.ctx, tc.err); got != tc.want {
+				t.Errorf("isCleanShutdown(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/mcp/shutdown_test.go
+++ b/internal/mcp/shutdown_test.go
@@ -42,8 +42,11 @@ func TestIsCleanShutdown(t *testing.T) {
 		{"plain io.EOF", live, io.EOF, true},
 		{"wrapped io.EOF", live, fmt.Errorf("read: %w", io.EOF), true},
 		// The SDK joins the EOF cause with %v, so io.EOF is not in the chain —
-		// the "server is closing" message is the only signal.
+		// the "server is closing" message plus an EOF cause is the only signal.
 		{"server is closing: EOF (%v-joined)", live, errors.New("server is closing: EOF"), true},
+		// A non-EOF transport failure wrapped in the same prefix is NOT clean:
+		// it must propagate so a broken session exits non-zero, not 0.
+		{"server is closing: non-EOF propagates", live, errors.New("server is closing: broken pipe"), false},
 		{"real failure", live, errors.New("database is locked"), false},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Closes #374.

## Context

Issue #374 asks for a `weos mcp` stdio transport so desktop MCP clients (Claude Desktop / Cursor) can launch the binary directly — no ephemeral port, no token paste. The stdio command and docs already existed on `v3` and met most acceptance criteria, but **live testing the handshake surfaced two bugs that break real desktop clients**, plus doc drift. This PR fixes those.

## Bugs fixed

1. **GORM logged to stdout, corrupting the JSON-RPC stream (HIGH).** `&gorm.Config{}` uses GORM's default logger, which writes SQL warnings/errors to **stdout**. The MCP stdio spec requires stdout to carry *only* protocol messages, so any GORM line breaks the client. Now the GORM logger writes to **stderr** and ignores `RecordNotFound` (the repositories already map it to a domain not-found error as normal control flow, so it was pure noise).
2. **Clean disconnect looked like a failure (MEDIUM).** When the client closes stdin (EOF) or signals the process, `server.Run` returned an error, so `weos mcp` exited non-zero and dumped cobra usage into the client's stderr. Now EOF / context-cancellation / the SDK's `server is closing` are treated as graceful shutdown (exit 0), and `SilenceUsage` keeps runtime errors from spamming help text.

## Docs

- Tutorial said "four tool groups" — corrected to five (adds **knowledge-graph**) and noted the **behavior** tools under resource-type.
- Added the `kg_*` and `resource_type_behavior_*` rows to the tool reference table (inputs verified against the tool schemas).

## Tests

- `TestGormConfig_LogsToStderrNotStdout` — captures os.Stdout/os.Stderr around a logged GORM error and asserts nothing reaches stdout (the protocol-corruption regression).
- `TestIsCleanShutdown` — table test over EOF / ctx-cancel / `server is closing` / real-error.

## Verification (live)

Drove the stdio handshake (`initialize` + `tools/list`) against the built binary:
- stdout is 100% valid JSON-RPC, 0 GORM lines leaked;
- all tool groups advertised (person/organization/resource/resource-type/knowledge-graph + behaviors);
- a disconnect mid-handshake exits 0 with no usage dump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)