### PR TITLE
Agents can recall what happened — scoped episodic queries over the event store (#409)

### DIFF
--- a/application/episodic_event_get.go
+++ b/application/episodic_event_get.go
@@ -1,0 +1,76 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/wepala/weos/v3/domain/repositories"
+)
+
+// FetchedEvent is one event with its full stored payload — the explicit
+// drill-in complement to the compact recall shape (epic #409, story #414).
+// Payload is returned exactly as stored; recall stays token-frugal by default
+// and this fetch is the only episodic surface that returns it.
+type FetchedEvent struct {
+	RecalledEvent
+	Payload map[string]any `json:"payload"`
+}
+
+// ErrUnknownEvent distinguishes a well-formed event URN that matches no
+// stored event — a clear error, never an empty success.
+var ErrUnknownEvent = fmt.Errorf("the event is unknown")
+
+// EventByURN returns one event's full payload by its urn:event: URN.
+func (r *episodicRecall) EventByURN(ctx context.Context, urn string) (*FetchedEvent, error) {
+	id, err := parseEventURN(urn)
+	if err != nil {
+		return nil, err
+	}
+	entry, err := r.events.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, fmt.Errorf("%w: no event %q in the log", ErrUnknownEvent, "urn:event:"+id)
+	}
+	referenced, err := r.referencesFor(ctx, []repositories.EventLogEntry{*entry})
+	if err != nil {
+		return nil, err
+	}
+	payload := entry.Payload
+	if payload == nil {
+		// A NULL-stored payload must still satisfy the tool's object-typed
+		// output schema; an empty object is the honest "no payload stored".
+		payload = map[string]any{}
+	}
+	fetched := &FetchedEvent{RecalledEvent: compactEvent(*entry), Payload: payload}
+	fetched.ReferencedResources = referenced[entry.ID]
+	return fetched, nil
+}
+
+// parseEventURN validates the urn:event:<id> shape and returns the raw ID.
+func parseEventURN(urn string) (string, error) {
+	urn = strings.TrimSpace(urn)
+	id, ok := strings.CutPrefix(urn, "urn:event:")
+	if !ok || id == "" || strings.Contains(id, ":") {
+		return "", fmt.Errorf(
+			"validation error: the identifier must be an event URN (urn:event:<id>), got %q", urn)
+	}
+	return id, nil
+}

--- a/application/episodic_event_get_test.go
+++ b/application/episodic_event_get_test.go
@@ -1,0 +1,99 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wepala/weos/v3/domain/repositories"
+)
+
+func TestEventByURNReturnsFullPayload(t *testing.T) {
+	stub := &stubEventLog{log: []repositories.EventLogEntry{{
+		ID:          "ev1",
+		AggregateID: "urn:task:2t111111111111111111111111",
+		EventType:   "Resource.Created",
+		CreatedAt:   time.Date(2026, 6, 20, 9, 0, 0, 0, time.UTC),
+		Payload: map[string]any{
+			"TypeSlug": "task",
+			"Data": map[string]any{
+				"name":        "May reconciliation",
+				"description": "Match receipts to the ledger",
+			},
+		},
+	}}}
+	refs := &recordingRefsRepo{refs: map[string][]string{
+		"ev1": {"urn:task:2t111111111111111111111111"},
+	}}
+	recall := &episodicRecall{events: stub, references: refs, now: time.Now}
+
+	fetched, err := recall.EventByURN(context.Background(), "urn:event:ev1")
+	if err != nil {
+		t.Fatalf("EventByURN: %v", err)
+	}
+	if fetched.ID != "urn:event:ev1" || fetched.EventType != "Resource.Created" {
+		t.Errorf("envelope facts wrong: %+v", fetched.RecalledEvent)
+	}
+	data, _ := fetched.Payload["Data"].(map[string]any)
+	if data["description"] != "Match receipts to the ledger" {
+		t.Errorf("full payload missing the description: %v", fetched.Payload)
+	}
+	if len(fetched.ReferencedResources) != 1 {
+		t.Errorf("referenced resources = %v, want the projected reference", fetched.ReferencedResources)
+	}
+}
+
+// TestEventByURNNormalizesNilPayload pins that a NULL-stored payload fetches
+// as an empty object — the MCP output schema types payload as a required
+// object, and null would fail it with an opaque protocol error.
+func TestEventByURNNormalizesNilPayload(t *testing.T) {
+	stub := &stubEventLog{log: []repositories.EventLogEntry{{
+		ID:          "bare",
+		AggregateID: "urn:task:2t111111111111111111111111",
+		EventType:   "Resource.Deleted",
+		CreatedAt:   time.Date(2026, 6, 20, 9, 0, 0, 0, time.UTC),
+	}}}
+	recall := &episodicRecall{events: stub, references: &recordingRefsRepo{}, now: time.Now}
+
+	fetched, err := recall.EventByURN(context.Background(), "urn:event:bare")
+	if err != nil {
+		t.Fatalf("EventByURN: %v", err)
+	}
+	if fetched.Payload == nil {
+		t.Error("nil stored payload not normalized to an empty object")
+	}
+}
+
+func TestEventByURNUnknownErrors(t *testing.T) {
+	recall := &episodicRecall{
+		events: &stubEventLog{}, references: &recordingRefsRepo{}, now: time.Now,
+	}
+	_, err := recall.EventByURN(context.Background(), "urn:event:absent")
+	if err == nil {
+		t.Fatal("unknown event accepted, want error")
+	}
+	if !errors.Is(err, ErrUnknownEvent) {
+		t.Errorf("error %v is not ErrUnknownEvent", err)
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "unknown") {
+		t.Errorf("error %q should say the event is unknown", err)
+	}
+}
+
+func TestEventByURNValidatesShape(t *testing.T) {
+	recall := &episodicRecall{
+		events: &stubEventLog{}, references: &recordingRefsRepo{}, now: time.Now,
+	}
+	for _, urn := range []string{"not-an-event-urn", "urn:task:2t111111111111111111111111", "urn:event:", ""} {
+		_, err := recall.EventByURN(context.Background(), urn)
+		if err == nil {
+			t.Fatalf("identifier %q accepted, want validation error", urn)
+		}
+		msg := strings.ToLower(err.Error())
+		if !strings.Contains(msg, "validation") || !strings.Contains(msg, "event urn") {
+			t.Errorf("error %q should mention validation and the event URN shape", err)
+		}
+	}
+}

--- a/application/episodic_recall.go
+++ b/application/episodic_recall.go
@@ -81,10 +81,14 @@ type EpisodicRecallResult struct {
 }
 
 // EpisodicRecall answers scoped, deterministic queries over the event store's
-// episodic record: time-windowed, filterable, time-ordered, paginated. Tools
-// retrieve; agents interpret — no ranking, no LLM calls.
+// episodic record: time-windowed, filterable, time-ordered, paginated recall,
+// plus structural similar-event search from a seed event. Tools retrieve;
+// agents interpret — no learned ranking, no LLM calls.
 type EpisodicRecall interface {
 	Recall(ctx context.Context, q EpisodicQuery) (*EpisodicRecallResult, error)
+	// Similar ranks events by deterministic structural similarity to the
+	// seed event (see the weight constants in episodic_similar.go).
+	Similar(ctx context.Context, q SimilarQuery) (*SimilarResult, error)
 }
 
 type episodicRecall struct {

--- a/application/episodic_recall.go
+++ b/application/episodic_recall.go
@@ -89,6 +89,9 @@ type EpisodicRecall interface {
 	// Similar ranks events by deterministic structural similarity to the
 	// seed event (see the weight constants in episodic_similar.go).
 	Similar(ctx context.Context, q SimilarQuery) (*SimilarResult, error)
+	// EventByURN returns one event's full stored payload — the explicit
+	// drill-in complement to the compact shapes above.
+	EventByURN(ctx context.Context, urn string) (*FetchedEvent, error)
 }
 
 type episodicRecall struct {

--- a/application/episodic_recall.go
+++ b/application/episodic_recall.go
@@ -1,0 +1,233 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/wepala/weos/v3/domain/repositories"
+	"github.com/wepala/weos/v3/pkg/identity"
+)
+
+const (
+	defaultEpisodicLimit = 20
+	maxEpisodicLimit     = 100
+	maxSummaryRunes      = 120
+)
+
+// relativeRange matches the supported relative time grammar: "last 7 days"
+// and "7 days ago". Anything fancier belongs to the calling agent, not here —
+// retrieval stays deterministic.
+var relativeRange = regexp.MustCompile(`^(?:last\s+(\d+)\s+days?|(\d+)\s+days?\s+ago)$`)
+
+// EpisodicQuery is a structured recall request over the event log. From and
+// Until accept RFC3339 timestamps or the relative forms "last N days" /
+// "N days ago"; empty bounds leave that side of the window open.
+type EpisodicQuery struct {
+	From         string
+	Until        string
+	AggregateID  string
+	EventType    string
+	ResourceType string
+	// Limit caps results (default 20, max 100 — over-asks are capped, not errors).
+	Limit  int
+	Cursor string
+}
+
+// RecalledEvent is the compact episodic result shape: enough to know what
+// happened and fetch more, never the full raw payload. ReferencedResources
+// joins the shape once the reference projection lands (epic #409, story #411).
+type RecalledEvent struct {
+	// ID is the event URN (urn:event:<id>), consistent with the
+	// prov:wasDerivedFrom identifiers in the memory preset.
+	ID           string `json:"id"`
+	EventType    string `json:"eventType"`
+	Timestamp    string `json:"timestamp"`
+	AggregateID  string `json:"aggregateId"`
+	ResourceType string `json:"resourceType,omitempty"`
+	Summary      string `json:"summary,omitempty"`
+}
+
+// EpisodicRecallResult is one page of recalled events.
+type EpisodicRecallResult struct {
+	Events  []RecalledEvent
+	Cursor  string
+	HasMore bool
+}
+
+// EpisodicRecall answers scoped, deterministic queries over the event store's
+// episodic record: time-windowed, filterable, time-ordered, paginated. Tools
+// retrieve; agents interpret — no ranking, no LLM calls.
+type EpisodicRecall interface {
+	Recall(ctx context.Context, q EpisodicQuery) (*EpisodicRecallResult, error)
+}
+
+type episodicRecall struct {
+	events repositories.EventLogRepository
+	// now is injectable for tests; production uses time.Now.
+	now func() time.Time
+}
+
+// NewEpisodicRecall builds the episodic recall service over the event-log
+// read surface.
+func NewEpisodicRecall(events repositories.EventLogRepository) EpisodicRecall {
+	return &episodicRecall{events: events, now: time.Now}
+}
+
+func (r *episodicRecall) Recall(ctx context.Context, q EpisodicQuery) (*EpisodicRecallResult, error) {
+	filter, err := r.buildFilter(q)
+	if err != nil {
+		return nil, err
+	}
+	page, err := r.events.Query(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	result := &EpisodicRecallResult{
+		Events:  make([]RecalledEvent, 0, len(page.Data)),
+		Cursor:  page.Cursor,
+		HasMore: page.HasMore,
+	}
+	for _, e := range page.Data {
+		result.Events = append(result.Events, compactEvent(e))
+	}
+	return result, nil
+}
+
+func (r *episodicRecall) buildFilter(q EpisodicQuery) (repositories.EventLogFilter, error) {
+	now := r.now().UTC()
+	from, err := parseTimeBound(q.From, now)
+	if err != nil {
+		return repositories.EventLogFilter{}, err
+	}
+	until, err := parseTimeBound(q.Until, now)
+	if err != nil {
+		return repositories.EventLogFilter{}, err
+	}
+	if !from.IsZero() && !until.IsZero() && from.After(until) {
+		return repositories.EventLogFilter{}, fmt.Errorf(
+			"validation error: the time range is invalid: from (%s) must be before until (%s)",
+			q.From, q.Until)
+	}
+	limit := q.Limit
+	if limit <= 0 {
+		limit = defaultEpisodicLimit
+	}
+	if limit > maxEpisodicLimit {
+		limit = maxEpisodicLimit
+	}
+	return repositories.EventLogFilter{
+		From:        from,
+		Until:       until,
+		AggregateID: q.AggregateID,
+		EventType:   q.EventType,
+		TypeSlug:    q.ResourceType,
+		Limit:       limit,
+		Cursor:      q.Cursor,
+	}, nil
+}
+
+// parseTimeBound resolves one window bound: empty stays open, RFC3339 is
+// absolute, and the relative grammar ("last 7 days", "7 days ago") counts
+// back from now.
+func parseTimeBound(s string, now time.Time) (time.Time, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, nil
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.UTC(), nil
+	}
+	if m := relativeRange.FindStringSubmatch(strings.ToLower(s)); m != nil {
+		digits := m[1]
+		if digits == "" {
+			digits = m[2]
+		}
+		days, err := strconv.Atoi(digits)
+		if err == nil {
+			return now.AddDate(0, 0, -days), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf(
+		"validation error: the time range is invalid: %q is neither an RFC3339 timestamp "+
+			`nor a relative range like "last 7 days"`, s)
+}
+
+// compactEvent maps a stored event to the compact shape. The summary carries
+// just the resource type and name pulled from the payload — never the payload
+// itself.
+func compactEvent(e repositories.EventLogEntry) RecalledEvent {
+	slug := payloadString(e.Payload, "TypeSlug")
+	if slug == "" {
+		slug = identity.ExtractResourceTypeSlug(e.AggregateID)
+	}
+	return RecalledEvent{
+		ID:           "urn:event:" + e.ID,
+		EventType:    e.EventType,
+		Timestamp:    e.CreatedAt.UTC().Format(time.RFC3339),
+		AggregateID:  e.AggregateID,
+		ResourceType: slug,
+		Summary:      summarizePayload(slug, e.Payload),
+	}
+}
+
+// summarizePayload builds the deterministic one-line summary: the resource
+// type plus the resource's name when the payload data carries one.
+func summarizePayload(slug string, payload map[string]any) string {
+	name := payloadName(payload)
+	summary := slug
+	if name != "" {
+		summary = strings.TrimSpace(summary + " " + strconv.Quote(name))
+	}
+	if runes := []rune(summary); len(runes) > maxSummaryRunes {
+		summary = string(runes[:maxSummaryRunes])
+	}
+	return summary
+}
+
+// payloadName digs the resource name out of the event payload's Data document
+// (top-level "name" first, then the first named @graph node).
+func payloadName(payload map[string]any) string {
+	data, ok := payload["Data"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	if name, ok := data["name"].(string); ok {
+		return name
+	}
+	graph, ok := data["@graph"].([]any)
+	if !ok {
+		return ""
+	}
+	for _, node := range graph {
+		if m, ok := node.(map[string]any); ok {
+			if name, ok := m["name"].(string); ok && name != "" {
+				return name
+			}
+		}
+	}
+	return ""
+}
+
+func payloadString(payload map[string]any, key string) string {
+	v, _ := payload[key].(string)
+	return v
+}

--- a/application/episodic_recall.go
+++ b/application/episodic_recall.go
@@ -53,8 +53,7 @@ type EpisodicQuery struct {
 }
 
 // RecalledEvent is the compact episodic result shape: enough to know what
-// happened and fetch more, never the full raw payload. ReferencedResources
-// joins the shape once the reference projection lands (epic #409, story #411).
+// happened and fetch more, never the full raw payload.
 type RecalledEvent struct {
 	// ID is the event URN (urn:event:<id>), consistent with the
 	// prov:wasDerivedFrom identifiers in the memory preset.
@@ -64,6 +63,11 @@ type RecalledEvent struct {
 	AggregateID  string `json:"aggregateId"`
 	ResourceType string `json:"resourceType,omitempty"`
 	Summary      string `json:"summary,omitempty"`
+	// ReferencedResources lists the resource URNs the event references — the
+	// aggregate itself plus resource URNs in the payload — from the
+	// event-reference projection (story #411). Empty until the projection has
+	// caught up with the event.
+	ReferencedResources []string `json:"referencedResources,omitempty"`
 }
 
 // EpisodicRecallResult is one page of recalled events.
@@ -81,15 +85,19 @@ type EpisodicRecall interface {
 }
 
 type episodicRecall struct {
-	events repositories.EventLogRepository
+	events     repositories.EventLogRepository
+	references repositories.EventReferenceRepository
 	// now is injectable for tests; production uses time.Now.
 	now func() time.Time
 }
 
 // NewEpisodicRecall builds the episodic recall service over the event-log
-// read surface.
-func NewEpisodicRecall(events repositories.EventLogRepository) EpisodicRecall {
-	return &episodicRecall{events: events, now: time.Now}
+// read surface and the event-reference projection.
+func NewEpisodicRecall(
+	events repositories.EventLogRepository,
+	references repositories.EventReferenceRepository,
+) EpisodicRecall {
+	return &episodicRecall{events: events, references: references, now: time.Now}
 }
 
 func (r *episodicRecall) Recall(ctx context.Context, q EpisodicQuery) (*EpisodicRecallResult, error) {
@@ -101,15 +109,36 @@ func (r *episodicRecall) Recall(ctx context.Context, q EpisodicQuery) (*Episodic
 	if err != nil {
 		return nil, err
 	}
+	referenced, err := r.referencesFor(ctx, page.Data)
+	if err != nil {
+		return nil, err
+	}
 	result := &EpisodicRecallResult{
 		Events:  make([]RecalledEvent, 0, len(page.Data)),
 		Cursor:  page.Cursor,
 		HasMore: page.HasMore,
 	}
 	for _, e := range page.Data {
-		result.Events = append(result.Events, compactEvent(e))
+		recalled := compactEvent(e)
+		recalled.ReferencedResources = referenced[e.ID]
+		result.Events = append(result.Events, recalled)
 	}
 	return result, nil
+}
+
+// referencesFor batch-loads the referenced-resource URNs for one page of
+// events (one query, no per-event lookups).
+func (r *episodicRecall) referencesFor(
+	ctx context.Context, events []repositories.EventLogEntry,
+) (map[string][]string, error) {
+	if r.references == nil || len(events) == 0 {
+		return nil, nil
+	}
+	ids := make([]string, 0, len(events))
+	for _, e := range events {
+		ids = append(ids, e.ID)
+	}
+	return r.references.ForEvents(ctx, ids)
 }
 
 func (r *episodicRecall) buildFilter(q EpisodicQuery) (repositories.EventLogFilter, error) {

--- a/application/episodic_recall.go
+++ b/application/episodic_recall.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/wepala/weos/v3/domain/repositories"
 	"github.com/wepala/weos/v3/pkg/identity"
@@ -40,11 +41,13 @@ var relativeRange = regexp.MustCompile(`^(?:last\s+(\d+)\s+days?|(\d+)\s+days?\s
 
 // EpisodicQuery is a structured recall request over the event log. From and
 // Until accept RFC3339 timestamps or the relative forms "last N days" /
-// "N days ago"; empty bounds leave that side of the window open.
+// "N days ago"; empty bounds leave that side of the window open. Anchors are
+// resource URNs; an event matches when any anchor is its aggregate or is
+// referenced in its payload.
 type EpisodicQuery struct {
 	From         string
 	Until        string
-	AggregateID  string
+	Anchors      []string
 	EventType    string
 	ResourceType string
 	// Limit caps results (default 20, max 100 — over-asks are capped, not errors).
@@ -156,6 +159,10 @@ func (r *episodicRecall) buildFilter(q EpisodicQuery) (repositories.EventLogFilt
 			"validation error: the time range is invalid: from (%s) must be before until (%s)",
 			q.From, q.Until)
 	}
+	anchors, err := normalizeAnchors(q.Anchors)
+	if err != nil {
+		return repositories.EventLogFilter{}, err
+	}
 	limit := q.Limit
 	if limit <= 0 {
 		limit = defaultEpisodicLimit
@@ -164,14 +171,30 @@ func (r *episodicRecall) buildFilter(q EpisodicQuery) (repositories.EventLogFilt
 		limit = maxEpisodicLimit
 	}
 	return repositories.EventLogFilter{
-		From:        from,
-		Until:       until,
-		AggregateID: q.AggregateID,
-		EventType:   q.EventType,
-		TypeSlug:    q.ResourceType,
-		Limit:       limit,
-		Cursor:      q.Cursor,
+		From:      from,
+		Until:     until,
+		Anchors:   anchors,
+		EventType: q.EventType,
+		TypeSlug:  q.ResourceType,
+		Limit:     limit,
+		Cursor:    q.Cursor,
 	}, nil
+}
+
+// normalizeAnchors trims and validates anchor URNs. Anchors must at least
+// look like URNs — a malformed anchor is a caller mistake worth surfacing
+// loudly, where an unknown-but-well-formed URN is simply an empty result.
+func normalizeAnchors(anchors []string) ([]string, error) {
+	out := make([]string, 0, len(anchors))
+	for _, a := range anchors {
+		a = strings.TrimSpace(a)
+		if !strings.HasPrefix(a, "urn:") || strings.ContainsFunc(a, unicode.IsSpace) {
+			return nil, fmt.Errorf(
+				"validation error: the resource URN %q is invalid — anchors must be URNs like urn:task:<id>", a)
+		}
+		out = append(out, a)
+	}
+	return out, nil
 }
 
 // parseTimeBound resolves one window bound: empty stays open, RFC3339 is

--- a/application/episodic_recall_test.go
+++ b/application/episodic_recall_test.go
@@ -1,0 +1,181 @@
+package application
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wepala/weos/v3/domain/repositories"
+)
+
+type stubEventLog struct {
+	lastFilter repositories.EventLogFilter
+	response   *repositories.PaginatedResponse[repositories.EventLogEntry]
+}
+
+func (s *stubEventLog) Query(
+	_ context.Context, filter repositories.EventLogFilter,
+) (*repositories.PaginatedResponse[repositories.EventLogEntry], error) {
+	s.lastFilter = filter
+	if s.response != nil {
+		return s.response, nil
+	}
+	return &repositories.PaginatedResponse[repositories.EventLogEntry]{}, nil
+}
+
+func fixedEpisodicRecall(stub *stubEventLog, now time.Time) *episodicRecall {
+	return &episodicRecall{events: stub, now: func() time.Time { return now }}
+}
+
+func TestParseTimeBound(t *testing.T) {
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name  string
+		in    string
+		want  time.Time
+		fails bool
+	}{
+		{name: "empty stays open", in: "", want: time.Time{}},
+		{name: "absolute RFC3339", in: "2026-06-15T00:00:00Z",
+			want: time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)},
+		{name: "last N days", in: "last 7 days", want: now.AddDate(0, 0, -7)},
+		{name: "N days ago", in: "3 days ago", want: now.AddDate(0, 0, -3)},
+		{name: "singular day", in: "1 day ago", want: now.AddDate(0, 0, -1)},
+		{name: "case insensitive", in: "Last 2 Days", want: now.AddDate(0, 0, -2)},
+		{name: "garbage", in: "not-a-timestamp", fails: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseTimeBound(tc.in, now)
+			if tc.fails {
+				if err == nil {
+					t.Fatalf("parseTimeBound(%q) succeeded, want error", tc.in)
+				}
+				if !strings.Contains(err.Error(), "validation") {
+					t.Errorf("error %q does not mention validation", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseTimeBound(%q): %v", tc.in, err)
+			}
+			if !got.Equal(tc.want) {
+				t.Errorf("parseTimeBound(%q) = %s, want %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEpisodicRecallRejectsReversedRange(t *testing.T) {
+	recall := fixedEpisodicRecall(&stubEventLog{}, time.Now().UTC())
+	_, err := recall.Recall(context.Background(), EpisodicQuery{
+		From: "2026-06-30T00:00:00Z", Until: "2026-06-01T00:00:00Z",
+	})
+	if err == nil {
+		t.Fatal("reversed range succeeded, want validation error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "validation") || !strings.Contains(msg, "time range") {
+		t.Errorf("error %q should mention validation and the time range", msg)
+	}
+}
+
+func TestEpisodicRecallClampsLimits(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{name: "default", in: 0, want: defaultEpisodicLimit},
+		{name: "negative", in: -5, want: defaultEpisodicLimit},
+		{name: "passthrough", in: 42, want: 42},
+		{name: "capped", in: 500, want: maxEpisodicLimit},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &stubEventLog{}
+			recall := fixedEpisodicRecall(stub, time.Now().UTC())
+			if _, err := recall.Recall(context.Background(), EpisodicQuery{Limit: tc.in}); err != nil {
+				t.Fatalf("Recall: %v", err)
+			}
+			if stub.lastFilter.Limit != tc.want {
+				t.Errorf("limit %d clamped to %d, want %d", tc.in, stub.lastFilter.Limit, tc.want)
+			}
+		})
+	}
+}
+
+func TestEpisodicRecallCompactShape(t *testing.T) {
+	occurred := time.Date(2026, 6, 20, 9, 0, 0, 0, time.UTC)
+	stub := &stubEventLog{response: &repositories.PaginatedResponse[repositories.EventLogEntry]{
+		Data: []repositories.EventLogEntry{{
+			ID:          "2z000000000000000000000000",
+			AggregateID: "urn:task:2z111111111111111111111111",
+			EventType:   "Resource.Created",
+			CreatedAt:   occurred,
+			Payload: map[string]any{
+				"TypeSlug": "task",
+				"Data": map[string]any{
+					"name":        "Chase overdue invoices",
+					"description": "Match receipts to the ledger",
+				},
+			},
+		}},
+		Cursor:  "next-page",
+		HasMore: true,
+	}}
+	recall := fixedEpisodicRecall(stub, time.Now().UTC())
+
+	res, err := recall.Recall(context.Background(), EpisodicQuery{})
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if res.Cursor != "next-page" || !res.HasMore {
+		t.Errorf("pagination not propagated: cursor=%q hasMore=%v", res.Cursor, res.HasMore)
+	}
+	if len(res.Events) != 1 {
+		t.Fatalf("got %d events, want 1", len(res.Events))
+	}
+	e := res.Events[0]
+	if e.ID != "urn:event:2z000000000000000000000000" {
+		t.Errorf("ID = %q, want the urn:event: form", e.ID)
+	}
+	if e.Timestamp != "2026-06-20T09:00:00Z" {
+		t.Errorf("Timestamp = %q, want RFC3339 of the stored created_at", e.Timestamp)
+	}
+	if e.ResourceType != "task" {
+		t.Errorf("ResourceType = %q, want task", e.ResourceType)
+	}
+	if !strings.Contains(e.Summary, "Chase overdue invoices") {
+		t.Errorf("Summary %q should carry the resource name", e.Summary)
+	}
+	if strings.Contains(e.Summary, "Match receipts to the ledger") {
+		t.Errorf("Summary %q must not leak the payload description", e.Summary)
+	}
+}
+
+func TestSummarizePayloadGraphFallback(t *testing.T) {
+	payload := map[string]any{
+		"Data": map[string]any{
+			"@graph": []any{
+				map[string]any{"@id": "urn:task:x"},
+				map[string]any{"@id": "urn:task:y", "name": "Draft Q3 invoice summary"},
+			},
+		},
+	}
+	got := summarizePayload("task", payload)
+	if !strings.Contains(got, "Draft Q3 invoice summary") {
+		t.Errorf("summary %q should pull the first named @graph node", got)
+	}
+}
+
+func TestSummarizePayloadTruncates(t *testing.T) {
+	payload := map[string]any{
+		"Data": map[string]any{"name": strings.Repeat("x", 300)},
+	}
+	got := summarizePayload("task", payload)
+	if runes := []rune(got); len(runes) > maxSummaryRunes {
+		t.Errorf("summary is %d runes, want at most %d", len(runes), maxSummaryRunes)
+	}
+}

--- a/application/episodic_recall_test.go
+++ b/application/episodic_recall_test.go
@@ -142,6 +142,42 @@ func TestEpisodicRecallRejectsReversedRange(t *testing.T) {
 	}
 }
 
+func TestEpisodicRecallValidatesAnchors(t *testing.T) {
+	stub := &stubEventLog{}
+	recall := fixedEpisodicRecall(stub, time.Now().UTC())
+
+	rejected := [][]string{
+		{"not-a-urn"},
+		// A single bad anchor rejects the whole call — never silently dropped.
+		{"urn:task:2t111111111111111111111111", "not-a-urn"},
+		{""},
+		{"urn:task:a b"},
+		{"urn:task:a b"}, // non-breaking space — pins unicode.IsSpace
+	}
+	for _, anchors := range rejected {
+		_, err := recall.Recall(context.Background(), EpisodicQuery{Anchors: anchors})
+		if err == nil {
+			t.Fatalf("anchors %q accepted, want validation error", anchors)
+		}
+		msg := strings.ToLower(err.Error())
+		if !strings.Contains(msg, "validation") || !strings.Contains(msg, "resource urn") {
+			t.Errorf("error %q should mention validation and the resource URN", err)
+		}
+	}
+
+	_, err := recall.Recall(context.Background(), EpisodicQuery{
+		Anchors: []string{" urn:task:2t111111111111111111111111 ", "urn:project:2p111111111111111111111111"},
+	})
+	if err != nil {
+		t.Fatalf("valid anchors rejected: %v", err)
+	}
+	want := []string{"urn:task:2t111111111111111111111111", "urn:project:2p111111111111111111111111"}
+	if len(stub.lastFilter.Anchors) != 2 ||
+		stub.lastFilter.Anchors[0] != want[0] || stub.lastFilter.Anchors[1] != want[1] {
+		t.Errorf("filter anchors = %v, want trimmed %v", stub.lastFilter.Anchors, want)
+	}
+}
+
 func TestEpisodicRecallClampsLimits(t *testing.T) {
 	cases := []struct {
 		name string

--- a/application/episodic_recall_test.go
+++ b/application/episodic_recall_test.go
@@ -13,6 +13,11 @@ import (
 type stubEventLog struct {
 	lastFilter repositories.EventLogFilter
 	response   *repositories.PaginatedResponse[repositories.EventLogEntry]
+	// log backs GetByID/Recent for similarity tests; recent, when set,
+	// overrides Recent's source so the candidate window can exclude entries
+	// (e.g. a seed older than the window).
+	log    []repositories.EventLogEntry
+	recent []repositories.EventLogEntry
 }
 
 func (s *stubEventLog) Query(
@@ -23,6 +28,30 @@ func (s *stubEventLog) Query(
 		return s.response, nil
 	}
 	return &repositories.PaginatedResponse[repositories.EventLogEntry]{}, nil
+}
+
+func (s *stubEventLog) GetByID(
+	_ context.Context, id string,
+) (*repositories.EventLogEntry, error) {
+	for i := range s.log {
+		if s.log[i].ID == id {
+			return &s.log[i], nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *stubEventLog) Recent(
+	_ context.Context, max int,
+) ([]repositories.EventLogEntry, error) {
+	src := s.log
+	if s.recent != nil {
+		src = s.recent
+	}
+	if len(src) > max {
+		return src[:max], nil
+	}
+	return src, nil
 }
 
 func fixedEpisodicRecall(stub *stubEventLog, now time.Time) *episodicRecall {
@@ -44,7 +73,15 @@ func (r *recordingRefsRepo) ForEvents(_ context.Context, ids []string) (map[stri
 	if r.err != nil {
 		return nil, r.err
 	}
-	return r.refs, nil
+	// Filter by the requested ids like the real repository does — a stub that
+	// returns everything would hide callers forgetting to ask for an ID.
+	out := map[string][]string{}
+	for _, id := range ids {
+		if refs, ok := r.refs[id]; ok {
+			out[id] = refs
+		}
+	}
+	return out, nil
 }
 
 func (r *recordingRefsRepo) Clear(context.Context) error { return nil }

--- a/application/episodic_recall_test.go
+++ b/application/episodic_recall_test.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -26,6 +27,66 @@ func (s *stubEventLog) Query(
 
 func fixedEpisodicRecall(stub *stubEventLog, now time.Time) *episodicRecall {
 	return &episodicRecall{events: stub, now: func() time.Time { return now }}
+}
+
+// recordingRefsRepo records ForEvents calls so tests can pin the batching
+// contract of the recall join.
+type recordingRefsRepo struct {
+	calls [][]string
+	refs  map[string][]string
+	err   error
+}
+
+func (r *recordingRefsRepo) SaveForEvent(context.Context, string, []string) error { return nil }
+
+func (r *recordingRefsRepo) ForEvents(_ context.Context, ids []string) (map[string][]string, error) {
+	r.calls = append(r.calls, ids)
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.refs, nil
+}
+
+func (r *recordingRefsRepo) Clear(context.Context) error { return nil }
+
+// TestEpisodicRecallJoinsReferences pins the reference join: one batched
+// ForEvents call per page, refs attached to the matching event only, and a
+// projection read error failing the recall (deliberate — not a silent
+// degradation to recall-without-refs).
+func TestEpisodicRecallJoinsReferences(t *testing.T) {
+	at := time.Date(2026, 6, 20, 9, 0, 0, 0, time.UTC)
+	stub := &stubEventLog{response: &repositories.PaginatedResponse[repositories.EventLogEntry]{
+		Data: []repositories.EventLogEntry{
+			{ID: "ev1", AggregateID: "urn:task:2t111111111111111111111111",
+				EventType: "Resource.Created", CreatedAt: at},
+			{ID: "ev2", AggregateID: "urn:task:2t222222222222222222222222",
+				EventType: "Resource.Created", CreatedAt: at.Add(time.Minute)},
+		},
+	}}
+	refs := &recordingRefsRepo{refs: map[string][]string{
+		"ev1": {"urn:project:2p111111111111111111111111", "urn:task:2t111111111111111111111111"},
+	}}
+	recall := &episodicRecall{events: stub, references: refs, now: time.Now}
+
+	res, err := recall.Recall(context.Background(), EpisodicQuery{})
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if len(refs.calls) != 1 || len(refs.calls[0]) != 2 ||
+		refs.calls[0][0] != "ev1" || refs.calls[0][1] != "ev2" {
+		t.Errorf("ForEvents calls = %v, want one batched call with [ev1 ev2]", refs.calls)
+	}
+	if len(res.Events[0].ReferencedResources) != 2 {
+		t.Errorf("ev1 refs = %v, want the projected pair", res.Events[0].ReferencedResources)
+	}
+	if res.Events[1].ReferencedResources != nil {
+		t.Errorf("ev2 refs = %v, want none", res.Events[1].ReferencedResources)
+	}
+
+	refs.err = fmt.Errorf("projection unavailable")
+	if _, err := recall.Recall(context.Background(), EpisodicQuery{}); err == nil {
+		t.Error("Recall succeeded despite a failing reference projection, want the error to propagate")
+	}
 }
 
 func TestParseTimeBound(t *testing.T) {

--- a/application/episodic_similar.go
+++ b/application/episodic_similar.go
@@ -1,0 +1,201 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/wepala/weos/v3/domain/repositories"
+	"github.com/wepala/weos/v3/pkg/identity"
+)
+
+// Similarity scoring weights (epic #409, story #413). Fixed and documented —
+// no learned ranking, no embeddings. Shared referenced resources DOMINATE:
+// one shared resource (weightSharedReference) outweighs a same-event-type,
+// same-resource-type candidate at maximal temporal proximity combined
+// (weightSameEventType + weightSameResourceType + weightProximityMax = 19).
+// Overlap scales with the number of shared resources. Temporal proximity
+// decays per day of distance from the seed and only refines the order of
+// structurally related events — a candidate with no structural affinity at
+// all (no shared reference, different event type, different resource type)
+// is not ranked, so config noise like type registrations never surfaces as
+// "similar". Ties break on ascending event ID.
+const (
+	weightSharedReference  = 100.0
+	weightSameEventType    = 10.0
+	weightSameResourceType = 5.0
+	weightProximityMax     = 4.0
+	// similarCandidateWindow bounds the ranking to the most recent events —
+	// sized for single-user local instances and stated in the tool description.
+	similarCandidateWindow = 1000
+	hoursPerDay            = 24
+)
+
+// SimilarQuery asks for events structurally similar to a seed event.
+type SimilarQuery struct {
+	// Seed is the seed event URN (urn:event:<id>).
+	Seed string
+	// Limit caps results (default 20, max 100 — over-asks are capped).
+	Limit int
+}
+
+// SimilarEvent is one ranked result: the compact event shape plus its
+// deterministic similarity score.
+type SimilarEvent struct {
+	RecalledEvent
+	Similarity float64 `json:"similarity"`
+}
+
+// SimilarResult is the ranked, limit-bounded result set.
+type SimilarResult struct {
+	Events []SimilarEvent
+}
+
+// ErrUnknownSeedEvent distinguishes a well-formed seed that matches no stored
+// event: similarity is undefined without a seed, so this is an error, not an
+// empty success.
+var ErrUnknownSeedEvent = fmt.Errorf("the seed event is unknown")
+
+func (r *episodicRecall) Similar(ctx context.Context, q SimilarQuery) (*SimilarResult, error) {
+	seedID, err := parseSeedURN(q.Seed)
+	if err != nil {
+		return nil, err
+	}
+	seed, err := r.events.GetByID(ctx, seedID)
+	if err != nil {
+		return nil, err
+	}
+	if seed == nil {
+		return nil, fmt.Errorf("%w: no event %q in the log", ErrUnknownSeedEvent, q.Seed)
+	}
+
+	limit := q.Limit
+	if limit <= 0 {
+		limit = defaultEpisodicLimit
+	}
+	if limit > maxEpisodicLimit {
+		limit = maxEpisodicLimit
+	}
+
+	candidates, err := r.events.Recent(ctx, similarCandidateWindow)
+	if err != nil {
+		return nil, err
+	}
+	referenced, err := r.referencesFor(ctx, append(candidates, *seed))
+	if err != nil {
+		return nil, err
+	}
+
+	ranked := rankBySimilarity(*seed, candidates, referenced)
+	if len(ranked) > limit {
+		ranked = ranked[:limit]
+	}
+	return &SimilarResult{Events: ranked}, nil
+}
+
+// parseSeedURN validates the urn:event:<id> shape and returns the raw ID.
+func parseSeedURN(seed string) (string, error) {
+	seed = strings.TrimSpace(seed)
+	id, ok := strings.CutPrefix(seed, "urn:event:")
+	if !ok || id == "" || strings.Contains(id, ":") {
+		return "", fmt.Errorf(
+			"validation error: the seed must be an event URN (urn:event:<id>), got %q", seed)
+	}
+	return id, nil
+}
+
+// rankBySimilarity scores every candidate against the seed and orders by
+// descending score with an ascending-ID tie-break — same seed, same log,
+// same ranking, always.
+func rankBySimilarity(
+	seed repositories.EventLogEntry,
+	candidates []repositories.EventLogEntry,
+	referenced map[string][]string,
+) []SimilarEvent {
+	seedRefs := make(map[string]bool, len(referenced[seed.ID]))
+	for _, urn := range referenced[seed.ID] {
+		seedRefs[urn] = true
+	}
+	seedSlug := resourceTypeOf(seed)
+
+	ranked := make([]SimilarEvent, 0, len(candidates))
+	for _, c := range candidates {
+		if c.ID == seed.ID {
+			continue
+		}
+		structural := structuralScore(seed, seedRefs, seedSlug, c, referenced[c.ID])
+		if structural == 0 {
+			continue
+		}
+		recalled := compactEvent(c)
+		recalled.ReferencedResources = referenced[c.ID]
+		ranked = append(ranked, SimilarEvent{
+			RecalledEvent: recalled,
+			Similarity:    structural + proximityScore(seed, c),
+		})
+	}
+	sort.SliceStable(ranked, func(i, j int) bool {
+		if ranked[i].Similarity != ranked[j].Similarity {
+			return ranked[i].Similarity > ranked[j].Similarity
+		}
+		return ranked[i].ID < ranked[j].ID
+	})
+	return ranked
+}
+
+// structuralScore applies the structural weights to one candidate; zero means
+// no affinity and the candidate is not ranked at all.
+func structuralScore(
+	seed repositories.EventLogEntry,
+	seedRefs map[string]bool,
+	seedSlug string,
+	candidate repositories.EventLogEntry,
+	candidateRefs []string,
+) float64 {
+	score := 0.0
+	for _, urn := range candidateRefs {
+		if seedRefs[urn] {
+			score += weightSharedReference
+		}
+	}
+	if candidate.EventType == seed.EventType {
+		score += weightSameEventType
+	}
+	if seedSlug != "" && resourceTypeOf(candidate) == seedSlug {
+		score += weightSameResourceType
+	}
+	return score
+}
+
+// proximityScore is the temporal refinement, decaying per day of distance.
+func proximityScore(seed, candidate repositories.EventLogEntry) float64 {
+	days := seed.CreatedAt.Sub(candidate.CreatedAt).Hours() / hoursPerDay
+	if days < 0 {
+		days = -days
+	}
+	return weightProximityMax / (1 + days)
+}
+
+// resourceTypeOf mirrors compactEvent's slug derivation for scoring.
+func resourceTypeOf(e repositories.EventLogEntry) string {
+	if slug := payloadString(e.Payload, "TypeSlug"); slug != "" {
+		return slug
+	}
+	return identity.ExtractResourceTypeSlug(e.AggregateID)
+}

--- a/application/episodic_similar_test.go
+++ b/application/episodic_similar_test.go
@@ -1,0 +1,302 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wepala/weos/v3/domain/repositories"
+)
+
+func similarFixture() (*stubEventLog, *recordingRefsRepo, *episodicRecall) {
+	at := func(day int) time.Time {
+		return time.Date(2026, 6, day, 9, 0, 0, 0, time.UTC)
+	}
+	project := "urn:project:2p111111111111111111111111"
+	stub := &stubEventLog{log: []repositories.EventLogEntry{
+		{ID: "seed", AggregateID: "urn:task:2t111111111111111111111111",
+			EventType: "Resource.Created", CreatedAt: at(10),
+			Payload: map[string]any{"TypeSlug": "task"}},
+		// Shares the project reference; far from the seed in time.
+		{ID: "shared-ref", AggregateID: "urn:task:2t222222222222222222222222",
+			EventType: "Resource.Created", CreatedAt: at(2),
+			Payload: map[string]any{"TypeSlug": "task"}},
+		// Same type + resource type, adjacent day, but no shared reference.
+		{ID: "same-kind", AggregateID: "urn:task:2t333333333333333333333333",
+			EventType: "Resource.Created", CreatedAt: at(9),
+			Payload: map[string]any{"TypeSlug": "task"}},
+		// Same event type only.
+		{ID: "same-type", AggregateID: "urn:project:2p444444444444444444444444",
+			EventType: "Resource.Created", CreatedAt: at(11),
+			Payload: map[string]any{"TypeSlug": "project"}},
+	}}
+	refs := &recordingRefsRepo{refs: map[string][]string{
+		"seed":       {"urn:task:2t111111111111111111111111", project},
+		"shared-ref": {"urn:task:2t222222222222222222222222", project},
+		"same-kind":  {"urn:task:2t333333333333333333333333"},
+		"same-type":  {"urn:project:2p444444444444444444444444"},
+	}}
+	return stub, refs, &episodicRecall{events: stub, references: refs, now: time.Now}
+}
+
+// TestSimilarSharedReferenceDominates pins the weight hierarchy: one shared
+// referenced resource outranks same-kind matches at maximal temporal
+// proximity, and the seed never ranks itself.
+func TestSimilarSharedReferenceDominates(t *testing.T) {
+	_, _, recall := similarFixture()
+	res, err := recall.Similar(context.Background(), SimilarQuery{Seed: "urn:event:seed"})
+	if err != nil {
+		t.Fatalf("Similar: %v", err)
+	}
+	got := make([]string, 0, len(res.Events))
+	for _, e := range res.Events {
+		got = append(got, strings.TrimPrefix(e.ID, "urn:event:"))
+	}
+	want := []string{"shared-ref", "same-kind", "same-type"}
+	if len(got) != len(want) {
+		t.Fatalf("ranked %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("ranking = %v, want %v", got, want)
+		}
+	}
+	if res.Events[0].Similarity <= res.Events[1].Similarity ||
+		res.Events[1].Similarity <= res.Events[2].Similarity {
+		t.Errorf("scores not strictly ordered: %+v", res.Events)
+	}
+}
+
+// TestSimilarDeterministicTieBreak pins the ascending-ID tie-break for fully
+// tied candidates.
+func TestSimilarDeterministicTieBreak(t *testing.T) {
+	at := time.Date(2026, 6, 10, 9, 0, 0, 0, time.UTC)
+	entry := func(id, agg string) repositories.EventLogEntry {
+		return repositories.EventLogEntry{ID: id, AggregateID: agg,
+			EventType: "Resource.Created", CreatedAt: at,
+			Payload: map[string]any{"TypeSlug": "task"}}
+	}
+	stub := &stubEventLog{log: []repositories.EventLogEntry{
+		entry("seed", "urn:task:2t111111111111111111111111"),
+		entry("tie-b", "urn:task:2t222222222222222222222222"),
+		entry("tie-a", "urn:task:2t333333333333333333333333"),
+	}}
+	refs := &recordingRefsRepo{refs: map[string][]string{}}
+	recall := &episodicRecall{events: stub, references: refs, now: time.Now}
+
+	for range 3 {
+		res, err := recall.Similar(context.Background(), SimilarQuery{Seed: "urn:event:seed"})
+		if err != nil {
+			t.Fatalf("Similar: %v", err)
+		}
+		if len(res.Events) != 2 ||
+			res.Events[0].ID != "urn:event:tie-a" || res.Events[1].ID != "urn:event:tie-b" {
+			t.Fatalf("tie-break order = %+v, want tie-a before tie-b", res.Events)
+		}
+	}
+}
+
+// TestSimilarSeedOutsideWindowStillScoresSharedRefs pins that a seed older
+// than the candidate window still contributes its references to scoring —
+// the seed is looked up by ID and its refs fetched alongside the candidates'.
+func TestSimilarSeedOutsideWindowStillScoresSharedRefs(t *testing.T) {
+	project := "urn:project:2p111111111111111111111111"
+	seed := repositories.EventLogEntry{
+		ID: "old-seed", AggregateID: "urn:task:2t111111111111111111111111",
+		EventType: "Resource.Created", CreatedAt: time.Date(2025, 1, 1, 9, 0, 0, 0, time.UTC),
+		Payload: map[string]any{"TypeSlug": "task"},
+	}
+	sharesRef := repositories.EventLogEntry{
+		ID: "shares-ref", AggregateID: "urn:note:2n111111111111111111111111",
+		EventType: "Resource.Updated", CreatedAt: time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC),
+		Payload: map[string]any{"TypeSlug": "note"},
+	}
+	sameTypeOnly := repositories.EventLogEntry{
+		ID: "same-type", AggregateID: "urn:task:2t222222222222222222222222",
+		EventType: "Resource.Created", CreatedAt: time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC),
+		Payload: map[string]any{"TypeSlug": "task"},
+	}
+	stub := &stubEventLog{
+		log:    []repositories.EventLogEntry{seed, sharesRef, sameTypeOnly},
+		recent: []repositories.EventLogEntry{sharesRef, sameTypeOnly}, // window excludes the seed
+	}
+	refs := &recordingRefsRepo{refs: map[string][]string{
+		"old-seed":   {"urn:task:2t111111111111111111111111", project},
+		"shares-ref": {"urn:note:2n111111111111111111111111", project},
+	}}
+	recall := &episodicRecall{events: stub, references: refs, now: time.Now}
+
+	res, err := recall.Similar(context.Background(), SimilarQuery{Seed: "urn:event:old-seed"})
+	if err != nil {
+		t.Fatalf("Similar: %v", err)
+	}
+	if len(res.Events) == 0 || res.Events[0].ID != "urn:event:shares-ref" {
+		t.Fatalf("ranking = %+v, want shares-ref first", res.Events)
+	}
+	if res.Events[0].Similarity < weightSharedReference {
+		t.Errorf("shared-ref score %f lost the reference component — the out-of-window seed's refs were not fetched",
+			res.Events[0].Similarity)
+	}
+}
+
+// TestSimilarSharedReferenceOverlapScales pins "overlap scales with the
+// number of shared resources": two shared refs beat one shared ref plus
+// every other component combined.
+func TestSimilarSharedReferenceOverlapScales(t *testing.T) {
+	p1 := "urn:project:2p111111111111111111111111"
+	p2 := "urn:project:2p222222222222222222222222"
+	at := func(day int) time.Time { return time.Date(2026, 6, day, 9, 0, 0, 0, time.UTC) }
+	stub := &stubEventLog{log: []repositories.EventLogEntry{
+		{ID: "seed", AggregateID: "urn:task:2t111111111111111111111111",
+			EventType: "Resource.Created", CreatedAt: at(10),
+			Payload: map[string]any{"TypeSlug": "task"}},
+		// Shares BOTH projects; everything else differs, and it is far away.
+		{ID: "two-refs", AggregateID: "urn:note:2n111111111111111111111111",
+			EventType: "Resource.Updated", CreatedAt: at(1),
+			Payload: map[string]any{"TypeSlug": "note"}},
+		// Shares one project plus same type, same slug, adjacent day.
+		{ID: "one-ref-close", AggregateID: "urn:task:2t222222222222222222222222",
+			EventType: "Resource.Created", CreatedAt: at(9),
+			Payload: map[string]any{"TypeSlug": "task"}},
+	}}
+	refs := &recordingRefsRepo{refs: map[string][]string{
+		"seed":          {"urn:task:2t111111111111111111111111", p1, p2},
+		"two-refs":      {"urn:note:2n111111111111111111111111", p1, p2},
+		"one-ref-close": {"urn:task:2t222222222222222222222222", p1},
+	}}
+	recall := &episodicRecall{events: stub, references: refs, now: time.Now}
+
+	res, err := recall.Similar(context.Background(), SimilarQuery{Seed: "urn:event:seed"})
+	if err != nil {
+		t.Fatalf("Similar: %v", err)
+	}
+	if len(res.Events) != 2 || res.Events[0].ID != "urn:event:two-refs" {
+		t.Fatalf("ranking = %+v, want two shared refs to outrank one-plus-everything", res.Events)
+	}
+}
+
+// TestSimilarProximityIsSymmetric pins that temporal distance counts the same
+// in both directions — a candidate N days after the seed scores exactly like
+// one N days before.
+func TestSimilarProximityIsSymmetric(t *testing.T) {
+	at := func(day int) time.Time { return time.Date(2026, 6, day, 9, 0, 0, 0, time.UTC) }
+	entry := func(id, agg string, day int) repositories.EventLogEntry {
+		return repositories.EventLogEntry{ID: id, AggregateID: agg,
+			EventType: "Resource.Created", CreatedAt: at(day),
+			Payload: map[string]any{"TypeSlug": "task"}}
+	}
+	stub := &stubEventLog{log: []repositories.EventLogEntry{
+		entry("seed", "urn:task:2t111111111111111111111111", 10),
+		entry("before", "urn:task:2t222222222222222222222222", 7),
+		entry("after", "urn:task:2t333333333333333333333333", 13),
+	}}
+	recall := &episodicRecall{
+		events: stub, references: &recordingRefsRepo{refs: map[string][]string{}}, now: time.Now,
+	}
+
+	res, err := recall.Similar(context.Background(), SimilarQuery{Seed: "urn:event:seed"})
+	if err != nil {
+		t.Fatalf("Similar: %v", err)
+	}
+	if len(res.Events) != 2 {
+		t.Fatalf("got %d results, want 2", len(res.Events))
+	}
+	if res.Events[0].Similarity != res.Events[1].Similarity {
+		t.Errorf("proximity is asymmetric: %f vs %f",
+			res.Events[0].Similarity, res.Events[1].Similarity)
+	}
+	if res.Events[0].ID != "urn:event:after" {
+		t.Errorf("tie-break order = %+v, want ascending event ID", res.Events)
+	}
+}
+
+// TestSimilarExcludesStructurallyUnrelatedEvents pins that temporal proximity
+// alone never qualifies a candidate: an event with no shared reference, a
+// different event type, and a different resource type is not ranked at all —
+// preset/type-registration noise stays out of "similar" results.
+func TestSimilarExcludesStructurallyUnrelatedEvents(t *testing.T) {
+	stub, _, _ := similarFixture()
+	stub.log = append(stub.log, repositories.EventLogEntry{
+		ID: "type-noise", AggregateID: "urn:type:task",
+		EventType: "ResourceType.Created",
+		CreatedAt: time.Date(2026, 6, 10, 9, 0, 1, 0, time.UTC), // seconds from the seed
+	})
+	refs := &recordingRefsRepo{refs: map[string][]string{
+		"seed": {"urn:task:2t111111111111111111111111"},
+	}}
+	recall := &episodicRecall{events: stub, references: refs, now: time.Now}
+
+	res, err := recall.Similar(context.Background(), SimilarQuery{Seed: "urn:event:seed"})
+	if err != nil {
+		t.Fatalf("Similar: %v", err)
+	}
+	for _, e := range res.Events {
+		if e.ID == "urn:event:type-noise" {
+			t.Errorf("structurally unrelated event ranked (score %f) on proximity alone", e.Similarity)
+		}
+	}
+}
+
+func TestSimilarSeedValidation(t *testing.T) {
+	_, _, recall := similarFixture()
+	for _, seed := range []string{
+		"not-an-event-urn", "urn:task:2t111111111111111111111111", "urn:event:", "", "urn:event:a:b",
+	} {
+		_, err := recall.Similar(context.Background(), SimilarQuery{Seed: seed})
+		if err == nil {
+			t.Fatalf("seed %q accepted, want validation error", seed)
+		}
+		msg := strings.ToLower(err.Error())
+		if !strings.Contains(msg, "validation") || !strings.Contains(msg, "event urn") {
+			t.Errorf("error %q should mention validation and the event URN shape", err)
+		}
+	}
+}
+
+func TestSimilarUnknownSeedErrors(t *testing.T) {
+	_, _, recall := similarFixture()
+	_, err := recall.Similar(context.Background(), SimilarQuery{Seed: "urn:event:absent"})
+	if err == nil {
+		t.Fatal("unknown seed accepted, want error")
+	}
+	if !errors.Is(err, ErrUnknownSeedEvent) {
+		t.Errorf("error %v is not ErrUnknownSeedEvent", err)
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "unknown") {
+		t.Errorf("error %q should say the seed event is unknown", err)
+	}
+}
+
+func TestSimilarClampsLimits(t *testing.T) {
+	stub, _, _ := similarFixture()
+	// Grow the log well past the hard maximum so the over-ask clamp is real.
+	at := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+	for i := range 120 {
+		stub.log = append(stub.log, repositories.EventLogEntry{
+			ID:          "bulk-" + string(rune('a'+i%26)) + string(rune('a'+i/26)),
+			AggregateID: "urn:task:2t555555555555555555555555",
+			EventType:   "Resource.Updated",
+			CreatedAt:   at.Add(time.Duration(i) * time.Hour),
+		})
+	}
+	refs := &recordingRefsRepo{refs: map[string][]string{}}
+	recall := &episodicRecall{events: stub, references: refs, now: time.Now}
+
+	res, err := recall.Similar(context.Background(), SimilarQuery{Seed: "urn:event:seed"})
+	if err != nil {
+		t.Fatalf("Similar: %v", err)
+	}
+	if len(res.Events) != defaultEpisodicLimit {
+		t.Errorf("default limit returned %d events, want %d", len(res.Events), defaultEpisodicLimit)
+	}
+
+	res, err = recall.Similar(context.Background(), SimilarQuery{Seed: "urn:event:seed", Limit: 500})
+	if err != nil {
+		t.Fatalf("Similar: %v", err)
+	}
+	if len(res.Events) != maxEpisodicLimit {
+		t.Errorf("over-ask returned %d events, want exactly %d", len(res.Events), maxEpisodicLimit)
+	}
+}

--- a/application/event_reference_group.go
+++ b/application/event_reference_group.go
@@ -1,0 +1,141 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
+
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/subscriptions"
+	"go.uber.org/fx"
+)
+
+// The event-reference projection answers "which events reference resource X"
+// (epic #409, story #411). Decision record: a dedicated projection table was
+// chosen over queryable JSON payload indexing because payload indexing is
+// engine-dependent (json_extract on SQLite vs jsonb operators on Postgres) —
+// an epic anti-pattern. The projection is a behavior like any other: derived
+// from the event log, replay-idempotent (insert-or-ignore keyed by event ID +
+// URN), and rebuildable via `weos worker checkpoint reset event-references
+// --truncate`. Later events never remove rows — episodic memory is history,
+// so references to since-deleted resources survive.
+
+// EventReferenceGroupParams bundles the reference projection's dependencies.
+type EventReferenceGroupParams struct {
+	fx.In
+	References repositories.EventReferenceRepository
+	Logger     entities.Logger
+}
+
+// ProvideEventReferenceGroup contributes the "event-references" subscriber
+// group. No StartAtHead: the projection's value is completeness over history,
+// so a fresh install replays the full log.
+func ProvideEventReferenceGroup(p EventReferenceGroupParams) []SubscriberGroup {
+	return []SubscriberGroup{{
+		Name:     "event-references",
+		Handler:  eventReferenceHandler(p.References, p.Logger),
+		Truncate: p.References.Clear,
+	}}
+}
+
+// eventReferenceHandler records, for every event, the resources it references.
+func eventReferenceHandler(
+	references repositories.EventReferenceRepository, logger entities.Logger,
+) subscriptions.Handler {
+	return func(ctx context.Context, event domain.EventEnvelope[any]) error {
+		if _, ok := event.Payload.(map[string]any); !ok && referenceBearingEvent(event.EventType) {
+			// Degrading to aggregate-only must be observable: a payload-shape
+			// change would otherwise quietly hollow out the projection.
+			logger.Error(ctx, "event references: unexpected event payload type; projecting aggregate only",
+				"event", event.ID, "eventType", event.EventType)
+		}
+		refs := ExtractEventReferences(event)
+		if len(refs) == 0 {
+			return nil
+		}
+		return references.SaveForEvent(ctx, event.ID, refs)
+	}
+}
+
+// referenceBearingEvent reports whether an event type's payload is expected
+// to carry resource references.
+func referenceBearingEvent(eventType string) bool {
+	return strings.HasPrefix(eventType, "Resource.") || strings.HasPrefix(eventType, "Triple.")
+}
+
+// ExtractEventReferences returns the resource URNs an event references, in
+// deterministic (sorted) order: the aggregate itself plus every resource URN
+// in the payload. Extraction is purely structural:
+//   - Resource.* events: every URN-shaped string anywhere under the payload's
+//     Data document (flat properties, @graph edge nodes, arrays alike);
+//   - Triple.* events: the subject and object terms;
+//   - anything else: just the aggregate.
+//
+// A "resource URN" follows the isGatedResourceURN precedent — plain resources
+// (urn:<slug>:<ksuid>) plus person and organization URNs. Event URNs
+// (urn:event:...) are excluded so provenance fields like wasDerivedFrom do not
+// read as resource references; type/theme/site URNs are configuration, not
+// data, and never match.
+func ExtractEventReferences(event domain.EventEnvelope[any]) []string {
+	seen := map[string]bool{}
+	addReference(seen, event.AggregateID)
+	if payload, ok := event.Payload.(map[string]any); ok {
+		if data, ok := payload["Data"]; ok {
+			collectReferenceURNs(data, seen)
+		}
+		for _, key := range []string{"subject", "object"} {
+			if term, ok := payload[key].(string); ok {
+				addReference(seen, term)
+			}
+		}
+	}
+	refs := make([]string, 0, len(seen))
+	for urn := range seen {
+		refs = append(refs, urn)
+	}
+	sort.Strings(refs)
+	return refs
+}
+
+// collectReferenceURNs walks an arbitrary JSON value collecting resource URNs.
+func collectReferenceURNs(value any, seen map[string]bool) {
+	switch v := value.(type) {
+	case string:
+		addReference(seen, v)
+	case map[string]any:
+		for _, nested := range v {
+			collectReferenceURNs(nested, seen)
+		}
+	case []any:
+		for _, item := range v {
+			collectReferenceURNs(item, seen)
+		}
+	}
+}
+
+func addReference(seen map[string]bool, candidate string) {
+	if strings.HasPrefix(candidate, "urn:event:") {
+		return
+	}
+	if isGatedResourceURN(candidate) {
+		seen[candidate] = true
+	}
+}

--- a/application/event_reference_group_test.go
+++ b/application/event_reference_group_test.go
@@ -1,0 +1,261 @@
+package application
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	pericarpdomain "github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
+)
+
+func refEnvelope(id, aggregateID, eventType string, payload map[string]any) pericarpdomain.EventEnvelope[any] {
+	return pericarpdomain.EventEnvelope[any]{
+		ID:          id,
+		AggregateID: aggregateID,
+		EventType:   eventType,
+		Payload:     payload,
+	}
+}
+
+func TestExtractEventReferences(t *testing.T) {
+	cases := []struct {
+		name  string
+		event pericarpdomain.EventEnvelope[any]
+		want  []string
+	}{
+		{
+			name: "no payload references reports just the aggregate",
+			event: refEnvelope("ev1", "urn:project:2p111111111111111111111111", "Resource.Created",
+				map[string]any{"TypeSlug": "project", "Data": map[string]any{"name": "Client onboarding"}}),
+			want: []string{"urn:project:2p111111111111111111111111"},
+		},
+		{
+			name: "flat payload property referencing another resource",
+			event: refEnvelope("ev2", "urn:task:2t111111111111111111111111", "Resource.Created",
+				map[string]any{"TypeSlug": "task", "Data": map[string]any{
+					"name": "Chase overdue invoices", "project": "urn:project:2p111111111111111111111111",
+				}}),
+			want: []string{
+				"urn:project:2p111111111111111111111111",
+				"urn:task:2t111111111111111111111111",
+			},
+		},
+		{
+			name: "graph edges node with @id maps and arrays",
+			event: refEnvelope("ev3", "urn:task:2t111111111111111111111111", "Resource.Updated",
+				map[string]any{"Data": map[string]any{
+					"@graph": []any{
+						map[string]any{"@id": "urn:task:2t111111111111111111111111", "name": "Task"},
+						map[string]any{
+							"@id": "urn:task:2t111111111111111111111111",
+							"https://schema.org/isPartOf": map[string]any{
+								"@id": "urn:project:2p111111111111111111111111",
+							},
+							"https://schema.org/attendee": []any{
+								map[string]any{"@id": "urn:person:2q111111111111111111111111"},
+							},
+						},
+					},
+				}}),
+			want: []string{
+				"urn:person:2q111111111111111111111111",
+				"urn:project:2p111111111111111111111111",
+				"urn:task:2t111111111111111111111111",
+			},
+		},
+		{
+			name: "triple event references subject and object",
+			event: refEnvelope("ev4", "urn:task:2t111111111111111111111111", "Triple.Created",
+				map[string]any{
+					"subject":   "urn:task:2t111111111111111111111111",
+					"predicate": "https://schema.org/isPartOf",
+					"object":    "urn:project:2p111111111111111111111111",
+				}),
+			want: []string{
+				"urn:project:2p111111111111111111111111",
+				"urn:task:2t111111111111111111111111",
+			},
+		},
+		{
+			name: "non-resource URNs and literals are ignored",
+			event: refEnvelope("ev5", "urn:fact:2f111111111111111111111111", "Resource.Created",
+				map[string]any{"Data": map[string]any{
+					"statement":      "the sky is blue",
+					"wasDerivedFrom": []any{"urn:event:2e111111111111111111111111"},
+					"seeAlso":        "urn:type:task",
+					"theme":          "urn:theme:default",
+				}}),
+			want: []string{"urn:fact:2f111111111111111111111111"},
+		},
+		{
+			name: "type-config aggregate yields no references",
+			event: refEnvelope("ev6", "urn:type:task", "ResourceType.Created",
+				map[string]any{"Slug": "task"}),
+			want: []string{},
+		},
+		{
+			name: "nil payload still reports the aggregate",
+			event: pericarpdomain.EventEnvelope[any]{
+				ID: "ev7", AggregateID: "urn:task:2t111111111111111111111111",
+				EventType: "Resource.Deleted",
+			},
+			want: []string{"urn:task:2t111111111111111111111111"},
+		},
+		{
+			name:  "empty aggregate and no payload yields nothing",
+			event: pericarpdomain.EventEnvelope[any]{ID: "ev8", EventType: "Resource.Created"},
+			want:  []string{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExtractEventReferences(tc.event)
+			if len(got) == 0 && len(tc.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("references = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+type fakeEventReferenceRepo struct {
+	saves map[string]map[string]int // eventID → URN → save count
+}
+
+func newFakeEventReferenceRepo() *fakeEventReferenceRepo {
+	return &fakeEventReferenceRepo{saves: map[string]map[string]int{}}
+}
+
+func (f *fakeEventReferenceRepo) SaveForEvent(_ context.Context, eventID string, urns []string) error {
+	rows, ok := f.saves[eventID]
+	if !ok {
+		rows = map[string]int{}
+		f.saves[eventID] = rows
+	}
+	for _, urn := range urns {
+		rows[urn]++
+	}
+	return nil
+}
+
+func (f *fakeEventReferenceRepo) ForEvents(_ context.Context, ids []string) (map[string][]string, error) {
+	out := map[string][]string{}
+	for _, id := range ids {
+		for urn := range f.saves[id] {
+			out[id] = append(out[id], urn)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeEventReferenceRepo) Clear(context.Context) error {
+	f.saves = map[string]map[string]int{}
+	return nil
+}
+
+// TestEventReferenceHandlerReplayIsIdempotent processes the same event twice;
+// the projected reference set must not change (the repository sees identical
+// keyed rows, which ON CONFLICT DO NOTHING makes a no-op in production).
+func TestEventReferenceHandlerReplayIsIdempotent(t *testing.T) {
+	repo := newFakeEventReferenceRepo()
+	handler := eventReferenceHandler(repo, noopLogger{})
+	event := refEnvelope("ev1", "urn:task:2t111111111111111111111111", "Triple.Created",
+		map[string]any{
+			"subject": "urn:task:2t111111111111111111111111",
+			"object":  "urn:project:2p111111111111111111111111",
+		})
+
+	for range 2 {
+		if err := handler(context.Background(), event); err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+	}
+
+	if len(repo.saves["ev1"]) != 2 {
+		t.Errorf("event ev1 projects %d URNs, want 2", len(repo.saves["ev1"]))
+	}
+	refs, _ := repo.ForEvents(context.Background(), []string{"ev1"})
+	if len(refs["ev1"]) != 2 {
+		t.Errorf("replay changed the reference set: %v", refs["ev1"])
+	}
+}
+
+// TestEventReferenceGroupDeclaresRebuild pins the group's contract: stable
+// checkpoint name, a Truncate action that actually clears the projection (so
+// --truncate rebuilds work), and no StartAtHead (completeness over history
+// requires replay from position 0).
+func TestEventReferenceGroupDeclaresRebuild(t *testing.T) {
+	repo := newFakeEventReferenceRepo()
+	groups := ProvideEventReferenceGroup(EventReferenceGroupParams{
+		References: repo,
+		Logger:     noopLogger{},
+	})
+	if len(groups) != 1 {
+		t.Fatalf("got %d groups, want 1", len(groups))
+	}
+	g := groups[0]
+	if g.Name != "event-references" {
+		t.Errorf("group name = %q, want event-references", g.Name)
+	}
+	if g.StartAtHead {
+		t.Error("group must not StartAtHead — the projection needs full history")
+	}
+	if g.Truncate == nil {
+		t.Fatal("group declares no Truncate; checkpoint reset --truncate would be rejected")
+	}
+	if err := repo.SaveForEvent(context.Background(), "ev1", []string{"urn:task:x"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := g.Truncate(context.Background()); err != nil {
+		t.Fatalf("Truncate: %v", err)
+	}
+	if refs, _ := repo.ForEvents(context.Background(), []string{"ev1"}); len(refs) != 0 {
+		t.Errorf("Truncate left projection rows behind: %v", refs)
+	}
+}
+
+// errorRecordingLogger captures error logs so tests can assert observability.
+type errorRecordingLogger struct {
+	noopLogger
+	errors []string
+}
+
+func (l *errorRecordingLogger) Error(_ context.Context, msg string, _ ...any) {
+	l.errors = append(l.errors, msg)
+}
+
+// TestEventReferenceHandlerLogsUnexpectedPayloadShape pins the degradation
+// contract: a reference-bearing event with a non-map payload still projects
+// its aggregate but logs the shape problem; other event types stay quiet.
+func TestEventReferenceHandlerLogsUnexpectedPayloadShape(t *testing.T) {
+	repo := newFakeEventReferenceRepo()
+	logger := &errorRecordingLogger{}
+	handler := eventReferenceHandler(repo, logger)
+
+	weird := pericarpdomain.EventEnvelope[any]{
+		ID: "ev1", AggregateID: "urn:task:2t111111111111111111111111",
+		EventType: "Triple.Created", Payload: "not-a-map",
+	}
+	if err := handler(context.Background(), weird); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if len(logger.errors) != 1 {
+		t.Errorf("reference-bearing event with weird payload logged %d errors, want 1", len(logger.errors))
+	}
+	if len(repo.saves["ev1"]) != 1 {
+		t.Errorf("aggregate-only fallback saved %d refs, want 1", len(repo.saves["ev1"]))
+	}
+
+	quiet := pericarpdomain.EventEnvelope[any]{
+		ID: "ev2", AggregateID: "urn:task:2t222222222222222222222222",
+		EventType: "User.LoggedIn", Payload: "not-a-map",
+	}
+	if err := handler(context.Background(), quiet); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if len(logger.errors) != 1 {
+		t.Errorf("non-reference-bearing event logged; errors = %v", logger.errors)
+	}
+}

--- a/application/module.go
+++ b/application/module.go
@@ -175,6 +175,10 @@ func Module(cfg config.Config, registry *PresetRegistry) fx.Option {
 		fx.Provide(gorm.ProvideLexicalIndex),
 		fx.Provide(AsSubscriberGroups(ProvideLexicalGroup)),
 		fx.Provide(NewLexicalSearch),
+		// Episodic recall (epic #409): scoped, deterministic queries over the
+		// event store — time-windowed, filterable, paginated. Read-side only.
+		fx.Provide(gorm.ProvideEventLogRepository),
+		fx.Provide(NewEpisodicRecall),
 		// In-app agent skills (epic #397): declarative agent-skill resources
 		// loaded into a registry the orchestrator builds sub-agents from;
 		// invalidated on skill resource events so changes apply live.

--- a/application/module.go
+++ b/application/module.go
@@ -177,7 +177,11 @@ func Module(cfg config.Config, registry *PresetRegistry) fx.Option {
 		fx.Provide(NewLexicalSearch),
 		// Episodic recall (epic #409): scoped, deterministic queries over the
 		// event store — time-windowed, filterable, paginated. Read-side only.
+		// The event-reference projection ("event-references" subscriber)
+		// records which resources each event touches; recall joins it in.
 		fx.Provide(gorm.ProvideEventLogRepository),
+		fx.Provide(gorm.ProvideEventReferenceRepository),
+		fx.Provide(AsSubscriberGroups(ProvideEventReferenceGroup)),
 		fx.Provide(NewEpisodicRecall),
 		// In-app agent skills (epic #397): declarative agent-skill resources
 		// loaded into a registry the orchestrator builds sub-agents from;

--- a/domain/repositories/event_log.go
+++ b/domain/repositories/event_log.go
@@ -27,8 +27,10 @@ type EventLogFilter struct {
 	// until). Zero times leave that side unbounded.
 	From  time.Time
 	Until time.Time
-	// AggregateID restricts to one aggregate's events (a resource URN).
-	AggregateID string
+	// Anchors restricts to events involving any of these resource URNs — as
+	// the event's aggregate or referenced in its payload (via the
+	// event-reference projection). Multiple anchors union (OR).
+	Anchors []string
 	// EventType restricts to one stored event-type string (e.g. "Resource.Created").
 	EventType string
 	// TypeSlug restricts to aggregates of one resource type via the

--- a/domain/repositories/event_log.go
+++ b/domain/repositories/event_log.go
@@ -1,0 +1,61 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package repositories
+
+import (
+	"context"
+	"time"
+)
+
+// EventLogFilter narrows an event-log query. Zero-value fields are not
+// applied, so filters combine freely.
+type EventLogFilter struct {
+	// From/Until bound the occurred-at window (inclusive from, exclusive
+	// until). Zero times leave that side unbounded.
+	From  time.Time
+	Until time.Time
+	// AggregateID restricts to one aggregate's events (a resource URN).
+	AggregateID string
+	// EventType restricts to one stored event-type string (e.g. "Resource.Created").
+	EventType string
+	// TypeSlug restricts to aggregates of one resource type via the
+	// urn:<typeSlug>:<ksuid> URN prefix.
+	TypeSlug string
+	// Limit caps the page size; callers are expected to clamp it first.
+	Limit int
+	// Cursor continues a previous page (opaque, produced by the repository).
+	Cursor string
+}
+
+// EventLogEntry is one persisted event, as read from the event store's table.
+// Payload is the raw stored payload map — summarization happens above the
+// repository so the compact shape stays a single application-layer concern.
+type EventLogEntry struct {
+	ID          string
+	AggregateID string
+	EventType   string
+	CreatedAt   time.Time
+	Payload     map[string]any
+}
+
+// EventLogRepository is the read-only, time-ordered query surface over the
+// event store's table. It never writes: events are immutable and derived data
+// belongs in projections, not the log.
+type EventLogRepository interface {
+	// Query returns events matching the filter in ascending (created_at, id)
+	// order — deterministic across identical calls.
+	Query(ctx context.Context, filter EventLogFilter) (*PaginatedResponse[EventLogEntry], error)
+}

--- a/domain/repositories/event_log.go
+++ b/domain/repositories/event_log.go
@@ -60,4 +60,9 @@ type EventLogRepository interface {
 	// Query returns events matching the filter in ascending (created_at, id)
 	// order — deterministic across identical calls.
 	Query(ctx context.Context, filter EventLogFilter) (*PaginatedResponse[EventLogEntry], error)
+	// GetByID returns one event by its raw store ID, or nil when unknown.
+	GetByID(ctx context.Context, id string) (*EventLogEntry, error)
+	// Recent returns up to max events in descending (created_at, id) order —
+	// the similarity ranking's deterministic candidate window.
+	Recent(ctx context.Context, max int) ([]EventLogEntry, error)
 }

--- a/domain/repositories/event_reference.go
+++ b/domain/repositories/event_reference.go
@@ -1,0 +1,34 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package repositories
+
+import "context"
+
+// EventReferenceRepository is the event-reference projection's persistence:
+// which resources each event references (the aggregate itself plus resource
+// URNs in the payload). The projection is a rebuildable read model derived
+// from the event log — rows are inserted idempotently and only Clear (the
+// rebuild path) ever removes them; later events never erase history.
+type EventReferenceRepository interface {
+	// SaveForEvent records the resource URNs one event references.
+	// Idempotent: replaying the same event is a no-op.
+	SaveForEvent(ctx context.Context, eventID string, resourceURNs []string) error
+	// ForEvents returns the referenced resource URNs per event ID for a batch
+	// of events, each list in deterministic order.
+	ForEvents(ctx context.Context, eventIDs []string) (map[string][]string, error)
+	// Clear truncates the projection so a checkpoint reset rebuilds it.
+	Clear(ctx context.Context) error
+}

--- a/infrastructure/database/gorm/event_log_repository.go
+++ b/infrastructure/database/gorm/event_log_repository.go
@@ -121,6 +121,56 @@ func (r *EventLogRepository) Query(
 	return resp, nil
 }
 
+// GetByID returns one event row by its raw store ID, nil when absent.
+func (r *EventLogRepository) GetByID(
+	ctx context.Context, id string,
+) (*repositories.EventLogEntry, error) {
+	var rows []infrastructure.GormEventModel
+	err := r.db.WithContext(ctx).
+		Model(&infrastructure.GormEventModel{}).
+		Where("id = ?", id).Limit(1).Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("event lookup failed: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	entry := entryFromModel(rows[0])
+	return &entry, nil
+}
+
+// Recent returns up to max events, newest first with an id tie-break, as the
+// similarity ranking's deterministic candidate window.
+func (r *EventLogRepository) Recent(
+	ctx context.Context, max int,
+) ([]repositories.EventLogEntry, error) {
+	if max <= 0 {
+		return nil, fmt.Errorf("recent events window must be positive, got %d", max)
+	}
+	var rows []infrastructure.GormEventModel
+	err := r.db.WithContext(ctx).
+		Model(&infrastructure.GormEventModel{}).
+		Order("created_at DESC, id DESC").Limit(max).Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("recent events query failed: %w", err)
+	}
+	entries := make([]repositories.EventLogEntry, 0, len(rows))
+	for _, m := range rows {
+		entries = append(entries, entryFromModel(m))
+	}
+	return entries, nil
+}
+
+func entryFromModel(m infrastructure.GormEventModel) repositories.EventLogEntry {
+	return repositories.EventLogEntry{
+		ID:          m.ID,
+		AggregateID: m.AggregateID,
+		EventType:   m.EventType,
+		CreatedAt:   m.CreatedAt,
+		Payload:     m.Payload,
+	}
+}
+
 // applyEventLogFilter adds the combinable WHERE clauses. The resource-type
 // filter leans only on the urn:<typeSlug>:<ksuid> URN shape — no payload
 // indexing, which diverges between SQLite and Postgres.

--- a/infrastructure/database/gorm/event_log_repository.go
+++ b/infrastructure/database/gorm/event_log_repository.go
@@ -1,0 +1,153 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package gorm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/wepala/weos/v3/domain/repositories"
+
+	pericarpdomain "github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/infrastructure"
+	"go.uber.org/fx"
+	"gorm.io/gorm"
+)
+
+// eventLogIndexes are the read-model indexes the episodic query surface needs.
+// CREATE INDEX IF NOT EXISTS is supported by both SQLite and Postgres, and the
+// events table itself is owned (and migrated) by pericarp, so plain idempotent
+// DDL mirrors how pericarp manages that table's own indexes.
+var eventLogIndexes = []string{
+	"CREATE INDEX IF NOT EXISTS idx_events_created_at ON events (created_at)",
+	"CREATE INDEX IF NOT EXISTS idx_events_event_type ON events (event_type)",
+}
+
+// EventLogRepository queries the pericarp events table read-only.
+type EventLogRepository struct {
+	db *gorm.DB
+}
+
+// EventLogRepositoryResult holds the repository for Fx injection.
+type EventLogRepositoryResult struct {
+	fx.Out
+	Repository repositories.EventLogRepository
+}
+
+// ProvideEventLogRepository builds the read-only event-log repository and
+// ensures its read-model indexes exist. It must construct after the event
+// store so the events table is already migrated.
+func ProvideEventLogRepository(params struct {
+	fx.In
+	DB *gorm.DB
+	// EventStore is unused directly; depending on it orders construction
+	// after pericarp has migrated the events table the indexes target.
+	EventStore pericarpdomain.EventStore
+}) (EventLogRepositoryResult, error) {
+	for _, ddl := range eventLogIndexes {
+		if err := params.DB.Exec(ddl).Error; err != nil {
+			return EventLogRepositoryResult{}, fmt.Errorf("failed to create event log index: %w", err)
+		}
+	}
+	return EventLogRepositoryResult{Repository: &EventLogRepository{db: params.DB}}, nil
+}
+
+// Query returns events matching the filter in ascending (created_at, id)
+// order with cursor pagination.
+func (r *EventLogRepository) Query(
+	ctx context.Context, filter repositories.EventLogFilter,
+) (*repositories.PaginatedResponse[repositories.EventLogEntry], error) {
+	limit := filter.Limit
+	if limit <= 0 {
+		return nil, fmt.Errorf("event log query limit must be positive, got %d", limit)
+	}
+
+	q := r.db.WithContext(ctx).Model(&infrastructure.GormEventModel{})
+	q = applyEventLogFilter(q, filter)
+	if filter.Cursor != "" {
+		cd, err := decodeCursor(filter.Cursor)
+		if err != nil {
+			return nil, fmt.Errorf("validation error: invalid cursor: %w", err)
+		}
+		after, err := time.Parse(time.RFC3339Nano, cd.Value)
+		if err != nil {
+			return nil, fmt.Errorf("validation error: invalid cursor: %w", err)
+		}
+		q = q.Where("created_at > ? OR (created_at = ? AND id > ?)", after, after, cd.ID)
+	}
+
+	var rows []infrastructure.GormEventModel
+	if err := q.Order("created_at ASC, id ASC").Limit(limit + 1).Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("event log query failed: %w", err)
+	}
+
+	hasMore := len(rows) > limit
+	if hasMore {
+		rows = rows[:limit]
+	}
+	resp := &repositories.PaginatedResponse[repositories.EventLogEntry]{
+		Data:    make([]repositories.EventLogEntry, 0, len(rows)),
+		Limit:   limit,
+		HasMore: hasMore,
+	}
+	for _, m := range rows {
+		resp.Data = append(resp.Data, repositories.EventLogEntry{
+			ID:          m.ID,
+			AggregateID: m.AggregateID,
+			EventType:   m.EventType,
+			CreatedAt:   m.CreatedAt,
+			Payload:     m.Payload,
+		})
+	}
+	if hasMore && len(rows) > 0 {
+		last := rows[len(rows)-1]
+		resp.Cursor = encodeCursor(last.CreatedAt.UTC().Format(time.RFC3339Nano), last.ID)
+	}
+	return resp, nil
+}
+
+// applyEventLogFilter adds the combinable WHERE clauses. The resource-type
+// filter leans only on the urn:<typeSlug>:<ksuid> URN shape — no payload
+// indexing, which diverges between SQLite and Postgres.
+func applyEventLogFilter(q *gorm.DB, filter repositories.EventLogFilter) *gorm.DB {
+	if !filter.From.IsZero() {
+		q = q.Where("created_at >= ?", filter.From)
+	}
+	if !filter.Until.IsZero() {
+		q = q.Where("created_at < ?", filter.Until)
+	}
+	if filter.AggregateID != "" {
+		q = q.Where("aggregate_id = ?", filter.AggregateID)
+	}
+	if filter.EventType != "" {
+		q = q.Where("event_type = ?", filter.EventType)
+	}
+	if filter.TypeSlug != "" {
+		q = q.Where(`aggregate_id LIKE ? ESCAPE '\'`, "urn:"+escapeLike(filter.TypeSlug)+":%")
+	}
+	return q
+}
+
+// escapeLike escapes LIKE wildcards in a user-supplied slug so slugs like
+// blog_post match literally. The explicit ESCAPE '\' clause in the query
+// makes the escaping portable across SQLite and Postgres.
+func escapeLike(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, "%", `\%`)
+	return strings.ReplaceAll(s, "_", `\_`)
+}

--- a/infrastructure/database/gorm/event_log_repository.go
+++ b/infrastructure/database/gorm/event_log_repository.go
@@ -131,8 +131,13 @@ func applyEventLogFilter(q *gorm.DB, filter repositories.EventLogFilter) *gorm.D
 	if !filter.Until.IsZero() {
 		q = q.Where("created_at < ?", filter.Until)
 	}
-	if filter.AggregateID != "" {
-		q = q.Where("aggregate_id = ?", filter.AggregateID)
+	if len(filter.Anchors) > 0 {
+		// An anchor matches as the aggregate directly (synchronous — no
+		// projection lag for an aggregate's own events) or through the
+		// event-reference projection for payload references.
+		q = q.Where(
+			"aggregate_id IN ? OR id IN (SELECT event_id FROM event_references WHERE resource_urn IN ?)",
+			filter.Anchors, filter.Anchors)
 	}
 	if filter.EventType != "" {
 		q = q.Where("event_type = ?", filter.EventType)

--- a/infrastructure/database/gorm/event_log_repository_test.go
+++ b/infrastructure/database/gorm/event_log_repository_test.go
@@ -223,6 +223,37 @@ func TestEventLogQuery_AnchorsMatchAggregateOrProjection(t *testing.T) {
 	}
 }
 
+// TestEventLogRecentWindow pins the similarity candidate window's contract:
+// newest first with an id DESC tie-break, capped at max (the oldest rows are
+// the ones dropped), and a loud error on a non-positive window.
+func TestEventLogRecentWindow(t *testing.T) {
+	t.Parallel()
+	repo, db := newEventLogTestRepo(t)
+	at := time.Date(2026, 6, 20, 9, 0, 0, 0, time.UTC)
+	seedLogEvent(t, db, "ev1", "urn:task:a1", "Resource.Created", at, 1)
+	seedLogEvent(t, db, "ev2", "urn:task:a2", "Resource.Created", at.Add(time.Hour), 2)
+	seedLogEvent(t, db, "ev3", "urn:task:a3", "Resource.Created", at.Add(2*time.Hour), 3)
+	// ev4 and ev5 share the newest timestamp — the id DESC tie-break decides.
+	seedLogEvent(t, db, "ev4", "urn:task:a4", "Resource.Created", at.Add(3*time.Hour), 4)
+	seedLogEvent(t, db, "ev5", "urn:task:a5", "Resource.Created", at.Add(3*time.Hour), 5)
+
+	got, err := repo.Recent(context.Background(), 3)
+	if err != nil {
+		t.Fatalf("Recent: %v", err)
+	}
+	ids := make([]string, 0, len(got))
+	for _, e := range got {
+		ids = append(ids, e.ID)
+	}
+	if !reflect.DeepEqual(ids, []string{"ev5", "ev4", "ev3"}) {
+		t.Errorf("Recent(3) = %v, want newest-first [ev5 ev4 ev3] with the oldest dropped", ids)
+	}
+
+	if _, err := repo.Recent(context.Background(), 0); err == nil {
+		t.Error("Recent(0) succeeded, want an error")
+	}
+}
+
 // TestEventLogQuery_WindowBounds pins from-inclusive / until-exclusive so
 // day-by-day paging (until = next from) never double-counts.
 func TestEventLogQuery_WindowBounds(t *testing.T) {

--- a/infrastructure/database/gorm/event_log_repository_test.go
+++ b/infrastructure/database/gorm/event_log_repository_test.go
@@ -1,0 +1,162 @@
+package gorm
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wepala/weos/v3/domain/repositories"
+
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/infrastructure"
+	"gorm.io/gorm"
+)
+
+func newEventLogTestRepo(t *testing.T) (*EventLogRepository, *gorm.DB) {
+	t.Helper()
+	db := newTestDB(t)
+	if err := db.AutoMigrate(&infrastructure.GormEventModel{}); err != nil {
+		t.Fatalf("failed to migrate events table: %v", err)
+	}
+	return &EventLogRepository{db: db}, db
+}
+
+func seedLogEvent(
+	t *testing.T, db *gorm.DB, id, aggregateID, eventType string, at time.Time, position int64,
+) {
+	t.Helper()
+	err := db.Create(&infrastructure.GormEventModel{
+		ID:          id,
+		AggregateID: aggregateID,
+		EventType:   eventType,
+		SequenceNo:  1,
+		Position:    position,
+		Payload:     infrastructure.JSONB{"TypeSlug": "task"},
+		CreatedAt:   at,
+	}).Error
+	if err != nil {
+		t.Fatalf("failed to seed event %s: %v", id, err)
+	}
+}
+
+// TestEventLogQuery_PaginatesEqualTimestamps drives the cursor's equality
+// tie-break: five events share one created_at (with sub-second precision), so
+// every page boundary exercises the (created_at = ? AND id > ?) arm. The walk
+// must visit each event exactly once, in id order.
+func TestEventLogQuery_PaginatesEqualTimestamps(t *testing.T) {
+	t.Parallel()
+	repo, db := newEventLogTestRepo(t)
+	at := time.Date(2026, 6, 20, 9, 0, 0, 123456789, time.UTC)
+	want := []string{"ev1", "ev2", "ev3", "ev4", "ev5"}
+	for i, id := range want {
+		seedLogEvent(t, db, id, fmt.Sprintf("urn:task:a%d", i+1), "Resource.Created", at, int64(i+1))
+	}
+
+	var got []string
+	filter := repositories.EventLogFilter{EventType: "Resource.Created", Limit: 2}
+	for {
+		page, err := repo.Query(context.Background(), filter)
+		if err != nil {
+			t.Fatalf("Query: %v", err)
+		}
+		for _, e := range page.Data {
+			got = append(got, e.ID)
+		}
+		if !page.HasMore {
+			break
+		}
+		if page.Cursor == "" {
+			t.Fatal("HasMore without a cursor")
+		}
+		filter.Cursor = page.Cursor
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("walked %d events %v, want %d", len(got), got, len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("walk order = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestEventLogQuery_RejectsMalformedCursors(t *testing.T) {
+	t.Parallel()
+	repo, _ := newEventLogTestRepo(t)
+	cases := []struct {
+		name   string
+		cursor string
+	}{
+		{name: "not base64", cursor: "not-a-cursor!!!"},
+		{name: "base64 but not json", cursor: base64.RawURLEncoding.EncodeToString([]byte("junk"))},
+		{name: "json but not a timestamp value",
+			cursor: base64.RawURLEncoding.EncodeToString([]byte(`{"v":"urn:task:x","id":"x"}`))},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := repo.Query(context.Background(), repositories.EventLogFilter{
+				Limit: 20, Cursor: tc.cursor,
+			})
+			if err == nil {
+				t.Fatal("malformed cursor accepted, want validation error")
+			}
+			msg := strings.ToLower(err.Error())
+			if !strings.Contains(msg, "validation") || !strings.Contains(msg, "cursor") {
+				t.Errorf("error %q should mention validation and the cursor", err)
+			}
+		})
+	}
+}
+
+// TestEventLogQuery_EscapesLikeWildcards pins the ESCAPE '\' behavior: an
+// underscore in a type slug matches literally, and a bare wildcard slug
+// matches nothing rather than everything.
+func TestEventLogQuery_EscapesLikeWildcards(t *testing.T) {
+	t.Parallel()
+	repo, db := newEventLogTestRepo(t)
+	at := time.Date(2026, 6, 20, 9, 0, 0, 0, time.UTC)
+	seedLogEvent(t, db, "ev1", "urn:invoice_line:k1", "Resource.Created", at, 1)
+	seedLogEvent(t, db, "ev2", "urn:invoiceXline:k2", "Resource.Created", at.Add(time.Minute), 2)
+
+	page, err := repo.Query(context.Background(), repositories.EventLogFilter{
+		TypeSlug: "invoice_line", Limit: 20,
+	})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(page.Data) != 1 || page.Data[0].ID != "ev1" {
+		t.Errorf("slug with underscore matched %+v, want only ev1", page.Data)
+	}
+
+	page, err = repo.Query(context.Background(), repositories.EventLogFilter{TypeSlug: "%", Limit: 20})
+	if err != nil {
+		t.Fatalf("Query with wildcard slug: %v", err)
+	}
+	if len(page.Data) != 0 {
+		t.Errorf("wildcard slug matched %d events, want none", len(page.Data))
+	}
+}
+
+// TestEventLogQuery_WindowBounds pins from-inclusive / until-exclusive so
+// day-by-day paging (until = next from) never double-counts.
+func TestEventLogQuery_WindowBounds(t *testing.T) {
+	t.Parallel()
+	repo, db := newEventLogTestRepo(t)
+	from := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	seedLogEvent(t, db, "ev-at-from", "urn:task:b1", "Resource.Created", from, 1)
+	seedLogEvent(t, db, "ev-at-until", "urn:task:b2", "Resource.Created", until, 2)
+
+	page, err := repo.Query(context.Background(), repositories.EventLogFilter{
+		From: from, Until: until, Limit: 20,
+	})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(page.Data) != 1 || page.Data[0].ID != "ev-at-from" {
+		t.Errorf("window returned %+v, want only the event at the from bound", page.Data)
+	}
+}

--- a/infrastructure/database/gorm/event_log_repository_test.go
+++ b/infrastructure/database/gorm/event_log_repository_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/wepala/weos/v3/domain/repositories"
+	weosmodels "github.com/wepala/weos/v3/infrastructure/models"
 
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/infrastructure"
 	"gorm.io/gorm"
@@ -31,10 +33,12 @@ func seedLogEvent(
 		ID:          id,
 		AggregateID: aggregateID,
 		EventType:   eventType,
-		SequenceNo:  1,
-		Position:    position,
-		Payload:     infrastructure.JSONB{"TypeSlug": "task"},
-		CreatedAt:   at,
+		// Position doubles as the per-aggregate sequence: unique per row, so
+		// multi-event aggregates never trip idx_aggregate_sequence.
+		SequenceNo: int(position),
+		Position:   position,
+		Payload:    infrastructure.JSONB{"TypeSlug": "task"},
+		CreatedAt:  at,
 	}).Error
 	if err != nil {
 		t.Fatalf("failed to seed event %s: %v", id, err)
@@ -137,6 +141,85 @@ func TestEventLogQuery_EscapesLikeWildcards(t *testing.T) {
 	}
 	if len(page.Data) != 0 {
 		t.Errorf("wildcard slug matched %d events, want none", len(page.Data))
+	}
+}
+
+// TestEventLogQuery_AnchorsMatchAggregateOrProjection pins the anchored
+// filter's union: an anchor matches events where it is the aggregate (works
+// with an empty projection — the synchronous path #410's scenarios rely on)
+// OR where the event-reference projection links it, and multiple anchors OR
+// together. Composition with the event-type filter narrows as usual.
+func TestEventLogQuery_AnchorsMatchAggregateOrProjection(t *testing.T) {
+	t.Parallel()
+	repo, db := newEventLogTestRepo(t)
+	if err := db.AutoMigrate(&weosmodels.EventReference{}); err != nil {
+		t.Fatalf("migrate event_references: %v", err)
+	}
+	at := time.Date(2026, 6, 20, 9, 0, 0, 0, time.UTC)
+	project := "urn:project:2p111111111111111111111111"
+	other := "urn:project:2p222222222222222222222222"
+	task := "urn:task:2t111111111111111111111111"
+	seedLogEvent(t, db, "ev-project", project, "Resource.Created", at, 1)
+	seedLogEvent(t, db, "ev-task", task, "Resource.Created", at.Add(time.Minute), 2)
+	seedLogEvent(t, db, "ev-other", other, "Resource.Created", at.Add(2*time.Minute), 3)
+	seedLogEvent(t, db, "ev-task-upd", task, "Resource.Updated", at.Add(3*time.Minute), 4)
+	refRepo := &EventReferenceRepository{db: db}
+	ctx := context.Background()
+	// The task events reference the project; the projection has no row for
+	// ev-project itself, so anchoring on the project exercises both branches.
+	if err := refRepo.SaveForEvent(ctx, "ev-task", []string{task, project}); err != nil {
+		t.Fatalf("seed refs: %v", err)
+	}
+	if err := refRepo.SaveForEvent(ctx, "ev-task-upd", []string{task, project}); err != nil {
+		t.Fatalf("seed refs: %v", err)
+	}
+
+	ids := func(filter repositories.EventLogFilter) []string {
+		t.Helper()
+		page, err := repo.Query(ctx, filter)
+		if err != nil {
+			t.Fatalf("Query: %v", err)
+		}
+		got := make([]string, 0, len(page.Data))
+		for _, e := range page.Data {
+			got = append(got, e.ID)
+		}
+		return got
+	}
+
+	if got := ids(repositories.EventLogFilter{Anchors: []string{project}, Limit: 20}); !reflect.DeepEqual(
+		got, []string{"ev-project", "ev-task", "ev-task-upd"}) {
+		t.Errorf("project anchor = %v, want aggregate + projection matches", got)
+	}
+	if got := ids(repositories.EventLogFilter{Anchors: []string{other}, Limit: 20}); !reflect.DeepEqual(
+		got, []string{"ev-other"}) {
+		t.Errorf("aggregate-only anchor (empty projection) = %v, want [ev-other]", got)
+	}
+	if got := ids(repositories.EventLogFilter{Anchors: []string{project, other}, Limit: 20}); len(got) != 4 {
+		t.Errorf("multi-anchor union = %v, want all four events", got)
+	}
+	if got := ids(repositories.EventLogFilter{
+		Anchors: []string{project}, EventType: "Resource.Updated", Limit: 20,
+	}); !reflect.DeepEqual(got, []string{"ev-task-upd"}) {
+		t.Errorf("anchor + event-type = %v, want [ev-task-upd]", got)
+	}
+	// Anchor + resource-type: the anchored project's own event drops out of
+	// the task-shaped LIKE while its referenced task events remain.
+	if got := ids(repositories.EventLogFilter{
+		Anchors: []string{project}, TypeSlug: "task", Limit: 20,
+	}); !reflect.DeepEqual(got, []string{"ev-task", "ev-task-upd"}) {
+		t.Errorf("anchor + resource-type = %v, want the task events only", got)
+	}
+	// An explicit empty (non-nil) anchors slice means unanchored, never
+	// match-nothing.
+	if got := ids(repositories.EventLogFilter{Anchors: []string{}, Limit: 20}); len(got) != 4 {
+		t.Errorf("empty anchors slice = %v, want all four events (unanchored)", got)
+	}
+	// An anchor matching an event through BOTH branches (its aggregate and a
+	// projection row) yields the event once — guards a future JOIN refactor.
+	if got := ids(repositories.EventLogFilter{Anchors: []string{task}, Limit: 20}); !reflect.DeepEqual(
+		got, []string{"ev-task", "ev-task-upd"}) {
+		t.Errorf("both-branch anchor = %v, want each event exactly once", got)
 	}
 }
 

--- a/infrastructure/database/gorm/event_reference_repository.go
+++ b/infrastructure/database/gorm/event_reference_repository.go
@@ -1,0 +1,111 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package gorm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/wepala/weos/v3/domain/repositories"
+	weosmodels "github.com/wepala/weos/v3/infrastructure/models"
+
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/subscriptions"
+	"go.uber.org/fx"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// EventReferenceRepository persists the event-reference projection.
+type EventReferenceRepository struct {
+	db *gorm.DB
+}
+
+// EventReferenceRepositoryResult holds the repository for Fx injection.
+type EventReferenceRepositoryResult struct {
+	fx.Out
+	Repository repositories.EventReferenceRepository
+}
+
+// ProvideEventReferenceRepository builds the event-reference projection
+// repository. The table itself is AutoMigrated with the other GORM models.
+func ProvideEventReferenceRepository(params struct {
+	fx.In
+	DB *gorm.DB
+}) (EventReferenceRepositoryResult, error) {
+	return EventReferenceRepositoryResult{Repository: &EventReferenceRepository{db: params.DB}}, nil
+}
+
+// SaveForEvent inserts one row per referenced URN, ignoring rows that already
+// exist — ON CONFLICT DO NOTHING works on both SQLite and Postgres, which
+// makes event replay idempotent with no read-before-write.
+func (r *EventReferenceRepository) SaveForEvent(
+	ctx context.Context, eventID string, resourceURNs []string,
+) error {
+	if eventID == "" || len(resourceURNs) == 0 {
+		return nil
+	}
+	rows := make([]weosmodels.EventReference, 0, len(resourceURNs))
+	for _, urn := range resourceURNs {
+		rows = append(rows, weosmodels.EventReference{EventID: eventID, ResourceURN: urn})
+	}
+	err := r.writer(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(&rows).Error
+	if err != nil {
+		return fmt.Errorf("failed to save event references for %s: %w", eventID, err)
+	}
+	return nil
+}
+
+// writer joins the subscriber batch transaction when one is on the context —
+// projection rows then commit atomically with the checkpoint, and on SQLite a
+// separate connection would deadlock against the batch's write lock. Outside
+// a batch (tests, tooling) it falls back to the pooled handle.
+func (r *EventReferenceRepository) writer(ctx context.Context) *gorm.DB {
+	if tx := subscriptions.TxFromContext(ctx); tx != nil {
+		return tx
+	}
+	return r.db.WithContext(ctx)
+}
+
+// ForEvents returns referenced URNs grouped by event ID, each group in
+// ascending URN order so identical queries recall identical shapes.
+func (r *EventReferenceRepository) ForEvents(
+	ctx context.Context, eventIDs []string,
+) (map[string][]string, error) {
+	result := make(map[string][]string, len(eventIDs))
+	if len(eventIDs) == 0 {
+		return result, nil
+	}
+	var rows []weosmodels.EventReference
+	err := r.db.WithContext(ctx).
+		Where("event_id IN ?", eventIDs).
+		Order("event_id ASC, resource_urn ASC").
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to load event references: %w", err)
+	}
+	for _, row := range rows {
+		result[row.EventID] = append(result[row.EventID], row.ResourceURN)
+	}
+	return result, nil
+}
+
+// Clear truncates the projection for rebuild (checkpoint reset --truncate).
+func (r *EventReferenceRepository) Clear(ctx context.Context) error {
+	if err := r.db.WithContext(ctx).Exec("DELETE FROM event_references").Error; err != nil {
+		return fmt.Errorf("failed to clear event references: %w", err)
+	}
+	return nil
+}

--- a/infrastructure/database/gorm/event_reference_repository_test.go
+++ b/infrastructure/database/gorm/event_reference_repository_test.go
@@ -1,0 +1,89 @@
+package gorm
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	weosmodels "github.com/wepala/weos/v3/infrastructure/models"
+)
+
+func newEventReferenceTestRepo(t *testing.T) *EventReferenceRepository {
+	t.Helper()
+	db := newTestDB(t)
+	if err := db.AutoMigrate(&weosmodels.EventReference{}); err != nil {
+		t.Fatalf("failed to migrate event_references: %v", err)
+	}
+	return &EventReferenceRepository{db: db}
+}
+
+// TestEventReferenceSaveIsIdempotent replays the same save; the projected
+// rows must not duplicate (ON CONFLICT DO NOTHING on the composite key).
+func TestEventReferenceSaveIsIdempotent(t *testing.T) {
+	t.Parallel()
+	repo := newEventReferenceTestRepo(t)
+	ctx := context.Background()
+	urns := []string{"urn:task:2t111111111111111111111111", "urn:project:2p111111111111111111111111"}
+
+	for range 2 {
+		if err := repo.SaveForEvent(ctx, "ev1", urns); err != nil {
+			t.Fatalf("SaveForEvent: %v", err)
+		}
+	}
+
+	refs, err := repo.ForEvents(ctx, []string{"ev1"})
+	if err != nil {
+		t.Fatalf("ForEvents: %v", err)
+	}
+	want := []string{"urn:project:2p111111111111111111111111", "urn:task:2t111111111111111111111111"}
+	if !reflect.DeepEqual(refs["ev1"], want) {
+		t.Errorf("refs = %v, want %v (sorted, no duplicates)", refs["ev1"], want)
+	}
+}
+
+func TestEventReferenceForEventsBatches(t *testing.T) {
+	t.Parallel()
+	repo := newEventReferenceTestRepo(t)
+	ctx := context.Background()
+	if err := repo.SaveForEvent(ctx, "ev1", []string{"urn:task:2t111111111111111111111111"}); err != nil {
+		t.Fatalf("SaveForEvent ev1: %v", err)
+	}
+	if err := repo.SaveForEvent(ctx, "ev2", []string{"urn:project:2p111111111111111111111111"}); err != nil {
+		t.Fatalf("SaveForEvent ev2: %v", err)
+	}
+
+	refs, err := repo.ForEvents(ctx, []string{"ev1", "ev2", "ev-unknown"})
+	if err != nil {
+		t.Fatalf("ForEvents: %v", err)
+	}
+	if len(refs) != 2 {
+		t.Errorf("got refs for %d events, want 2: %v", len(refs), refs)
+	}
+	if _, ok := refs["ev-unknown"]; ok {
+		t.Error("unknown event should have no entry, not an empty one")
+	}
+
+	empty, err := repo.ForEvents(ctx, nil)
+	if err != nil || len(empty) != 0 {
+		t.Errorf("ForEvents(nil) = %v, %v; want empty, nil", empty, err)
+	}
+}
+
+func TestEventReferenceClearTruncates(t *testing.T) {
+	t.Parallel()
+	repo := newEventReferenceTestRepo(t)
+	ctx := context.Background()
+	if err := repo.SaveForEvent(ctx, "ev1", []string{"urn:task:2t111111111111111111111111"}); err != nil {
+		t.Fatalf("SaveForEvent: %v", err)
+	}
+	if err := repo.Clear(ctx); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	refs, err := repo.ForEvents(ctx, []string{"ev1"})
+	if err != nil {
+		t.Fatalf("ForEvents: %v", err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("projection not empty after Clear: %v", refs)
+	}
+}

--- a/infrastructure/database/gorm/lexical_index.go
+++ b/infrastructure/database/gorm/lexical_index.go
@@ -24,6 +24,7 @@ import (
 	"github.com/wepala/weos/v3/domain/repositories"
 	"github.com/wepala/weos/v3/internal/config"
 
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/subscriptions"
 	"gorm.io/gorm"
 )
 
@@ -56,8 +57,22 @@ type sqliteLexicalIndex struct {
 
 func (s *sqliteLexicalIndex) Active() bool { return true }
 
+// writer joins the subscriber batch transaction when one is on the context.
+// The batch transaction holds SQLite's write lock (txlock=immediate), so a
+// write on a separate pooled connection would deadlock against the handler's
+// own batch until the busy timeout — and then retry inside the still-open
+// batch, starving every other writer in the process.
+func (s *sqliteLexicalIndex) writer(ctx context.Context) *gorm.DB {
+	if tx := subscriptions.TxFromContext(ctx); tx != nil {
+		return tx
+	}
+	return s.db.WithContext(ctx)
+}
+
 func (s *sqliteLexicalIndex) Index(ctx context.Context, id, typeSlug, content string) error {
-	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	// Transaction nests as a savepoint when the writer is the batch
+	// transaction, keeping the delete+insert pair atomic either way.
+	return s.writer(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Exec("DELETE FROM resource_search WHERE id = ?", id).Error; err != nil {
 			return fmt.Errorf("lexical index: clear %s: %w", id, err)
 		}
@@ -72,7 +87,7 @@ func (s *sqliteLexicalIndex) Index(ctx context.Context, id, typeSlug, content st
 }
 
 func (s *sqliteLexicalIndex) Remove(ctx context.Context, id string) error {
-	if err := s.db.WithContext(ctx).Exec("DELETE FROM resource_search WHERE id = ?", id).Error; err != nil {
+	if err := s.writer(ctx).Exec("DELETE FROM resource_search WHERE id = ?", id).Error; err != nil {
 		return fmt.Errorf("lexical index: remove %s: %w", id, err)
 	}
 	return nil

--- a/infrastructure/database/gorm/lexical_index_tx_test.go
+++ b/infrastructure/database/gorm/lexical_index_tx_test.go
@@ -1,0 +1,152 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package gorm
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/wepala/weos/v3/infrastructure/models"
+	"github.com/wepala/weos/v3/internal/config"
+
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/subscriptions"
+	"gorm.io/gorm"
+)
+
+// TestLexicalIndex_JoinsBatchTransaction is the regression guardrail for the
+// SQLite self-deadlock fixed on the epic #409 branch: the lexical group's
+// Index/Remove writes ran on a pooled connection while the subscriber's batch
+// transaction held the write lock (_txlock=immediate), blocking until
+// busy_timeout and then retrying inside the still-open batch. The writes must
+// join the batch transaction via subscriptions.TxFromContext. Same shape as
+// TestProjectionWrite_JoinsBatchTransaction, which guards the projection
+// manager against the identical bug class.
+func TestLexicalIndex_JoinsBatchTransaction(t *testing.T) {
+	db := newWALTestDB(t)
+	idx := ProvideLexicalIndex(db, config.Default(), &testLogger{})
+	if !idx.Active() {
+		t.Skip("FTS5 unavailable; lexical index inactive")
+	}
+
+	cps, err := subscriptions.NewGormCheckpointStore(db)
+	if err != nil {
+		t.Fatalf("new checkpoint store: %v", err)
+	}
+	batch, acquired, err := cps.Acquire(context.Background(), "lexical-guardrail")
+	if err != nil || !acquired {
+		t.Fatalf("acquire batch: acquired=%v err=%v", acquired, err)
+	}
+	defer func() { _ = batch.Rollback() }()
+	handlerCtx := batch.HandlerContext(context.Background())
+
+	// Index (nested Transaction → savepoint under the batch tx) and Remove
+	// must both complete without deadlocking against the batch's write lock.
+	done := make(chan error, 1)
+	go func() {
+		if err := idx.Index(handlerCtx, "urn:task:g1", "task", "guardrail content"); err != nil {
+			done <- err
+			return
+		}
+		done <- idx.Remove(handlerCtx, "urn:task:gone")
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("lexical write inside the batch transaction failed "+
+				"(deadlock regression — write did not join the batch tx): %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("lexical write blocked inside the batch transaction " +
+			"(deadlock regression — write did not join the batch tx)")
+	}
+
+	// Pre-commit, a pooled read must not see the uncommitted index row.
+	if got := countSearchRows(t, db); got != 0 {
+		t.Fatalf("pre-commit pooled read sees %d rows, want 0 (write leaked outside the batch tx)", got)
+	}
+	if err := batch.Commit(context.Background(), 1); err != nil {
+		t.Fatalf("commit batch: %v", err)
+	}
+	if got := countSearchRows(t, db); got != 1 {
+		t.Fatalf("post-commit read sees %d rows, want 1", got)
+	}
+}
+
+// TestEventReferenceSave_JoinsBatchTransaction pins the same guarantee for the
+// event-reference projection's SaveForEvent.
+func TestEventReferenceSave_JoinsBatchTransaction(t *testing.T) {
+	db := newWALTestDB(t)
+	if err := db.AutoMigrate(&models.EventReference{}); err != nil {
+		t.Fatalf("migrate event_references: %v", err)
+	}
+	repo := &EventReferenceRepository{db: db}
+
+	cps, err := subscriptions.NewGormCheckpointStore(db)
+	if err != nil {
+		t.Fatalf("new checkpoint store: %v", err)
+	}
+	batch, acquired, err := cps.Acquire(context.Background(), "event-refs-guardrail")
+	if err != nil || !acquired {
+		t.Fatalf("acquire batch: acquired=%v err=%v", acquired, err)
+	}
+	defer func() { _ = batch.Rollback() }()
+	handlerCtx := batch.HandlerContext(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- repo.SaveForEvent(handlerCtx, "ev1", []string{"urn:task:g1"})
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("reference write inside the batch transaction failed "+
+				"(deadlock regression — write did not join the batch tx): %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("reference write blocked inside the batch transaction " +
+			"(deadlock regression — write did not join the batch tx)")
+	}
+
+	refs, err := repo.ForEvents(context.Background(), []string{"ev1"})
+	if err != nil {
+		t.Fatalf("ForEvents: %v", err)
+	}
+	if len(refs) != 0 {
+		t.Fatalf("pre-commit pooled read sees refs %v, want none (write leaked outside the batch tx)", refs)
+	}
+	if err := batch.Commit(context.Background(), 1); err != nil {
+		t.Fatalf("commit batch: %v", err)
+	}
+	refs, err = repo.ForEvents(context.Background(), []string{"ev1"})
+	if err != nil {
+		t.Fatalf("ForEvents post-commit: %v", err)
+	}
+	if len(refs["ev1"]) != 1 {
+		t.Fatalf("post-commit refs = %v, want the saved reference", refs)
+	}
+}
+
+// countSearchRows counts resource_search rows through the pooled connection
+// (deliberately not the batch transaction).
+func countSearchRows(t *testing.T, db *gorm.DB) int {
+	t.Helper()
+	var count int
+	if err := db.Raw(`SELECT COUNT(*) FROM resource_search`).Row().Scan(&count); err != nil {
+		t.Fatalf("count resource_search rows: %v", err)
+	}
+	return count
+}

--- a/infrastructure/database/gorm/provider.go
+++ b/infrastructure/database/gorm/provider.go
@@ -96,6 +96,7 @@ func ProvideGormDB(params struct {
 		&weosmodels.RoleSettings{},
 		&weosmodels.RoleResourceAccess{},
 		&weosmodels.Triple{},
+		&weosmodels.EventReference{},
 		&weosmodels.ResourcePermission{},
 		&weosmodels.BehaviorSettings{},
 		&oauth.OAuthClient{},

--- a/infrastructure/models/event_reference.go
+++ b/infrastructure/models/event_reference.go
@@ -1,0 +1,15 @@
+package models
+
+// EventReference is one edge of the event-reference projection: the event
+// identified by EventID references the resource identified by ResourceURN.
+// Rows are derived from the event log by the "event-references" subscriber
+// and are only ever inserted or truncated (for rebuild) — never updated, so
+// replay is idempotent by construction.
+type EventReference struct {
+	EventID     string `gorm:"primaryKey;not null;column:event_id"`
+	ResourceURN string `gorm:"primaryKey;not null;column:resource_urn;index:idx_event_refs_resource"`
+}
+
+func (EventReference) TableName() string {
+	return "event_references"
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -111,6 +111,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	var resourceService application.ResourceService
 	var kgService application.KnowledgeGraphService
 	var lexicalSearch application.LexicalSearch
+	var episodicRecall application.EpisodicRecall
 	var resourcePermService application.ResourcePermissionService
 	var fileService application.FileService
 	var authService authapp.AuthenticationService
@@ -144,6 +145,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		fx.Populate(&resourceService),
 		fx.Populate(&kgService),
 		fx.Populate(&lexicalSearch),
+		fx.Populate(&episodicRecall),
 		fx.Populate(&resourcePermService),
 		fx.Populate(&fileService),
 		fx.Populate(&authService),
@@ -462,7 +464,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	if serveViper.GetBool("enabled") {
 		mcpSrv, mcpErr := mcpserver.NewConfiguredServer(
-			resourceTypeService, resourceService, kgService, lexicalSearch, slog.Default(),
+			resourceTypeService, resourceService, kgService, lexicalSearch, episodicRecall, slog.Default(),
 		)
 		if mcpErr != nil {
 			return fmt.Errorf("failed to create MCP server: %w", mcpErr)

--- a/internal/mcp/agent_toolset_test.go
+++ b/internal/mcp/agent_toolset_test.go
@@ -53,7 +53,8 @@ func (stubLexicalSearch) Search(context.Context, string, int) ([]repositories.Le
 func fullServer(t *testing.T) *gomcp.Server {
 	t.Helper()
 	server, err := NewMCPServer(
-		&stubResourceTypeService{}, &stubResourceService{}, &stubKGService{active: true}, stubLexicalSearch{}, nil,
+		&stubResourceTypeService{}, &stubResourceService{}, &stubKGService{active: true}, stubLexicalSearch{},
+		nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("NewMCPServer: %v", err)

--- a/internal/mcp/configurer_test.go
+++ b/internal/mcp/configurer_test.go
@@ -70,7 +70,7 @@ func TestNewHTTPHandlerAppliesConfigurers(t *testing.T) {
 	called := 0
 	RegisterMCPConfigurer(func(_ *mcp.Server, _ ConfigurerDeps) { called++ })
 
-	if _, err := NewHTTPHandler(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, slog.Default()); err != nil {
+	if _, err := NewHTTPHandler(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, slog.Default()); err != nil {
 		t.Fatalf("NewHTTPHandler: %v", err)
 	}
 	if called != 1 {

--- a/internal/mcp/episodic_tools.go
+++ b/internal/mcp/episodic_tools.go
@@ -46,6 +46,17 @@ type EpisodicRecallOutput struct {
 	HasMore bool                        `json:"has_more"`
 }
 
+// EpisodicSimilarInput asks for events structurally similar to a seed event.
+type EpisodicSimilarInput struct {
+	Seed  string `json:"seed" jsonschema:"the seed event URN (urn:event:<id>) from an episodic_recall result"`
+	Limit int    `json:"limit,omitempty" jsonschema:"max events to return (default 20, max 100)"`
+}
+
+// EpisodicSimilarOutput lists ranked events, most similar first.
+type EpisodicSimilarOutput struct {
+	Results []application.SimilarEvent `json:"results"`
+}
+
 // registerEpisodicTools registers the episodic-memory tool group.
 func registerEpisodicTools(server *mcp.Server, episodic application.EpisodicRecall) {
 	mcp.AddTool(server, &mcp.Tool{
@@ -76,5 +87,24 @@ func registerEpisodicTools(server *mcp.Server, episodic application.EpisodicReca
 			Cursor:  res.Cursor,
 			HasMore: res.HasMore,
 		}, nil
+	})
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "episodic_similar",
+		Description: "Find events structurally similar to a seed event, ranked by a fixed, " +
+			"deterministic score: +100 per shared referenced resource (dominant), +10 same " +
+			"event type, +5 same resource type, up to +4 for temporal proximity (decaying " +
+			"per day, refines order only — events with no structural affinity are not " +
+			"ranked); ties break on event ID. Ranks the most recent 1000 events. Reference " +
+			"scoring reads a projection that may briefly lag very recent events. No " +
+			"embeddings, no learned ranking. Get seed URNs from episodic_recall results.",
+		Annotations: annReadOnly(),
+	}, func(
+		ctx context.Context, _ *mcp.CallToolRequest, in EpisodicSimilarInput,
+	) (*mcp.CallToolResult, EpisodicSimilarOutput, error) {
+		res, err := episodic.Similar(ctx, application.SimilarQuery{Seed: in.Seed, Limit: in.Limit})
+		if err != nil {
+			return nil, EpisodicSimilarOutput{}, err
+		}
+		return nil, EpisodicSimilarOutput{Results: res.Events}, nil
 	})
 }

--- a/internal/mcp/episodic_tools.go
+++ b/internal/mcp/episodic_tools.go
@@ -57,6 +57,11 @@ type EpisodicSimilarOutput struct {
 	Results []application.SimilarEvent `json:"results"`
 }
 
+// EpisodicEventGetInput identifies one event to fetch in full.
+type EpisodicEventGetInput struct {
+	URN string `json:"urn" jsonschema:"the event URN (urn:event:<id>) from any episodic tool's results"`
+}
+
 // registerEpisodicTools registers the episodic-memory tool group.
 func registerEpisodicTools(server *mcp.Server, episodic application.EpisodicRecall) {
 	mcp.AddTool(server, &mcp.Tool{
@@ -106,5 +111,20 @@ func registerEpisodicTools(server *mcp.Server, episodic application.EpisodicReca
 			return nil, EpisodicSimilarOutput{}, err
 		}
 		return nil, EpisodicSimilarOutput{Results: res.Events}, nil
+	})
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "episodic_event_get",
+		Description: "Fetch one event's full stored payload by its URN. Recall results stay " +
+			"compact by default — use this to drill into a single event an episodic tool " +
+			"surfaced. Unknown or malformed URNs return a clear error.",
+		Annotations: annReadOnly(),
+	}, func(
+		ctx context.Context, _ *mcp.CallToolRequest, in EpisodicEventGetInput,
+	) (*mcp.CallToolResult, application.FetchedEvent, error) {
+		fetched, err := episodic.EventByURN(ctx, in.URN)
+		if err != nil {
+			return nil, application.FetchedEvent{}, err
+		}
+		return nil, *fetched, nil
 	})
 }

--- a/internal/mcp/episodic_tools.go
+++ b/internal/mcp/episodic_tools.go
@@ -1,0 +1,78 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package mcp
+
+import (
+	"context"
+
+	"github.com/wepala/weos/v3/application"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// EpisodicRecallInput is a scoped query over the event log. All filters combine.
+type EpisodicRecallInput struct {
+	//nolint:lll // jsonschema description
+	From string `json:"from,omitempty" jsonschema:"start of the time window — RFC3339 or relative (last 7 days, 3 days ago)"`
+	//nolint:lll // jsonschema description
+	Until string `json:"until,omitempty" jsonschema:"end of the time window — RFC3339 or relative; open when omitted"`
+	About string `json:"about,omitempty" jsonschema:"only events on this aggregate/resource URN"`
+	//nolint:lll // jsonschema description
+	EventType    string `json:"eventType,omitempty" jsonschema:"only events of this stored type (e.g. Resource.Created)"`
+	ResourceType string `json:"resourceType,omitempty" jsonschema:"only events on resources of this type slug"`
+	Limit        int    `json:"limit,omitempty" jsonschema:"max events to return (default 20, max 100)"`
+	//nolint:lll // jsonschema description
+	Cursor string `json:"cursor,omitempty" jsonschema:"pagination cursor from previous call — re-send the same filters with it"`
+}
+
+// EpisodicRecallOutput is one time-ordered page of compact events.
+type EpisodicRecallOutput struct {
+	Events  []application.RecalledEvent `json:"events"`
+	Cursor  string                      `json:"cursor,omitempty"`
+	HasMore bool                        `json:"has_more"`
+}
+
+// registerEpisodicTools registers the episodic-memory tool group.
+func registerEpisodicTools(server *mcp.Server, episodic application.EpisodicRecall) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "episodic_recall",
+		Description: "Recall what happened from the event log: a time-ordered, paginated slice of " +
+			"events, filterable by time window (absolute or relative), aggregate/resource URN, " +
+			"event type, and resource type. Results are compact summaries — deterministic " +
+			"retrieval, no ranking. Use memory_recall for consolidated facts.",
+		Annotations: annReadOnly(),
+	}, func(
+		ctx context.Context, _ *mcp.CallToolRequest, in EpisodicRecallInput,
+	) (*mcp.CallToolResult, EpisodicRecallOutput, error) {
+		res, err := episodic.Recall(ctx, application.EpisodicQuery{
+			From:         in.From,
+			Until:        in.Until,
+			AggregateID:  in.About,
+			EventType:    in.EventType,
+			ResourceType: in.ResourceType,
+			Limit:        in.Limit,
+			Cursor:       in.Cursor,
+		})
+		if err != nil {
+			return nil, EpisodicRecallOutput{}, err
+		}
+		return nil, EpisodicRecallOutput{
+			Events:  res.Events,
+			Cursor:  res.Cursor,
+			HasMore: res.HasMore,
+		}, nil
+	})
+}

--- a/internal/mcp/episodic_tools.go
+++ b/internal/mcp/episodic_tools.go
@@ -29,7 +29,8 @@ type EpisodicRecallInput struct {
 	From string `json:"from,omitempty" jsonschema:"start of the time window — RFC3339 or relative (last 7 days, 3 days ago)"`
 	//nolint:lll // jsonschema description
 	Until string `json:"until,omitempty" jsonschema:"end of the time window — RFC3339 or relative; open when omitted"`
-	About string `json:"about,omitempty" jsonschema:"only events on this aggregate/resource URN"`
+	//nolint:lll // jsonschema description
+	About []string `json:"about,omitempty" jsonschema:"only events involving these resource URNs — as the event's aggregate or referenced in its payload"`
 	//nolint:lll // jsonschema description
 	EventType    string `json:"eventType,omitempty" jsonschema:"only events of this stored type (e.g. Resource.Created)"`
 	ResourceType string `json:"resourceType,omitempty" jsonschema:"only events on resources of this type slug"`
@@ -50,7 +51,8 @@ func registerEpisodicTools(server *mcp.Server, episodic application.EpisodicReca
 	mcp.AddTool(server, &mcp.Tool{
 		Name: "episodic_recall",
 		Description: "Recall what happened from the event log: a time-ordered, paginated slice of " +
-			"events, filterable by time window (absolute or relative), aggregate/resource URN, " +
+			"events, filterable by time window (absolute or relative), anchor resource URNs " +
+			"(one or more — matched as the event's aggregate or referenced in its payload), " +
 			"event type, and resource type. Results are compact summaries — deterministic " +
 			"retrieval, no ranking. Use memory_recall for consolidated facts.",
 		Annotations: annReadOnly(),
@@ -60,7 +62,7 @@ func registerEpisodicTools(server *mcp.Server, episodic application.EpisodicReca
 		res, err := episodic.Recall(ctx, application.EpisodicQuery{
 			From:         in.From,
 			Until:        in.Until,
-			AggregateID:  in.About,
+			Anchors:      in.About,
 			EventType:    in.EventType,
 			ResourceType: in.ResourceType,
 			Limit:        in.Limit,

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -35,9 +35,10 @@ func NewConfiguredServer(
 	resourceService application.ResourceService,
 	kgService application.KnowledgeGraphService,
 	lexicalSearch application.LexicalSearch,
+	episodicRecall application.EpisodicRecall,
 	logger *slog.Logger,
 ) (*gomcp.Server, error) {
-	server, err := NewMCPServer(resourceTypeService, resourceService, kgService, lexicalSearch, nil)
+	server, err := NewMCPServer(resourceTypeService, resourceService, kgService, lexicalSearch, episodicRecall, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create MCP server: %w", err)
 	}
@@ -69,9 +70,11 @@ func NewHTTPHandler(
 	resourceService application.ResourceService,
 	kgService application.KnowledgeGraphService,
 	lexicalSearch application.LexicalSearch,
+	episodicRecall application.EpisodicRecall,
 	logger *slog.Logger,
 ) (http.Handler, error) {
-	server, err := NewConfiguredServer(resourceTypeService, resourceService, kgService, lexicalSearch, logger)
+	server, err := NewConfiguredServer(
+		resourceTypeService, resourceService, kgService, lexicalSearch, episodicRecall, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mcp/handler_test.go
+++ b/internal/mcp/handler_test.go
@@ -179,7 +179,7 @@ func toolNames(t *testing.T, server *gomcp.Server) []string {
 }
 
 func TestNewMCPServer_AllServices(t *testing.T) {
-	server, err := NewMCPServer(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil)
+	server, err := NewMCPServer(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -213,7 +213,7 @@ func TestNewMCPServer_AllServices(t *testing.T) {
 }
 
 func TestNewMCPServer_Subset(t *testing.T) {
-	server, err := NewMCPServer(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, []string{"person"})
+	server, err := NewMCPServer(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, []string{"person"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestNewMCPServer_Subset(t *testing.T) {
 
 func TestNewMCPServer_ResourceTypeIncludesPresets(t *testing.T) {
 	server, err := NewMCPServer(
-		&stubResourceTypeService{}, &stubResourceService{}, nil, nil, []string{"resource-type"},
+		&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, []string{"resource-type"},
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -253,21 +253,21 @@ func TestNewMCPServer_ResourceTypeIncludesPresets(t *testing.T) {
 }
 
 func TestNewMCPServer_NilResourceTypeService(t *testing.T) {
-	_, err := NewMCPServer(nil, &stubResourceService{}, nil, nil, nil)
+	_, err := NewMCPServer(nil, &stubResourceService{}, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for nil resourceTypeService")
 	}
 }
 
 func TestNewMCPServer_NilResourceService(t *testing.T) {
-	_, err := NewMCPServer(&stubResourceTypeService{}, nil, nil, nil, nil)
+	_, err := NewMCPServer(&stubResourceTypeService{}, nil, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for nil resourceService")
 	}
 }
 
 func TestNewHTTPHandler_ReturnsHandler(t *testing.T) {
-	handler, err := NewHTTPHandler(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil)
+	handler, err := NewHTTPHandler(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -277,7 +277,7 @@ func TestNewHTTPHandler_ReturnsHandler(t *testing.T) {
 }
 
 func TestNewHTTPHandler_AcceptsMCPRequest(t *testing.T) {
-	handler, err := NewHTTPHandler(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil)
+	handler, err := NewHTTPHandler(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -304,7 +304,7 @@ func TestNewHTTPHandler_AcceptsMCPRequest(t *testing.T) {
 }
 
 func TestNewHTTPHandler_NilServices(t *testing.T) {
-	_, err := NewHTTPHandler(nil, nil, nil, nil, nil)
+	_, err := NewHTTPHandler(nil, nil, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for nil services")
 	}

--- a/internal/mcp/kg_tools_test.go
+++ b/internal/mcp/kg_tools_test.go
@@ -90,7 +90,7 @@ func TestNewMCPServer_KnowledgeGraphServiceOptional(t *testing.T) {
 	// Passing nil kgService must not break server creation; the tools just
 	// don't appear. (Mirrors how downstream callers like the HTTP handler
 	// can opt out.)
-	server, err := NewMCPServer(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil)
+	server, err := NewMCPServer(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewMCPServer with nil KG: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestNewMCPServer_KnowledgeGraphServiceOptional(t *testing.T) {
 func TestNewMCPServer_KnowledgeGraphRegisteredWhenServiceProvided(t *testing.T) {
 	t.Parallel()
 	server, err := NewMCPServer(
-		&stubResourceTypeService{}, &stubResourceService{}, &stubKGService{active: true}, nil, nil,
+		&stubResourceTypeService{}, &stubResourceService{}, &stubKGService{active: true}, nil, nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("NewMCPServer: %v", err)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -106,6 +106,7 @@ func NewMCPServer(
 	resourceService application.ResourceService,
 	kgService application.KnowledgeGraphService,
 	lexicalSearch application.LexicalSearch,
+	episodicRecall application.EpisodicRecall,
 	enabledServices []string,
 ) (*mcp.Server, error) {
 	if isNilInterface(resourceTypeService) {
@@ -161,6 +162,11 @@ func NewMCPServer(
 			search = lexicalSearch
 		}
 		registerMemoryTools(server, application.NewPlaybookService(resourceService), recall, search)
+		// Episodic recall needs the event-log repository and IS threaded in;
+		// when nil (tests, minimal wiring) episodic_recall is not registered.
+		if !isNilInterface(episodicRecall) {
+			registerEpisodicTools(server, episodicRecall)
+		}
 	}
 
 	return server, nil
@@ -175,6 +181,7 @@ func Run(enabledServices []string) error {
 	var resourceService application.ResourceService
 	var kgService application.KnowledgeGraphService
 	var lexicalSearch application.LexicalSearch
+	var episodicRecall application.EpisodicRecall
 
 	app := fx.New(
 		fx.NopLogger,
@@ -183,6 +190,7 @@ func Run(enabledServices []string) error {
 		fx.Populate(&resourceService),
 		fx.Populate(&kgService),
 		fx.Populate(&lexicalSearch),
+		fx.Populate(&episodicRecall),
 	)
 
 	startCtx, startCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
@@ -199,7 +207,8 @@ func Run(enabledServices []string) error {
 		}
 	}()
 
-	server, err := NewMCPServer(resourceTypeService, resourceService, kgService, lexicalSearch, enabledServices)
+	server, err := NewMCPServer(
+		resourceTypeService, resourceService, kgService, lexicalSearch, episodicRecall, enabledServices)
 	if err != nil {
 		return fmt.Errorf("failed to create MCP server: %w", err)
 	}

--- a/tests/e2e/entity_anchored_recall_test.go
+++ b/tests/e2e/entity_anchored_recall_test.go
@@ -1,0 +1,216 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cucumber/godog"
+)
+
+// TestEntityAnchoredRecall runs the entity-anchored recall acceptance
+// scenarios (epic #409, story #412): episodic_recall anchored on one or more
+// resource URNs returns the events involving them, via the event-reference
+// projection. Anchored reads are eventually consistent, so this suite runs
+// the background subscribers in-process and polls, like event_references.
+// Filter on demand with:
+// GODOG_TAGS=@wip go test ./tests/e2e/ -run TestEntityAnchoredRecall -v
+func TestEntityAnchoredRecall(t *testing.T) {
+	tags := "~@wip"
+	if override := os.Getenv("GODOG_TAGS"); override != "" {
+		tags = override
+	}
+	suite := godog.TestSuite{
+		Name:                "entity-anchored-recall",
+		ScenarioInitializer: initEntityAnchoredRecallScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"features/entity_anchored_recall.feature"},
+			Tags:     tags,
+			Strict:   true,
+			TestingT: t,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("entity-anchored recall acceptance scenarios failed")
+	}
+}
+
+type anchoredWorld struct {
+	*eventRefsWorld
+}
+
+func initEntityAnchoredRecallScenario(sc *godog.ScenarioContext) {
+	w := &anchoredWorld{eventRefsWorld: &eventRefsWorld{episodicWorld: &episodicWorld{
+		mcpWorld:   &mcpWorld{runWorkers: true},
+		aggregates: map[string]string{},
+		seqs:       map[string]int{},
+	}}}
+
+	sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		w.teardown()
+		return ctx, nil
+	})
+
+	sc.Step(`^a clean WeOS knowledge graph$`, w.aCleanKnowledgeGraph)
+	sc.Step(`^the "([^"]*)" preset is installed$`, w.presetIsInstalled)
+	sc.Step(`^a "([^"]*)" named "([^"]*)" exists$`, w.aResourceExists)
+	sc.Step(`^a "([^"]*)" named "([^"]*)" exists linked to the project "([^"]*)"$`, w.aResourceExistsLinked)
+	sc.Step(`^the following activity is recorded in the event log:$`, w.activityIsRecorded)
+	sc.Step(`^(\d+) "([^"]*)" resources linked to "([^"]*)" were created on consecutive days starting "([^"]*)"$`,
+		w.linkedResourcesCreatedOnConsecutiveDays)
+	sc.Step(`^the project "([^"]*)" has since been deleted$`, w.projectDeleted)
+	sc.Step(`^I call episodic_recall for events about the resource named "([^"]*)"$`, w.callAboutResource)
+	sc.Step(`^I call episodic_recall for events about the resources named "([^"]*)" and "([^"]*)"$`,
+		w.callAboutResources)
+	sc.Step(`^I call episodic_recall for events about the resource "([^"]*)"$`, w.callAboutLiteral)
+	sc.Step(`^I call episodic_recall with the filters:$`, w.callWithFilters)
+	sc.Step(`^I have recalled the first page of events about "([^"]*)"$`, w.recallFirstPageAbout)
+	sc.Step(`^I call episodic_recall with the cursor from the first page$`, w.callWithCursor)
+	sc.Step(`^the call succeeds$`, w.theCallSucceeds)
+	sc.Step(`^the call fails with a validation error$`, w.theCallFailsWithValidationError)
+	sc.Step(`^the recall includes the "([^"]*)" event for "([^"]*)"$`, w.recallIncludesEventForPolled)
+	sc.Step(`^the recall does not include an event for "([^"]*)"$`, w.recallExcludesEventsFor)
+	sc.Step(`^the recall returns exactly these events in order:$`, w.recallReturnsExactlyPolled)
+	sc.Step(`^the recall returns (\d+) events$`, w.recallReturnsCountPolled)
+	sc.Step(`^the recall returns no events$`, w.recallReturnsNone)
+	sc.Step(`^the recall reports more events are available$`, w.recallReportsMore)
+	sc.Step(`^the recall reports no more events are available$`, w.recallReportsNoMore)
+	sc.Step(`^the recall provides a cursor for the next page$`, w.recallProvidesCursor)
+	sc.Step(`^no event from the first page is repeated$`, w.noFirstPageEventRepeated)
+	sc.Step(`^the referenced resources for that event include "([^"]*)"$`, w.matchedEventRefsInclude)
+	sc.Step(`^the error explains the resource URN is invalid$`, w.errorExplainsInvalidAnchor)
+}
+
+// --- Actions ---
+
+func (w *anchoredWorld) callAboutResources(ctx context.Context, first, second string) error {
+	anchors := make([]string, 0, 2)
+	for _, name := range []string{first, second} {
+		urn, ok := w.aggregates[name]
+		if !ok {
+			return fmt.Errorf("no seeded resource named %q", name)
+		}
+		anchors = append(anchors, urn)
+	}
+	return w.callEpisodic(ctx, map[string]any{"about": anchors})
+}
+
+func (w *anchoredWorld) callAboutLiteral(ctx context.Context, urn string) error {
+	return w.callEpisodic(ctx, map[string]any{"about": []string{urn}})
+}
+
+// linkedResourcesCreatedOnConsecutiveDays seeds count resources whose payload
+// references the named project, one day apart.
+func (w *anchoredWorld) linkedResourcesCreatedOnConsecutiveDays(
+	ctx context.Context, count int, typeSlug, projectName, start string,
+) error {
+	projectURN, ok := w.aggregates[projectName]
+	if !ok {
+		return fmt.Errorf("no seeded resource named %q", projectName)
+	}
+	startAt, err := parseOccurredAt(start)
+	if err != nil {
+		return err
+	}
+	for i := range count {
+		name := fmt.Sprintf("%s %03d", typeSlug, i+1)
+		if err := w.seedEvent(ctx, typeSlug, name, map[string]any{"project": projectURN},
+			"Resource.Created", startAt.AddDate(0, 0, i)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// recallFirstPageAbout waits for the anchored view to stabilize (the
+// projection is asynchronous), then pins page one of the anchored query.
+func (w *anchoredWorld) recallFirstPageAbout(ctx context.Context, name string) error {
+	urn, ok := w.aggregates[name]
+	if !ok {
+		return fmt.Errorf("no seeded resource named %q", name)
+	}
+	// The page-one capture is only meaningful once the projection has caught
+	// up past a full default page — this step exists for the cursor
+	// scenarios, which seed >20 anchored events; reusing it with a smaller
+	// fixture would never stabilize and error out below. Never proceed with a
+	// partial page: the downstream failures ("no cursor captured") would
+	// point away from the real cause.
+	probe := map[string]any{"about": []string{urn}, "limit": 100}
+	deadline := time.Now().Add(refsPollTimeout)
+	prev, stable := -1, 0
+	for stable < 2 {
+		if time.Now().After(deadline) {
+			return fmt.Errorf(
+				"anchored projection did not stabilize past 20 events within %s (last count %d)",
+				refsPollTimeout, prev)
+		}
+		if err := w.callEpisodic(ctx, probe); err != nil {
+			return err
+		}
+		page, err := w.page()
+		if err != nil {
+			return fmt.Errorf("anchored probe: %w", err)
+		}
+		if n := len(page.Events); n == prev && n > 20 {
+			stable++
+		} else {
+			stable = 0
+			prev = len(page.Events)
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	if err := w.callAboutResource(ctx, name); err != nil {
+		return err
+	}
+	return w.captureFirstPage()
+}
+
+// --- Outcomes ---
+
+// pollAssert retries a page-level assertion while the reference projection
+// catches up, re-running the last recall between attempts.
+func (w *anchoredWorld) pollAssert(ctx context.Context, assert func() error) error {
+	deadline := time.Now().Add(refsPollTimeout)
+	for {
+		err := assert()
+		if err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return err
+		}
+		time.Sleep(100 * time.Millisecond)
+		if w.lastArgs == nil {
+			continue
+		}
+		if callErr := w.callEpisodic(ctx, w.lastArgs); callErr != nil {
+			return callErr
+		}
+	}
+}
+
+func (w *anchoredWorld) recallIncludesEventForPolled(
+	ctx context.Context, eventType, name string,
+) error {
+	return w.pollAssert(ctx, func() error { return w.recallIncludesEventFor(eventType, name) })
+}
+
+func (w *anchoredWorld) recallReturnsExactlyPolled(ctx context.Context, table *godog.Table) error {
+	return w.pollAssert(ctx, func() error { return w.recallReturnsExactly(table) })
+}
+
+func (w *anchoredWorld) recallReturnsCountPolled(ctx context.Context, count int) error {
+	return w.pollAssert(ctx, func() error { return w.recallReturnsCount(count) })
+}
+
+func (w *anchoredWorld) errorExplainsInvalidAnchor() error {
+	msg := strings.ToLower(w.errMessage())
+	if !strings.Contains(msg, "resource urn") || !strings.Contains(msg, "invalid") {
+		return fmt.Errorf("error %q does not explain the resource URN is invalid", w.errMessage())
+	}
+	return nil
+}

--- a/tests/e2e/episodic_recall_test.go
+++ b/tests/e2e/episodic_recall_test.go
@@ -56,10 +56,9 @@ type episodicWorld struct {
 	// seqs tracks the next sequence number per aggregate.
 	seqs      map[string]int
 	firstPage *episodicPage
-	// firstFrom/firstUntil replay the first page's window on the cursor call,
-	// the same way resource_list callers re-send their filters each page.
-	firstFrom  string
-	firstUntil string
+	// firstArgs replays the first page's filters on the cursor call, the same
+	// way resource_list callers re-send their filters each page.
+	firstArgs map[string]any
 	// lastMatched is the event the most recent includes-assertion found, for
 	// follow-up "that event" assertions. lastArgs and the lastInclude pair
 	// let async-projection assertions re-run that call+match while polling.
@@ -297,7 +296,7 @@ func (w *episodicWorld) callAboutResource(ctx context.Context, name string) erro
 	if !ok {
 		return fmt.Errorf("no seeded resource named %q", name)
 	}
-	return w.callEpisodic(ctx, map[string]any{"about": aggregateID})
+	return w.callEpisodic(ctx, map[string]any{"about": []string{aggregateID}})
 }
 
 func (w *episodicWorld) callEventType(ctx context.Context, eventType string) error {
@@ -318,6 +317,14 @@ func (w *episodicWorld) callWithFilters(ctx context.Context, table *godog.Table)
 		if len(row.Cells) != 2 {
 			return fmt.Errorf("filter rows need exactly a filter and a value")
 		}
+		if row.Cells[0].Value == "about" {
+			urn, ok := w.aggregates[row.Cells[1].Value]
+			if !ok {
+				return fmt.Errorf("no seeded resource named %q", row.Cells[1].Value)
+			}
+			args["about"] = []string{urn}
+			continue
+		}
 		key, ok := keys[row.Cells[0].Value]
 		if !ok {
 			return fmt.Errorf("unsupported filter %q", row.Cells[0].Value)
@@ -335,12 +342,18 @@ func (w *episodicWorld) recallFirstPage(ctx context.Context, from, until string)
 	if err := w.callBetween(ctx, from, until); err != nil {
 		return err
 	}
+	return w.captureFirstPage()
+}
+
+// captureFirstPage stashes the current response and its arguments so the
+// cursor step can continue the same query, whatever its filters were.
+func (w *episodicWorld) captureFirstPage() error {
 	page, err := w.page()
 	if err != nil {
 		return fmt.Errorf("first page: %w", err)
 	}
 	w.firstPage = page
-	w.firstFrom, w.firstUntil = from, until
+	w.firstArgs = w.lastArgs
 	return nil
 }
 
@@ -380,9 +393,10 @@ func (w *episodicWorld) callWithCursor(ctx context.Context) error {
 	if w.firstPage == nil || w.firstPage.Cursor == "" {
 		return fmt.Errorf("no cursor captured from a first page")
 	}
-	return w.callEpisodic(ctx, map[string]any{
-		"from": w.firstFrom, "until": w.firstUntil, "cursor": w.firstPage.Cursor,
-	})
+	args := map[string]any{}
+	maps.Copy(args, w.firstArgs)
+	args["cursor"] = w.firstPage.Cursor
+	return w.callEpisodic(ctx, args)
 }
 
 // --- Outcomes ---

--- a/tests/e2e/episodic_recall_test.go
+++ b/tests/e2e/episodic_recall_test.go
@@ -1,0 +1,663 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/pkg/identity"
+
+	pericarpdomain "github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
+	"github.com/cucumber/godog"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestEpisodicRecall runs the episodic_recall MCP-tool acceptance scenarios
+// (epic #409, story #410) against a freshly booted application with a clean
+// SQLite database. Filter on demand with:
+// GODOG_TAGS=@wip go test ./tests/e2e/ -run TestEpisodicRecall -v
+func TestEpisodicRecall(t *testing.T) {
+	tags := "~@wip"
+	if override := os.Getenv("GODOG_TAGS"); override != "" {
+		tags = override
+	}
+	suite := godog.TestSuite{
+		Name:                "episodic-recall",
+		ScenarioInitializer: initEpisodicRecallScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"features/episodic_recall.feature"},
+			Tags:     tags,
+			Strict:   true,
+			TestingT: t,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("episodic recall acceptance scenarios failed")
+	}
+}
+
+// episodicWorld extends the shared MCP world with event-log seeding and the
+// bookkeeping the pagination/determinism scenarios need.
+type episodicWorld struct {
+	*mcpWorld
+	// aggregates maps a seeded resource's name to its aggregate URN so
+	// scenarios can speak in names while assertions match on IDs.
+	aggregates map[string]string
+	// seqs tracks the next sequence number per aggregate.
+	seqs      map[string]int
+	firstPage *episodicPage
+	// firstFrom/firstUntil replay the first page's window on the cursor call,
+	// the same way resource_list callers re-send their filters each page.
+	firstFrom  string
+	firstUntil string
+	// lastMatched is the event the most recent includes-assertion found, for
+	// follow-up "that event" assertions.
+	lastMatched *episodicEvent
+	// secondText holds the second response of the determinism scenario.
+	secondText string
+}
+
+// episodicEvent mirrors the compact result shape episodic_recall returns.
+type episodicEvent struct {
+	ID           string `json:"id"`
+	EventType    string `json:"eventType"`
+	Timestamp    string `json:"timestamp"`
+	AggregateID  string `json:"aggregateId"`
+	ResourceType string `json:"resourceType"`
+	Summary      string `json:"summary"`
+}
+
+type episodicPage struct {
+	Events  []episodicEvent `json:"events"`
+	Cursor  string          `json:"cursor"`
+	HasMore bool            `json:"has_more"`
+}
+
+func initEpisodicRecallScenario(sc *godog.ScenarioContext) {
+	w := &episodicWorld{
+		mcpWorld:   &mcpWorld{},
+		aggregates: map[string]string{},
+		seqs:       map[string]int{},
+	}
+
+	sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		w.teardown()
+		return ctx, nil
+	})
+
+	sc.Step(`^a clean WeOS knowledge graph$`, w.aCleanKnowledgeGraph)
+	sc.Step(`^the "([^"]*)" preset is installed$`, w.presetIsInstalled)
+	sc.Step(`^the following activity is recorded in the event log:$`, w.activityIsRecorded)
+	sc.Step(`^(\d+) "([^"]*)" resources were created on consecutive days starting "([^"]*)"$`,
+		w.resourcesCreatedOnConsecutiveDays)
+	sc.Step(`^I call episodic_recall for events between "([^"]*)" and "([^"]*)"$`, w.callBetween)
+	sc.Step(`^I call episodic_recall for events between "([^"]*)" and "([^"]*)" twice$`, w.callBetweenTwice)
+	sc.Step(`^I call episodic_recall for events from the last (\d+) days$`, w.callLastDays)
+	sc.Step(`^I call episodic_recall for events about the resource named "([^"]*)"$`, w.callAboutResource)
+	sc.Step(`^I call episodic_recall for events of type "([^"]*)"$`, w.callEventType)
+	sc.Step(`^I call episodic_recall for events of resource type "([^"]*)"$`, w.callResourceType)
+	sc.Step(`^I call episodic_recall with the filters:$`, w.callWithFilters)
+	sc.Step(`^I call episodic_recall requesting up to (\d+) events$`, w.callWithLimit)
+	sc.Step(`^I have recalled the first page of events between "([^"]*)" and "([^"]*)"$`, w.recallFirstPage)
+	sc.Step(`^I call episodic_recall with the cursor from the first page$`, w.callWithCursor)
+	sc.Step(`^I call episodic_recall with the cursor "([^"]*)"$`, w.callWithLiteralCursor)
+	sc.Step(`^I call resource_create for type "([^"]*)" with the data:$`, w.iCallResourceCreateTracked)
+	sc.Step(`^the call succeeds$`, w.theCallSucceeds)
+	sc.Step(`^the call fails with a validation error$`, w.theCallFailsWithValidationError)
+	sc.Step(`^the recall returns exactly these events in order:$`, w.recallReturnsExactly)
+	sc.Step(`^the recall returns (\d+) events$`, w.recallReturnsCount)
+	sc.Step(`^the recall returns no events$`, w.recallReturnsNone)
+	sc.Step(`^the recall reports more events are available$`, w.recallReportsMore)
+	sc.Step(`^the recall reports no more events are available$`, w.recallReportsNoMore)
+	sc.Step(`^the recall provides a cursor for the next page$`, w.recallProvidesCursor)
+	sc.Step(`^no event from the first page is repeated$`, w.noFirstPageEventRepeated)
+	sc.Step(`^every recalled event carries:$`, w.everyEventCarries)
+	sc.Step(`^the recall does not include the full payload text "([^"]*)"$`, w.recallExcludesPayloadText)
+	sc.Step(`^every recalled event has type "([^"]*)"$`, w.everyEventHasType)
+	sc.Step(`^every recalled event is for a "([^"]*)" resource$`, w.everyEventIsForResourceType)
+	sc.Step(`^the recall includes the "([^"]*)" event for "([^"]*)"$`, w.recallIncludesEventFor)
+	sc.Step(`^the recall does not include an event for "([^"]*)"$`, w.recallExcludesEventsFor)
+	sc.Step(`^the error explains the time range is invalid$`, w.errorExplainsInvalidTimeRange)
+	sc.Step(`^the error explains the cursor is invalid$`, w.errorExplainsInvalidCursor)
+	sc.Step(`^the payload summary for that event carries "([^"]*)"$`, w.matchedEventSummaryCarries)
+	sc.Step(`^both recalls return identical events in identical order$`, w.bothRecallsIdentical)
+}
+
+// --- Seeding ---
+
+var daysAgo = regexp.MustCompile(`^(\d+) days? ago$`)
+
+// parseOccurredAt accepts RFC3339 or the relative "N days ago" the feature
+// file uses for scenarios anchored to the current date.
+func parseOccurredAt(s string) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.UTC(), nil
+	}
+	if m := daysAgo.FindStringSubmatch(strings.TrimSpace(s)); m != nil {
+		days, err := strconv.Atoi(m[1])
+		if err == nil {
+			return time.Now().UTC().AddDate(0, 0, -days), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unsupported occurred-at value %q", s)
+}
+
+// seedEvent appends one event with a controlled occurred-at timestamp
+// directly to the event store — the entity API always stamps time.Now(), so
+// backdating has to bypass it. Payload shapes mirror the real resource events.
+func (w *episodicWorld) seedEvent(
+	ctx context.Context, typeSlug, name, description, eventType string, occurredAt time.Time,
+) error {
+	if w.eventStore == nil {
+		return fmt.Errorf("application not booted")
+	}
+	aggregateID, ok := w.aggregates[name]
+	if !ok {
+		aggregateID = identity.NewResource(typeSlug)
+		w.aggregates[name] = aggregateID
+	}
+	w.seqs[aggregateID]++
+
+	data := map[string]any{"name": name}
+	if description != "" {
+		data["description"] = description
+	}
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	var payload any
+	switch eventType {
+	case "Resource.Created":
+		payload = entities.ResourceCreated{TypeSlug: typeSlug, Data: raw, Timestamp: occurredAt}
+	case "Resource.Updated":
+		payload = entities.ResourceUpdated{Data: raw, Timestamp: occurredAt}
+	default:
+		return fmt.Errorf("seeding step does not support event type %q", eventType)
+	}
+
+	envelope := pericarpdomain.NewEventEnvelope(payload, aggregateID, eventType, w.seqs[aggregateID])
+	envelope.Created = occurredAt
+	return w.eventStore.Append(ctx, aggregateID, -1, envelope)
+}
+
+func (w *episodicWorld) activityIsRecorded(ctx context.Context, table *godog.Table) error {
+	if len(table.Rows) < 2 {
+		return fmt.Errorf("activity table needs a header and at least one row")
+	}
+	cols := map[string]int{}
+	for i, cell := range table.Rows[0].Cells {
+		cols[cell.Value] = i
+	}
+	for _, required := range []string{"resource-type", "name", "event-type", "occurred-at"} {
+		if _, ok := cols[required]; !ok {
+			return fmt.Errorf("activity table is missing the %q column", required)
+		}
+	}
+	for _, row := range table.Rows[1:] {
+		occurredAt, err := parseOccurredAt(row.Cells[cols["occurred-at"]].Value)
+		if err != nil {
+			return err
+		}
+		description := ""
+		if i, ok := cols["description"]; ok {
+			description = row.Cells[i].Value
+		}
+		if err := w.seedEvent(ctx,
+			row.Cells[cols["resource-type"]].Value,
+			row.Cells[cols["name"]].Value,
+			description,
+			row.Cells[cols["event-type"]].Value,
+			occurredAt,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *episodicWorld) resourcesCreatedOnConsecutiveDays(
+	ctx context.Context, count int, typeSlug, start string,
+) error {
+	startAt, err := parseOccurredAt(start)
+	if err != nil {
+		return err
+	}
+	for i := range count {
+		name := fmt.Sprintf("%s %03d", typeSlug, i+1)
+		if err := w.seedEvent(
+			ctx, typeSlug, name, "", "Resource.Created", startAt.AddDate(0, 0, i),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// --- Actions ---
+
+func (w *episodicWorld) callEpisodic(ctx context.Context, args map[string]any) error {
+	raw, err := json.Marshal(args)
+	if err != nil {
+		return err
+	}
+	res, err := w.client.CallTool(ctx, &mcp.CallToolParams{
+		Name: "episodic_recall", Arguments: json.RawMessage(raw),
+	})
+	w.lastResult = res
+	w.lastErr = err
+	w.lastText = textOf(res)
+	return nil
+}
+
+func (w *episodicWorld) callBetween(ctx context.Context, from, until string) error {
+	return w.callEpisodic(ctx, map[string]any{"from": from, "until": until})
+}
+
+func (w *episodicWorld) callBetweenTwice(ctx context.Context, from, until string) error {
+	if err := w.callBetween(ctx, from, until); err != nil {
+		return err
+	}
+	first := w.lastText
+	if err := w.callBetween(ctx, from, until); err != nil {
+		return err
+	}
+	w.secondText = w.lastText
+	w.lastText = first
+	return nil
+}
+
+func (w *episodicWorld) callLastDays(ctx context.Context, days int) error {
+	return w.callEpisodic(ctx, map[string]any{"from": fmt.Sprintf("last %d days", days)})
+}
+
+func (w *episodicWorld) callAboutResource(ctx context.Context, name string) error {
+	aggregateID, ok := w.aggregates[name]
+	if !ok {
+		return fmt.Errorf("no seeded resource named %q", name)
+	}
+	return w.callEpisodic(ctx, map[string]any{"about": aggregateID})
+}
+
+func (w *episodicWorld) callEventType(ctx context.Context, eventType string) error {
+	return w.callEpisodic(ctx, map[string]any{"eventType": eventType})
+}
+
+func (w *episodicWorld) callResourceType(ctx context.Context, typeSlug string) error {
+	return w.callEpisodic(ctx, map[string]any{"resourceType": typeSlug})
+}
+
+func (w *episodicWorld) callWithFilters(ctx context.Context, table *godog.Table) error {
+	args := map[string]any{}
+	keys := map[string]string{
+		"from": "from", "until": "until",
+		"event-type": "eventType", "resource-type": "resourceType",
+	}
+	for _, row := range table.Rows[1:] {
+		if len(row.Cells) != 2 {
+			return fmt.Errorf("filter rows need exactly a filter and a value")
+		}
+		key, ok := keys[row.Cells[0].Value]
+		if !ok {
+			return fmt.Errorf("unsupported filter %q", row.Cells[0].Value)
+		}
+		args[key] = row.Cells[1].Value
+	}
+	return w.callEpisodic(ctx, args)
+}
+
+func (w *episodicWorld) callWithLimit(ctx context.Context, limit int) error {
+	return w.callEpisodic(ctx, map[string]any{"limit": limit})
+}
+
+func (w *episodicWorld) recallFirstPage(ctx context.Context, from, until string) error {
+	if err := w.callBetween(ctx, from, until); err != nil {
+		return err
+	}
+	page, err := w.page()
+	if err != nil {
+		return fmt.Errorf("first page: %w", err)
+	}
+	w.firstPage = page
+	w.firstFrom, w.firstUntil = from, until
+	return nil
+}
+
+func (w *episodicWorld) callWithLiteralCursor(ctx context.Context, cursor string) error {
+	return w.callEpisodic(ctx, map[string]any{"cursor": cursor})
+}
+
+// iCallResourceCreateTracked creates a resource through the live tool and
+// records its name → URN mapping so recall assertions can resolve it like the
+// seeded ones.
+func (w *episodicWorld) iCallResourceCreateTracked(
+	ctx context.Context, typeSlug string, data *godog.DocString,
+) error {
+	if err := w.iCallResourceCreate(ctx, typeSlug, data); err != nil {
+		return err
+	}
+	if w.lastErr != nil || w.lastResult == nil || w.lastResult.IsError {
+		return fmt.Errorf("resource_create failed: %s", w.lastText)
+	}
+	var in struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(data.Content), &in); err != nil || in.Name == "" {
+		return fmt.Errorf("no name in resource_create input: %s", data.Content)
+	}
+	var out struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(w.lastText), &out); err != nil || out.ID == "" {
+		return fmt.Errorf("no id in resource_create result: %s", w.lastText)
+	}
+	w.aggregates[in.Name] = out.ID
+	return nil
+}
+
+func (w *episodicWorld) callWithCursor(ctx context.Context) error {
+	if w.firstPage == nil || w.firstPage.Cursor == "" {
+		return fmt.Errorf("no cursor captured from a first page")
+	}
+	return w.callEpisodic(ctx, map[string]any{
+		"from": w.firstFrom, "until": w.firstUntil, "cursor": w.firstPage.Cursor,
+	})
+}
+
+// --- Outcomes ---
+
+func (w *episodicWorld) page() (*episodicPage, error) {
+	if w.lastErr != nil {
+		return nil, fmt.Errorf("episodic_recall protocol error: %v", w.lastErr)
+	}
+	if w.lastResult == nil || w.lastResult.IsError {
+		return nil, fmt.Errorf("episodic_recall failed: %s", w.lastText)
+	}
+	var page episodicPage
+	if err := json.Unmarshal([]byte(w.lastText), &page); err != nil {
+		return nil, fmt.Errorf("unparseable episodic_recall output: %s", w.lastText)
+	}
+	return &page, nil
+}
+
+// resourceName reverse-maps an aggregate URN to the seeded resource's name
+// for readable assertion failures.
+func (w *episodicWorld) resourceName(aggregateID string) string {
+	for name, id := range w.aggregates {
+		if id == aggregateID {
+			return name
+		}
+	}
+	return aggregateID
+}
+
+func (w *episodicWorld) recallReturnsExactly(table *godog.Table) error {
+	page, err := w.page()
+	if err != nil {
+		return err
+	}
+	expected := table.Rows[1:]
+	if len(page.Events) != len(expected) {
+		return fmt.Errorf("recall returned %d events, want %d: %s",
+			len(page.Events), len(expected), w.lastText)
+	}
+	for i, row := range expected {
+		wantName, wantType := row.Cells[0].Value, row.Cells[1].Value
+		wantAggregate, ok := w.aggregates[wantName]
+		if !ok {
+			return fmt.Errorf("no seeded resource named %q", wantName)
+		}
+		got := page.Events[i]
+		if got.AggregateID != wantAggregate || got.EventType != wantType {
+			return fmt.Errorf("event %d = %s on %q, want %s on %q",
+				i, got.EventType, w.resourceName(got.AggregateID), wantType, wantName)
+		}
+	}
+	return nil
+}
+
+func (w *episodicWorld) recallReturnsCount(count int) error {
+	page, err := w.page()
+	if err != nil {
+		return err
+	}
+	if len(page.Events) != count {
+		return fmt.Errorf("recall returned %d events, want %d", len(page.Events), count)
+	}
+	return nil
+}
+
+func (w *episodicWorld) recallReturnsNone() error {
+	return w.recallReturnsCount(0)
+}
+
+func (w *episodicWorld) recallReportsMore() error {
+	page, err := w.page()
+	if err != nil {
+		return err
+	}
+	if !page.HasMore {
+		return fmt.Errorf("recall reports no more events, want has_more")
+	}
+	return nil
+}
+
+func (w *episodicWorld) recallReportsNoMore() error {
+	page, err := w.page()
+	if err != nil {
+		return err
+	}
+	if page.HasMore {
+		return fmt.Errorf("recall reports more events, want none")
+	}
+	return nil
+}
+
+func (w *episodicWorld) recallProvidesCursor() error {
+	page, err := w.page()
+	if err != nil {
+		return err
+	}
+	if page.Cursor == "" {
+		return fmt.Errorf("recall provided no cursor")
+	}
+	return nil
+}
+
+func (w *episodicWorld) noFirstPageEventRepeated() error {
+	if w.firstPage == nil {
+		return fmt.Errorf("no first page captured")
+	}
+	page, err := w.page()
+	if err != nil {
+		return err
+	}
+	seen := make(map[string]bool, len(w.firstPage.Events))
+	for _, e := range w.firstPage.Events {
+		seen[e.ID] = true
+	}
+	for _, e := range page.Events {
+		if seen[e.ID] {
+			return fmt.Errorf("event %s appears on both pages", e.ID)
+		}
+	}
+	return nil
+}
+
+func (w *episodicWorld) everyEventCarries(table *godog.Table) error {
+	page, err := w.page()
+	if err != nil {
+		return err
+	}
+	if len(page.Events) == 0 {
+		return fmt.Errorf("recall returned no events to inspect")
+	}
+	for i, e := range page.Events {
+		for _, row := range table.Rows[1:] {
+			if err := eventCarries(e, row.Cells[0].Value); err != nil {
+				return fmt.Errorf("event %d: %w", i, err)
+			}
+		}
+	}
+	return nil
+}
+
+func eventCarries(e episodicEvent, field string) error {
+	switch field {
+	case "event URN":
+		if !strings.HasPrefix(e.ID, "urn:event:") {
+			return fmt.Errorf("id %q is not an event URN", e.ID)
+		}
+	case "event type":
+		if e.EventType == "" {
+			return fmt.Errorf("missing event type")
+		}
+	case "timestamp":
+		if _, err := time.Parse(time.RFC3339, e.Timestamp); err != nil {
+			return fmt.Errorf("timestamp %q is not RFC3339", e.Timestamp)
+		}
+	case "aggregate ID":
+		if e.AggregateID == "" {
+			return fmt.Errorf("missing aggregate ID")
+		}
+	case "payload summary":
+		if e.Summary == "" {
+			return fmt.Errorf("missing payload summary")
+		}
+	default:
+		return fmt.Errorf("unknown field %q", field)
+	}
+	return nil
+}
+
+func (w *episodicWorld) recallExcludesPayloadText(text string) error {
+	if _, err := w.page(); err != nil {
+		return err
+	}
+	if strings.Contains(w.lastText, text) {
+		return fmt.Errorf("full payload text %q leaked into the recall output", text)
+	}
+	return nil
+}
+
+func (w *episodicWorld) everyEventHasType(eventType string) error {
+	page, err := w.page()
+	if err != nil {
+		return err
+	}
+	if len(page.Events) == 0 {
+		return fmt.Errorf("recall returned no events")
+	}
+	for _, e := range page.Events {
+		if e.EventType != eventType {
+			return fmt.Errorf("event %s has type %s, want %s", e.ID, e.EventType, eventType)
+		}
+	}
+	return nil
+}
+
+func (w *episodicWorld) everyEventIsForResourceType(typeSlug string) error {
+	page, err := w.page()
+	if err != nil {
+		return err
+	}
+	if len(page.Events) == 0 {
+		return fmt.Errorf("recall returned no events")
+	}
+	for _, e := range page.Events {
+		if !strings.HasPrefix(e.AggregateID, "urn:"+typeSlug+":") {
+			return fmt.Errorf("event %s is on %s, want a %q resource", e.ID, e.AggregateID, typeSlug)
+		}
+	}
+	return nil
+}
+
+func (w *episodicWorld) recallIncludesEventFor(eventType, name string) error {
+	page, err := w.page()
+	if err != nil {
+		return err
+	}
+	aggregateID, ok := w.aggregates[name]
+	if !ok {
+		return fmt.Errorf("no seeded resource named %q", name)
+	}
+	for i, e := range page.Events {
+		if e.AggregateID == aggregateID && e.EventType == eventType {
+			w.lastMatched = &page.Events[i]
+			return nil
+		}
+	}
+	return fmt.Errorf("recall missing the %s event for %q: %s", eventType, name, w.lastText)
+}
+
+func (w *episodicWorld) recallExcludesEventsFor(name string) error {
+	page, err := w.page()
+	if err != nil {
+		return err
+	}
+	aggregateID, ok := w.aggregates[name]
+	if !ok {
+		return fmt.Errorf("no seeded resource named %q", name)
+	}
+	for _, e := range page.Events {
+		if e.AggregateID == aggregateID {
+			return fmt.Errorf("recall unexpectedly includes the %s event for %q", e.EventType, name)
+		}
+	}
+	return nil
+}
+
+func (w *episodicWorld) errorExplainsInvalidCursor() error {
+	msg := strings.ToLower(w.errMessage())
+	if !strings.Contains(msg, "cursor") {
+		return fmt.Errorf("error %q does not explain the cursor is invalid", w.errMessage())
+	}
+	return nil
+}
+
+func (w *episodicWorld) matchedEventSummaryCarries(text string) error {
+	if w.lastMatched == nil {
+		return fmt.Errorf("no event matched by a preceding includes step")
+	}
+	if !strings.Contains(w.lastMatched.Summary, text) {
+		return fmt.Errorf("summary %q does not carry %q", w.lastMatched.Summary, text)
+	}
+	return nil
+}
+
+func (w *episodicWorld) errorExplainsInvalidTimeRange() error {
+	msg := strings.ToLower(w.errMessage())
+	if !strings.Contains(msg, "time range") {
+		return fmt.Errorf("error %q does not explain the time range is invalid", w.errMessage())
+	}
+	return nil
+}
+
+func (w *episodicWorld) bothRecallsIdentical() error {
+	first, err := w.page()
+	if err != nil {
+		return fmt.Errorf("first recall: %w", err)
+	}
+	var second episodicPage
+	if err := json.Unmarshal([]byte(w.secondText), &second); err != nil {
+		return fmt.Errorf("unparseable second recall output: %s", w.secondText)
+	}
+	if len(first.Events) != len(second.Events) {
+		return fmt.Errorf("recalls returned %d and %d events", len(first.Events), len(second.Events))
+	}
+	for i := range first.Events {
+		if first.Events[i] != second.Events[i] {
+			return fmt.Errorf("event %d differs between recalls: %+v vs %+v",
+				i, first.Events[i], second.Events[i])
+		}
+	}
+	return nil
+}

--- a/tests/e2e/episodic_recall_test.go
+++ b/tests/e2e/episodic_recall_test.go
@@ -53,6 +53,9 @@ type episodicWorld struct {
 	// aggregates maps a seeded resource's name to its aggregate URN so
 	// scenarios can speak in names while assertions match on IDs.
 	aggregates map[string]string
+	// eventIDs maps "name|eventType" of a seeded event to its urn:event: URN
+	// so similarity scenarios can name their seed.
+	eventIDs map[string]string
 	// seqs tracks the next sequence number per aggregate.
 	seqs      map[string]int
 	firstPage *episodicPage
@@ -190,6 +193,9 @@ func (w *episodicWorld) seedEvent(
 
 	envelope := pericarpdomain.NewEventEnvelope(payload, aggregateID, eventType, w.seqs[aggregateID])
 	envelope.Created = occurredAt
+	if w.eventIDs != nil {
+		w.eventIDs[name+"|"+eventType] = "urn:event:" + envelope.ID
+	}
 	return w.eventStore.Append(ctx, aggregateID, -1, envelope)
 }
 

--- a/tests/e2e/episodic_recall_test.go
+++ b/tests/e2e/episodic_recall_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -59,20 +61,25 @@ type episodicWorld struct {
 	firstFrom  string
 	firstUntil string
 	// lastMatched is the event the most recent includes-assertion found, for
-	// follow-up "that event" assertions.
-	lastMatched *episodicEvent
+	// follow-up "that event" assertions. lastArgs and the lastInclude pair
+	// let async-projection assertions re-run that call+match while polling.
+	lastMatched     *episodicEvent
+	lastArgs        map[string]any
+	lastIncludeType string
+	lastIncludeName string
 	// secondText holds the second response of the determinism scenario.
 	secondText string
 }
 
 // episodicEvent mirrors the compact result shape episodic_recall returns.
 type episodicEvent struct {
-	ID           string `json:"id"`
-	EventType    string `json:"eventType"`
-	Timestamp    string `json:"timestamp"`
-	AggregateID  string `json:"aggregateId"`
-	ResourceType string `json:"resourceType"`
-	Summary      string `json:"summary"`
+	ID                  string   `json:"id"`
+	EventType           string   `json:"eventType"`
+	Timestamp           string   `json:"timestamp"`
+	AggregateID         string   `json:"aggregateId"`
+	ResourceType        string   `json:"resourceType"`
+	Summary             string   `json:"summary"`
+	ReferencedResources []string `json:"referencedResources"`
 }
 
 type episodicPage struct {
@@ -154,7 +161,7 @@ func parseOccurredAt(s string) (time.Time, error) {
 // directly to the event store — the entity API always stamps time.Now(), so
 // backdating has to bypass it. Payload shapes mirror the real resource events.
 func (w *episodicWorld) seedEvent(
-	ctx context.Context, typeSlug, name, description, eventType string, occurredAt time.Time,
+	ctx context.Context, typeSlug, name string, extra map[string]any, eventType string, occurredAt time.Time,
 ) error {
 	if w.eventStore == nil {
 		return fmt.Errorf("application not booted")
@@ -167,9 +174,7 @@ func (w *episodicWorld) seedEvent(
 	w.seqs[aggregateID]++
 
 	data := map[string]any{"name": name}
-	if description != "" {
-		data["description"] = description
-	}
+	maps.Copy(data, extra)
 	raw, err := json.Marshal(data)
 	if err != nil {
 		return err
@@ -207,14 +212,21 @@ func (w *episodicWorld) activityIsRecorded(ctx context.Context, table *godog.Tab
 		if err != nil {
 			return err
 		}
-		description := ""
-		if i, ok := cols["description"]; ok {
-			description = row.Cells[i].Value
+		extra := map[string]any{}
+		if i, ok := cols["description"]; ok && row.Cells[i].Value != "" {
+			extra["description"] = row.Cells[i].Value
+		}
+		if i, ok := cols["project"]; ok && row.Cells[i].Value != "" {
+			projectURN, ok := w.aggregates[row.Cells[i].Value]
+			if !ok {
+				return fmt.Errorf("project %q must be seeded before rows referencing it", row.Cells[i].Value)
+			}
+			extra["project"] = projectURN
 		}
 		if err := w.seedEvent(ctx,
 			row.Cells[cols["resource-type"]].Value,
 			row.Cells[cols["name"]].Value,
-			description,
+			extra,
 			row.Cells[cols["event-type"]].Value,
 			occurredAt,
 		); err != nil {
@@ -234,7 +246,7 @@ func (w *episodicWorld) resourcesCreatedOnConsecutiveDays(
 	for i := range count {
 		name := fmt.Sprintf("%s %03d", typeSlug, i+1)
 		if err := w.seedEvent(
-			ctx, typeSlug, name, "", "Resource.Created", startAt.AddDate(0, 0, i),
+			ctx, typeSlug, name, nil, "Resource.Created", startAt.AddDate(0, 0, i),
 		); err != nil {
 			return err
 		}
@@ -245,6 +257,7 @@ func (w *episodicWorld) resourcesCreatedOnConsecutiveDays(
 // --- Actions ---
 
 func (w *episodicWorld) callEpisodic(ctx context.Context, args map[string]any) error {
+	w.lastArgs = args
 	raw, err := json.Marshal(args)
 	if err != nil {
 		return err
@@ -581,6 +594,7 @@ func (w *episodicWorld) everyEventIsForResourceType(typeSlug string) error {
 }
 
 func (w *episodicWorld) recallIncludesEventFor(eventType, name string) error {
+	w.lastIncludeType, w.lastIncludeName = eventType, name
 	page, err := w.page()
 	if err != nil {
 		return err
@@ -654,7 +668,7 @@ func (w *episodicWorld) bothRecallsIdentical() error {
 		return fmt.Errorf("recalls returned %d and %d events", len(first.Events), len(second.Events))
 	}
 	for i := range first.Events {
-		if first.Events[i] != second.Events[i] {
+		if !reflect.DeepEqual(first.Events[i], second.Events[i]) {
 			return fmt.Errorf("event %d differs between recalls: %+v vs %+v",
 				i, first.Events[i], second.Events[i])
 		}

--- a/tests/e2e/event_payload_fetch_test.go
+++ b/tests/e2e/event_payload_fetch_test.go
@@ -1,0 +1,198 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cucumber/godog"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestEventPayloadFetch runs the full-payload fetch acceptance scenarios
+// (epic #409, story #414): episodic_event_get returns one event's stored
+// payload by URN — the explicit drill-in complement to the compact recall
+// shape. Fetching reads the event store directly (no projection), so this
+// suite runs worker-less. Filter on demand with:
+// GODOG_TAGS=@wip go test ./tests/e2e/ -run TestEventPayloadFetch -v
+func TestEventPayloadFetch(t *testing.T) {
+	tags := "~@wip"
+	if override := os.Getenv("GODOG_TAGS"); override != "" {
+		tags = override
+	}
+	suite := godog.TestSuite{
+		Name:                "event-payload-fetch",
+		ScenarioInitializer: initEventPayloadFetchScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"features/event_payload_fetch.feature"},
+			Tags:     tags,
+			Strict:   true,
+			TestingT: t,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("event payload fetch acceptance scenarios failed")
+	}
+}
+
+// fetchedEvent mirrors episodic_event_get's output: the compact shape plus
+// the full stored payload.
+type fetchedEvent struct {
+	ID          string         `json:"id"`
+	EventType   string         `json:"eventType"`
+	Timestamp   string         `json:"timestamp"`
+	AggregateID string         `json:"aggregateId"`
+	Payload     map[string]any `json:"payload"`
+}
+
+type payloadFetchWorld struct {
+	*episodicWorld
+}
+
+func initEventPayloadFetchScenario(sc *godog.ScenarioContext) {
+	w := &payloadFetchWorld{episodicWorld: &episodicWorld{
+		mcpWorld:   &mcpWorld{},
+		aggregates: map[string]string{},
+		seqs:       map[string]int{},
+		eventIDs:   map[string]string{},
+	}}
+
+	sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		w.teardown()
+		return ctx, nil
+	})
+
+	sc.Step(`^a clean WeOS knowledge graph$`, w.aCleanKnowledgeGraph)
+	sc.Step(`^the "([^"]*)" preset is installed$`, w.presetIsInstalled)
+	sc.Step(`^the following activity is recorded in the event log:$`, w.activityIsRecorded)
+	sc.Step(`^I call episodic_recall for events between "([^"]*)" and "([^"]*)"$`, w.callBetween)
+	sc.Step(`^I call episodic_event_get with the URN of the "([^"]*)" event for "([^"]*)"$`, w.fetchNamedEvent)
+	sc.Step(`^I call episodic_event_get with the event "([^"]*)"$`, w.fetchLiteral)
+	sc.Step(`^I call episodic_event_get with the event URN from the first recalled event$`, w.fetchFirstRecalled)
+	sc.Step(`^the call succeeds$`, w.theCallSucceeds)
+	sc.Step(`^the call fails$`, w.theCallFails)
+	sc.Step(`^the call fails with a validation error$`, w.theCallFailsWithValidationError)
+	sc.Step(`^the fetched event carries:$`, w.fetchedEventCarries)
+	sc.Step(`^the fetched payload contains the text "([^"]*)"$`, w.fetchedPayloadContains)
+	sc.Step(`^the fetched event is the "([^"]*)" event for "([^"]*)"$`, w.fetchedEventIs)
+	sc.Step(`^the error explains the event is unknown$`, w.errorExplainsUnknownEvent)
+	sc.Step(`^the error explains the identifier must be an event URN$`, w.errorExplainsEventURNShape)
+}
+
+// --- Actions ---
+
+func (w *payloadFetchWorld) fetch(ctx context.Context, urn string) error {
+	res, err := w.client.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "episodic_event_get",
+		Arguments: json.RawMessage(fmt.Sprintf(`{"urn":%q}`, urn)),
+	})
+	w.lastResult = res
+	w.lastErr = err
+	w.lastText = textOf(res)
+	return nil
+}
+
+func (w *payloadFetchWorld) fetchNamedEvent(ctx context.Context, eventType, name string) error {
+	urn, ok := w.eventIDs[name+"|"+eventType]
+	if !ok {
+		return fmt.Errorf("no seeded %s event for %q", eventType, name)
+	}
+	return w.fetch(ctx, urn)
+}
+
+func (w *payloadFetchWorld) fetchLiteral(ctx context.Context, urn string) error {
+	return w.fetch(ctx, urn)
+}
+
+func (w *payloadFetchWorld) fetchFirstRecalled(ctx context.Context) error {
+	page, err := w.page()
+	if err != nil {
+		return fmt.Errorf("no recall to take a URN from: %w", err)
+	}
+	if len(page.Events) == 0 {
+		return fmt.Errorf("the recall returned no events to fetch")
+	}
+	return w.fetch(ctx, page.Events[0].ID)
+}
+
+// --- Outcomes ---
+
+func (w *payloadFetchWorld) fetched() (*fetchedEvent, error) {
+	if w.lastErr != nil {
+		return nil, fmt.Errorf("episodic_event_get protocol error: %v", w.lastErr)
+	}
+	if w.lastResult == nil || w.lastResult.IsError {
+		return nil, fmt.Errorf("episodic_event_get failed: %s", w.lastText)
+	}
+	var event fetchedEvent
+	if err := json.Unmarshal([]byte(w.lastText), &event); err != nil {
+		return nil, fmt.Errorf("unparseable episodic_event_get output: %s", w.lastText)
+	}
+	return &event, nil
+}
+
+func (w *payloadFetchWorld) fetchedEventCarries(table *godog.Table) error {
+	event, err := w.fetched()
+	if err != nil {
+		return err
+	}
+	shape := episodicEvent{
+		ID: event.ID, EventType: event.EventType,
+		Timestamp: event.Timestamp, AggregateID: event.AggregateID,
+	}
+	for _, row := range table.Rows[1:] {
+		if err := eventCarries(shape, row.Cells[0].Value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *payloadFetchWorld) fetchedPayloadContains(text string) error {
+	event, err := w.fetched()
+	if err != nil {
+		return err
+	}
+	raw, err := json.Marshal(event.Payload)
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(string(raw), text) {
+		return fmt.Errorf("fetched payload %s does not contain %q", raw, text)
+	}
+	return nil
+}
+
+func (w *payloadFetchWorld) fetchedEventIs(eventType, name string) error {
+	event, err := w.fetched()
+	if err != nil {
+		return err
+	}
+	aggregateID, ok := w.aggregates[name]
+	if !ok {
+		return fmt.Errorf("no seeded resource named %q", name)
+	}
+	if event.EventType != eventType || event.AggregateID != aggregateID {
+		return fmt.Errorf("fetched %s on %q, want %s on %q",
+			event.EventType, w.resourceName(event.AggregateID), eventType, name)
+	}
+	return nil
+}
+
+func (w *payloadFetchWorld) errorExplainsUnknownEvent() error {
+	if !strings.Contains(strings.ToLower(w.errMessage()), "unknown") {
+		return fmt.Errorf("error %q does not explain the event is unknown", w.errMessage())
+	}
+	return nil
+}
+
+func (w *payloadFetchWorld) errorExplainsEventURNShape() error {
+	if !strings.Contains(strings.ToLower(w.errMessage()), "event urn") {
+		return fmt.Errorf("error %q does not explain the identifier must be an event URN", w.errMessage())
+	}
+	return nil
+}

--- a/tests/e2e/event_references_test.go
+++ b/tests/e2e/event_references_test.go
@@ -1,0 +1,235 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cucumber/godog"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestEventReferences runs the event-reference projection acceptance
+// scenarios (epic #409, story #411): every recalled event reports the
+// resources it references, and the projection rebuilds from the event log.
+// Unlike the other MCP suites this one runs the background subscribers
+// in-process — the projection is asynchronous, so assertions poll.
+// Filter on demand with:
+// GODOG_TAGS=@wip go test ./tests/e2e/ -run TestEventReferences -v
+func TestEventReferences(t *testing.T) {
+	tags := "~@wip"
+	if override := os.Getenv("GODOG_TAGS"); override != "" {
+		tags = override
+	}
+	suite := godog.TestSuite{
+		Name:                "event-references",
+		ScenarioInitializer: initEventReferencesScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"features/event_references.feature"},
+			Tags:     tags,
+			Strict:   true,
+			TestingT: t,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("event reference acceptance scenarios failed")
+	}
+}
+
+// refsPollTimeout bounds how long assertions wait for the asynchronous
+// event-references subscriber to catch up.
+const refsPollTimeout = 5 * time.Second
+
+type eventRefsWorld struct {
+	*episodicWorld
+}
+
+func initEventReferencesScenario(sc *godog.ScenarioContext) {
+	w := &eventRefsWorld{episodicWorld: &episodicWorld{
+		mcpWorld:   &mcpWorld{runWorkers: true},
+		aggregates: map[string]string{},
+		seqs:       map[string]int{},
+	}}
+
+	sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		w.teardown()
+		return ctx, nil
+	})
+
+	sc.Step(`^a clean WeOS knowledge graph$`, w.aCleanKnowledgeGraph)
+	sc.Step(`^the "([^"]*)" preset is installed$`, w.presetIsInstalled)
+	sc.Step(`^the following activity is recorded in the event log:$`, w.activityIsRecorded)
+	sc.Step(`^I call episodic_recall for events between "([^"]*)" and "([^"]*)"$`, w.callBetween)
+	sc.Step(`^I call episodic_recall for events of type "([^"]*)"$`, w.callEventType)
+	sc.Step(`^the call succeeds$`, w.theCallSucceeds)
+	sc.Step(`^the recall includes the "([^"]*)" event for "([^"]*)"$`, w.recallIncludesEventFor)
+	sc.Step(`^a "([^"]*)" named "([^"]*)" exists$`, w.aResourceExists)
+	sc.Step(`^a "([^"]*)" named "([^"]*)" exists linked to the project "([^"]*)"$`, w.aResourceExistsLinked)
+	sc.Step(`^I create a "([^"]*)" named "([^"]*)" linked to the project "([^"]*)"$`, w.aResourceExistsLinked)
+	sc.Step(`^the project "([^"]*)" has since been deleted$`, w.projectDeleted)
+	sc.Step(`^the event reference projection is rebuilt from the event log$`, w.projectionRebuilt)
+	sc.Step(`^the referenced resources for that event are exactly:$`, w.matchedEventRefsExactly)
+	sc.Step(`^the referenced resources for that event include "([^"]*)"$`, w.matchedEventRefsInclude)
+}
+
+// createTracked creates a resource through the live resource_create tool and
+// records its name → URN mapping.
+func (w *eventRefsWorld) createTracked(
+	ctx context.Context, typeSlug, name string, data map[string]any,
+) error {
+	if data == nil {
+		data = map[string]any{}
+	}
+	data["name"] = name
+	raw, err := json.Marshal(map[string]any{"type_slug": typeSlug, "data": data})
+	if err != nil {
+		return err
+	}
+	res, err := w.client.CallTool(ctx, &mcp.CallToolParams{
+		Name: "resource_create", Arguments: json.RawMessage(raw),
+	})
+	if err != nil {
+		return fmt.Errorf("resource_create protocol error: %w", err)
+	}
+	if res.IsError {
+		return fmt.Errorf("resource_create failed: %s", textOf(res))
+	}
+	var out struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(textOf(res)), &out); err != nil || out.ID == "" {
+		return fmt.Errorf("no id in resource_create result: %s", textOf(res))
+	}
+	w.aggregates[name] = out.ID
+	return nil
+}
+
+func (w *eventRefsWorld) aResourceExists(ctx context.Context, typeSlug, name string) error {
+	return w.createTracked(ctx, typeSlug, name, nil)
+}
+
+func (w *eventRefsWorld) aResourceExistsLinked(
+	ctx context.Context, typeSlug, name, projectName string,
+) error {
+	projectURN, ok := w.aggregates[projectName]
+	if !ok {
+		return fmt.Errorf("no known project named %q", projectName)
+	}
+	return w.createTracked(ctx, typeSlug, name, map[string]any{"project": projectURN})
+}
+
+func (w *eventRefsWorld) projectDeleted(ctx context.Context, name string) error {
+	urn, ok := w.aggregates[name]
+	if !ok {
+		return fmt.Errorf("no known project named %q", name)
+	}
+	res, err := w.client.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "resource_delete",
+		Arguments: json.RawMessage(fmt.Sprintf(`{"id":%q}`, urn)),
+	})
+	if err != nil {
+		return fmt.Errorf("resource_delete protocol error: %w", err)
+	}
+	if res.IsError {
+		return fmt.Errorf("resource_delete failed: %s", textOf(res))
+	}
+	return nil
+}
+
+func (w *eventRefsWorld) projectionRebuilt(ctx context.Context) error {
+	if w.manager == nil {
+		return fmt.Errorf("worker manager not booted")
+	}
+	return w.manager.ResetCheckpoint(ctx, "event-references", true)
+}
+
+// pollMatchedRefs waits for the asynchronous projection to satisfy check on
+// the last matched event's references, re-running the last recall while the
+// subscriber catches up. Each poll re-matches from the fresh response — a
+// stale match must neither satisfy the check nor shape the timeout error —
+// and the freshest failure (include miss or refs mismatch) is what a timeout
+// reports.
+func (w *eventRefsWorld) pollMatchedRefs(ctx context.Context, check func([]string) error) error {
+	deadline := time.Now().Add(refsPollTimeout)
+	var lastErr error
+	for {
+		if w.lastMatched != nil {
+			if lastErr = check(w.lastMatched.ReferencedResources); lastErr == nil {
+				return nil
+			}
+		} else if lastErr == nil {
+			lastErr = fmt.Errorf("no event matched by a preceding includes step")
+		}
+		if time.Now().After(deadline) {
+			return lastErr
+		}
+		time.Sleep(100 * time.Millisecond)
+		if w.lastArgs == nil {
+			continue
+		}
+		if callErr := w.callEpisodic(ctx, w.lastArgs); callErr != nil {
+			return callErr
+		}
+		if w.lastIncludeType != "" {
+			w.lastMatched = nil
+			if inclErr := w.recallIncludesEventFor(w.lastIncludeType, w.lastIncludeName); inclErr != nil {
+				lastErr = inclErr
+			}
+		}
+	}
+}
+
+func (w *eventRefsWorld) matchedEventRefsExactly(ctx context.Context, table *godog.Table) error {
+	want := make([]string, 0, len(table.Rows)-1)
+	for _, row := range table.Rows[1:] {
+		urn, ok := w.aggregates[row.Cells[0].Value]
+		if !ok {
+			return fmt.Errorf("no known resource named %q", row.Cells[0].Value)
+		}
+		want = append(want, urn)
+	}
+	sort.Strings(want)
+	return w.pollMatchedRefs(ctx, func(got []string) error {
+		sorted := append([]string(nil), got...)
+		sort.Strings(sorted)
+		if len(sorted) != len(want) {
+			return fmt.Errorf("referenced resources = %v, want %v", w.named(sorted), w.named(want))
+		}
+		for i := range want {
+			if sorted[i] != want[i] {
+				return fmt.Errorf("referenced resources = %v, want %v", w.named(sorted), w.named(want))
+			}
+		}
+		return nil
+	})
+}
+
+func (w *eventRefsWorld) matchedEventRefsInclude(ctx context.Context, name string) error {
+	urn, ok := w.aggregates[name]
+	if !ok {
+		return fmt.Errorf("no known resource named %q", name)
+	}
+	return w.pollMatchedRefs(ctx, func(got []string) error {
+		for _, ref := range got {
+			if ref == urn {
+				return nil
+			}
+		}
+		return fmt.Errorf("referenced resources %v do not include %q", w.named(got), name)
+	})
+}
+
+// named maps URNs back to seeded names for readable failures.
+func (w *eventRefsWorld) named(urns []string) string {
+	names := make([]string, 0, len(urns))
+	for _, urn := range urns {
+		names = append(names, w.resourceName(urn))
+	}
+	return strings.Join(names, ", ")
+}

--- a/tests/e2e/features/entity_anchored_recall.feature
+++ b/tests/e2e/features/entity_anchored_recall.feature
@@ -1,0 +1,108 @@
+Feature: Entity-anchored recall of events
+  As an LLM client connected to the WeOS MCP server
+  I want to anchor episodic recall on one or more resources
+  So that I can retrieve the events involving the entities a user asks about
+
+  Background:
+    Given a clean WeOS knowledge graph
+    And the "tasks" preset is installed
+
+  Scenario: Anchoring on a resource finds every event that references it
+    Given a "project" named "Client onboarding" exists
+    And a "task" named "Chase overdue invoices" exists linked to the project "Client onboarding"
+    When I call episodic_recall for events about the resource named "Client onboarding"
+    Then the call succeeds
+    And the recall includes the "Resource.Created" event for "Client onboarding"
+    And the recall includes the "Resource.Created" event for "Chase overdue invoices"
+    And the recall includes the "Triple.Created" event for "Chase overdue invoices"
+    And the referenced resources for that event include "Client onboarding"
+
+  Scenario: Anchoring on a task does not return the linked project's own events
+    Given a "project" named "Client onboarding" exists
+    And a "task" named "Chase overdue invoices" exists linked to the project "Client onboarding"
+    When I call episodic_recall for events about the resource named "Chase overdue invoices"
+    Then the call succeeds
+    And the recall includes the "Resource.Created" event for "Chase overdue invoices"
+    And the recall does not include an event for "Client onboarding"
+
+  Scenario: Multiple anchors return the union of their events in chronological order
+    Given the following activity is recorded in the event log:
+      | resource-type | name                     | event-type       | occurred-at          | project           |
+      | project       | Client onboarding        | Resource.Created | 2026-06-10T09:00:00Z |                   |
+      | project       | Website refresh          | Resource.Created | 2026-06-12T09:00:00Z |                   |
+      | task          | Chase overdue invoices   | Resource.Created | 2026-06-20T09:00:00Z | Client onboarding |
+      | task          | Redesign landing page    | Resource.Created | 2026-06-22T10:00:00Z | Website refresh   |
+      | task          | Draft Q3 invoice summary | Resource.Created | 2026-06-24T11:00:00Z |                   |
+    When I call episodic_recall for events about the resources named "Client onboarding" and "Website refresh"
+    Then the call succeeds
+    And the recall returns exactly these events in order:
+      | resource               | event-type       |
+      | Client onboarding      | Resource.Created |
+      | Website refresh        | Resource.Created |
+      | Chase overdue invoices | Resource.Created |
+      | Redesign landing page  | Resource.Created |
+
+  Scenario: An anchor composes with the time window and event type filters
+    Given the following activity is recorded in the event log:
+      | resource-type | name                     | event-type       | occurred-at          | project           |
+      | project       | Client onboarding        | Resource.Created | 2026-06-10T09:00:00Z |                   |
+      | task          | Chase overdue invoices   | Resource.Created | 2026-06-20T09:00:00Z | Client onboarding |
+      | task          | Draft Q3 invoice summary | Resource.Created | 2026-06-22T10:00:00Z |                   |
+      | task          | Chase overdue invoices   | Resource.Updated | 2026-06-25T11:00:00Z | Client onboarding |
+      | task          | Update contract terms    | Resource.Created | 2026-07-05T10:00:00Z | Client onboarding |
+    When I call episodic_recall with the filters:
+      | filter     | value                |
+      | about      | Client onboarding    |
+      | from       | 2026-06-15T00:00:00Z |
+      | until      | 2026-06-30T00:00:00Z |
+      | event-type | Resource.Created     |
+    Then the call succeeds
+    And the recall returns exactly these events in order:
+      | resource               | event-type       |
+      | Chase overdue invoices | Resource.Created |
+
+  Scenario: Anchoring on a deleted resource still returns its history
+    Given a "project" named "Client onboarding" exists
+    And a "task" named "Chase overdue invoices" exists linked to the project "Client onboarding"
+    And the project "Client onboarding" has since been deleted
+    When I call episodic_recall for events about the resource named "Client onboarding"
+    Then the call succeeds
+    And the recall includes the "Resource.Created" event for "Client onboarding"
+    And the recall includes the "Triple.Created" event for "Chase overdue invoices"
+
+  Scenario: An anchored recall without an explicit limit returns the default page of 20 events
+    Given the following activity is recorded in the event log:
+      | resource-type | name       | event-type       | occurred-at          |
+      | project       | Acme audit | Resource.Created | 2026-05-30T09:00:00Z |
+    And 25 "task" resources linked to "Acme audit" were created on consecutive days starting "2026-06-01T09:00:00Z"
+    When I call episodic_recall for events about the resource named "Acme audit"
+    Then the call succeeds
+    And the recall returns 20 events
+    And the recall reports more events are available
+    And the recall provides a cursor for the next page
+
+  Scenario: The cursor continues an anchored recall without repeating events
+    Given the following activity is recorded in the event log:
+      | resource-type | name       | event-type       | occurred-at          |
+      | project       | Acme audit | Resource.Created | 2026-05-30T09:00:00Z |
+    And 25 "task" resources linked to "Acme audit" were created on consecutive days starting "2026-06-01T09:00:00Z"
+    And I have recalled the first page of events about "Acme audit"
+    When I call episodic_recall with the cursor from the first page
+    Then the call succeeds
+    And the recall returns 6 events
+    And no event from the first page is repeated
+    And the recall reports no more events are available
+
+  Scenario: An anchor with no recorded events returns an empty result
+    Given the following activity is recorded in the event log:
+      | resource-type | name                   | event-type       | occurred-at          |
+      | task          | Chase overdue invoices | Resource.Created | 2026-06-20T09:00:00Z |
+    When I call episodic_recall for events about the resource "urn:project:2NqxYzWvUtSrQpOnMlKjIhGfEdC"
+    Then the call succeeds
+    And the recall returns no events
+    And the recall reports no more events are available
+
+  Scenario: A malformed anchor is rejected with a clear error
+    When I call episodic_recall for events about the resource "not-a-urn"
+    Then the call fails with a validation error
+    And the error explains the resource URN is invalid

--- a/tests/e2e/features/episodic_recall.feature
+++ b/tests/e2e/features/episodic_recall.feature
@@ -1,0 +1,169 @@
+Feature: Query the event log via the MCP episodic_recall tool
+  As an LLM client connected to the WeOS MCP server
+  I want to query the event log by time window and combinable filters
+  So that I can answer "what happened between X and Y" from the twin's history
+
+  Background:
+    Given a clean WeOS knowledge graph
+    And the "tasks" preset is installed
+
+  Scenario: A time window returns matching events in chronological order
+    Given the following activity is recorded in the event log:
+      | resource-type | name                     | event-type       | occurred-at          |
+      | project       | Client onboarding        | Resource.Created | 2026-06-10T09:00:00Z |
+      | task          | Draft Q3 invoice summary | Resource.Created | 2026-06-20T09:00:00Z |
+      | task          | Chase overdue invoices   | Resource.Created | 2026-06-28T14:30:00Z |
+    When I call episodic_recall for events between "2026-06-15T00:00:00Z" and "2026-06-30T00:00:00Z"
+    Then the call succeeds
+    And the recall returns exactly these events in order:
+      | resource                 | event-type       |
+      | Draft Q3 invoice summary | Resource.Created |
+      | Chase overdue invoices   | Resource.Created |
+
+  Scenario: Recalled events use the compact shape instead of the full payload
+    Given the following activity is recorded in the event log:
+      | resource-type | name               | description                   | event-type       | occurred-at          |
+      | project       | May reconciliation | Match receipts to the ledger  | Resource.Created | 2026-06-20T09:00:00Z |
+    When I call episodic_recall for events between "2026-06-01T00:00:00Z" and "2026-06-30T00:00:00Z"
+    Then the call succeeds
+    And every recalled event carries:
+      | field           |
+      | event URN       |
+      | event type      |
+      | timestamp       |
+      | aggregate ID    |
+      | payload summary |
+    And the recall does not include the full payload text "Match receipts to the ledger"
+
+  Scenario: Filtering by aggregate ID returns only that resource's events
+    Given the following activity is recorded in the event log:
+      | resource-type | name                     | event-type       | occurred-at          |
+      | task          | Draft Q3 invoice summary | Resource.Created | 2026-06-20T09:00:00Z |
+      | task          | Chase overdue invoices   | Resource.Created | 2026-06-21T10:00:00Z |
+      | task          | Chase overdue invoices   | Resource.Updated | 2026-06-25T11:00:00Z |
+    When I call episodic_recall for events about the resource named "Chase overdue invoices"
+    Then the call succeeds
+    And the recall returns exactly these events in order:
+      | resource               | event-type       |
+      | Chase overdue invoices | Resource.Created |
+      | Chase overdue invoices | Resource.Updated |
+
+  Scenario: Filtering by event type returns only events of that type
+    Given the following activity is recorded in the event log:
+      | resource-type | name                     | event-type       | occurred-at          |
+      | task          | Draft Q3 invoice summary | Resource.Created | 2026-06-20T09:00:00Z |
+      | task          | Draft Q3 invoice summary | Resource.Updated | 2026-06-22T15:00:00Z |
+      | task          | Chase overdue invoices   | Resource.Created | 2026-06-23T10:00:00Z |
+    When I call episodic_recall for events of type "Resource.Updated"
+    Then the call succeeds
+    And every recalled event has type "Resource.Updated"
+    And the recall includes the "Resource.Updated" event for "Draft Q3 invoice summary"
+
+  Scenario: Filtering by resource type returns only that type's events
+    Given the following activity is recorded in the event log:
+      | resource-type | name                   | event-type       | occurred-at          |
+      | project       | Client onboarding      | Resource.Created | 2026-06-10T09:00:00Z |
+      | task          | Chase overdue invoices | Resource.Created | 2026-06-20T09:00:00Z |
+    When I call episodic_recall for events of resource type "task"
+    Then the call succeeds
+    And every recalled event is for a "task" resource
+    And the recall includes the "Resource.Created" event for "Chase overdue invoices"
+    And the recall does not include an event for "Client onboarding"
+
+  Scenario: Combined filters narrow the results together
+    Given the following activity is recorded in the event log:
+      | resource-type | name                     | event-type       | occurred-at          |
+      | project       | Client onboarding        | Resource.Created | 2026-06-16T09:00:00Z |
+      | task          | Draft Q3 invoice summary | Resource.Created | 2026-06-10T09:00:00Z |
+      | task          | Draft Q3 invoice summary | Resource.Updated | 2026-06-20T09:00:00Z |
+      | task          | Chase overdue invoices   | Resource.Created | 2026-06-21T10:00:00Z |
+    When I call episodic_recall with the filters:
+      | filter        | value                |
+      | from          | 2026-06-15T00:00:00Z |
+      | until         | 2026-06-30T00:00:00Z |
+      | event-type    | Resource.Created     |
+      | resource-type | task                 |
+    Then the call succeeds
+    And the recall returns exactly these events in order:
+      | resource               | event-type       |
+      | Chase overdue invoices | Resource.Created |
+
+  Scenario: A relative time range returns only events inside the window
+    Given the following activity is recorded in the event log:
+      | resource-type | name                   | event-type       | occurred-at |
+      | task          | Archive 2025 contracts | Resource.Created | 10 days ago |
+      | task          | Chase overdue invoices | Resource.Created | 2 days ago  |
+    When I call episodic_recall for events from the last 7 days
+    Then the call succeeds
+    And the recall includes the "Resource.Created" event for "Chase overdue invoices"
+    And the recall does not include an event for "Archive 2025 contracts"
+
+  Scenario: A recall without an explicit limit returns the default page of 20 events
+    Given 25 "task" resources were created on consecutive days starting "2026-06-01T09:00:00Z"
+    When I call episodic_recall for events between "2026-06-01T00:00:00Z" and "2026-07-01T00:00:00Z"
+    Then the call succeeds
+    And the recall returns 20 events
+    And the recall reports more events are available
+    And the recall provides a cursor for the next page
+
+  Scenario: The cursor returns the next page without repeating events
+    Given 25 "task" resources were created on consecutive days starting "2026-06-01T09:00:00Z"
+    And I have recalled the first page of events between "2026-06-01T00:00:00Z" and "2026-07-01T00:00:00Z"
+    When I call episodic_recall with the cursor from the first page
+    Then the call succeeds
+    And the recall returns 5 events
+    And no event from the first page is repeated
+    And the recall reports no more events are available
+
+  Scenario: A limit above the hard maximum returns at most 100 events
+    Given 105 "task" resources were created on consecutive days starting "2026-03-01T09:00:00Z"
+    When I call episodic_recall requesting up to 500 events
+    Then the call succeeds
+    And the recall returns 100 events
+    And the recall reports more events are available
+
+  Scenario: A window with no recorded activity returns an empty result
+    Given the following activity is recorded in the event log:
+      | resource-type | name                   | event-type       | occurred-at          |
+      | task          | Chase overdue invoices | Resource.Created | 2026-06-20T09:00:00Z |
+    When I call episodic_recall for events between "2026-01-01T00:00:00Z" and "2026-01-31T23:59:59Z"
+    Then the call succeeds
+    And the recall returns no events
+    And the recall reports no more events are available
+
+  Scenario Outline: An invalid time range is rejected with a clear error
+    When I call episodic_recall for events between "<from>" and "<until>"
+    Then the call fails with a validation error
+    And the error explains the time range is invalid
+
+    Examples:
+      | from                 | until                |
+      | 2026-06-30T00:00:00Z | 2026-06-01T00:00:00Z |
+      | not-a-timestamp      | 2026-06-30T00:00:00Z |
+
+  Scenario: The same query returns identical results every time
+    Given the following activity is recorded in the event log:
+      | resource-type | name                     | event-type       | occurred-at          |
+      | task          | Draft Q3 invoice summary | Resource.Created | 2026-06-20T09:00:00Z |
+      | task          | Chase overdue invoices   | Resource.Created | 2026-06-20T09:00:00Z |
+    When I call episodic_recall for events between "2026-06-01T00:00:00Z" and "2026-06-30T00:00:00Z" twice
+    Then both recalls return identical events in identical order
+
+  Scenario: An invalid pagination cursor is rejected with a clear error
+    When I call episodic_recall with the cursor "not-a-cursor"
+    Then the call fails with a validation error
+    And the error explains the cursor is invalid
+
+  Scenario: A resource created through the live resource_create tool appears in recall
+    When I call resource_create for type "task" with the data:
+      """
+      {
+        "name": "Chase overdue invoices",
+        "status": "open",
+        "priority": "high"
+      }
+      """
+    And I call episodic_recall for events from the last 1 days
+    Then the call succeeds
+    And the recall includes the "Resource.Created" event for "Chase overdue invoices"
+    And the payload summary for that event carries "Chase overdue invoices"

--- a/tests/e2e/features/event_payload_fetch.feature
+++ b/tests/e2e/features/event_payload_fetch.feature
@@ -1,0 +1,46 @@
+Feature: Fetch a full event payload by URN
+  As an LLM client connected to the WeOS MCP server
+  I want to fetch one event's full payload by its URN
+  So that I can drill into a moment recall surfaced without paying for full payloads by default
+
+  Background:
+    Given a clean WeOS knowledge graph
+    And the "tasks" preset is installed
+
+  Scenario: Fetching an event by URN returns its full payload
+    Given the following activity is recorded in the event log:
+      | resource-type | name               | description                  | event-type       | occurred-at          |
+      | project       | May reconciliation | Match receipts to the ledger | Resource.Created | 2026-06-20T09:00:00Z |
+    When I call episodic_event_get with the URN of the "Resource.Created" event for "May reconciliation"
+    Then the call succeeds
+    And the fetched event carries:
+      | field        |
+      | event URN    |
+      | event type   |
+      | timestamp    |
+      | aggregate ID |
+    And the fetched payload contains the text "Match receipts to the ledger"
+
+  Scenario: An event URN taken from a recall result fetches that same event
+    Given the following activity is recorded in the event log:
+      | resource-type | name                   | event-type       | occurred-at          |
+      | task          | Chase overdue invoices | Resource.Created | 2026-06-20T09:00:00Z |
+    When I call episodic_recall for events between "2026-06-01T00:00:00Z" and "2026-06-30T00:00:00Z"
+    And I call episodic_event_get with the event URN from the first recalled event
+    Then the call succeeds
+    And the fetched event is the "Resource.Created" event for "Chase overdue invoices"
+
+  Scenario: Fetching an event that does not exist is rejected with a clear error
+    When I call episodic_event_get with the event "urn:event:2NqxYzWvUtSrQpOnMlKjIhGfEdC"
+    Then the call fails
+    And the error explains the event is unknown
+
+  Scenario Outline: A fetch identifier that is not an event URN is rejected with a clear error
+    When I call episodic_event_get with the event "<urn>"
+    Then the call fails with a validation error
+    And the error explains the identifier must be an event URN
+
+    Examples:
+      | urn                                  |
+      | urn:task:2NqxYzWvUtSrQpOnMlKjIhGfEdC |
+      | not-an-event-urn                     |

--- a/tests/e2e/features/event_references.feature
+++ b/tests/e2e/features/event_references.feature
@@ -1,0 +1,64 @@
+Feature: Recalled events report the resources they reference
+  As an LLM client connected to the WeOS MCP server
+  I want every recalled event to carry the IDs of the resources it references
+  So that I can trace which events touched a resource across the twin's history
+
+  Background:
+    Given a clean WeOS knowledge graph
+    And the "tasks" preset is installed
+
+  Scenario: An event with no payload references reports exactly its own resource
+    Given the following activity is recorded in the event log:
+      | resource-type | name              | event-type       | occurred-at          |
+      | project       | Client onboarding | Resource.Created | 2026-06-18T08:00:00Z |
+    When I call episodic_recall for events between "2026-06-01T00:00:00Z" and "2026-06-30T00:00:00Z"
+    Then the call succeeds
+    And the recall includes the "Resource.Created" event for "Client onboarding"
+    And the referenced resources for that event are exactly:
+      | resource          |
+      | Client onboarding |
+
+  Scenario: An event whose payload references another resource reports both resources
+    Given the following activity is recorded in the event log:
+      | resource-type | name                   | event-type       | occurred-at          | project           |
+      | project       | Client onboarding      | Resource.Created | 2026-06-18T08:00:00Z |                   |
+      | task          | Chase overdue invoices | Resource.Created | 2026-06-20T09:00:00Z | Client onboarding |
+    When I call episodic_recall for events between "2026-06-01T00:00:00Z" and "2026-06-30T00:00:00Z"
+    Then the call succeeds
+    And the recall includes the "Resource.Created" event for "Chase overdue invoices"
+    And the referenced resources for that event are exactly:
+      | resource               |
+      | Chase overdue invoices |
+      | Client onboarding      |
+
+  Scenario: A relationship event reports both resources it links
+    Given a "project" named "Client onboarding" exists
+    When I create a "task" named "Chase overdue invoices" linked to the project "Client onboarding"
+    And I call episodic_recall for events of type "Triple.Created"
+    Then the call succeeds
+    And the recall includes the "Triple.Created" event for "Chase overdue invoices"
+    And the referenced resources for that event are exactly:
+      | resource               |
+      | Chase overdue invoices |
+      | Client onboarding      |
+
+  Scenario: References to a deleted resource remain part of recalled history
+    Given a "project" named "Client onboarding" exists
+    And a "task" named "Chase overdue invoices" exists linked to the project "Client onboarding"
+    And the project "Client onboarding" has since been deleted
+    When I call episodic_recall for events of type "Triple.Created"
+    Then the call succeeds
+    And the recall includes the "Triple.Created" event for "Chase overdue invoices"
+    And the referenced resources for that event include "Client onboarding"
+
+  Scenario: A rebuilt reference projection reports the same references from the event log
+    Given a "project" named "Client onboarding" exists
+    And a "task" named "Chase overdue invoices" exists linked to the project "Client onboarding"
+    When the event reference projection is rebuilt from the event log
+    And I call episodic_recall for events of type "Triple.Created"
+    Then the call succeeds
+    And the recall includes the "Triple.Created" event for "Chase overdue invoices"
+    And the referenced resources for that event are exactly:
+      | resource               |
+      | Chase overdue invoices |
+      | Client onboarding      |

--- a/tests/e2e/features/similar_event_search.feature
+++ b/tests/e2e/features/similar_event_search.feature
@@ -1,0 +1,116 @@
+Feature: Similar-event search from a seed event
+  As an LLM client connected to the WeOS MCP server
+  I want events ranked by structural similarity to a seed event
+  So that I can surface comparable past activity from the twin's history
+
+  Background:
+    Given a clean WeOS knowledge graph
+    And the "tasks" preset is installed
+
+  Scenario: Events sharing a referenced resource outrank events that are merely the same kind
+    Given the following activity is recorded in the event log:
+      | resource-type | name                     | event-type       | occurred-at          | project           |
+      | project       | Client onboarding        | Resource.Created | 2026-06-01T09:00:00Z |                   |
+      | project       | Website refresh          | Resource.Created | 2026-06-11T09:00:00Z |                   |
+      | task          | Update contract terms    | Resource.Created | 2026-06-02T09:00:00Z | Client onboarding |
+      | task          | Draft Q3 invoice summary | Resource.Created | 2026-06-09T09:00:00Z |                   |
+      | task          | Chase overdue invoices   | Resource.Created | 2026-06-10T09:00:00Z | Client onboarding |
+    When I call episodic_similar seeded with the "Resource.Created" event for "Chase overdue invoices"
+    Then the call succeeds
+    And the results do not include the seed event
+    And the results list exactly these events in order:
+      | resource                 | event-type       |
+      | Update contract terms    | Resource.Created |
+      | Client onboarding        | Resource.Created |
+      | Draft Q3 invoice summary | Resource.Created |
+      | Website refresh          | Resource.Created |
+
+  Scenario: Temporal proximity breaks the tie between otherwise equal events
+    Given the following activity is recorded in the event log:
+      | resource-type | name                     | event-type       | occurred-at          | project           |
+      | project       | Client onboarding        | Resource.Created | 2026-06-01T08:00:00Z |                   |
+      | task          | Update contract terms    | Resource.Created | 2026-06-01T09:00:00Z | Client onboarding |
+      | task          | Schedule onboarding call | Resource.Created | 2026-06-14T09:00:00Z | Client onboarding |
+      | task          | Chase overdue invoices   | Resource.Created | 2026-06-15T09:00:00Z | Client onboarding |
+    When I call episodic_similar seeded with the "Resource.Created" event for "Chase overdue invoices"
+    Then the call succeeds
+    And the results list exactly these events in order:
+      | resource                 | event-type       |
+      | Schedule onboarding call | Resource.Created |
+      | Update contract terms    | Resource.Created |
+      | Client onboarding        | Resource.Created |
+
+  Scenario: A seed that shares no references still returns ranked results
+    Given the following activity is recorded in the event log:
+      | resource-type | name                     | event-type       | occurred-at          |
+      | task          | Update contract terms    | Resource.Created | 2026-06-09T09:00:00Z |
+      | task          | Draft Q3 invoice summary | Resource.Created | 2026-06-10T09:00:00Z |
+      | project       | Website refresh          | Resource.Created | 2026-06-11T09:00:00Z |
+    When I call episodic_similar seeded with the "Resource.Created" event for "Draft Q3 invoice summary"
+    Then the call succeeds
+    And the results list exactly these events in order:
+      | resource              | event-type       |
+      | Update contract terms | Resource.Created |
+      | Website refresh       | Resource.Created |
+
+  Scenario: The same seed returns the identical ranking every time, even for tied events
+    Given the following activity is recorded in the event log:
+      | resource-type | name                     | event-type       | occurred-at          | project           |
+      | project       | Client onboarding        | Resource.Created | 2026-06-01T09:00:00Z |                   |
+      | task          | Chase overdue invoices   | Resource.Created | 2026-06-10T09:00:00Z | Client onboarding |
+      | task          | Update contract terms    | Resource.Created | 2026-06-12T09:00:00Z | Client onboarding |
+      | task          | Schedule onboarding call | Resource.Created | 2026-06-12T09:00:00Z | Client onboarding |
+    When I call episodic_similar seeded with the "Resource.Created" event for "Chase overdue invoices" twice
+    Then both searches return identical events in identical order
+
+  Scenario: Results use the compact event shape ordered from most to least similar
+    Given the following activity is recorded in the event log:
+      | resource-type | name                   | event-type       | occurred-at          | project           |
+      | project       | Client onboarding      | Resource.Created | 2026-06-01T09:00:00Z |                   |
+      | task          | Chase overdue invoices | Resource.Created | 2026-06-10T09:00:00Z | Client onboarding |
+      | task          | Update contract terms  | Resource.Created | 2026-06-12T09:00:00Z | Client onboarding |
+    When I call episodic_similar seeded with the "Resource.Created" event for "Chase overdue invoices"
+    Then the call succeeds
+    And every result carries:
+      | field                |
+      | event URN            |
+      | event type           |
+      | timestamp            |
+      | aggregate ID         |
+      | payload summary      |
+      | referenced resources |
+      | similarity score     |
+    And the results are ordered from most to least similar
+
+  Scenario: A similarity search without an explicit limit returns at most 20 events
+    Given the following activity is recorded in the event log:
+      | resource-type | name       | event-type       | occurred-at          |
+      | project       | Acme audit | Resource.Created | 2026-05-30T09:00:00Z |
+    And 25 "task" resources linked to "Acme audit" were created on consecutive days starting "2026-06-01T09:00:00Z"
+    When I call episodic_similar seeded with the "Resource.Created" event for "Acme audit"
+    Then the call succeeds
+    And the results contain 20 events
+
+  Scenario: A limit above the hard maximum returns at most 100 events
+    Given the following activity is recorded in the event log:
+      | resource-type | name       | event-type       | occurred-at          |
+      | project       | Acme audit | Resource.Created | 2026-02-28T09:00:00Z |
+    And 105 "task" resources linked to "Acme audit" were created on consecutive days starting "2026-03-01T09:00:00Z"
+    When I call episodic_similar seeded with the "Resource.Created" event for "Acme audit" requesting up to 500 events
+    Then the call succeeds
+    And the results contain 100 events
+
+  Scenario: A seed event that does not exist is rejected with a clear error
+    When I call episodic_similar seeded with the event "urn:event:2NqxYzWvUtSrQpOnMlKjIhGfEdC"
+    Then the call fails
+    And the error explains the seed event is unknown
+
+  Scenario Outline: A seed that is not an event URN is rejected with a clear error
+    When I call episodic_similar seeded with the event "<seed>"
+    Then the call fails with a validation error
+    And the error explains the seed must be an event URN
+
+    Examples:
+      | seed                                 |
+      | urn:task:2NqxYzWvUtSrQpOnMlKjIhGfEdC |
+      | not-an-event-urn                     |

--- a/tests/e2e/features/tool_annotations.feature
+++ b/tests/e2e/features/tool_annotations.feature
@@ -21,3 +21,7 @@ Feature: Tool annotations advertise what mutates
   Scenario: Every advertised tool carries an explicit annotation
     When I list the server's tools
     Then every tool declares whether it is read-only or mutating
+
+  Scenario: The episodic_recall tool is advertised as read-only
+    When I list the server's tools
+    Then the tool "episodic_recall" is advertised as read-only

--- a/tests/e2e/mcp_memory_recall_test.go
+++ b/tests/e2e/mcp_memory_recall_test.go
@@ -75,16 +75,6 @@ func initMemoryRecallScenario(sc *godog.ScenarioContext) {
 		w.playbookOutcomeReports)
 }
 
-func (w *memoryWorld) presetIsInstalled(ctx context.Context, name string) error {
-	if w.rts == nil {
-		return fmt.Errorf("application not booted")
-	}
-	if _, err := w.rts.InstallPreset(ctx, name, true); err != nil {
-		return fmt.Errorf("failed to install %q preset: %w", name, err)
-	}
-	return nil
-}
-
 // createFact records a fact through the same MCP tool an agent would use and
 // returns its URN.
 func (w *memoryWorld) createFact(ctx context.Context, data map[string]any) (string, error) {

--- a/tests/e2e/mcp_resource_create_test.go
+++ b/tests/e2e/mcp_resource_create_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/wepala/weos/v3/internal/config"
 	mcpserver "github.com/wepala/weos/v3/internal/mcp"
 
+	pericarpdomain "github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
 	"github.com/cucumber/godog"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.uber.org/fx"
@@ -54,6 +55,9 @@ type mcpWorld struct {
 	srvSess *mcp.ServerSession
 	cancel  context.CancelFunc
 	rts     application.ResourceTypeService
+	// eventStore backs direct event seeding (episodic recall scenarios need
+	// controlled occurred-at timestamps the entity API never exposes).
+	eventStore pericarpdomain.EventStore
 
 	pendingContext string
 	pendingSchema  string
@@ -110,11 +114,13 @@ func (w *mcpWorld) aCleanKnowledgeGraph(_ context.Context) error {
 	var rts application.ResourceTypeService
 	var rs application.ResourceService
 	var kg application.KnowledgeGraphService
+	var episodic application.EpisodicRecall
+	var eventStore pericarpdomain.EventStore
 
 	app := fx.New(
 		fx.NopLogger,
 		application.Module(cfg, presets.NewDefaultRegistry()),
-		fx.Populate(&rts, &rs, &kg),
+		fx.Populate(&rts, &rs, &kg, &episodic, &eventStore),
 	)
 	startCtx, startCancel := context.WithTimeout(sessCtx, fx.DefaultTimeout)
 	defer startCancel()
@@ -122,8 +128,9 @@ func (w *mcpWorld) aCleanKnowledgeGraph(_ context.Context) error {
 		return fmt.Errorf("failed to start app: %w", err)
 	}
 	w.app = app
+	w.eventStore = eventStore
 
-	server, err := mcpserver.NewMCPServer(rts, rs, kg, nil, nil)
+	server, err := mcpserver.NewMCPServer(rts, rs, kg, nil, episodic, nil)
 	if err != nil {
 		return fmt.Errorf("failed to build MCP server: %w", err)
 	}
@@ -147,6 +154,16 @@ func (w *mcpWorld) aCleanKnowledgeGraph(_ context.Context) error {
 
 	// Stash the type service so the next Background step can seed the schema.
 	w.rts = rts
+	return nil
+}
+
+func (w *mcpWorld) presetIsInstalled(ctx context.Context, name string) error {
+	if w.rts == nil {
+		return fmt.Errorf("application not booted")
+	}
+	if _, err := w.rts.InstallPreset(ctx, name, true); err != nil {
+		return fmt.Errorf("failed to install %q preset: %w", name, err)
+	}
 	return nil
 }
 

--- a/tests/e2e/mcp_resource_create_test.go
+++ b/tests/e2e/mcp_resource_create_test.go
@@ -58,6 +58,10 @@ type mcpWorld struct {
 	// eventStore backs direct event seeding (episodic recall scenarios need
 	// controlled occurred-at timestamps the entity API never exposes).
 	eventStore pericarpdomain.EventStore
+	// runWorkers opts a suite into in-process background subscribers
+	// (projections like event-references); manager drives checkpoint rebuilds.
+	runWorkers bool
+	manager    *application.Manager
 
 	pendingContext string
 	pendingSchema  string
@@ -104,6 +108,10 @@ func (w *mcpWorld) aCleanKnowledgeGraph(_ context.Context) error {
 	w.tmpDir = dir
 	cfg.DatabaseDSN = filepath.Join(dir, "test.db") // ProvideGormDB adds the worker pragmas
 	cfg.LogLevel = "error"
+	if lvl := os.Getenv("E2E_LOG_LEVEL"); lvl != "" {
+		cfg.LogLevel = lvl
+	}
+	cfg.Worker.RunInProcess = w.runWorkers
 
 	// Both MCP sessions must outlive any single step, so anchor them to a
 	// scenario-scoped context (canceled in teardown) rather than the per-step
@@ -116,11 +124,12 @@ func (w *mcpWorld) aCleanKnowledgeGraph(_ context.Context) error {
 	var kg application.KnowledgeGraphService
 	var episodic application.EpisodicRecall
 	var eventStore pericarpdomain.EventStore
+	var manager *application.Manager
 
 	app := fx.New(
 		fx.NopLogger,
 		application.Module(cfg, presets.NewDefaultRegistry()),
-		fx.Populate(&rts, &rs, &kg, &episodic, &eventStore),
+		fx.Populate(&rts, &rs, &kg, &episodic, &eventStore, &manager),
 	)
 	startCtx, startCancel := context.WithTimeout(sessCtx, fx.DefaultTimeout)
 	defer startCancel()
@@ -129,6 +138,7 @@ func (w *mcpWorld) aCleanKnowledgeGraph(_ context.Context) error {
 	}
 	w.app = app
 	w.eventStore = eventStore
+	w.manager = manager
 
 	server, err := mcpserver.NewMCPServer(rts, rs, kg, nil, episodic, nil)
 	if err != nil {

--- a/tests/e2e/similar_event_search_test.go
+++ b/tests/e2e/similar_event_search_test.go
@@ -1,0 +1,350 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cucumber/godog"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestSimilarEventSearch runs the similar-event search acceptance scenarios
+// (epic #409, story #413): episodic_similar ranks events by deterministic
+// structural similarity to a seed event. Ranking reads the event-reference
+// projection, so the suite runs the background subscribers in-process and
+// polls. Filter on demand with:
+// GODOG_TAGS=@wip go test ./tests/e2e/ -run TestSimilarEventSearch -v
+func TestSimilarEventSearch(t *testing.T) {
+	tags := "~@wip"
+	if override := os.Getenv("GODOG_TAGS"); override != "" {
+		tags = override
+	}
+	suite := godog.TestSuite{
+		Name:                "similar-event-search",
+		ScenarioInitializer: initSimilarEventSearchScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"features/similar_event_search.feature"},
+			Tags:     tags,
+			Strict:   true,
+			TestingT: t,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("similar-event search acceptance scenarios failed")
+	}
+}
+
+// similarEvent mirrors one ranked result: the compact shape plus its score.
+// Similarity is a pointer so shape assertions can tell "absent" from zero.
+type similarEvent struct {
+	ID                  string   `json:"id"`
+	EventType           string   `json:"eventType"`
+	Timestamp           string   `json:"timestamp"`
+	AggregateID         string   `json:"aggregateId"`
+	ResourceType        string   `json:"resourceType"`
+	Summary             string   `json:"summary"`
+	ReferencedResources []string `json:"referencedResources"`
+	Similarity          *float64 `json:"similarity"`
+}
+
+type similarPage struct {
+	Results []similarEvent `json:"results"`
+}
+
+type similarWorld struct {
+	*anchoredWorld
+	// similarArgs replays the last episodic_similar call while polling.
+	similarArgs map[string]any
+	seedURN     string
+	// firstText/secondText hold the determinism pair's raw responses.
+	firstText  string
+	secondText string
+}
+
+func initSimilarEventSearchScenario(sc *godog.ScenarioContext) {
+	w := &similarWorld{anchoredWorld: &anchoredWorld{eventRefsWorld: &eventRefsWorld{
+		episodicWorld: &episodicWorld{
+			mcpWorld:   &mcpWorld{runWorkers: true},
+			aggregates: map[string]string{},
+			seqs:       map[string]int{},
+			eventIDs:   map[string]string{},
+		},
+	}}}
+
+	sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		w.teardown()
+		return ctx, nil
+	})
+
+	sc.Step(`^a clean WeOS knowledge graph$`, w.aCleanKnowledgeGraph)
+	sc.Step(`^the "([^"]*)" preset is installed$`, w.presetIsInstalled)
+	sc.Step(`^the following activity is recorded in the event log:$`, w.activityIsRecorded)
+	sc.Step(`^(\d+) "([^"]*)" resources linked to "([^"]*)" were created on consecutive days starting "([^"]*)"$`,
+		w.linkedResourcesCreatedOnConsecutiveDays)
+	sc.Step(`^I call episodic_similar seeded with the "([^"]*)" event for "([^"]*)"$`, w.callSimilarSeededNamed)
+	sc.Step(`^I call episodic_similar seeded with the "([^"]*)" event for "([^"]*)" twice$`,
+		w.callSimilarSeededNamedTwice)
+	//nolint:lll // step regex
+	sc.Step(`^I call episodic_similar seeded with the "([^"]*)" event for "([^"]*)" requesting up to (\d+) events$`,
+		w.callSimilarSeededNamedWithLimit)
+	sc.Step(`^I call episodic_similar seeded with the event "([^"]*)"$`, w.callSimilarSeededLiteral)
+	sc.Step(`^the call succeeds$`, w.theCallSucceeds)
+	sc.Step(`^the call fails$`, w.theCallFails)
+	sc.Step(`^the call fails with a validation error$`, w.theCallFailsWithValidationError)
+	sc.Step(`^the results do not include the seed event$`, w.resultsExcludeSeed)
+	sc.Step(`^the results list exactly these events in order:$`, w.resultsListExactly)
+	sc.Step(`^the results contain (\d+) events$`, w.resultsContainCount)
+	sc.Step(`^every result carries:$`, w.everyResultCarries)
+	sc.Step(`^the results are ordered from most to least similar$`, w.resultsOrderedByScore)
+	sc.Step(`^both searches return identical events in identical order$`, w.bothSearchesIdentical)
+	sc.Step(`^the error explains the seed event is unknown$`, w.errorExplainsUnknownSeed)
+	sc.Step(`^the error explains the seed must be an event URN$`, w.errorExplainsSeedShape)
+}
+
+// --- Actions ---
+
+func (w *similarWorld) callSimilar(ctx context.Context, args map[string]any) error {
+	w.similarArgs = args
+	raw, err := json.Marshal(args)
+	if err != nil {
+		return err
+	}
+	res, err := w.client.CallTool(ctx, &mcp.CallToolParams{
+		Name: "episodic_similar", Arguments: json.RawMessage(raw),
+	})
+	w.lastResult = res
+	w.lastErr = err
+	w.lastText = textOf(res)
+	return nil
+}
+
+func (w *similarWorld) seedFor(eventType, name string) (string, error) {
+	urn, ok := w.eventIDs[name+"|"+eventType]
+	if !ok {
+		return "", fmt.Errorf("no seeded %s event for %q", eventType, name)
+	}
+	return urn, nil
+}
+
+func (w *similarWorld) callSimilarSeededNamed(ctx context.Context, eventType, name string) error {
+	seed, err := w.seedFor(eventType, name)
+	if err != nil {
+		return err
+	}
+	w.seedURN = seed
+	return w.callSimilar(ctx, map[string]any{"seed": seed})
+}
+
+// callSimilarSeededNamedTwice captures a back-to-back pair of responses. The
+// reference projection lands asynchronously, so a pair straddling a partial
+// catch-up can genuinely differ — retry the whole pair within the poll budget
+// so the determinism assertion tests the contract, not projection timing. A
+// still-mismatched pair at deadline is kept for the assertion to report.
+func (w *similarWorld) callSimilarSeededNamedTwice(ctx context.Context, eventType, name string) error {
+	deadline := time.Now().Add(refsPollTimeout)
+	for {
+		if err := w.callSimilarSeededNamed(ctx, eventType, name); err != nil {
+			return err
+		}
+		if w.lastResult == nil || w.lastResult.IsError {
+			return fmt.Errorf("first similar call failed: %s", w.lastText)
+		}
+		first := w.lastText
+		if err := w.callSimilar(ctx, w.similarArgs); err != nil {
+			return err
+		}
+		w.firstText, w.secondText = first, w.lastText
+		if first == w.lastText || time.Now().After(deadline) {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func (w *similarWorld) callSimilarSeededNamedWithLimit(
+	ctx context.Context, eventType, name string, limit int,
+) error {
+	seed, err := w.seedFor(eventType, name)
+	if err != nil {
+		return err
+	}
+	w.seedURN = seed
+	return w.callSimilar(ctx, map[string]any{"seed": seed, "limit": limit})
+}
+
+func (w *similarWorld) callSimilarSeededLiteral(ctx context.Context, seed string) error {
+	w.seedURN = seed
+	return w.callSimilar(ctx, map[string]any{"seed": seed})
+}
+
+// --- Outcomes ---
+
+func (w *similarWorld) similar() (*similarPage, error) {
+	if w.lastErr != nil {
+		return nil, fmt.Errorf("episodic_similar protocol error: %v", w.lastErr)
+	}
+	if w.lastResult == nil || w.lastResult.IsError {
+		return nil, fmt.Errorf("episodic_similar failed: %s", w.lastText)
+	}
+	var page similarPage
+	if err := json.Unmarshal([]byte(w.lastText), &page); err != nil {
+		return nil, fmt.Errorf("unparseable episodic_similar output: %s", w.lastText)
+	}
+	return &page, nil
+}
+
+// pollSimilar retries a ranked-result assertion while the reference
+// projection catches up, re-running the last search between attempts.
+func (w *similarWorld) pollSimilar(ctx context.Context, assert func(*similarPage) error) error {
+	deadline := time.Now().Add(refsPollTimeout)
+	for {
+		page, err := w.similar()
+		if err == nil {
+			err = assert(page)
+		}
+		if err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return err
+		}
+		time.Sleep(100 * time.Millisecond)
+		if callErr := w.callSimilar(ctx, w.similarArgs); callErr != nil {
+			return callErr
+		}
+	}
+}
+
+func (w *similarWorld) resultsExcludeSeed(ctx context.Context) error {
+	return w.pollSimilar(ctx, func(page *similarPage) error {
+		for _, e := range page.Results {
+			if e.ID == w.seedURN {
+				return fmt.Errorf("the seed event %s ranked itself", w.seedURN)
+			}
+		}
+		return nil
+	})
+}
+
+func (w *similarWorld) resultsListExactly(ctx context.Context, table *godog.Table) error {
+	return w.pollSimilar(ctx, func(page *similarPage) error {
+		expected := table.Rows[1:]
+		if len(page.Results) != len(expected) {
+			return fmt.Errorf("got %d results, want %d: %s", len(page.Results), len(expected), w.lastText)
+		}
+		for i, row := range expected {
+			wantName, wantType := row.Cells[0].Value, row.Cells[1].Value
+			wantAggregate, ok := w.aggregates[wantName]
+			if !ok {
+				return fmt.Errorf("no seeded resource named %q", wantName)
+			}
+			got := page.Results[i]
+			if got.AggregateID != wantAggregate || got.EventType != wantType {
+				return fmt.Errorf("result %d = %s on %q, want %s on %q",
+					i, got.EventType, w.resourceName(got.AggregateID), wantType, wantName)
+			}
+		}
+		return nil
+	})
+}
+
+func (w *similarWorld) resultsContainCount(ctx context.Context, count int) error {
+	return w.pollSimilar(ctx, func(page *similarPage) error {
+		if len(page.Results) != count {
+			return fmt.Errorf("got %d results, want %d", len(page.Results), count)
+		}
+		return nil
+	})
+}
+
+func (w *similarWorld) everyResultCarries(ctx context.Context, table *godog.Table) error {
+	return w.pollSimilar(ctx, func(page *similarPage) error {
+		if len(page.Results) == 0 {
+			return fmt.Errorf("no results to inspect")
+		}
+		for i, e := range page.Results {
+			for _, row := range table.Rows[1:] {
+				if err := similarResultCarries(e, row.Cells[0].Value); err != nil {
+					return fmt.Errorf("result %d: %w", i, err)
+				}
+			}
+		}
+		return nil
+	})
+}
+
+func similarResultCarries(e similarEvent, field string) error {
+	switch field {
+	case "referenced resources":
+		if len(e.ReferencedResources) == 0 {
+			return fmt.Errorf("missing referenced resources")
+		}
+		return nil
+	case "similarity score":
+		if e.Similarity == nil {
+			return fmt.Errorf("missing similarity score")
+		}
+		return nil
+	default:
+		return eventCarries(episodicEvent{
+			ID: e.ID, EventType: e.EventType, Timestamp: e.Timestamp,
+			AggregateID: e.AggregateID, ResourceType: e.ResourceType, Summary: e.Summary,
+		}, field)
+	}
+}
+
+func (w *similarWorld) resultsOrderedByScore(ctx context.Context) error {
+	return w.pollSimilar(ctx, func(page *similarPage) error {
+		for i := 1; i < len(page.Results); i++ {
+			prev, cur := page.Results[i-1].Similarity, page.Results[i].Similarity
+			if prev == nil || cur == nil {
+				return fmt.Errorf("result missing a similarity score")
+			}
+			if *cur > *prev {
+				return fmt.Errorf("results not ordered by score: %f before %f", *prev, *cur)
+			}
+		}
+		return nil
+	})
+}
+
+func (w *similarWorld) bothSearchesIdentical() error {
+	var first similarPage
+	if err := json.Unmarshal([]byte(w.firstText), &first); err != nil {
+		return fmt.Errorf("unparseable first search output: %s", w.firstText)
+	}
+	var second similarPage
+	if err := json.Unmarshal([]byte(w.secondText), &second); err != nil {
+		return fmt.Errorf("unparseable second search output: %s", w.secondText)
+	}
+	if len(first.Results) != len(second.Results) {
+		return fmt.Errorf("searches returned %d and %d results", len(first.Results), len(second.Results))
+	}
+	for i := range first.Results {
+		if first.Results[i].ID != second.Results[i].ID {
+			return fmt.Errorf("result %d differs between searches: %s vs %s",
+				i, first.Results[i].ID, second.Results[i].ID)
+		}
+	}
+	return nil
+}
+
+func (w *similarWorld) errorExplainsUnknownSeed() error {
+	if !strings.Contains(strings.ToLower(w.errMessage()), "unknown") {
+		return fmt.Errorf("error %q does not explain the seed event is unknown", w.errMessage())
+	}
+	return nil
+}
+
+func (w *similarWorld) errorExplainsSeedShape() error {
+	if !strings.Contains(strings.ToLower(w.errMessage()), "event urn") {
+		return fmt.Errorf("error %q does not explain the seed must be an event URN", w.errMessage())
+	}
+	return nil
+}


### PR DESCRIPTION
Implements epic #409: the Pericarp event store becomes queryable episodic memory for agents — scoped, deterministic retrieval tools; agents interpret.

## Stories
- Closes #410 — `episodic_recall`: time-windowed, filterable, cursor-paginated slices of the event log in a compact shape (event URN, type, timestamp, aggregate ID, name-only summary — never the raw payload). Read-model indexes on `events(created_at)` / `events(event_type)` as idempotent DDL, safe on SQLite and Postgres.
- Closes #411 — the `event_references` projection: which resources each event touches (the aggregate plus payload URNs), maintained by a checkpointed subscriber — replay-idempotent, rebuildable via `weos worker checkpoint reset event-references --truncate`, never trimmed by later events (references to deleted resources survive as history). Chosen over JSON payload indexing, which diverges between engines. Recall results now carry `referencedResources`.
- Closes #412 — entity-anchored search: `about` takes one or more resource URNs, matched as the event's aggregate (synchronous) OR via the projection; multi-anchor unions; anchors compose with all other filters and pagination; malformed anchors fail loudly.
- Closes #413 — `episodic_similar`: deterministic structural ranking from a seed event (+100 per shared referenced resource — dominant by construction, +10 same event type, +5 same resource type, ≤+4 temporal decay; zero structural affinity is never ranked; ties break on event ID).
- Closes #414 — `episodic_event_get`: the explicit full-payload drill-in by event URN; unknown/malformed URNs error clearly.

## Also in this PR
- Fixes a latent SQLite self-deadlock in the epic #386 lexical index: subscriber handlers must write through the batch transaction (`subscriptions.TxFromContext`) rather than a second pooled connection that blocks on the batch's own write lock under `txlock=immediate`. Guardrail tests pin the lexical index and the new projection to the batch-transaction path.
- The event-references/anchored/similar e2e suites are the first to run background subscribers in-process (`runWorkers` opt-in on the shared world), with bounded polls that fail loudly if the projection never stabilizes.

## Testing
- 45 godog acceptance scenarios across 5 feature files, all promoted into the default regression suite (SDET-authored contracts, test-first per story).
- Unit + repo-level tests for time parsing, limits, cursor tie-breaks, LIKE escaping, reference extraction, replay idempotency, scoring weights/dominance/symmetry, and batch-transaction guardrails.
- `make test` green (one pre-existing, unrelated `web/dist` embed failure on fresh checkouts — CI builds the SPA); `golangci-lint` clean.

## Follow-up
- #415 — scope the episodic surface away from auth-domain events before multi-account deployments (review finding; no secrets leak today, but auth event payloads carry PII).

🤖 Generated with [Claude Code](https://claude.com/claude-code)