### PR TITLE
fix(mcp): clearer resource validation errors (#381) + object schema/context support (#382)

### DIFF
--- a/application/resource_service.go
+++ b/application/resource_service.go
@@ -17,6 +17,7 @@ import (
 	esapp "github.com/akeemphilbert/pericarp/pkg/eventsourcing/application"
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
 	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/santhosh-tekuri/jsonschema/v6/kind"
 	"go.uber.org/fx"
 )
 
@@ -707,6 +708,22 @@ func (s *resourceService) reconcileTriples(
 	return nil
 }
 
+// schemaResourceID is a stable, in-memory identifier for the compiled schema.
+// It is an absolute URI so the validator never resolves a relative name against
+// the process working directory — doing so leaked a host file path (e.g.
+// file:///…/schema.json#) into error messages (issue #381).
+const schemaResourceID = "mem://weos/resource-schema"
+
+// validationError is a client-input validation failure carrying a clean,
+// caller-facing message. It satisfies errors.Is(err, ErrValidation) so callers
+// (e.g. HTTP handlers) still map it to a 4xx, while Error() stays human-readable
+// and free of validator internals or host paths (issue #381).
+type validationError struct{ msg string }
+
+func (e *validationError) Error() string { return e.msg }
+
+func (e *validationError) Is(target error) bool { return target == ErrValidation }
+
 func validateAgainstSchema(schema, data json.RawMessage) error {
 	if len(schema) == 0 {
 		return nil
@@ -718,20 +735,115 @@ func validateAgainstSchema(schema, data json.RawMessage) error {
 	}
 
 	c := jsonschema.NewCompiler()
-	if err := c.AddResource("schema.json", schemaDoc); err != nil {
+	if err := c.AddResource(schemaResourceID, schemaDoc); err != nil {
 		return fmt.Errorf("invalid schema: %w", err)
 	}
-	sch, err := c.Compile("schema.json")
+	sch, err := c.Compile(schemaResourceID)
 	if err != nil {
 		return fmt.Errorf("failed to compile schema: %w", err)
 	}
 
 	var v any
 	if err := json.Unmarshal(data, &v); err != nil {
-		return errors.Join(ErrValidation, fmt.Errorf("invalid JSON data: %w", err))
+		return &validationError{msg: fmt.Sprintf("data is not valid JSON: %v", err)}
 	}
 	if err := sch.Validate(v); err != nil {
-		return errors.Join(ErrValidation, err)
+		var ve *jsonschema.ValidationError
+		if errors.As(err, &ve) {
+			return &validationError{msg: humanizeSchemaError(ve)}
+		}
+		// Defensive: an unexpected validator error still reads as a validation
+		// failure to the caller, without leaking internals.
+		return &validationError{msg: "data does not match the resource type schema"}
 	}
 	return nil
+}
+
+// humanizeSchemaError turns a JSON Schema validation failure into a concise,
+// actionable message that names the offending field (rooted at the "data"
+// argument) and summarizes each violation — never the raw library rendering.
+func humanizeSchemaError(ve *jsonschema.ValidationError) string {
+	violations := collectSchemaViolations(ve)
+	switch len(violations) {
+	case 0:
+		return "data does not match the resource type schema"
+	case 1:
+		return violations[0]
+	default:
+		return "data does not match the resource type schema: " + strings.Join(violations, "; ")
+	}
+}
+
+// collectSchemaViolations flattens the validation-error tree to its leaf causes
+// and renders each as a short, field-qualified sentence (deduplicated).
+func collectSchemaViolations(ve *jsonschema.ValidationError) []string {
+	var out []string
+	seen := make(map[string]bool)
+	var walk func(e *jsonschema.ValidationError)
+	walk = func(e *jsonschema.ValidationError) {
+		if len(e.Causes) > 0 {
+			for _, c := range e.Causes {
+				walk(c)
+			}
+			return
+		}
+		msg := describeSchemaViolation(e)
+		if !seen[msg] {
+			seen[msg] = true
+			out = append(out, msg)
+		}
+	}
+	walk(ve)
+	return out
+}
+
+func describeSchemaViolation(e *jsonschema.ValidationError) string {
+	field := dataFieldRef(e.InstanceLocation)
+	switch k := e.ErrorKind.(type) {
+	case *kind.Type:
+		return fmt.Sprintf("%s must be %s, but got %s", field, wantTypePhrase(k.Want), k.Got)
+	case *kind.Required:
+		if len(k.Missing) == 1 {
+			return fmt.Sprintf("%s is missing required property %q", field, k.Missing[0])
+		}
+		return fmt.Sprintf("%s is missing required properties: %s", field, strings.Join(k.Missing, ", "))
+	case *kind.Enum:
+		return fmt.Sprintf("%s must be one of %s", field, enumValues(k.Want))
+	default:
+		keyword := "schema"
+		if path := e.ErrorKind.KeywordPath(); len(path) > 0 {
+			keyword = path[0]
+		}
+		return fmt.Sprintf("%s does not satisfy the %q constraint", field, keyword)
+	}
+}
+
+// dataFieldRef renders a JSON instance location as a caller-facing reference
+// rooted at the "data" argument: [] -> "data", ["name"] -> "data.name".
+func dataFieldRef(loc []string) string {
+	if len(loc) == 0 {
+		return "data"
+	}
+	var b strings.Builder
+	b.WriteString("data")
+	for _, seg := range loc {
+		b.WriteByte('.')
+		b.WriteString(seg)
+	}
+	return b.String()
+}
+
+func wantTypePhrase(want []string) string {
+	if len(want) == 1 && want[0] == "object" {
+		return "a JSON object"
+	}
+	return strings.Join(want, " or ")
+}
+
+func enumValues(want []any) string {
+	parts := make([]string, 0, len(want))
+	for _, v := range want {
+		parts = append(parts, fmt.Sprintf("%v", v))
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
 }

--- a/application/resource_validation_test.go
+++ b/application/resource_validation_test.go
@@ -1,0 +1,106 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package application
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// objectSchema requires a JSON object with a string "name" and an optional
+// "status" constrained to an enum.
+const objectSchema = `{
+  "type": "object",
+  "properties": {
+    "name": {"type": "string"},
+    "status": {"enum": ["active", "archived"]}
+  },
+  "required": ["name"]
+}`
+
+func TestValidateAgainstSchema_ValidObjectPasses(t *testing.T) {
+	err := validateAgainstSchema(json.RawMessage(objectSchema),
+		json.RawMessage(`{"name":"Summarize Inbox","status":"active"}`))
+	if err != nil {
+		t.Fatalf("expected valid data to pass, got: %v", err)
+	}
+}
+
+func TestValidateAgainstSchema_EmptySchemaSkips(t *testing.T) {
+	if err := validateAgainstSchema(nil, json.RawMessage(`"anything"`)); err != nil {
+		t.Fatalf("expected no validation without a schema, got: %v", err)
+	}
+}
+
+func TestValidateAgainstSchema_StringPayloadIsClearAndLeakFree(t *testing.T) {
+	err := validateAgainstSchema(json.RawMessage(objectSchema), json.RawMessage(`"not an object"`))
+	if err == nil {
+		t.Fatal("expected a validation error for a string payload")
+	}
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("error must satisfy errors.Is(ErrValidation) so handlers map it to 4xx; got: %v", err)
+	}
+
+	msg := err.Error()
+	// Clear + actionable: names the argument and the expected type.
+	for _, want := range []string{"data", "object", "must"} {
+		if !strings.Contains(strings.ToLower(msg), want) {
+			t.Errorf("message should mention %q; got: %s", want, msg)
+		}
+	}
+	// Regression guards for issue #381.
+	for _, banned := range []string{"got string, want object", "file://", "schema.json", "/Users/"} {
+		if strings.Contains(msg, banned) {
+			t.Errorf("message leaked %q (issue #381); got: %s", banned, msg)
+		}
+	}
+}
+
+func TestValidateAgainstSchema_MissingRequiredNamesProperty(t *testing.T) {
+	err := validateAgainstSchema(json.RawMessage(objectSchema), json.RawMessage(`{"status":"active"}`))
+	if err == nil {
+		t.Fatal("expected a validation error for missing required property")
+	}
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("expected ErrValidation, got: %v", err)
+	}
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "name") || !strings.Contains(msg, "missing") {
+		t.Errorf("expected the missing property to be named; got: %s", err.Error())
+	}
+}
+
+func TestValidateAgainstSchema_EnumNamesAllowedValues(t *testing.T) {
+	err := validateAgainstSchema(json.RawMessage(objectSchema),
+		json.RawMessage(`{"name":"x","status":"bogus"}`))
+	if err == nil {
+		t.Fatal("expected a validation error for an out-of-enum value")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "data.status") {
+		t.Errorf("expected the nested field path data.status; got: %s", msg)
+	}
+	if !strings.Contains(msg, "active") || !strings.Contains(msg, "archived") {
+		t.Errorf("expected the allowed enum values to be listed; got: %s", msg)
+	}
+}
+
+func TestValidateAgainstSchema_InvalidJSONData(t *testing.T) {
+	err := validateAgainstSchema(json.RawMessage(objectSchema), json.RawMessage(`{not json`))
+	if err == nil {
+		t.Fatal("expected an error for malformed JSON data")
+	}
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("expected ErrValidation, got: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "valid json") {
+		t.Errorf("expected a 'not valid JSON' message; got: %s", err.Error())
+	}
+}

--- a/internal/mcp/resource_type_tools.go
+++ b/internal/mcp/resource_type_tools.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/wepala/weos/v3/application"
@@ -12,22 +13,56 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// rawJSON converts a free-form MCP input value (decoded from JSON) back into a
+// json.RawMessage for a service command. A nil value yields a nil message, which
+// the service treats as "field absent".
+func rawJSON(v any) (json.RawMessage, error) {
+	if v == nil {
+		return nil, nil
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(b), nil
+}
+
+// rawContextAndSchema converts the free-form context and schema inputs into
+// json.RawMessage for a service command, attributing any error to its field.
+func rawContextAndSchema(contextVal, schemaVal any) (json.RawMessage, json.RawMessage, error) {
+	contextRaw, err := rawJSON(contextVal)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid context: %w", err)
+	}
+	schemaRaw, err := rawJSON(schemaVal)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid schema: %w", err)
+	}
+	return contextRaw, schemaRaw, nil
+}
+
+// Context and Schema are typed `any` (not json.RawMessage): the MCP SDK infers
+// json.RawMessage — a []byte — as a JSON array/null, so an object argument is
+// rejected at input validation before the handler runs (issue #382). `any`
+// infers as free-form JSON, which correctly accepts an object Schema and a
+// JSON-LD Context that may be a string, array, or object. The handler marshals
+// them back to json.RawMessage for the service command.
 type CreateResourceTypeInput struct {
-	Name        string          `json:"name" jsonschema:"resource type display name"`
-	Slug        string          `json:"slug" jsonschema:"URL-friendly identifier"`
-	Description string          `json:"description,omitempty" jsonschema:"resource type description"`
-	Context     json.RawMessage `json:"context,omitempty" jsonschema:"JSON-LD context"`
-	Schema      json.RawMessage `json:"schema,omitempty" jsonschema:"JSON Schema for validation"`
+	Name        string `json:"name" jsonschema:"resource type display name"`
+	Slug        string `json:"slug" jsonschema:"URL-friendly identifier"`
+	Description string `json:"description,omitempty" jsonschema:"resource type description"`
+	Context     any    `json:"context,omitempty" jsonschema:"JSON-LD context (string, array, or object)"`
+	Schema      any    `json:"schema,omitempty" jsonschema:"JSON Schema for validation (object)"`
 }
 
 type UpdateResourceTypeInput struct {
-	ID          string          `json:"id" jsonschema:"resource type ID (URN)"`
-	Name        string          `json:"name" jsonschema:"resource type display name"`
-	Slug        string          `json:"slug,omitempty" jsonschema:"URL slug"`
-	Description string          `json:"description,omitempty" jsonschema:"resource type description"`
-	Context     json.RawMessage `json:"context,omitempty" jsonschema:"JSON-LD context"`
-	Schema      json.RawMessage `json:"schema,omitempty" jsonschema:"JSON Schema for validation"`
-	Status      string          `json:"status,omitempty" jsonschema:"status (active or archived)"`
+	ID          string `json:"id" jsonschema:"resource type ID (URN)"`
+	Name        string `json:"name" jsonschema:"resource type display name"`
+	Slug        string `json:"slug,omitempty" jsonschema:"URL slug"`
+	Description string `json:"description,omitempty" jsonschema:"resource type description"`
+	Context     any    `json:"context,omitempty" jsonschema:"JSON-LD context (string, array, or object)"`
+	Schema      any    `json:"schema,omitempty" jsonschema:"JSON Schema for validation (object)"`
+	Status      string `json:"status,omitempty" jsonschema:"status (active or archived)"`
 }
 
 type DeleteResourceTypeInput struct {
@@ -44,15 +79,20 @@ type ListResourceTypesInput struct {
 	IncludeAll bool   `json:"includeAll,omitempty" jsonschema:"include value object and abstract types (hidden from navigation by default)"`
 }
 
+// Context and Schema are typed `any` for the same reason as the input structs:
+// the MCP SDK validates structured output against the inferred schema, and a
+// json.RawMessage field infers as a JSON array/null — so returning an object
+// context/schema would fail output validation (issue #382). toResourceTypeOutput
+// decodes the stored json.RawMessage into a value.
 type ResourceTypeOutput struct {
-	ID          string          `json:"id"`
-	Name        string          `json:"name"`
-	Slug        string          `json:"slug"`
-	Description string          `json:"description,omitempty"`
-	Context     json.RawMessage `json:"context,omitempty"`
-	Schema      json.RawMessage `json:"schema,omitempty"`
-	Status      string          `json:"status"`
-	CreatedAt   time.Time       `json:"created_at"`
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Slug        string    `json:"slug"`
+	Description string    `json:"description,omitempty"`
+	Context     any       `json:"context,omitempty"`
+	Schema      any       `json:"schema,omitempty"`
+	Status      string    `json:"status"`
+	CreatedAt   time.Time `json:"created_at"`
 }
 
 type ListResourceTypesOutput struct {
@@ -67,11 +107,24 @@ func toResourceTypeOutput(e *entities.ResourceType) ResourceTypeOutput {
 		Name:        e.Name(),
 		Slug:        e.Slug(),
 		Description: e.Description(),
-		Context:     e.Context(),
-		Schema:      e.Schema(),
+		Context:     jsonValue(e.Context()),
+		Schema:      jsonValue(e.Schema()),
 		Status:      e.Status(),
 		CreatedAt:   e.CreatedAt(),
 	}
+}
+
+// jsonValue decodes a stored json.RawMessage into a value for structured MCP
+// output. Empty input yields nil (the field is omitted).
+func jsonValue(raw json.RawMessage) any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return nil
+	}
+	return v
 }
 
 func registerResourceTypeTools(server *mcp.Server, svc application.ResourceTypeService) {
@@ -81,9 +134,13 @@ func registerResourceTypeTools(server *mcp.Server, svc application.ResourceTypeS
 	}, func(
 		ctx context.Context, _ *mcp.CallToolRequest, input CreateResourceTypeInput,
 	) (*mcp.CallToolResult, ResourceTypeOutput, error) {
+		contextRaw, schemaRaw, err := rawContextAndSchema(input.Context, input.Schema)
+		if err != nil {
+			return nil, ResourceTypeOutput{}, err
+		}
 		entity, err := svc.Create(ctx, application.CreateResourceTypeCommand{
 			Name: input.Name, Slug: input.Slug, Description: input.Description,
-			Context: input.Context, Schema: input.Schema,
+			Context: contextRaw, Schema: schemaRaw,
 		})
 		if err != nil {
 			return nil, ResourceTypeOutput{}, err
@@ -138,10 +195,14 @@ func registerResourceTypeTools(server *mcp.Server, svc application.ResourceTypeS
 	}, func(
 		ctx context.Context, _ *mcp.CallToolRequest, input UpdateResourceTypeInput,
 	) (*mcp.CallToolResult, ResourceTypeOutput, error) {
+		contextRaw, schemaRaw, err := rawContextAndSchema(input.Context, input.Schema)
+		if err != nil {
+			return nil, ResourceTypeOutput{}, err
+		}
 		entity, err := svc.Update(ctx, application.UpdateResourceTypeCommand{
 			ID: input.ID, Name: input.Name, Slug: input.Slug,
-			Description: input.Description, Context: input.Context,
-			Schema: input.Schema, Status: input.Status,
+			Description: input.Description, Context: contextRaw,
+			Schema: schemaRaw, Status: input.Status,
 		})
 		if err != nil {
 			return nil, ResourceTypeOutput{}, err

--- a/internal/mcp/resource_type_tools.go
+++ b/internal/mcp/resource_type_tools.go
@@ -115,14 +115,17 @@ func toResourceTypeOutput(e *entities.ResourceType) ResourceTypeOutput {
 }
 
 // jsonValue decodes a stored json.RawMessage into a value for structured MCP
-// output. Empty input yields nil (the field is omitted).
+// output. Empty input yields nil (the field is omitted). Stored context/schema
+// is validated on write, so a decode failure here is not expected; if it ever
+// happens we surface the raw JSON as a string rather than silently dropping it,
+// so corrupted data is visible to the caller instead of hidden.
 func jsonValue(raw json.RawMessage) any {
 	if len(raw) == 0 {
 		return nil
 	}
 	var v any
 	if err := json.Unmarshal(raw, &v); err != nil {
-		return nil
+		return string(raw)
 	}
 	return v
 }

--- a/internal/mcp/resource_type_tools.go
+++ b/internal/mcp/resource_type_tools.go
@@ -27,6 +27,15 @@ func rawJSON(v any) (json.RawMessage, error) {
 	return json.RawMessage(b), nil
 }
 
+// valueOr returns v unless it is empty, in which case it returns fallback. Used
+// for patch-style updates where an omitted string means "leave unchanged".
+func valueOr(v, fallback string) string {
+	if v == "" {
+		return fallback
+	}
+	return v
+}
+
 // rawContextAndSchema converts the free-form context and schema inputs into
 // json.RawMessage for a service command, attributing any error to its field.
 func rawContextAndSchema(contextVal, schemaVal any) (json.RawMessage, json.RawMessage, error) {
@@ -55,9 +64,11 @@ type CreateResourceTypeInput struct {
 	Schema      any    `json:"schema,omitempty" jsonschema:"JSON Schema for validation (object)"`
 }
 
+// On update only ID is required; every other field is optional and, when
+// omitted, left unchanged (patch semantics applied in the handler).
 type UpdateResourceTypeInput struct {
 	ID          string `json:"id" jsonschema:"resource type ID (URN)"`
-	Name        string `json:"name" jsonschema:"resource type display name"`
+	Name        string `json:"name,omitempty" jsonschema:"resource type display name"`
 	Slug        string `json:"slug,omitempty" jsonschema:"URL slug"`
 	Description string `json:"description,omitempty" jsonschema:"resource type description"`
 	Context     any    `json:"context,omitempty" jsonschema:"JSON-LD context (string, array, or object)"`
@@ -198,15 +209,34 @@ func registerResourceTypeTools(server *mcp.Server, svc application.ResourceTypeS
 	}, func(
 		ctx context.Context, _ *mcp.CallToolRequest, input UpdateResourceTypeInput,
 	) (*mcp.CallToolResult, ResourceTypeOutput, error) {
-		contextRaw, schemaRaw, err := rawContextAndSchema(input.Context, input.Schema)
+		// Patch semantics: the service does a full replace, so load the current
+		// type and keep any field the caller omits. Otherwise updating one field
+		// (e.g. description) would clear the slug — which the service then
+		// rejects as empty — or silently wipe the context/schema (issue #382 review).
+		existing, err := svc.GetByID(ctx, input.ID)
 		if err != nil {
 			return nil, ResourceTypeOutput{}, err
 		}
-		entity, err := svc.Update(ctx, application.UpdateResourceTypeCommand{
-			ID: input.ID, Name: input.Name, Slug: input.Slug,
-			Description: input.Description, Context: contextRaw,
-			Schema: schemaRaw, Status: input.Status,
-		})
+		cmd := application.UpdateResourceTypeCommand{
+			ID:          input.ID,
+			Name:        valueOr(input.Name, existing.Name()),
+			Slug:        valueOr(input.Slug, existing.Slug()),
+			Description: valueOr(input.Description, existing.Description()),
+			Status:      valueOr(input.Status, existing.Status()),
+			Context:     existing.Context(),
+			Schema:      existing.Schema(),
+		}
+		if input.Context != nil {
+			if cmd.Context, err = rawJSON(input.Context); err != nil {
+				return nil, ResourceTypeOutput{}, fmt.Errorf("invalid context: %w", err)
+			}
+		}
+		if input.Schema != nil {
+			if cmd.Schema, err = rawJSON(input.Schema); err != nil {
+				return nil, ResourceTypeOutput{}, fmt.Errorf("invalid schema: %w", err)
+			}
+		}
+		entity, err := svc.Update(ctx, cmd)
 		if err != nil {
 			return nil, ResourceTypeOutput{}, err
 		}

--- a/tests/e2e/features/resource_create.feature
+++ b/tests/e2e/features/resource_create.feature
@@ -22,7 +22,6 @@ Feature: Create a resource via the MCP resource_create tool
     And the returned resource data has name "Summarize Inbox"
     And fetching the returned resource by its identifier returns the same capability
 
-  @wip
   Scenario: Creating a capability with a string payload returns a clear validation error
     When I call resource_create for type "capability" with the data:
       """

--- a/tests/e2e/features/resource_type_create.feature
+++ b/tests/e2e/features/resource_type_create.feature
@@ -1,0 +1,39 @@
+Feature: Create a resource type via the MCP resource_type_create tool
+  As an LLM client connected to the WeOS MCP server
+  I want to define a resource type by passing its JSON-LD context and JSON Schema as JSON
+  So that I can create new content types over MCP without falling back to the CLI
+
+  Background:
+    Given a clean WeOS knowledge graph
+
+  Scenario: Creating a resource type with an object JSON Schema succeeds and the type is usable
+    Given the JSON-LD context:
+      """
+      { "@vocab": "https://schema.org/" }
+      """
+    And the JSON Schema:
+      """
+      {
+        "type": "object",
+        "properties": { "name": { "type": "string" } },
+        "required": ["name"]
+      }
+      """
+    When I create the resource type "capability" over MCP
+    Then the resource type "capability" is created
+    And a "capability" resource can be created with:
+      """
+      { "name": "Summarize Inbox" }
+      """
+
+  Scenario: Creating a resource type with a string JSON-LD context succeeds
+    Given the JSON-LD context:
+      """
+      "https://schema.org/"
+      """
+    And the JSON Schema:
+      """
+      { "type": "object", "properties": { "headline": { "type": "string" } } }
+      """
+    When I create the resource type "article" over MCP
+    Then the resource type "article" is created

--- a/tests/e2e/features/resource_type_create.feature
+++ b/tests/e2e/features/resource_type_create.feature
@@ -1,7 +1,7 @@
-Feature: Create a resource type via the MCP resource_type_create tool
+Feature: Manage resource types via the MCP resource_type tools
   As an LLM client connected to the WeOS MCP server
-  I want to define a resource type by passing its JSON-LD context and JSON Schema as JSON
-  So that I can create new content types over MCP without falling back to the CLI
+  I want to define and update a resource type by passing its JSON-LD context and JSON Schema as JSON
+  So that I can manage content types over MCP without falling back to the CLI
 
   Background:
     Given a clean WeOS knowledge graph
@@ -37,3 +37,20 @@ Feature: Create a resource type via the MCP resource_type_create tool
       """
     When I create the resource type "article" over MCP
     Then the resource type "article" is created
+
+  Scenario: Updating one field over MCP preserves the type's JSON Schema
+    Given the JSON-LD context:
+      """
+      { "@vocab": "https://schema.org/" }
+      """
+    And the JSON Schema:
+      """
+      {
+        "type": "object",
+        "properties": { "name": { "type": "string" } },
+        "required": ["name"]
+      }
+      """
+    And I create the resource type "capability" over MCP
+    When I update the resource type "capability" with description "Refined capability"
+    Then the resource type "capability" still requires a "name" property

--- a/tests/e2e/mcp_resource_create_test.go
+++ b/tests/e2e/mcp_resource_create_test.go
@@ -20,11 +20,10 @@ import (
 )
 
 // TestMCPResourceCreate runs the resource_create MCP-tool acceptance scenarios
-// against a freshly booted application with a clean SQLite database. The @wip
-// scenarios are quarantined (they encode behavior the app does not yet meet) and
-// are excluded by default; run them on demand to see the open defect with:
-//
-//	GODOG_TAGS=@wip go test ./tests/e2e/ -run TestMCPResourceCreate -v
+// against a freshly booted application with a clean SQLite database. All
+// scenarios are part of the regression suite; the @wip tag is honored so a
+// future scenario can be quarantined without changing this runner. Filter on
+// demand with: GODOG_TAGS=@wip go test ./tests/e2e/ -run TestMCPResourceCreate -v
 func TestMCPResourceCreate(t *testing.T) {
 	tags := "~@wip"
 	if override := os.Getenv("GODOG_TAGS"); override != "" {

--- a/tests/e2e/mcp_resource_create_test.go
+++ b/tests/e2e/mcp_resource_create_test.go
@@ -55,6 +55,9 @@ type mcpWorld struct {
 	cancel  context.CancelFunc
 	rts     application.ResourceTypeService
 
+	pendingContext string
+	pendingSchema  string
+
 	lastResult *mcp.CallToolResult
 	lastErr    error
 	lastText   string

--- a/tests/e2e/mcp_resource_type_create_test.go
+++ b/tests/e2e/mcp_resource_type_create_test.go
@@ -52,6 +52,8 @@ func initResourceTypeCreateScenario(sc *godog.ScenarioContext) {
 	sc.Step(`^I create the resource type "([^"]*)" over MCP$`, w.iCreateResourceType)
 	sc.Step(`^the resource type "([^"]*)" is created$`, w.theResourceTypeIsCreated)
 	sc.Step(`^a "([^"]*)" resource can be created with:$`, w.aResourceCanBeCreatedWith)
+	sc.Step(`^I update the resource type "([^"]*)" with description "([^"]*)"$`, w.iUpdateResourceTypeDescription)
+	sc.Step(`^the resource type "([^"]*)" still requires a "([^"]*)" property$`, w.theResourceTypeStillRequires)
 }
 
 func (w *mcpWorld) theJSONLDContext(doc *godog.DocString) error {
@@ -106,4 +108,41 @@ func (w *mcpWorld) aResourceCanBeCreatedWith(ctx context.Context, slug string, d
 		return fmt.Errorf("expected the new type to be usable, but resource_create failed: %s", textOf(res))
 	}
 	return nil
+}
+
+func (w *mcpWorld) iUpdateResourceTypeDescription(ctx context.Context, _, description string) error {
+	m, err := w.resultMap() // the just-created type, carrying its id
+	if err != nil {
+		return err
+	}
+	id, _ := m["id"].(string)
+	args := fmt.Sprintf(`{"id":%q,"description":%q}`, id, description)
+	res, err := w.client.CallTool(ctx, &mcp.CallToolParams{
+		Name: "resource_type_update", Arguments: json.RawMessage(args),
+	})
+	w.lastResult = res
+	w.lastErr = err
+	w.lastText = textOf(res)
+	return nil
+}
+
+func (w *mcpWorld) theResourceTypeStillRequires(_, prop string) error {
+	if err := w.theCallSucceeds(); err != nil {
+		return err
+	}
+	m, err := w.resultMap()
+	if err != nil {
+		return err
+	}
+	schema, ok := m["schema"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("update cleared the schema (issue #382 review): %s", w.lastText)
+	}
+	required, _ := schema["required"].([]any)
+	for _, r := range required {
+		if s, _ := r.(string); s == prop {
+			return nil
+		}
+	}
+	return fmt.Errorf("expected schema to still require %q after update; got: %s", prop, w.lastText)
 }

--- a/tests/e2e/mcp_resource_type_create_test.go
+++ b/tests/e2e/mcp_resource_type_create_test.go
@@ -1,0 +1,109 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cucumber/godog"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestMCPResourceTypeCreate exercises the resource_type_create MCP tool against a
+// freshly booted application with a clean SQLite database. It is the regression
+// guard for issue #382: an object JSON Schema (and a string/object JSON-LD
+// context) must round-trip through the tool, which previously failed at the MCP
+// input-schema layer because the fields were typed json.RawMessage.
+func TestMCPResourceTypeCreate(t *testing.T) {
+	tags := "~@wip"
+	if override := os.Getenv("GODOG_TAGS"); override != "" {
+		tags = override
+	}
+	suite := godog.TestSuite{
+		Name:                "mcp-resource-type-create",
+		ScenarioInitializer: initResourceTypeCreateScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"features/resource_type_create.feature"},
+			Tags:     tags,
+			Strict:   true,
+			TestingT: t,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("resource_type_create acceptance scenarios failed")
+	}
+}
+
+func initResourceTypeCreateScenario(sc *godog.ScenarioContext) {
+	w := &mcpWorld{}
+
+	sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		w.teardown()
+		return ctx, nil
+	})
+
+	sc.Step(`^a clean WeOS knowledge graph$`, w.aCleanKnowledgeGraph)
+	sc.Step(`^the JSON-LD context:$`, w.theJSONLDContext)
+	sc.Step(`^the JSON Schema:$`, w.theJSONSchema)
+	sc.Step(`^I create the resource type "([^"]*)" over MCP$`, w.iCreateResourceType)
+	sc.Step(`^the resource type "([^"]*)" is created$`, w.theResourceTypeIsCreated)
+	sc.Step(`^a "([^"]*)" resource can be created with:$`, w.aResourceCanBeCreatedWith)
+}
+
+func (w *mcpWorld) theJSONLDContext(doc *godog.DocString) error {
+	w.pendingContext = doc.Content
+	return nil
+}
+
+func (w *mcpWorld) theJSONSchema(doc *godog.DocString) error {
+	w.pendingSchema = doc.Content
+	return nil
+}
+
+func (w *mcpWorld) iCreateResourceType(ctx context.Context, slug string) error {
+	args := fmt.Sprintf(`{"name":%q,"slug":%q,"description":%q,"context":%s,"schema":%s}`,
+		titleCase(slug), slug, "Acceptance type "+slug, w.pendingContext, w.pendingSchema)
+	res, err := w.client.CallTool(ctx, &mcp.CallToolParams{
+		Name: "resource_type_create", Arguments: json.RawMessage(args),
+	})
+	w.lastResult = res
+	w.lastErr = err
+	w.lastText = textOf(res)
+	return nil
+}
+
+func (w *mcpWorld) theResourceTypeIsCreated(slug string) error {
+	if err := w.theCallSucceeds(); err != nil {
+		return err
+	}
+	m, err := w.resultMap()
+	if err != nil {
+		return err
+	}
+	if got, _ := m["slug"].(string); got != slug {
+		return fmt.Errorf("expected slug %q, got %q", slug, got)
+	}
+	id, _ := m["id"].(string)
+	if want := "urn:type:" + slug; !strings.HasPrefix(id, want) {
+		return fmt.Errorf("expected id to start with %q, got %q", want, id)
+	}
+	return nil
+}
+
+func (w *mcpWorld) aResourceCanBeCreatedWith(ctx context.Context, slug string, data *godog.DocString) error {
+	args := fmt.Sprintf(`{"type_slug":%q,"data":%s}`, slug, data.Content)
+	res, err := w.client.CallTool(ctx, &mcp.CallToolParams{
+		Name: "resource_create", Arguments: json.RawMessage(args),
+	})
+	if err != nil {
+		return fmt.Errorf("resource_create protocol error: %v", err)
+	}
+	if res.IsError {
+		return fmt.Errorf("expected the new type to be usable, but resource_create failed: %s", textOf(res))
+	}
+	return nil
+}


### PR DESCRIPTION
Two related MCP resource defects, found during QA of `resource_create`.

## #381 — clear, leak-free validation errors

`resource_create` (and the resource service generally) surfaced the raw `santhosh-tekuri/jsonschema` rendering when `data` failed the type's JSON Schema — cryptic and **leaking an absolute host path** (`file:///…/schema.json#`, because the schema compiled under the relative id `schema.json`, resolved against the CWD).

- Compile the schema under a stable in-memory id (`mem://weos/resource-schema`) — no host path can appear in messages.
- Translate the `ValidationError` tree into a concise, field-qualified summary rooted at `data` (`humanizeSchemaError`). E.g. string payload → `data must be a JSON object, but got string`; missing field → `data is missing required property "name"`; bad enum → `data.status must be one of [active, archived]`.
- New unexported `validationError` whose `Is(target)` matches `ErrValidation`, so HTTP handlers still map it to 4xx while `Error()` stays clean.

## #382 — resource_type tools accept object schema/context

`resource_type_create` / `resource_type_update` could not accept an object JSON-LD context or JSON Schema: those fields were `json.RawMessage` (`[]byte`), which the MCP go-sdk infers as a JSON array/null, so an object was rejected at input validation. The same broke the **output** side (`ResourceTypeOutput.Context`/`Schema`), so the tool couldn't even return the created type.

- Retype Context/Schema to `any` on the inputs and on `ResourceTypeOutput` (`any` also correctly allows a string/array JSON-LD context). Marshal inputs back to `json.RawMessage` for the service (`rawJSON`/`rawContextAndSchema`); decode stored bytes for output (`jsonValue`). nil round-trips so an omitted field stays absent.

## Tests

- Un-quarantines the previously-`@wip` `resource_create` string-payload scenario.
- New `resource_type_create` godog feature: round-trips an object schema (and a string context) through the tool over MCP, then creates a resource of the new type to prove it's usable end-to-end.
- New `application/resource_validation_test.go` unit tests (type/required/enum/invalid-JSON + regression guards against the leaked text/path).
- `go test ./internal/mcp/... ./application/... ./api/... ./tests/e2e/...` passes.

Reviewed via `pr-review-toolkit` (no material issues; root cause for #382 confirmed against the SDK's schema-inference source).

Closes #381
Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)