### PR TITLE
fix(mcp): give resource output data field a JSON Schema

### DIFF
--- a/internal/mcp/resource_tools.go
+++ b/internal/mcp/resource_tools.go
@@ -42,7 +42,7 @@ type ListResourcesInput struct {
 type ResourceOutput struct {
 	ID        string    `json:"id"`
 	TypeSlug  string    `json:"type_slug"`
-	Data      any       `json:"data"`
+	Data      any       `json:"data" jsonschema:"resource data as JSON-LD object"`
 	Status    string    `json:"status"`
 	CreatedAt time.Time `json:"created_at"`
 }


### PR DESCRIPTION
## Problem

MCP clients that validate `outputSchema` property values as schema *objects* (e.g. Claude Code) reject the `resource_create`, `resource_get`, and `resource_update` tools with:

```
outputSchema.properties.data: Invalid input
```

`ResourceOutput.Data` is typed `any` with no `jsonschema` tag, so the go-sdk reflects it to an empty schema, which `google/jsonschema-go` marshals as the boolean `true` (`{}` → `true`). A bare `"data": true` is a valid JSON Schema, but clients expecting each property to be a schema object reject it — breaking `tools/list` for all three tools.

The *input* `data` fields already carry `jsonschema:"..."` description tags, which make their schemas non-empty (`{"description": ...}`), so only the outputs failed.

## Fix

Add a `jsonschema` description tag to `ResourceOutput.Data`, mirroring the input structs. The field reflects to a valid object schema (`{"description": "resource data as JSON-LD object"}`) while keeping `any` semantics. This also fixes the nested `data` in `resource_list`'s array elements.

## Verification

Rebuilt and probed the live MCP server's `tools/list`: `resource_create`, `resource_get`, `resource_update`, and `resource_list` now expose valid object schemas for `data`; no boolean `data` schemas remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)