### PR TITLE
fix(mcp): infer object schemas for resource data and type context/schema (#382)

### DIFF
--- a/internal/mcp/resource_tools.go
+++ b/internal/mcp/resource_tools.go
@@ -13,14 +13,19 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// Data is map[string]any (not any): an `any` field infers an empty schema that marshals to
+// `true`, which omits `"type":"object"` from the input schema — so MCP clients send `data` as a
+// JSON string and the server then validates a string against the type's object schema and fails
+// ("got string, want object"). map[string]any infers `{"type":"object", ...}`, so the client
+// sends an object. (weos issue #382, input side.)
 type CreateResourceInput struct {
-	TypeSlug string `json:"type_slug" jsonschema:"resource type slug"`
-	Data     any    `json:"data" jsonschema:"resource data as JSON object"`
+	TypeSlug string         `json:"type_slug" jsonschema:"resource type slug"`
+	Data     map[string]any `json:"data" jsonschema:"resource data as JSON object"`
 }
 
 type UpdateResourceInput struct {
-	ID   string `json:"id" jsonschema:"resource ID (URN)"`
-	Data any    `json:"data" jsonschema:"updated resource data as JSON object"`
+	ID   string         `json:"id" jsonschema:"resource ID (URN)"`
+	Data map[string]any `json:"data" jsonschema:"updated resource data as JSON object"`
 }
 
 type DeleteResourceInput struct {

--- a/internal/mcp/resource_type_tools.go
+++ b/internal/mcp/resource_type_tools.go
@@ -100,8 +100,13 @@ type ResourceTypeOutput struct {
 	Name        string    `json:"name"`
 	Slug        string    `json:"slug"`
 	Description string    `json:"description,omitempty"`
-	Context     any       `json:"context,omitempty"`
-	Schema      any       `json:"schema,omitempty"`
+	// A jsonschema description tag is required on these `any` fields: without it the inferred
+	// schema is empty and marshals to the boolean schema `true`, which MCP clients reject as an
+	// invalid property schema (dropping the whole tool list). With a tag it marshals to
+	// {"description": ...} — a valid, permissive object schema that still accepts the polymorphic
+	// stored value (string | array | object). (weos issue #382, output side.)
+	Context     any       `json:"context,omitempty" jsonschema:"JSON-LD context (string, array, or object)"`
+	Schema      any       `json:"schema,omitempty" jsonschema:"JSON Schema for validation (object)"`
 	Status      string    `json:"status"`
 	CreatedAt   time.Time `json:"created_at"`
 }


### PR DESCRIPTION
## What

Follow-up to #384 fixing two MCP schema-inference bugs surfaced under issue #382.

### Input side — `data` typed `any` → `map[string]any`
`CreateResourceInput.Data` / `UpdateResourceInput.Data` were `any`. An `any` field infers an empty schema that marshals to `true`, omitting `"type":"object"` from the tool's input schema. MCP clients then send `data` as a JSON **string**, and the server validates that string against the type's object schema and fails (`got string, want object`). Typing it `map[string]any` infers `{"type":"object", ...}`, so clients send an object.

### Output side — `jsonschema` tags on `Context` / `Schema`
`ResourceTypeOutput.Context` / `.Schema` are `any` with no `jsonschema` tag, so they infer the boolean schema `true` — which MCP clients reject as an invalid property schema, dropping the **whole tool list**. Adding description tags makes them marshal to a valid, permissive object schema that still accepts the polymorphic stored value (string | array | object).

## Why safe
- `input.Data` is only consumed via `json.Marshal`, so the `any` → `map[string]any` change is behavior-preserving on the server side.
- `go build ./internal/mcp/...` and `go vet ./internal/mcp/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)