### PR TITLE
feat(mcp): RegisterMCPConfigurer hook for custom downstream tools

### DIFF
--- a/internal/mcp/configurer.go
+++ b/internal/mcp/configurer.go
@@ -1,0 +1,71 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package mcp
+
+import (
+	"log/slog"
+
+	"github.com/wepala/weos/v3/application"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// MCP tool extension point. The built-in tool groups (person, resource,
+// knowledge-graph, …) cover generic CRUD, but a downstream binary may
+// need a custom, non-CRUD tool — e.g. a write-gated import that must run
+// through a behavior pipeline rather than write resources directly. This
+// mirrors RegisterEchoConfigurer for HTTP routes: a binary registers a
+// configurer in init(), and it runs against the server on every
+// transport (stdio and Streamable HTTP) after the built-in groups.
+
+// ConfigurerDeps exposes the services a custom MCP tool needs. It is the
+// subset of the MCP server's wiring that is safe and useful to hand to
+// downstream tools. Logger may be nil (configurers should fall back to a
+// default); it writes to stderr so it never corrupts the stdio protocol
+// channel.
+type ConfigurerDeps struct {
+	ResourceService     application.ResourceService
+	ResourceTypeService application.ResourceTypeService
+	Logger              *slog.Logger
+}
+
+// MCPConfigurer registers additional tools on the server after the
+// built-in groups are added.
+type MCPConfigurer func(server *mcp.Server, deps ConfigurerDeps)
+
+// customConfigurers holds the configurers registered by downstream
+// binaries via RegisterMCPConfigurer.
+var customConfigurers []MCPConfigurer
+
+// RegisterMCPConfigurer registers a configurer to run against the MCP
+// server on every transport. Call from an init() in the downstream
+// binary, the same way custom presets and Echo configurers are wired.
+// nil configurers are ignored.
+func RegisterMCPConfigurer(c MCPConfigurer) {
+	if c != nil {
+		customConfigurers = append(customConfigurers, c)
+	}
+}
+
+// applyConfigurers runs every registered configurer against the server.
+// Called by each transport's constructor after the built-in groups are
+// registered, so a custom tool is available identically over stdio and
+// HTTP.
+func applyConfigurers(server *mcp.Server, deps ConfigurerDeps) {
+	for _, c := range customConfigurers {
+		c(server, deps)
+	}
+}

--- a/internal/mcp/configurer.go
+++ b/internal/mcp/configurer.go
@@ -34,8 +34,11 @@ import (
 // ConfigurerDeps exposes the services a custom MCP tool needs. It is the
 // subset of the MCP server's wiring that is safe and useful to hand to
 // downstream tools. Logger may be nil (configurers should fall back to a
-// default); it writes to stderr so it never corrupts the stdio protocol
-// channel.
+// default). Its destination depends on the transport: the stdio path
+// supplies a stderr logger (so it can't corrupt the stdout protocol
+// channel), while the HTTP path passes through the caller-provided
+// logger, which may write elsewhere — a tool needing a specific
+// destination should not assume one.
 type ConfigurerDeps struct {
 	ResourceService     application.ResourceService
 	ResourceTypeService application.ResourceTypeService

--- a/internal/mcp/configurer_test.go
+++ b/internal/mcp/configurer_test.go
@@ -1,0 +1,98 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package mcp
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// withCleanConfigurers isolates a test from the package-global configurer
+// registry, restoring whatever was there before.
+func withCleanConfigurers(t *testing.T) {
+	t.Helper()
+	saved := customConfigurers
+	customConfigurers = nil
+	t.Cleanup(func() { customConfigurers = saved })
+}
+
+// applyConfigurers runs every registered configurer once, passing the
+// dependency bundle through; nil registrations are ignored.
+func TestApplyConfigurersRunsRegisteredAndIgnoresNil(t *testing.T) {
+	withCleanConfigurers(t)
+
+	calls := 0
+	var gotDeps ConfigurerDeps
+	RegisterMCPConfigurer(func(_ *mcp.Server, deps ConfigurerDeps) {
+		calls++
+		gotDeps = deps
+	})
+	RegisterMCPConfigurer(nil) // must be ignored, not panic
+
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	deps := ConfigurerDeps{
+		ResourceService:     &stubResourceService{},
+		ResourceTypeService: &stubResourceTypeService{},
+		Logger:              slog.Default(),
+	}
+	applyConfigurers(srv, deps)
+
+	if calls != 1 {
+		t.Fatalf("configurer ran %d times, want 1 (nil ignored)", calls)
+	}
+	if gotDeps.ResourceService == nil || gotDeps.ResourceTypeService == nil || gotDeps.Logger == nil {
+		t.Errorf("deps not threaded through: %+v", gotDeps)
+	}
+}
+
+// The HTTP transport applies registered configurers when the handler is
+// constructed — the same applyConfigurers call the stdio Run path uses,
+// so a downstream tool is registered on either transport.
+func TestNewHTTPHandlerAppliesConfigurers(t *testing.T) {
+	withCleanConfigurers(t)
+
+	called := 0
+	RegisterMCPConfigurer(func(_ *mcp.Server, _ ConfigurerDeps) { called++ })
+
+	if _, err := NewHTTPHandler(&stubResourceTypeService{}, &stubResourceService{}, nil, slog.Default()); err != nil {
+		t.Fatalf("NewHTTPHandler: %v", err)
+	}
+	if called != 1 {
+		t.Errorf("HTTP transport did not apply the configurer (called=%d, want 1)", called)
+	}
+}
+
+// A configurer can actually register a tool on the server it's handed —
+// the end the hook exists for.
+func TestConfigurerCanRegisterTool(t *testing.T) {
+	withCleanConfigurers(t)
+
+	type emptyIn struct{}
+	type emptyOut struct{}
+	RegisterMCPConfigurer(func(s *mcp.Server, _ ConfigurerDeps) {
+		mcp.AddTool(s, &mcp.Tool{Name: "downstream_tool", Description: "test"},
+			func(_ context.Context, _ *mcp.CallToolRequest, _ emptyIn) (*mcp.CallToolResult, emptyOut, error) {
+				return nil, emptyOut{}, nil
+			})
+	})
+
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	// Should not panic and should leave the configurer free to add tools.
+	applyConfigurers(srv, ConfigurerDeps{Logger: slog.Default()})
+}

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -39,6 +39,13 @@ func NewHTTPHandler(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create MCP server: %w", err)
 	}
+	// Custom tools registered by downstream binaries run on every
+	// transport; the HTTP path applies them here.
+	applyConfigurers(server, ConfigurerDeps{
+		ResourceService:     resourceService,
+		ResourceTypeService: resourceTypeService,
+		Logger:              logger,
+	})
 	return gomcp.NewStreamableHTTPHandler(func(_ *http.Request) *gomcp.Server {
 		return server
 	}, &gomcp.StreamableHTTPOptions{

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -181,13 +181,14 @@ func Run(enabledServices []string) error {
 		return fmt.Errorf("failed to create MCP server: %w", err)
 	}
 	// Custom tools registered by downstream binaries run on every
-	// transport; the stdio path applies them here. The logger writes to
-	// stderr (slog's default), so it never corrupts the stdout protocol
-	// channel.
+	// transport; the stdio path applies them here. Use an explicit stderr
+	// logger rather than slog.Default(): the default can be redirected to
+	// stdout by downstream code, which would corrupt the stdio MCP
+	// protocol stream.
 	applyConfigurers(server, ConfigurerDeps{
 		ResourceService:     resourceService,
 		ResourceTypeService: resourceTypeService,
-		Logger:              slog.Default(),
+		Logger:              slog.New(slog.NewTextHandler(os.Stderr, nil)),
 	})
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/signal"
 	"reflect"
@@ -179,6 +180,15 @@ func Run(enabledServices []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create MCP server: %w", err)
 	}
+	// Custom tools registered by downstream binaries run on every
+	// transport; the stdio path applies them here. The logger writes to
+	// stderr (slog's default), so it never corrupts the stdout protocol
+	// channel.
+	applyConfigurers(server, ConfigurerDeps{
+		ResourceService:     resourceService,
+		ResourceTypeService: resourceTypeService,
+		Logger:              slog.Default(),
+	})
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -24,7 +24,10 @@ package cli
 
 import (
 	internalcli "github.com/wepala/weos/v3/internal/cli"
+	mcpserver "github.com/wepala/weos/v3/internal/mcp"
 	"go.uber.org/fx"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // Execute runs the weos CLI root command.
@@ -51,4 +54,18 @@ func RegisterFxOptions(opts ...fx.Option) {
 // before Execute().
 func RegisterEchoConfigurer(c internalcli.EchoConfigurer) {
 	internalcli.RegisterEchoConfigurer(c)
+}
+
+// MCPConfigurerDeps re-exports the dependency bundle handed to a custom
+// MCP tool configurer (see RegisterMCPConfigurer).
+type MCPConfigurerDeps = mcpserver.ConfigurerDeps
+
+// RegisterMCPConfigurer registers a function that adds custom tools to
+// the MCP server, on every transport (stdio and Streamable HTTP), after
+// the built-in tool groups. Use this from a downstream binary's init()
+// to expose a custom, non-CRUD tool — e.g. one that writes through a
+// behavior pipeline rather than directly to projection tables. Must be
+// called before Execute(). Mirrors RegisterEchoConfigurer for HTTP.
+func RegisterMCPConfigurer(c func(server *mcp.Server, deps mcpserver.ConfigurerDeps)) {
+	mcpserver.RegisterMCPConfigurer(c)
 }

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -66,6 +66,6 @@ type MCPConfigurerDeps = mcpserver.ConfigurerDeps
 // to expose a custom, non-CRUD tool — e.g. one that writes through a
 // behavior pipeline rather than directly to projection tables. Must be
 // called before Execute(). Mirrors RegisterEchoConfigurer for HTTP.
-func RegisterMCPConfigurer(c func(server *mcp.Server, deps mcpserver.ConfigurerDeps)) {
+func RegisterMCPConfigurer(c func(server *mcp.Server, deps MCPConfigurerDeps)) {
 	mcpserver.RegisterMCPConfigurer(c)
 }


### PR DESCRIPTION
## What

Adds an extension point so a downstream binary (e.g. finexity) can register a custom, non-CRUD MCP tool — mirroring `RegisterEchoConfigurer` for HTTP routes.

- `internal/mcp.RegisterMCPConfigurer(fn)` collects configurers; both transports (stdio `Run`, Streamable HTTP `NewHTTPHandler`) call `applyConfigurers` after the built-in tool groups, so a custom tool is available identically over either.
- `ConfigurerDeps` hands the tool the `ResourceService`/`ResourceTypeService` and an stderr-safe `*slog.Logger`.
- `pkg/cli` re-exports `RegisterMCPConfigurer` + `MCPConfigurerDeps` so downstream binaries (which can't import `internal/`) can register from an `init()`.

## Why

The built-in MCP tool groups cover generic CRUD, but finexity needs a write-gated `import_statement` tool that runs through its behavior pipeline + integrity gate rather than writing resources directly. This is the framework-shaped half of finexity epic #55, story #59.

## Notes

- Built-in tool groups are untouched; `applyConfigurers` runs once per server construction (no double-registration).
- finexity's consuming PR (wepala/finexity#TBD) depends on this; it needs a tagged weos release for standalone builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)