### PR TITLE
feat(agents): approve-with-edits + direct skill invocation + scripted test model

### DIFF
--- a/api/handlers/agent_handler.go
+++ b/api/handlers/agent_handler.go
@@ -60,20 +60,24 @@ func (h *AgentHandler) SendMessage(c echo.Context) error {
 
 // Confirm handles POST /agent/conversations/:conversationID/confirmations/:callID.
 // It answers a pending mutating-tool confirmation and streams the rest of
-// the turn.
+// the turn. An approval may carry a payload object that replaces the tool
+// call's arguments (approve-with-edits); binding enforces that a present
+// payload is a JSON object.
 func (h *AgentHandler) Confirm(c echo.Context) error {
 	// Pointer bool: a body that omits "confirmed" must be a 400, not a
 	// silent rejection of the pending call.
 	var body struct {
-		Confirmed *bool `json:"confirmed"`
+		Confirmed *bool          `json:"confirmed"`
+		Payload   map[string]any `json:"payload"`
 	}
 	if err := c.Bind(&body); err != nil || body.Confirmed == nil {
-		return respondError(c, http.StatusBadRequest, "confirmed is required")
+		return respondError(c, http.StatusBadRequest,
+			"confirmed (boolean) is required; payload, when present, must be a JSON object")
 	}
 	return h.stream(c, func(emit appagents.EventSink) error {
 		return h.agent.ResumeConfirmation(
 			c.Request().Context(), c.Param("conversationID"), userIDFrom(c),
-			c.Param("callID"), *body.Confirmed, emit,
+			c.Param("callID"), *body.Confirmed, body.Payload, emit,
 		)
 	})
 }

--- a/api/handlers/agent_handler.go
+++ b/api/handlers/agent_handler.go
@@ -61,23 +61,31 @@ func (h *AgentHandler) SendMessage(c echo.Context) error {
 // Confirm handles POST /agent/conversations/:conversationID/confirmations/:callID.
 // It answers a pending mutating-tool confirmation and streams the rest of
 // the turn. An approval may carry a payload object that replaces the tool
-// call's arguments (approve-with-edits); binding enforces that a present
-// payload is a JSON object.
+// call's arguments (approve-with-edits); a present payload must be a JSON
+// object.
 func (h *AgentHandler) Confirm(c echo.Context) error {
 	// Pointer bool: a body that omits "confirmed" must be a 400, not a
-	// silent rejection of the pending call.
+	// silent rejection of the pending call. Payload binds as raw JSON so
+	// an explicit null is rejected instead of being mistaken for an
+	// omitted payload (which falls back to the model-proposed args).
 	var body struct {
-		Confirmed *bool          `json:"confirmed"`
-		Payload   map[string]any `json:"payload"`
+		Confirmed *bool           `json:"confirmed"`
+		Payload   json.RawMessage `json:"payload"`
 	}
+	const confirmUsage = "confirmed (boolean) is required; payload, when present, must be a JSON object"
 	if err := c.Bind(&body); err != nil || body.Confirmed == nil {
-		return respondError(c, http.StatusBadRequest,
-			"confirmed (boolean) is required; payload, when present, must be a JSON object")
+		return respondError(c, http.StatusBadRequest, confirmUsage)
+	}
+	var payload map[string]any
+	if len(body.Payload) > 0 {
+		if err := json.Unmarshal(body.Payload, &payload); err != nil || payload == nil {
+			return respondError(c, http.StatusBadRequest, confirmUsage)
+		}
 	}
 	return h.stream(c, func(emit appagents.EventSink) error {
 		return h.agent.ResumeConfirmation(
 			c.Request().Context(), c.Param("conversationID"), userIDFrom(c),
-			c.Param("callID"), *body.Confirmed, body.Payload, emit,
+			c.Param("callID"), *body.Confirmed, payload, emit,
 		)
 	})
 }

--- a/api/handlers/agent_handler.go
+++ b/api/handlers/agent_handler.go
@@ -43,7 +43,9 @@ func NewAgentHandler(agent application.ConversationalAgent, logger entities.Logg
 }
 
 // SendMessage handles POST /agent/conversations/:conversationID/messages.
-// The response is a server-sent event stream of entities.AgentEvent.
+// The response is a server-sent event stream of entities.AgentEvent. An
+// optional ?skill=<name> converses with that one skill directly instead of
+// the coordinator (direct invocation for deterministic client flows).
 func (h *AgentHandler) SendMessage(c echo.Context) error {
 	var body struct {
 		Message string `json:"message"`
@@ -53,7 +55,8 @@ func (h *AgentHandler) SendMessage(c echo.Context) error {
 	}
 	return h.stream(c, func(emit appagents.EventSink) error {
 		return h.agent.ConverseStream(
-			c.Request().Context(), c.Param("conversationID"), userIDFrom(c), body.Message, emit,
+			c.Request().Context(), c.Param("conversationID"), userIDFrom(c),
+			body.Message, c.QueryParam("skill"), emit,
 		)
 	})
 }
@@ -85,7 +88,7 @@ func (h *AgentHandler) Confirm(c echo.Context) error {
 	return h.stream(c, func(emit appagents.EventSink) error {
 		return h.agent.ResumeConfirmation(
 			c.Request().Context(), c.Param("conversationID"), userIDFrom(c),
-			c.Param("callID"), *body.Confirmed, payload, emit,
+			c.Param("callID"), *body.Confirmed, payload, c.QueryParam("skill"), emit,
 		)
 	})
 }

--- a/api/handlers/agent_handler_test.go
+++ b/api/handlers/agent_handler_test.go
@@ -20,6 +20,7 @@ type fakeAgent struct {
 	gotMessage string
 	gotCallID  string
 	confirmed  bool
+	gotPayload map[string]any
 }
 
 func (f *fakeAgent) Configured() bool { return f.configured }
@@ -41,10 +42,11 @@ func (f *fakeAgent) ConverseStream(
 }
 
 func (f *fakeAgent) ResumeConfirmation(
-	_ context.Context, _, _, callID string, confirmed bool, emit appagents.EventSink,
+	_ context.Context, _, _, callID string, confirmed bool, payload map[string]any, emit appagents.EventSink,
 ) error {
 	f.gotCallID = callID
 	f.confirmed = confirmed
+	f.gotPayload = payload
 	emit(entities.AgentEvent{Type: entities.AgentEventDone})
 	return nil
 }
@@ -136,6 +138,55 @@ func TestAgentHandler_ConfirmResumesTurn(t *testing.T) {
 	}
 	if agent.gotCallID != "call-9" || !agent.confirmed {
 		t.Errorf("resume args = %q %v", agent.gotCallID, agent.confirmed)
+	}
+}
+
+func TestAgentHandler_ConfirmPassesEditedArgsPayload(t *testing.T) {
+	agent := &fakeAgent{configured: true}
+	h := NewAgentHandler(agent, nopLogger{})
+
+	rec := agentRequest(t, h.Confirm, http.MethodPost,
+		"/agent/conversations/c1/confirmations/call-9",
+		`{"confirmed":true,"payload":{"interpretations":[{"line":1,"category":"groceries"}]}}`,
+		"conversationID", "c1", "callID", "call-9")
+
+	if !strings.Contains(rec.Body.String(), "event: done") {
+		t.Fatalf("stream missing done: %s", rec.Body.String())
+	}
+	if agent.gotPayload == nil {
+		t.Fatal("payload was not passed through to ResumeConfirmation")
+	}
+	if _, ok := agent.gotPayload["interpretations"]; !ok {
+		t.Errorf("payload = %v", agent.gotPayload)
+	}
+}
+
+func TestAgentHandler_ConfirmWithoutPayloadPassesNil(t *testing.T) {
+	agent := &fakeAgent{configured: true, gotPayload: map[string]any{"sentinel": true}}
+	h := NewAgentHandler(agent, nopLogger{})
+
+	agentRequest(t, h.Confirm, http.MethodPost,
+		"/agent/conversations/c1/confirmations/call-9", `{"confirmed":true}`,
+		"conversationID", "c1", "callID", "call-9")
+
+	if agent.gotPayload != nil {
+		t.Errorf("omitted payload must reach the agent as nil, got %v", agent.gotPayload)
+	}
+}
+
+func TestAgentHandler_ConfirmRejectsNonObjectPayload(t *testing.T) {
+	agent := &fakeAgent{configured: true}
+	h := NewAgentHandler(agent, nopLogger{})
+
+	rec := agentRequest(t, h.Confirm, http.MethodPost,
+		"/agent/conversations/c1/confirmations/call-9", `{"confirmed":true,"payload":[1,2]}`,
+		"conversationID", "c1", "callID", "call-9")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("non-object payload must be 400, got %d", rec.Code)
+	}
+	if agent.gotCallID != "" {
+		t.Error("ResumeConfirmation must not run with a malformed payload")
 	}
 }
 

--- a/api/handlers/agent_handler_test.go
+++ b/api/handlers/agent_handler_test.go
@@ -190,6 +190,22 @@ func TestAgentHandler_ConfirmRejectsNonObjectPayload(t *testing.T) {
 	}
 }
 
+func TestAgentHandler_ConfirmRejectsNullPayload(t *testing.T) {
+	agent := &fakeAgent{configured: true}
+	h := NewAgentHandler(agent, nopLogger{})
+
+	rec := agentRequest(t, h.Confirm, http.MethodPost,
+		"/agent/conversations/c1/confirmations/call-9", `{"confirmed":true,"payload":null}`,
+		"conversationID", "c1", "callID", "call-9")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("explicit null payload must be 400, not a silent fallback to model args; got %d", rec.Code)
+	}
+	if agent.gotCallID != "" {
+		t.Error("ResumeConfirmation must not run with a null payload")
+	}
+}
+
 func TestAgentHandler_ConfirmRequiresExplicitDecision(t *testing.T) {
 	agent := &fakeAgent{configured: true}
 	h := NewAgentHandler(agent, nopLogger{})

--- a/api/handlers/agent_handler_test.go
+++ b/api/handlers/agent_handler_test.go
@@ -21,6 +21,7 @@ type fakeAgent struct {
 	gotCallID  string
 	confirmed  bool
 	gotPayload map[string]any
+	gotSkill   string
 }
 
 func (f *fakeAgent) Configured() bool { return f.configured }
@@ -30,9 +31,10 @@ func (f *fakeAgent) Converse(context.Context, string, string, string) (widgets.R
 }
 
 func (f *fakeAgent) ConverseStream(
-	_ context.Context, _, _, message string, emit appagents.EventSink,
+	_ context.Context, _, _, message, skill string, emit appagents.EventSink,
 ) error {
 	f.gotMessage = message
+	f.gotSkill = skill
 	emit(entities.AgentEvent{Type: entities.AgentEventText, Text: "hel"})
 	emit(entities.AgentEvent{Type: entities.AgentEventText, Text: "lo"})
 	resp := widgets.FromText("hello")
@@ -42,11 +44,13 @@ func (f *fakeAgent) ConverseStream(
 }
 
 func (f *fakeAgent) ResumeConfirmation(
-	_ context.Context, _, _, callID string, confirmed bool, payload map[string]any, emit appagents.EventSink,
+	_ context.Context, _, _, callID string, confirmed bool, payload map[string]any,
+	skill string, emit appagents.EventSink,
 ) error {
 	f.gotCallID = callID
 	f.confirmed = confirmed
 	f.gotPayload = payload
+	f.gotSkill = skill
 	emit(entities.AgentEvent{Type: entities.AgentEventDone})
 	return nil
 }
@@ -138,6 +142,36 @@ func TestAgentHandler_ConfirmResumesTurn(t *testing.T) {
 	}
 	if agent.gotCallID != "call-9" || !agent.confirmed {
 		t.Errorf("resume args = %q %v", agent.gotCallID, agent.confirmed)
+	}
+}
+
+func TestAgentHandler_SkillParamThreadsThrough(t *testing.T) {
+	agent := &fakeAgent{configured: true}
+	h := NewAgentHandler(agent, nopLogger{})
+
+	agentRequest(t, h.SendMessage, http.MethodPost,
+		"/agent/conversations/c1/messages?skill=statement_import", `{"message":"hi"}`,
+		"conversationID", "c1")
+	if agent.gotSkill != "statement_import" {
+		t.Errorf("SendMessage skill = %q", agent.gotSkill)
+	}
+
+	agentRequest(t, h.Confirm, http.MethodPost,
+		"/agent/conversations/c1/confirmations/call-9?skill=statement_import", `{"confirmed":true}`,
+		"conversationID", "c1", "callID", "call-9")
+	if agent.gotSkill != "statement_import" {
+		t.Errorf("Confirm skill = %q", agent.gotSkill)
+	}
+}
+
+func TestAgentHandler_NoSkillParamMeansCoordinator(t *testing.T) {
+	agent := &fakeAgent{configured: true, gotSkill: "sentinel"}
+	h := NewAgentHandler(agent, nopLogger{})
+
+	agentRequest(t, h.SendMessage, http.MethodPost,
+		"/agent/conversations/c1/messages", `{"message":"hi"}`, "conversationID", "c1")
+	if agent.gotSkill != "" {
+		t.Errorf("omitted skill must reach the agent empty, got %q", agent.gotSkill)
 	}
 }
 

--- a/application/agent_service.go
+++ b/application/agent_service.go
@@ -43,9 +43,14 @@ type ConversationalAgent interface {
 	ConverseStream(ctx context.Context, conversationID, userID, message string, emit appagents.EventSink) error
 	// ResumeConfirmation answers a pending mutating-tool confirmation and
 	// streams the rest of the turn. Pending confirmations live in the
-	// durable session, so they survive refreshes and restarts.
+	// durable session, so they survive refreshes and restarts. A non-nil
+	// payload on an approval replaces the tool call's arguments wholesale
+	// (approve-with-edits): what executes is exactly what the user
+	// submitted. A nil payload runs the original arguments; a payload on a
+	// rejection is ignored.
 	ResumeConfirmation(
-		ctx context.Context, conversationID, userID, callID string, confirmed bool, emit appagents.EventSink,
+		ctx context.Context, conversationID, userID, callID string, confirmed bool,
+		payload map[string]any, emit appagents.EventSink,
 	) error
 	// History returns the conversation so far, oldest first.
 	History(ctx context.Context, conversationID, userID string) ([]entities.AgentMessage, error)

--- a/application/agent_service.go
+++ b/application/agent_service.go
@@ -39,18 +39,22 @@ type ConversationalAgent interface {
 	// versioned widget contract (pkg/widgets).
 	Converse(ctx context.Context, conversationID, userID, message string) (widgets.Response, error)
 	// ConverseStream runs one turn, emitting text deltas, any pending tool
-	// confirmation (input_requested), then widgets and done.
-	ConverseStream(ctx context.Context, conversationID, userID, message string, emit appagents.EventSink) error
+	// confirmation (input_requested), then widgets and done. A non-empty
+	// skill converses with that one skill directly — built as the turn's
+	// root agent, bypassing coordinator routing — so a client's flow stays
+	// deterministic; empty keeps the coordinator.
+	ConverseStream(ctx context.Context, conversationID, userID, message, skill string, emit appagents.EventSink) error
 	// ResumeConfirmation answers a pending mutating-tool confirmation and
 	// streams the rest of the turn. Pending confirmations live in the
 	// durable session, so they survive refreshes and restarts. A non-nil
 	// payload on an approval replaces the tool call's arguments wholesale
 	// (approve-with-edits): what executes is exactly what the user
 	// submitted. A nil payload runs the original arguments; a payload on a
-	// rejection is ignored.
+	// rejection is ignored. skill must repeat the value the paused turn ran
+	// with (the resume rebuilds the same root agent).
 	ResumeConfirmation(
 		ctx context.Context, conversationID, userID, callID string, confirmed bool,
-		payload map[string]any, emit appagents.EventSink,
+		payload map[string]any, skill string, emit appagents.EventSink,
 	) error
 	// History returns the conversation so far, oldest first.
 	History(ctx context.Context, conversationID, userID string) ([]entities.AgentMessage, error)

--- a/application/agent_skills.go
+++ b/application/agent_skills.go
@@ -26,6 +26,7 @@ import (
 	"github.com/wepala/weos/v3/domain/entities"
 	"github.com/wepala/weos/v3/domain/repositories"
 
+	"github.com/akeemphilbert/pericarp/pkg/auth"
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
 )
 
@@ -119,9 +120,11 @@ func (r *SkillRegistry) load(ctx context.Context) ([]entities.SkillDefinition, e
 	// Skills are installed app capabilities, not per-user data: a skill
 	// seeded at boot (a preset fixture, a downstream binary's seed hook)
 	// carries no account attribution, and the caller's account-scoped
-	// visibility would hide it from every authenticated user. List them
-	// through an identity-free context, which the service reads unscoped.
-	listCtx := context.Background()
+	// visibility would hide it from every authenticated user. Strip only
+	// the identity — the service then reads unscoped — keeping the
+	// caller's context so cancellation and deadlines still bound the
+	// listing (load holds the registry mutex).
+	listCtx := auth.ContextWithAgent(ctx, nil)
 	for {
 		page, err := r.resources.List(listCtx, AgentSkillTypeSlug, cursor, 100, repositories.SortOptions{})
 		if err != nil {

--- a/application/agent_skills.go
+++ b/application/agent_skills.go
@@ -116,8 +116,14 @@ func (r *SkillRegistry) load(ctx context.Context) ([]entities.SkillDefinition, e
 	var defs []entities.SkillDefinition
 	seen := map[string]string{} // skill name -> resource URN
 	cursor := ""
+	// Skills are installed app capabilities, not per-user data: a skill
+	// seeded at boot (a preset fixture, a downstream binary's seed hook)
+	// carries no account attribution, and the caller's account-scoped
+	// visibility would hide it from every authenticated user. List them
+	// through an identity-free context, which the service reads unscoped.
+	listCtx := context.Background()
 	for {
-		page, err := r.resources.List(ctx, AgentSkillTypeSlug, cursor, 100, repositories.SortOptions{})
+		page, err := r.resources.List(listCtx, AgentSkillTypeSlug, cursor, 100, repositories.SortOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("list %s resources: %w", AgentSkillTypeSlug, err)
 		}

--- a/application/agent_skills_test.go
+++ b/application/agent_skills_test.go
@@ -8,17 +8,21 @@ import (
 
 	"github.com/wepala/weos/v3/domain/entities"
 	"github.com/wepala/weos/v3/domain/repositories"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
 )
 
 // fakeSkillSource pages agent-skill resources out of a static slice.
 type fakeSkillSource struct {
 	resources []*entities.Resource
 	err       error
+	gotCtx    context.Context
 }
 
 func (f *fakeSkillSource) List(
-	_ context.Context, typeSlug, _ string, _ int, _ repositories.SortOptions,
+	ctx context.Context, typeSlug, _ string, _ int, _ repositories.SortOptions,
 ) (repositories.PaginatedResponse[*entities.Resource], error) {
+	f.gotCtx = ctx
 	if f.err != nil {
 		return repositories.PaginatedResponse[*entities.Resource]{}, f.err
 	}
@@ -39,6 +43,32 @@ func skillResource(t *testing.T, id string, data string) *entities.Resource {
 
 const goodSkillJSON = `{"schemaVersion":1,"name":"researcher","description":"Finds things",` +
 	`"instructions":"Search first.","tools":["kg_search_entities"],"mode":"task"}`
+
+func TestSkillRegistry_ListStripsIdentityKeepsCancellation(t *testing.T) {
+	source := &fakeSkillSource{resources: []*entities.Resource{
+		skillResource(t, "urn:agent-skill:one", goodSkillJSON),
+	}}
+	registry := &SkillRegistry{resources: source, logger: noopLogger{}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = auth.ContextWithAgent(ctx, &auth.Identity{AgentID: "u1", ActiveAccountID: "acc1"})
+
+	if _, err := registry.Skills(ctx); err != nil {
+		t.Fatalf("Skills: %v", err)
+	}
+	// Skills are app capabilities: the listing must read unscoped even when
+	// the caller is authenticated...
+	if got := auth.AgentFromCtx(source.gotCtx); got != nil {
+		t.Errorf("listing must be identity-free, saw agent %q", got.AgentID)
+	}
+	// ...but must still die with the caller — not run on detached from
+	// context.Background() while holding the registry mutex.
+	cancel()
+	if source.gotCtx.Err() == nil {
+		t.Error("listing context must inherit the caller's cancellation")
+	}
+}
 
 func TestParseSkillDefinition_AppliesDefaults(t *testing.T) {
 	def, err := ParseSkillDefinition("urn:agent-skill:x", json.RawMessage(

--- a/application/agents/orchestrator.go
+++ b/application/agents/orchestrator.go
@@ -17,6 +17,7 @@ package agents
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -206,7 +207,80 @@ func (o *Orchestrator) ResumeConfirmation(
 	case !confirmed:
 		episode = "[rejected a pending action]"
 	}
+	// The episode carries what was proposed and what the user chose, so the
+	// turn's note gives consolidation the correction signal — proposed-vs-
+	// chosen per approval — not just the fact that something was approved.
+	episode += o.confirmationEpisodeDetail(ctx, userID, conversationID, callID, payload)
 	return o.runTurn(ctx, conversationID, userID, content, episode, skill, emit)
+}
+
+// episodeDetailCap bounds one proposed/chosen blob in an episode; a huge
+// tool payload must not turn the note store into a payload archive.
+const episodeDetailCap = 4000
+
+// confirmationEpisodeDetail renders the pending call's proposal (its
+// original arguments, read from the durable session) and the user's chosen
+// payload as note-friendly lines. Best-effort: a session read failure just
+// yields a plainer episode — remembering must not break answering.
+func (o *Orchestrator) confirmationEpisodeDetail(
+	ctx context.Context, userID, conversationID, callID string, payload map[string]any,
+) string {
+	detail := ""
+	if tool, args := o.pendingCallProposal(ctx, userID, conversationID, callID); tool != "" {
+		detail += "\ntool: " + tool
+		if len(args) > 0 {
+			detail += "\nproposed: " + boundedJSON(args, episodeDetailCap)
+		}
+	}
+	if payload != nil {
+		detail += "\nchosen: " + boundedJSON(payload, episodeDetailCap)
+	}
+	return detail
+}
+
+// pendingCallProposal finds the paused tool call in the conversation's
+// session and returns the tool name and the arguments the model proposed.
+func (o *Orchestrator) pendingCallProposal(
+	ctx context.Context, userID, conversationID, callID string,
+) (string, map[string]any) {
+	resp, err := o.sessions.Get(ctx, &session.GetRequest{
+		AppName:   OrchestratorAppName,
+		UserID:    userID,
+		SessionID: conversationID,
+	})
+	if err != nil {
+		o.logger.Debug(ctx, "episode detail unavailable: session read failed", "error", err.Error())
+		return "", nil
+	}
+	for event := range resp.Session.Events().All() {
+		if event.Content == nil {
+			continue
+		}
+		for _, p := range event.Content.Parts {
+			if p == nil || p.FunctionCall == nil ||
+				p.FunctionCall.Name != toolconfirmation.FunctionCallName || p.FunctionCall.ID != callID {
+				continue
+			}
+			orig, oerr := toolconfirmation.OriginalCallFrom(p.FunctionCall)
+			if oerr != nil || orig == nil {
+				return "", nil
+			}
+			return orig.Name, orig.Args
+		}
+	}
+	return "", nil
+}
+
+// boundedJSON renders v as JSON, truncated to cap bytes.
+func boundedJSON(v any, cap int) string {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return ""
+	}
+	if len(raw) > cap {
+		return string(raw[:cap]) + "…(truncated)"
+	}
+	return string(raw)
 }
 
 // History returns the conversation so far, oldest first. A conversation

--- a/application/agents/orchestrator.go
+++ b/application/agents/orchestrator.go
@@ -271,16 +271,35 @@ func (o *Orchestrator) pendingCallProposal(
 	return "", nil
 }
 
-// boundedJSON renders v as JSON, truncated to cap bytes.
-func boundedJSON(v any, cap int) string {
+// boundedJSON renders v as JSON within limit bytes — by dropping whole
+// interpretation lines (with an omittedLines count) when the value carries
+// an interpretations array, never by cutting mid-JSON: every consumer of
+// the blob parses the whole thing, so a byte-truncated blob would lose
+// EVERY line's signal, not just the overflow.
+func boundedJSON(v any, limit int) string {
 	raw, err := json.Marshal(v)
 	if err != nil {
-		return ""
+		return "{}"
 	}
-	if len(raw) > cap {
-		return string(raw[:cap]) + "…(truncated)"
+	if len(raw) <= limit {
+		return string(raw)
 	}
-	return string(raw)
+	if m, ok := v.(map[string]any); ok {
+		if lines, ok := m["interpretations"].([]any); ok {
+			trimmed := make(map[string]any, len(m)+1)
+			for k, val := range m {
+				trimmed[k] = val
+			}
+			for n := len(lines) - 1; n >= 0; n-- {
+				trimmed["interpretations"] = lines[:n]
+				trimmed["omittedLines"] = len(lines) - n
+				if raw, err = json.Marshal(trimmed); err == nil && len(raw) <= limit {
+					return string(raw)
+				}
+			}
+		}
+	}
+	return `{"omitted":"the blob exceeded the episode size cap"}`
 }
 
 // History returns the conversation so far, oldest first. A conversation

--- a/application/agents/orchestrator.go
+++ b/application/agents/orchestrator.go
@@ -175,20 +175,31 @@ func (o *Orchestrator) ConverseStream(
 // ResumeConfirmation answers a pending tool confirmation (per the ADK
 // tool-confirmation protocol) and streams the rest of the turn. The pending
 // call lives in the durable session, so a confirmation survives refreshes
-// and restarts.
+// and restarts. A non-nil payload rides the confirmation response into
+// ADK's ToolConfirmation.Payload — the toolset substitutes it for the
+// call's arguments on approval (approve-with-edits) — and is durable for
+// the same reason the confirmation is.
 func (o *Orchestrator) ResumeConfirmation(
-	ctx context.Context, conversationID, userID, callID string, confirmed bool, emit EventSink,
+	ctx context.Context, conversationID, userID, callID string, confirmed bool,
+	payload map[string]any, emit EventSink,
 ) error {
+	response := map[string]any{"confirmed": confirmed}
+	if payload != nil {
+		response["payload"] = payload
+	}
 	content := &genai.Content{
 		Role: genai.RoleUser,
 		Parts: []*genai.Part{{FunctionResponse: &genai.FunctionResponse{
 			Name:     toolconfirmation.FunctionCallName,
 			ID:       callID,
-			Response: map[string]any{"confirmed": confirmed},
+			Response: response,
 		}}},
 	}
 	episode := "[approved a pending action]"
-	if !confirmed {
+	switch {
+	case confirmed && payload != nil:
+		episode = "[approved a pending action with edits]"
+	case !confirmed:
 		episode = "[rejected a pending action]"
 	}
 	return o.runTurn(ctx, conversationID, userID, content, episode, emit)

--- a/application/agents/orchestrator.go
+++ b/application/agents/orchestrator.go
@@ -151,7 +151,7 @@ func (o *Orchestrator) Converse(
 	ctx context.Context, conversationID, userID, message string,
 ) (widgets.Response, error) {
 	var out widgets.Response
-	err := o.ConverseStream(ctx, conversationID, userID, message, func(e entities.AgentEvent) {
+	err := o.ConverseStream(ctx, conversationID, userID, message, "", func(e entities.AgentEvent) {
 		if e.Type == entities.AgentEventWidgets && e.Widgets != nil {
 			out = *e.Widgets
 		}
@@ -164,12 +164,14 @@ type EventSink func(entities.AgentEvent)
 
 // ConverseStream runs one turn, emitting text deltas as the model produces
 // them, an input_requested event when a mutating tool awaits the user's
-// confirmation, and finally the validated widgets plus done.
+// confirmation, and finally the validated widgets plus done. A non-empty
+// skill converses with that one skill directly (built as the root agent,
+// no coordinator routing); empty keeps the coordinator.
 func (o *Orchestrator) ConverseStream(
-	ctx context.Context, conversationID, userID, message string, emit EventSink,
+	ctx context.Context, conversationID, userID, message, skill string, emit EventSink,
 ) error {
 	content := &genai.Content{Parts: []*genai.Part{{Text: message}}, Role: genai.RoleUser}
-	return o.runTurn(ctx, conversationID, userID, content, message, emit)
+	return o.runTurn(ctx, conversationID, userID, content, message, skill, emit)
 }
 
 // ResumeConfirmation answers a pending tool confirmation (per the ADK
@@ -178,10 +180,12 @@ func (o *Orchestrator) ConverseStream(
 // and restarts. A non-nil payload rides the confirmation response into
 // ADK's ToolConfirmation.Payload — the toolset substitutes it for the
 // call's arguments on approval (approve-with-edits) — and is durable for
-// the same reason the confirmation is.
+// the same reason the confirmation is. skill must name the same skill the
+// paused turn ran as (the resumed turn rebuilds the same root); empty means
+// the coordinator.
 func (o *Orchestrator) ResumeConfirmation(
 	ctx context.Context, conversationID, userID, callID string, confirmed bool,
-	payload map[string]any, emit EventSink,
+	payload map[string]any, skill string, emit EventSink,
 ) error {
 	response := map[string]any{"confirmed": confirmed}
 	if payload != nil {
@@ -202,7 +206,7 @@ func (o *Orchestrator) ResumeConfirmation(
 	case !confirmed:
 		episode = "[rejected a pending action]"
 	}
-	return o.runTurn(ctx, conversationID, userID, content, episode, emit)
+	return o.runTurn(ctx, conversationID, userID, content, episode, skill, emit)
 }
 
 // History returns the conversation so far, oldest first. A conversation
@@ -251,15 +255,16 @@ func isSessionNotFound(err error) bool {
 }
 
 // runTurn drives the runner for one inbound content (a user message or a
-// confirmation response) and emits the turn's events.
+// confirmation response) and emits the turn's events. A non-empty skill
+// builds that skill as the root instead of the coordinator.
 func (o *Orchestrator) runTurn(
 	ctx context.Context, conversationID, userID string,
-	content *genai.Content, episodeMessage string, emit EventSink,
+	content *genai.Content, episodeMessage, skill string, emit EventSink,
 ) error {
 	if !o.Configured() {
 		return ErrNotConfigured
 	}
-	root, err := o.buildRoot(ctx)
+	root, err := o.rootFor(ctx, skill)
 	if err != nil {
 		return err
 	}
@@ -347,6 +352,55 @@ func (o *Orchestrator) recordEpisode(ctx context.Context, conversationID, userID
 		o.logger.Error(ctx, "failed to record conversation episode",
 			"conversationID", conversationID, "error", err.Error())
 	}
+}
+
+// rootFor picks the turn's root agent: the named skill built as root
+// (direct invocation), or the coordinator when skill is empty.
+func (o *Orchestrator) rootFor(ctx context.Context, skill string) (agent.Agent, error) {
+	if skill == "" {
+		return o.buildRoot(ctx)
+	}
+	return o.buildSkillRoot(ctx, skill)
+}
+
+// buildSkillRoot builds one named skill as the conversation's root agent —
+// the direct-invocation path a client uses to keep its flow deterministic
+// instead of relying on coordinator routing.
+func (o *Orchestrator) buildSkillRoot(ctx context.Context, name string) (agent.Agent, error) {
+	o.mu.RLock()
+	skills := o.skills
+	toolsets := o.toolsets
+	o.mu.RUnlock()
+
+	if skills == nil {
+		return nil, fmt.Errorf("unknown skill %q: no skills are loaded", name)
+	}
+	defs, err := skills(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load skills: %w", err)
+	}
+	var def *entities.SkillDefinition
+	for i := range defs {
+		if defs[i].Name == name {
+			def = &defs[i]
+			break
+		}
+	}
+	if def == nil {
+		return nil, fmt.Errorf("unknown skill %q", name)
+	}
+
+	var ts tool.Toolset
+	if toolsets != nil {
+		if ts, err = toolsets(ctx); err != nil {
+			return nil, fmt.Errorf("open toolset: %w", err)
+		}
+	}
+	root, err := BuildSkillRootAgent(*def, o.model, ts)
+	if err != nil {
+		return nil, fmt.Errorf("build skill root %q: %w", name, err)
+	}
+	return root, nil
 }
 
 // buildRoot assembles the coordinator with one sub-agent per loaded skill.

--- a/application/agents/orchestrator.go
+++ b/application/agents/orchestrator.go
@@ -181,13 +181,22 @@ func (o *Orchestrator) ConverseStream(
 // and restarts. A non-nil payload rides the confirmation response into
 // ADK's ToolConfirmation.Payload — the toolset substitutes it for the
 // call's arguments on approval (approve-with-edits) — and is durable for
-// the same reason the confirmation is. skill must name the same skill the
-// paused turn ran as (the resumed turn rebuilds the same root); empty means
-// the coordinator.
+// the same reason the confirmation is. On a rejection the payload is
+// dropped: nothing executes, so persisting edited args would only bloat
+// the session. skill must name the same skill the paused turn ran as (the
+// resumed turn rebuilds the same root); empty means the coordinator.
 func (o *Orchestrator) ResumeConfirmation(
 	ctx context.Context, conversationID, userID, callID string, confirmed bool,
 	payload map[string]any, skill string, emit EventSink,
 ) error {
+	// Checked here as well as in runTurn: the episode-detail session read
+	// below would otherwise dereference a nil session service.
+	if !o.Configured() {
+		return ErrNotConfigured
+	}
+	if !confirmed {
+		payload = nil
+	}
 	response := map[string]any{"confirmed": confirmed}
 	if payload != nil {
 		response["payload"] = payload

--- a/application/agents/orchestrator.go
+++ b/application/agents/orchestrator.go
@@ -367,7 +367,13 @@ func (o *Orchestrator) runTurn(
 	}
 
 	text := out.String()
-	if episodeMessage != "" && text != "" {
+	if episodeMessage != "" && text == "" {
+		// A turn can legitimately end with no prose (e.g. a rejection whose
+		// next action was another tool call). The episode still matters —
+		// "rejections are written back" is only true if a silent turn is
+		// recorded too.
+		o.recordEpisode(ctx, conversationID, userID, episodeMessage, "[no textual reply]")
+	} else if episodeMessage != "" {
 		o.recordEpisode(ctx, conversationID, userID, episodeMessage, text)
 	}
 	// Server-side validation: whatever the model produced renders — contract

--- a/application/agents/orchestrator_test.go
+++ b/application/agents/orchestrator_test.go
@@ -152,6 +152,26 @@ func TestOrchestrator_UnknownSkillErrors(t *testing.T) {
 	}
 }
 
+func TestConfirmationEpisodeDetail_MissingCallStaysPlain(t *testing.T) {
+	o := NewOrchestrator(scriptedLLM{text: "ok"}, session.InMemoryService(), testLogger{})
+
+	// No such session/call: the episode gains only the chosen payload — a
+	// session read failure must never break remembering the user's choice.
+	detail := o.confirmationEpisodeDetail(context.Background(), "u1", "conv-x", "call-9",
+		map[string]any{"statementId": "urn:statement:1"})
+	if !strings.Contains(detail, `"statementId":"urn:statement:1"`) || strings.Contains(detail, "proposed:") {
+		t.Errorf("detail = %q, want chosen-only", detail)
+	}
+}
+
+func TestBoundedJSON_Truncates(t *testing.T) {
+	long := strings.Repeat("x", 5000)
+	out := boundedJSON(map[string]any{"v": long}, 100)
+	if len(out) > 120 || !strings.Contains(out, "…(truncated)") {
+		t.Errorf("boundedJSON did not truncate: %d bytes", len(out))
+	}
+}
+
 func TestOrchestrator_ConverseMultiTurnSharesSession(t *testing.T) {
 	o := NewOrchestrator(scriptedLLM{text: "answer"}, session.InMemoryService(), testLogger{})
 

--- a/application/agents/orchestrator_test.go
+++ b/application/agents/orchestrator_test.go
@@ -2,6 +2,7 @@ package agents
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"iter"
 	"strings"
@@ -164,11 +165,29 @@ func TestConfirmationEpisodeDetail_MissingCallStaysPlain(t *testing.T) {
 	}
 }
 
-func TestBoundedJSON_Truncates(t *testing.T) {
-	long := strings.Repeat("x", 5000)
-	out := boundedJSON(map[string]any{"v": long}, 100)
-	if len(out) > 120 || !strings.Contains(out, "…(truncated)") {
-		t.Errorf("boundedJSON did not truncate: %d bytes", len(out))
+func TestBoundedJSON_DropsWholeLinesNeverMidJSON(t *testing.T) {
+	// An oversized interpretations payload trims whole lines and stays
+	// valid JSON with an omittedLines count.
+	lines := make([]any, 0, 100)
+	for i := 0; i < 100; i++ {
+		lines = append(lines, map[string]any{"description": strings.Repeat("m", 80), "treatment": "expense"})
+	}
+	out := boundedJSON(map[string]any{"statementId": "urn:statement:1", "interpretations": lines}, 2000)
+	if len(out) > 2000 {
+		t.Fatalf("blob exceeds the cap: %d bytes", len(out))
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("capped blob must stay valid JSON: %v — %s", err, out)
+	}
+	if parsed["omittedLines"] == nil {
+		t.Error("a trimmed blob must say how many lines were dropped")
+	}
+
+	// A non-conforming oversized value degrades to a valid marker object.
+	out = boundedJSON(map[string]any{"v": strings.Repeat("x", 5000)}, 100)
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("fallback blob must stay valid JSON: %v", err)
 	}
 }
 

--- a/application/agents/orchestrator_test.go
+++ b/application/agents/orchestrator_test.go
@@ -93,6 +93,65 @@ func TestOrchestrator_BuildRootSkipsBrokenSkill(t *testing.T) {
 	}
 }
 
+func TestOrchestrator_DirectSkillInvocation(t *testing.T) {
+	o := NewOrchestrator(scriptedLLM{text: "ok"}, session.InMemoryService(), testLogger{})
+	o.SetSkillSource(func(context.Context) ([]entities.SkillDefinition, error) {
+		return []entities.SkillDefinition{
+			// ModeTask on purpose: the root build must override it (a root
+			// task agent would get a parentless finish_task tool).
+			{SchemaVersion: 1, Name: "statement_import", Description: "d", Instructions: "i",
+				Mode: entities.SkillModeTask},
+		}, nil
+	})
+
+	root, err := o.buildSkillRoot(context.Background(), "statement_import")
+	if err != nil {
+		t.Fatalf("buildSkillRoot: %v", err)
+	}
+	if root.Name() != "statement_import" {
+		t.Errorf("root = %q, want the skill itself", root.Name())
+	}
+	if len(root.SubAgents()) != 0 {
+		t.Errorf("a skill root must have no sub-agents, got %d", len(root.SubAgents()))
+	}
+
+	// The seam is additive: a full turn against the skill still emits the
+	// standard event sequence.
+	var types []string
+	err = o.ConverseStream(context.Background(), "c1", "u1", "q", "statement_import",
+		func(e entities.AgentEvent) { types = append(types, e.Type) })
+	if err != nil {
+		t.Fatalf("ConverseStream(skill): %v", err)
+	}
+	if len(types) == 0 || types[len(types)-1] != entities.AgentEventDone {
+		t.Errorf("event types = %v, want a done-terminated turn", types)
+	}
+}
+
+func TestOrchestrator_UnknownSkillErrors(t *testing.T) {
+	o := NewOrchestrator(scriptedLLM{text: "ok"}, session.InMemoryService(), testLogger{})
+	o.SetSkillSource(func(context.Context) ([]entities.SkillDefinition, error) {
+		return []entities.SkillDefinition{
+			{SchemaVersion: 1, Name: "other", Description: "d", Instructions: "i",
+				Mode: entities.SkillModeTask},
+		}, nil
+	})
+
+	err := o.ConverseStream(context.Background(), "c1", "u1", "q", "statement_import",
+		func(entities.AgentEvent) {})
+	if err == nil || !strings.Contains(err.Error(), `unknown skill "statement_import"`) {
+		t.Fatalf("expected unknown-skill error, got: %v", err)
+	}
+
+	// No skills loaded at all must also be a clear error, not a nil deref.
+	bare := NewOrchestrator(scriptedLLM{text: "ok"}, session.InMemoryService(), testLogger{})
+	err = bare.ConverseStream(context.Background(), "c1", "u1", "q", "statement_import",
+		func(entities.AgentEvent) {})
+	if err == nil || !strings.Contains(err.Error(), "unknown skill") {
+		t.Fatalf("expected unknown-skill error with no skills loaded, got: %v", err)
+	}
+}
+
 func TestOrchestrator_ConverseMultiTurnSharesSession(t *testing.T) {
 	o := NewOrchestrator(scriptedLLM{text: "answer"}, session.InMemoryService(), testLogger{})
 
@@ -145,7 +204,7 @@ func TestOrchestrator_ConverseStreamEmitsTextWidgetsDone(t *testing.T) {
 	o := NewOrchestrator(scriptedLLM{text: "streamed"}, session.InMemoryService(), testLogger{})
 
 	var types []string
-	err := o.ConverseStream(context.Background(), "c1", "u1", "q", func(e entities.AgentEvent) {
+	err := o.ConverseStream(context.Background(), "c1", "u1", "q", "", func(e entities.AgentEvent) {
 		types = append(types, e.Type)
 	})
 	if err != nil {

--- a/application/agents/orchestrator_test.go
+++ b/application/agents/orchestrator_test.go
@@ -153,6 +153,41 @@ func TestOrchestrator_UnknownSkillErrors(t *testing.T) {
 	}
 }
 
+func TestOrchestrator_ResumeConfirmationNotConfigured(t *testing.T) {
+	o := NewOrchestrator(nil, nil, testLogger{})
+
+	// The episode-detail session read must not run (nil session service
+	// would panic); the call must fail like every other unconfigured turn.
+	err := o.ResumeConfirmation(context.Background(), "c1", "u1", "call-1", true,
+		map[string]any{"a": 1}, "", func(entities.AgentEvent) {})
+	if !errors.Is(err, ErrNotConfigured) {
+		t.Fatalf("expected ErrNotConfigured, got: %v", err)
+	}
+}
+
+func TestOrchestrator_RejectionDropsPayload(t *testing.T) {
+	o := NewOrchestrator(scriptedLLM{text: "ok"}, session.InMemoryService(), testLogger{})
+	var episode string
+	o.SetEpisodeRecorder(func(_ context.Context, _, _, message, _ string) error {
+		episode = message
+		return nil
+	})
+
+	// The contract: a payload on a rejection is ignored — neither the
+	// confirmation response nor the episode may carry the edited args.
+	err := o.ResumeConfirmation(context.Background(), "c1", "u1", "call-1", false,
+		map[string]any{"edited": "args"}, "", func(entities.AgentEvent) {})
+	if err != nil {
+		t.Fatalf("ResumeConfirmation: %v", err)
+	}
+	if !strings.Contains(episode, "[rejected a pending action]") {
+		t.Fatalf("episode = %q, want the rejection marker", episode)
+	}
+	if strings.Contains(episode, "chosen:") || strings.Contains(episode, "edited") {
+		t.Errorf("a rejected payload leaked into the episode: %q", episode)
+	}
+}
+
 func TestConfirmationEpisodeDetail_MissingCallStaysPlain(t *testing.T) {
 	o := NewOrchestrator(scriptedLLM{text: "ok"}, session.InMemoryService(), testLogger{})
 

--- a/application/agents/orchestrator_test.go
+++ b/application/agents/orchestrator_test.go
@@ -98,10 +98,13 @@ func TestOrchestrator_DirectSkillInvocation(t *testing.T) {
 	o := NewOrchestrator(scriptedLLM{text: "ok"}, session.InMemoryService(), testLogger{})
 	o.SetSkillSource(func(context.Context) ([]entities.SkillDefinition, error) {
 		return []entities.SkillDefinition{
-			// ModeTask on purpose: the root build must override it (a root
-			// task agent would get a parentless finish_task tool).
+			// Non-chat modes on purpose: the root build must override both —
+			// the ADK runner rejects any non-chat root, and a root task agent
+			// would additionally get a parentless finish_task tool.
 			{SchemaVersion: 1, Name: "statement_import", Description: "d", Instructions: "i",
 				Mode: entities.SkillModeTask},
+			{SchemaVersion: 1, Name: "quick_answer", Description: "d", Instructions: "i",
+				Mode: entities.SkillModeSingleTurn},
 		}, nil
 	})
 
@@ -117,15 +120,18 @@ func TestOrchestrator_DirectSkillInvocation(t *testing.T) {
 	}
 
 	// The seam is additive: a full turn against the skill still emits the
-	// standard event sequence.
-	var types []string
-	err = o.ConverseStream(context.Background(), "c1", "u1", "q", "statement_import",
-		func(e entities.AgentEvent) { types = append(types, e.Type) })
-	if err != nil {
-		t.Fatalf("ConverseStream(skill): %v", err)
-	}
-	if len(types) == 0 || types[len(types)-1] != entities.AgentEventDone {
-		t.Errorf("event types = %v, want a done-terminated turn", types)
+	// standard event sequence — for the single_turn skill too, which would
+	// fail outright if the root build preserved its declared mode.
+	for _, skillName := range []string{"statement_import", "quick_answer"} {
+		var types []string
+		err = o.ConverseStream(context.Background(), "c-"+skillName, "u1", "q", skillName,
+			func(e entities.AgentEvent) { types = append(types, e.Type) })
+		if err != nil {
+			t.Fatalf("ConverseStream(%s): %v", skillName, err)
+		}
+		if len(types) == 0 || types[len(types)-1] != entities.AgentEventDone {
+			t.Errorf("%s event types = %v, want a done-terminated turn", skillName, types)
+		}
 	}
 }
 

--- a/application/agents/skill_agent.go
+++ b/application/agents/skill_agent.go
@@ -119,9 +119,12 @@ func BuildSkillAgent(def entities.SkillDefinition, m model.LLM, toolset tool.Too
 
 // BuildSkillRootAgent builds the skill as a conversation's root agent (the
 // direct-invocation path, bypassing the coordinator). The declared
-// delegation mode is deliberately ignored: a root ModeTask agent would
-// self-install a finish_task tool with no parent to consume it, letting the
-// model end a turn with no output.
+// delegation mode is deliberately ignored — it governs how a PARENT invokes
+// the skill, and a root has no parent. Chat is also the only mode the ADK
+// runner accepts for a root ("root agent must be a chat LlmAgent"): a
+// ModeSingleTurn root would fail every turn outright, and a ModeTask root
+// would self-install a finish_task tool with no parent to consume it. The
+// skill's instructions ride along unchanged either way.
 func BuildSkillRootAgent(def entities.SkillDefinition, m model.LLM, toolset tool.Toolset) (agent.Agent, error) {
 	return buildSkillAgent(def, m, toolset, llmagent.ModeChat)
 }

--- a/application/agents/skill_agent.go
+++ b/application/agents/skill_agent.go
@@ -110,16 +110,30 @@ var widgetResponseSchema = &genai.Schema{
 // factory is the only place a skill becomes code, which is what lets
 // projects add skills without recompiling.
 func BuildSkillAgent(def entities.SkillDefinition, m model.LLM, toolset tool.Toolset) (agent.Agent, error) {
+	mode := llmagent.ModeTask
+	if def.Mode == entities.SkillModeSingleTurn {
+		mode = llmagent.ModeSingleTurn
+	}
+	return buildSkillAgent(def, m, toolset, mode)
+}
+
+// BuildSkillRootAgent builds the skill as a conversation's root agent (the
+// direct-invocation path, bypassing the coordinator). The declared
+// delegation mode is deliberately ignored: a root ModeTask agent would
+// self-install a finish_task tool with no parent to consume it, letting the
+// model end a turn with no output.
+func BuildSkillRootAgent(def entities.SkillDefinition, m model.LLM, toolset tool.Toolset) (agent.Agent, error) {
+	return buildSkillAgent(def, m, toolset, llmagent.ModeChat)
+}
+
+func buildSkillAgent(
+	def entities.SkillDefinition, m model.LLM, toolset tool.Toolset, mode llmagent.Mode,
+) (agent.Agent, error) {
 	// Validate defensively (nil known-tools: allowlist membership was the
 	// registry's job); a definition that slipped past loading must not build
 	// a half-configured agent.
 	if err := def.Validate(nil); err != nil {
 		return nil, fmt.Errorf("invalid skill definition %q: %w", def.ID, err)
-	}
-
-	mode := llmagent.ModeTask
-	if def.Mode == entities.SkillModeSingleTurn {
-		mode = llmagent.ModeSingleTurn
 	}
 
 	// The memory brief is only truthful when the tool surface exists —

--- a/infrastructure/agents/adk_config.go
+++ b/infrastructure/agents/adk_config.go
@@ -42,7 +42,7 @@ func NewADKConfig(cfg config.Config) *ADKConfig {
 
 	modelID := cfg.LLM.GeminiModel
 	if modelID == "" {
-		modelID = "gemini-2.0-flash"
+		modelID = "gemini-2.5-flash"
 	}
 
 	return &ADKConfig{

--- a/infrastructure/agents/orchestrator_provider.go
+++ b/infrastructure/agents/orchestrator_provider.go
@@ -46,7 +46,20 @@ func ProvideOrchestrator(cfg config.Config, logger entities.Logger) (*appagents.
 		return appagents.NewOrchestrator(nil, nil, logger), nil
 	}
 
-	sessions, err := database.NewSessionService(gormdb.DialectorForDSN(cfg.DatabaseDSN))
+	// The agent session store is high-churn (an event appended per turn
+	// step) and independent of the resource graph. On SQLite it shares the
+	// single-writer lock with the resource store and the background
+	// subscribers, so under load — a conversation turn writing while memory
+	// consolidation writes a fact — the two contend. AGENT_SESSION_DSN
+	// points the session store at its own database to remove that
+	// contention; it defaults to the main DSN (one file, unchanged
+	// behavior). Postgres has no single-writer limit, so this only matters
+	// for SQLite deployments.
+	sessionDSN := cfg.DatabaseDSN
+	if v := os.Getenv("AGENT_SESSION_DSN"); v != "" {
+		sessionDSN = v
+	}
+	sessions, err := database.NewSessionService(gormdb.DialectorForDSN(sessionDSN))
 	if err != nil {
 		return nil, fmt.Errorf("create agent session service: %w", err)
 	}

--- a/infrastructure/agents/orchestrator_provider.go
+++ b/infrastructure/agents/orchestrator_provider.go
@@ -18,12 +18,14 @@ package agents
 import (
 	"context"
 	"fmt"
+	"os"
 
 	appagents "github.com/wepala/weos/v3/application/agents"
 	"github.com/wepala/weos/v3/domain/entities"
 	gormdb "github.com/wepala/weos/v3/infrastructure/database/gorm"
 	"github.com/wepala/weos/v3/internal/config"
 
+	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/session/database"
 )
 
@@ -36,14 +38,12 @@ import (
 // GORM-backed session service over the same DSN), so multi-turn
 // conversations survive process restarts.
 func ProvideOrchestrator(cfg config.Config, logger entities.Logger) (*appagents.Orchestrator, error) {
-	adk := NewADKConfig(cfg)
-	if adk == nil {
-		return appagents.NewOrchestrator(nil, nil, logger), nil
-	}
-
-	m, err := adk.CreateGeminiModel(context.Background())
+	m, err := provideModel(cfg, logger)
 	if err != nil {
-		return nil, fmt.Errorf("create agent model: %w", err)
+		return nil, err
+	}
+	if m == nil {
+		return appagents.NewOrchestrator(nil, nil, logger), nil
 	}
 
 	sessions, err := database.NewSessionService(gormdb.DialectorForDSN(cfg.DatabaseDSN))
@@ -55,4 +55,29 @@ func ProvideOrchestrator(cfg config.Config, logger entities.Logger) (*appagents.
 	}
 
 	return appagents.NewOrchestrator(m, sessions, logger), nil
+}
+
+// provideModel picks the agent's LLM: the scripted test model when
+// WEOS_AGENT_SCRIPT is set (deterministic turns, no key — see #420), else
+// Gemini when configured, else nil (agent unconfigured).
+func provideModel(cfg config.Config, logger entities.Logger) (model.LLM, error) {
+	if script := os.Getenv(AgentScriptEnv); script != "" {
+		m, err := NewScriptedModel(script)
+		if err != nil {
+			return nil, fmt.Errorf("load %s: %w", AgentScriptEnv, err)
+		}
+		logger.Warn(context.Background(),
+			"agent runs on a SCRIPTED model (test harness) — never use this in production",
+			"script", script)
+		return m, nil
+	}
+	adk := NewADKConfig(cfg)
+	if adk == nil {
+		return nil, nil
+	}
+	m, err := adk.CreateGeminiModel(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("create agent model: %w", err)
+	}
+	return m, nil
 }

--- a/infrastructure/agents/scripted_model.go
+++ b/infrastructure/agents/scripted_model.go
@@ -18,6 +18,7 @@ package agents
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"iter"
 	"os"
@@ -26,6 +27,7 @@ import (
 	"sync/atomic"
 
 	"google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/tool/toolconfirmation"
 	"google.golang.org/genai"
 )
 
@@ -54,12 +56,14 @@ type scriptCall struct {
 	ArgsFromToolOutputField string `json:"argsFromToolOutputField,omitempty"`
 }
 
-// scriptRule matches one moment of a conversation. Exactly one trigger:
+// scriptRule matches one moment of a conversation. At most one trigger:
 // WhenMessageContains matches the latest user text; AfterTool matches the
-// function response of a just-executed tool; neither set = the default.
-// The action is a Call or a Reply; ReplyFromToolOutput renders the matched
-// tool's real response instead of canned text, so a scenario can assert
-// the genuine outcome (e.g. "already imported") through the scripted rail.
+// function response of a just-executed tool; AfterToolFailed its failed
+// response; none set = the default rule. The action is a Call or a Reply
+// (never both); ReplyFromToolOutput renders the matched tool's real
+// response instead of canned text, so a scenario can assert the genuine
+// outcome (e.g. "already imported") through the scripted rail. validate
+// enforces this shape at load.
 type scriptRule struct {
 	WhenMessageContains string `json:"whenMessageContains,omitempty"`
 	AfterTool           string `json:"afterTool,omitempty"`
@@ -91,14 +95,37 @@ func NewScriptedModel(path string) (model.LLM, error) {
 		return nil, fmt.Errorf("parse agent script %s: %w", path, err)
 	}
 	for i, r := range file.Rules {
-		if r.Call == nil && r.Reply == "" && !r.ReplyFromToolOutput {
-			return nil, fmt.Errorf("agent script %s: rule %d has neither call nor reply", path, i)
-		}
-		if r.ReplyFromToolOutput && r.AfterTool == "" && r.AfterToolFailed == "" {
-			return nil, fmt.Errorf("agent script %s: rule %d: replyFromToolOutput needs afterTool", path, i)
+		if err := r.validate(); err != nil {
+			return nil, fmt.Errorf("agent script %s: rule %d: %w", path, i, err)
 		}
 	}
 	return &scriptedModel{rules: file.Rules}, nil
+}
+
+// validate enforces the shape the scriptRule comment promises. Loose rules
+// are rejected at load, not tolerated at match time: a rule with several
+// triggers or a call plus a reply would otherwise fire half its intent
+// (respond prefers the call, silently dropping the reply).
+func (r scriptRule) validate() error {
+	triggers := 0
+	for _, t := range []string{r.WhenMessageContains, r.AfterTool, r.AfterToolFailed} {
+		if t != "" {
+			triggers++
+		}
+	}
+	if triggers > 1 {
+		return errors.New("has multiple triggers; use at most one of whenMessageContains, afterTool, afterToolFailed")
+	}
+	if r.Call == nil && r.Reply == "" && !r.ReplyFromToolOutput {
+		return errors.New("has neither call nor reply")
+	}
+	if r.Call != nil && (r.Reply != "" || r.ReplyFromToolOutput) {
+		return errors.New("has both call and reply; the action must be one or the other")
+	}
+	if r.ReplyFromToolOutput && r.AfterTool == "" && r.AfterToolFailed == "" {
+		return errors.New("replyFromToolOutput needs afterTool or afterToolFailed")
+	}
+	return nil
 }
 
 func (s *scriptedModel) Name() string { return "scripted" }
@@ -136,8 +163,9 @@ func (s *scriptedModel) match(req *model.LLMRequest) (*scriptRule, map[string]an
 		}
 	}
 	for i := range s.rules {
-		if s.rules[i].AfterTool == "" && s.rules[i].WhenMessageContains == "" {
-			return &s.rules[i], nil
+		r := &s.rules[i]
+		if r.AfterTool == "" && r.AfterToolFailed == "" && r.WhenMessageContains == "" {
+			return r, nil
 		}
 	}
 	return nil, nil
@@ -216,7 +244,7 @@ func latestMoment(req *model.LLMRequest) (lastTool, lastText string, toolOutput 
 				continue
 			}
 			if p.FunctionResponse != nil {
-				if p.FunctionResponse.Name == "adk_request_confirmation" {
+				if p.FunctionResponse.Name == toolconfirmation.FunctionCallName {
 					continue // the protocol frame, not a tool outcome
 				}
 				if isAwaitingConfirmation(p.FunctionResponse.Response) {

--- a/infrastructure/agents/scripted_model.go
+++ b/infrastructure/agents/scripted_model.go
@@ -219,6 +219,12 @@ func latestMoment(req *model.LLMRequest) (lastTool, lastText string, toolOutput 
 				if p.FunctionResponse.Name == "adk_request_confirmation" {
 					continue // the protocol frame, not a tool outcome
 				}
+				if isAwaitingConfirmation(p.FunctionResponse.Response) {
+					// The pause artifact ("requires confirmation") the flow
+					// records when a mutating call first pauses — not a tool
+					// outcome; a fresh user message may legitimately follow.
+					continue
+				}
 				return p.FunctionResponse.Name, "", p.FunctionResponse.Response
 			}
 			if p.Text != "" && c.Role == genai.RoleUser {
@@ -227,6 +233,17 @@ func latestMoment(req *model.LLMRequest) (lastTool, lastText string, toolOutput 
 		}
 	}
 	return "", "", nil
+}
+
+// isAwaitingConfirmation reports whether a function response is the pause
+// artifact ADK records when a mutating call awaits approval — distinct
+// from a real failure (e.g. a rejection), which IS an outcome.
+func isAwaitingConfirmation(response map[string]any) bool {
+	if response == nil {
+		return false
+	}
+	errText, _ := response["error"].(string)
+	return strings.Contains(errText, "requires confirmation")
 }
 
 // latestUserText returns the most recent user-authored text content.

--- a/infrastructure/agents/scripted_model.go
+++ b/infrastructure/agents/scripted_model.go
@@ -61,8 +61,12 @@ type scriptCall struct {
 // tool's real response instead of canned text, so a scenario can assert
 // the genuine outcome (e.g. "already imported") through the scripted rail.
 type scriptRule struct {
-	WhenMessageContains string      `json:"whenMessageContains,omitempty"`
-	AfterTool           string      `json:"afterTool,omitempty"`
+	WhenMessageContains string `json:"whenMessageContains,omitempty"`
+	AfterTool           string `json:"afterTool,omitempty"`
+	// AfterToolFailed matches a tool's FAILED function response (e.g. a
+	// rejected confirmation) — checked before AfterTool so a script can
+	// stop a chain instead of marching on after a rejection.
+	AfterToolFailed     string      `json:"afterToolFailed,omitempty"`
 	Call                *scriptCall `json:"call,omitempty"`
 	Reply               string      `json:"reply,omitempty"`
 	ReplyFromToolOutput bool        `json:"replyFromToolOutput,omitempty"`
@@ -90,7 +94,7 @@ func NewScriptedModel(path string) (model.LLM, error) {
 		if r.Call == nil && r.Reply == "" && !r.ReplyFromToolOutput {
 			return nil, fmt.Errorf("agent script %s: rule %d has neither call nor reply", path, i)
 		}
-		if r.ReplyFromToolOutput && r.AfterTool == "" {
+		if r.ReplyFromToolOutput && r.AfterTool == "" && r.AfterToolFailed == "" {
 			return nil, fmt.Errorf("agent script %s: rule %d: replyFromToolOutput needs afterTool", path, i)
 		}
 	}
@@ -118,10 +122,13 @@ func (s *scriptedModel) GenerateContent(
 // returns the matched tool's response map for replyFromToolOutput.
 func (s *scriptedModel) match(req *model.LLMRequest) (*scriptRule, map[string]any) {
 	lastTool, lastText, toolOutput := latestMoment(req)
+	failed := toolOutput != nil && toolOutput["error"] != nil
 	for i := range s.rules {
 		r := &s.rules[i]
 		switch {
-		case r.AfterTool != "" && lastTool != "" && r.AfterTool == lastTool:
+		case r.AfterToolFailed != "" && lastTool != "" && r.AfterToolFailed == lastTool && failed:
+			return r, toolOutput
+		case r.AfterTool != "" && lastTool != "" && r.AfterTool == lastTool && !failed:
 			return r, toolOutput
 		case r.WhenMessageContains != "" && lastText != "" &&
 			strings.Contains(strings.ToLower(lastText), strings.ToLower(r.WhenMessageContains)):

--- a/infrastructure/agents/scripted_model.go
+++ b/infrastructure/agents/scripted_model.go
@@ -1,0 +1,227 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package agents
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"iter"
+	"os"
+	"regexp"
+	"strings"
+	"sync/atomic"
+
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+// Scripted agent model (test harness, #420): WEOS_AGENT_SCRIPT points at a
+// JSON script and the orchestrator runs deterministic turns without an LLM
+// — no key, no network, no spend. Everything except the model's judgment is
+// the real pipeline: tool calls execute over MCP, mutating tools pause for
+// confirmation, approve-with-edits substitutes payloads. Test-only, the
+// same convention as a downstream app's fixture knobs; never set it in
+// production.
+
+// AgentScriptEnv names the env var holding the script path.
+const AgentScriptEnv = "WEOS_AGENT_SCRIPT"
+
+// scriptCall is a tool call a rule emits. Args are either fixed or
+// extracted from a ```json fenced block in the user's message — how a test
+// binding smuggles exact tool arguments through the conversation.
+type scriptCall struct {
+	Tool                string         `json:"tool"`
+	Args                map[string]any `json:"args,omitempty"`
+	ArgsFromMessageJSON bool           `json:"argsFromMessageJSON,omitempty"`
+}
+
+// scriptRule matches one moment of a conversation. Exactly one trigger:
+// WhenMessageContains matches the latest user text; AfterTool matches the
+// function response of a just-executed tool; neither set = the default.
+// The action is a Call, a Reply, or both (reply after call is invalid —
+// the model answers once per turn; a chained call is the way to continue).
+type scriptRule struct {
+	WhenMessageContains string      `json:"whenMessageContains,omitempty"`
+	AfterTool           string      `json:"afterTool,omitempty"`
+	Call                *scriptCall `json:"call,omitempty"`
+	Reply               string      `json:"reply,omitempty"`
+}
+
+// scriptedModel is a model.LLM driven by ordered rules.
+type scriptedModel struct {
+	rules  []scriptRule
+	callID atomic.Int64
+}
+
+// NewScriptedModel loads a script file into a deterministic model.
+func NewScriptedModel(path string) (model.LLM, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read agent script: %w", err)
+	}
+	var file struct {
+		Rules []scriptRule `json:"rules"`
+	}
+	if err := json.Unmarshal(raw, &file); err != nil {
+		return nil, fmt.Errorf("parse agent script %s: %w", path, err)
+	}
+	for i, r := range file.Rules {
+		if r.Call == nil && r.Reply == "" {
+			return nil, fmt.Errorf("agent script %s: rule %d has neither call nor reply", path, i)
+		}
+	}
+	return &scriptedModel{rules: file.Rules}, nil
+}
+
+func (s *scriptedModel) Name() string { return "scripted" }
+
+// GenerateContent matches the request's latest moment against the rules and
+// emits the scripted action. It never errors on a non-match: the default
+// rule (or a built-in fallback reply) answers, so a scripted run degrades
+// to a visible no-op turn instead of a hung one.
+func (s *scriptedModel) GenerateContent(
+	_ context.Context, req *model.LLMRequest, _ bool,
+) iter.Seq2[*model.LLMResponse, error] {
+	rule := s.match(req)
+	return func(yield func(*model.LLMResponse, error) bool) {
+		yield(s.respond(req, rule), nil)
+	}
+}
+
+// match picks the first applicable rule: afterTool rules when the latest
+// content is a tool's function response, whenMessageContains rules when it
+// is user text, then the first trigger-less rule as the default.
+func (s *scriptedModel) match(req *model.LLMRequest) *scriptRule {
+	lastTool, lastText := latestMoment(req)
+	for i := range s.rules {
+		r := &s.rules[i]
+		switch {
+		case r.AfterTool != "" && lastTool != "" && r.AfterTool == lastTool:
+			return r
+		case r.WhenMessageContains != "" && lastText != "" &&
+			strings.Contains(strings.ToLower(lastText), strings.ToLower(r.WhenMessageContains)):
+			return r
+		}
+	}
+	for i := range s.rules {
+		if s.rules[i].AfterTool == "" && s.rules[i].WhenMessageContains == "" {
+			return &s.rules[i]
+		}
+	}
+	return nil
+}
+
+// respond renders the rule as a model response — a minted function call or
+// a widget-JSON reply.
+func (s *scriptedModel) respond(req *model.LLMRequest, rule *scriptRule) *model.LLMResponse {
+	if rule != nil && rule.Call != nil {
+		args := rule.Call.Args
+		if rule.Call.ArgsFromMessageJSON {
+			args = fencedJSONArgs(latestUserText(req))
+		}
+		if args == nil {
+			args = map[string]any{}
+		}
+		return &model.LLMResponse{Content: &genai.Content{
+			Role: genai.RoleModel,
+			Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{
+				ID:   fmt.Sprintf("scripted-call-%d", s.callID.Add(1)),
+				Name: rule.Call.Tool,
+				Args: args,
+			}}},
+		}}
+	}
+	reply := "The scripted agent has no rule for this turn."
+	if rule != nil && rule.Reply != "" {
+		reply = rule.Reply
+	}
+	widget, _ := json.Marshal(map[string]any{
+		"schemaVersion": 1,
+		"widgets":       []map[string]any{{"type": "markdown", "markdown": reply}},
+	})
+	return &model.LLMResponse{Content: &genai.Content{
+		Role:  genai.RoleModel,
+		Parts: []*genai.Part{{Text: string(widget)}},
+	}}
+}
+
+// latestMoment scans the request tail: the name of the tool whose function
+// response arrived last (skipping the confirmation protocol's own frames),
+// or the latest user text.
+func latestMoment(req *model.LLMRequest) (lastTool, lastText string) {
+	if req == nil {
+		return "", ""
+	}
+	for i := len(req.Contents) - 1; i >= 0; i-- {
+		c := req.Contents[i]
+		if c == nil {
+			continue
+		}
+		for j := len(c.Parts) - 1; j >= 0; j-- {
+			p := c.Parts[j]
+			if p == nil {
+				continue
+			}
+			if p.FunctionResponse != nil {
+				if p.FunctionResponse.Name == "adk_request_confirmation" {
+					continue // the protocol frame, not a tool outcome
+				}
+				return p.FunctionResponse.Name, ""
+			}
+			if p.Text != "" && c.Role == genai.RoleUser {
+				return "", p.Text
+			}
+		}
+	}
+	return "", ""
+}
+
+// latestUserText returns the most recent user-authored text content.
+func latestUserText(req *model.LLMRequest) string {
+	if req == nil {
+		return ""
+	}
+	for i := len(req.Contents) - 1; i >= 0; i-- {
+		c := req.Contents[i]
+		if c == nil || c.Role != genai.RoleUser {
+			continue
+		}
+		for j := len(c.Parts) - 1; j >= 0; j-- {
+			if p := c.Parts[j]; p != nil && p.Text != "" {
+				return p.Text
+			}
+		}
+	}
+	return ""
+}
+
+var fencedJSON = regexp.MustCompile("(?s)```(?:json)?\\s*(\\{.*?\\})\\s*```")
+
+// fencedJSONArgs extracts the first ```json fenced object from a message.
+// A missing or unparseable block yields nil (the caller substitutes {}),
+// which surfaces as a tool validation error — visible, not hung.
+func fencedJSONArgs(message string) map[string]any {
+	m := fencedJSON.FindStringSubmatch(message)
+	if len(m) < 2 {
+		return nil
+	}
+	var args map[string]any
+	if err := json.Unmarshal([]byte(m[1]), &args); err != nil {
+		return nil
+	}
+	return args
+}

--- a/infrastructure/agents/scripted_model.go
+++ b/infrastructure/agents/scripted_model.go
@@ -47,6 +47,11 @@ type scriptCall struct {
 	Tool                string         `json:"tool"`
 	Args                map[string]any `json:"args,omitempty"`
 	ArgsFromMessageJSON bool           `json:"argsFromMessageJSON,omitempty"`
+	// ArgsFromToolOutputField takes the named field of the PREVIOUS tool's
+	// output object as this call's arguments — how a scripted chain passes a
+	// tool-composed object (e.g. run_interpretation's proposal) to the next
+	// call the way a live model would.
+	ArgsFromToolOutputField string `json:"argsFromToolOutputField,omitempty"`
 }
 
 // scriptRule matches one moment of a conversation. Exactly one trigger:
@@ -138,6 +143,16 @@ func (s *scriptedModel) respond(req *model.LLMRequest, rule *scriptRule, toolOut
 		args := rule.Call.Args
 		if rule.Call.ArgsFromMessageJSON {
 			args = fencedJSONArgs(latestUserText(req))
+		}
+		if f := rule.Call.ArgsFromToolOutputField; f != "" && toolOutput != nil {
+			// MCP structured outputs arrive wrapped under "output".
+			source := toolOutput
+			if inner, ok := toolOutput["output"].(map[string]any); ok {
+				source = inner
+			}
+			if picked, ok := source[f].(map[string]any); ok {
+				args = picked
+			}
 		}
 		if args == nil {
 			args = map[string]any{}

--- a/infrastructure/agents/scripted_model.go
+++ b/infrastructure/agents/scripted_model.go
@@ -52,13 +52,15 @@ type scriptCall struct {
 // scriptRule matches one moment of a conversation. Exactly one trigger:
 // WhenMessageContains matches the latest user text; AfterTool matches the
 // function response of a just-executed tool; neither set = the default.
-// The action is a Call, a Reply, or both (reply after call is invalid —
-// the model answers once per turn; a chained call is the way to continue).
+// The action is a Call or a Reply; ReplyFromToolOutput renders the matched
+// tool's real response instead of canned text, so a scenario can assert
+// the genuine outcome (e.g. "already imported") through the scripted rail.
 type scriptRule struct {
 	WhenMessageContains string      `json:"whenMessageContains,omitempty"`
 	AfterTool           string      `json:"afterTool,omitempty"`
 	Call                *scriptCall `json:"call,omitempty"`
 	Reply               string      `json:"reply,omitempty"`
+	ReplyFromToolOutput bool        `json:"replyFromToolOutput,omitempty"`
 }
 
 // scriptedModel is a model.LLM driven by ordered rules.
@@ -80,8 +82,11 @@ func NewScriptedModel(path string) (model.LLM, error) {
 		return nil, fmt.Errorf("parse agent script %s: %w", path, err)
 	}
 	for i, r := range file.Rules {
-		if r.Call == nil && r.Reply == "" {
+		if r.Call == nil && r.Reply == "" && !r.ReplyFromToolOutput {
 			return nil, fmt.Errorf("agent script %s: rule %d has neither call nor reply", path, i)
+		}
+		if r.ReplyFromToolOutput && r.AfterTool == "" {
+			return nil, fmt.Errorf("agent script %s: rule %d: replyFromToolOutput needs afterTool", path, i)
 		}
 	}
 	return &scriptedModel{rules: file.Rules}, nil
@@ -96,38 +101,39 @@ func (s *scriptedModel) Name() string { return "scripted" }
 func (s *scriptedModel) GenerateContent(
 	_ context.Context, req *model.LLMRequest, _ bool,
 ) iter.Seq2[*model.LLMResponse, error] {
-	rule := s.match(req)
+	rule, toolOutput := s.match(req)
 	return func(yield func(*model.LLMResponse, error) bool) {
-		yield(s.respond(req, rule), nil)
+		yield(s.respond(req, rule, toolOutput), nil)
 	}
 }
 
 // match picks the first applicable rule: afterTool rules when the latest
 // content is a tool's function response, whenMessageContains rules when it
-// is user text, then the first trigger-less rule as the default.
-func (s *scriptedModel) match(req *model.LLMRequest) *scriptRule {
-	lastTool, lastText := latestMoment(req)
+// is user text, then the first trigger-less rule as the default. It also
+// returns the matched tool's response map for replyFromToolOutput.
+func (s *scriptedModel) match(req *model.LLMRequest) (*scriptRule, map[string]any) {
+	lastTool, lastText, toolOutput := latestMoment(req)
 	for i := range s.rules {
 		r := &s.rules[i]
 		switch {
 		case r.AfterTool != "" && lastTool != "" && r.AfterTool == lastTool:
-			return r
+			return r, toolOutput
 		case r.WhenMessageContains != "" && lastText != "" &&
 			strings.Contains(strings.ToLower(lastText), strings.ToLower(r.WhenMessageContains)):
-			return r
+			return r, nil
 		}
 	}
 	for i := range s.rules {
 		if s.rules[i].AfterTool == "" && s.rules[i].WhenMessageContains == "" {
-			return &s.rules[i]
+			return &s.rules[i], nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 // respond renders the rule as a model response — a minted function call or
 // a widget-JSON reply.
-func (s *scriptedModel) respond(req *model.LLMRequest, rule *scriptRule) *model.LLMResponse {
+func (s *scriptedModel) respond(req *model.LLMRequest, rule *scriptRule, toolOutput map[string]any) *model.LLMResponse {
 	if rule != nil && rule.Call != nil {
 		args := rule.Call.Args
 		if rule.Call.ArgsFromMessageJSON {
@@ -146,7 +152,18 @@ func (s *scriptedModel) respond(req *model.LLMRequest, rule *scriptRule) *model.
 		}}
 	}
 	reply := "The scripted agent has no rule for this turn."
-	if rule != nil && rule.Reply != "" {
+	switch {
+	case rule != nil && rule.ReplyFromToolOutput && toolOutput != nil:
+		// The tool's real response, verbatim — so a scenario can assert the
+		// genuine outcome through the scripted rail.
+		raw, err := json.Marshal(toolOutput)
+		if err == nil {
+			reply = string(raw)
+		}
+		if rule.Reply != "" {
+			reply = rule.Reply + "\n" + reply
+		}
+	case rule != nil && rule.Reply != "":
 		reply = rule.Reply
 	}
 	widget, _ := json.Marshal(map[string]any{
@@ -159,12 +176,12 @@ func (s *scriptedModel) respond(req *model.LLMRequest, rule *scriptRule) *model.
 	}}
 }
 
-// latestMoment scans the request tail: the name of the tool whose function
-// response arrived last (skipping the confirmation protocol's own frames),
-// or the latest user text.
-func latestMoment(req *model.LLMRequest) (lastTool, lastText string) {
+// latestMoment scans the request tail: the name (and response map) of the
+// tool whose function response arrived last (skipping the confirmation
+// protocol's own frames), or the latest user text.
+func latestMoment(req *model.LLMRequest) (lastTool, lastText string, toolOutput map[string]any) {
 	if req == nil {
-		return "", ""
+		return "", "", nil
 	}
 	for i := len(req.Contents) - 1; i >= 0; i-- {
 		c := req.Contents[i]
@@ -180,14 +197,14 @@ func latestMoment(req *model.LLMRequest) (lastTool, lastText string) {
 				if p.FunctionResponse.Name == "adk_request_confirmation" {
 					continue // the protocol frame, not a tool outcome
 				}
-				return p.FunctionResponse.Name, ""
+				return p.FunctionResponse.Name, "", p.FunctionResponse.Response
 			}
 			if p.Text != "" && c.Role == genai.RoleUser {
-				return "", p.Text
+				return "", p.Text, nil
 			}
 		}
 	}
-	return "", ""
+	return "", "", nil
 }
 
 // latestUserText returns the most recent user-authored text content.

--- a/infrastructure/agents/scripted_model_test.go
+++ b/infrastructure/agents/scripted_model_test.go
@@ -1,0 +1,141 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package agents
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+const testScript = `{
+  "rules": [
+    {"whenMessageContains": "import the statement",
+     "call": {"tool": "import_statement", "argsFromMessageJSON": true}},
+    {"afterTool": "import_statement", "reply": "Imported."},
+    {"reply": "Nothing scripted for that."}
+  ]
+}`
+
+func scriptedFromString(t *testing.T, script string) model.LLM {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "script.json")
+	if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	m, err := NewScriptedModel(path)
+	if err != nil {
+		t.Fatalf("NewScriptedModel: %v", err)
+	}
+	return m
+}
+
+func oneResponse(t *testing.T, m model.LLM, req *model.LLMRequest) *model.LLMResponse {
+	t.Helper()
+	for resp, err := range m.GenerateContent(context.Background(), req, false) {
+		if err != nil {
+			t.Fatalf("GenerateContent: %v", err)
+		}
+		return resp
+	}
+	t.Fatal("no response yielded")
+	return nil
+}
+
+func userMessage(text string) *model.LLMRequest {
+	return &model.LLMRequest{Contents: []*genai.Content{
+		{Role: genai.RoleUser, Parts: []*genai.Part{{Text: text}}},
+	}}
+}
+
+func TestScriptedModel_MessageRuleEmitsToolCallWithFencedArgs(t *testing.T) {
+	m := scriptedFromString(t, testScript)
+
+	resp := oneResponse(t, m, userMessage(
+		"Please import the statement.\n```json\n{\"fileName\":\"march.csv\",\"openingBalance\":\"100.00\"}\n```"))
+	call := resp.Content.Parts[0].FunctionCall
+	if call == nil || call.Name != "import_statement" {
+		t.Fatalf("expected an import_statement call, got %+v", resp.Content.Parts[0])
+	}
+	if call.ID == "" {
+		t.Error("the scripted model must mint a function-call id")
+	}
+	if call.Args["fileName"] != "march.csv" {
+		t.Errorf("args = %v, want the fenced JSON block's contents", call.Args)
+	}
+}
+
+func TestScriptedModel_AfterToolRuleReplies(t *testing.T) {
+	m := scriptedFromString(t, testScript)
+
+	resp := oneResponse(t, m, &model.LLMRequest{Contents: []*genai.Content{
+		{Role: genai.RoleUser, Parts: []*genai.Part{{Text: "import the statement"}}},
+		{Role: genai.RoleModel, Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{
+			ID: "scripted-call-1", Name: "import_statement", Args: map[string]any{}}}}},
+		{Role: genai.RoleUser, Parts: []*genai.Part{{FunctionResponse: &genai.FunctionResponse{
+			ID: "scripted-call-1", Name: "import_statement",
+			Response: map[string]any{"output": "ok"}}}}},
+	}})
+	text := resp.Content.Parts[0].Text
+	if !strings.Contains(text, "Imported.") || !strings.Contains(text, "schemaVersion") {
+		t.Errorf("after-tool reply = %q, want the scripted reply wrapped as widget JSON", text)
+	}
+}
+
+func TestScriptedModel_DefaultRuleAndFallback(t *testing.T) {
+	m := scriptedFromString(t, testScript)
+	resp := oneResponse(t, m, userMessage("something unscripted"))
+	if !strings.Contains(resp.Content.Parts[0].Text, "Nothing scripted") {
+		t.Errorf("default reply = %q", resp.Content.Parts[0].Text)
+	}
+
+	// No default rule in the script → built-in fallback, never a hang.
+	bare := scriptedFromString(t, `{"rules": [{"whenMessageContains": "x", "reply": "y"}]}`)
+	resp = oneResponse(t, bare, userMessage("something else"))
+	if !strings.Contains(resp.Content.Parts[0].Text, "no rule") {
+		t.Errorf("fallback reply = %q", resp.Content.Parts[0].Text)
+	}
+}
+
+func TestScriptedModel_ConfirmationFrameIsNotAToolOutcome(t *testing.T) {
+	m := scriptedFromString(t, testScript)
+
+	// A confirmation response frame must not match afterTool rules — the
+	// real tool outcome arrives in a later frame.
+	resp := oneResponse(t, m, &model.LLMRequest{Contents: []*genai.Content{
+		{Role: genai.RoleUser, Parts: []*genai.Part{{FunctionResponse: &genai.FunctionResponse{
+			ID: "call-9", Name: "adk_request_confirmation",
+			Response: map[string]any{"confirmed": true}}}}},
+	}})
+	if strings.Contains(resp.Content.Parts[0].Text, "Imported.") {
+		t.Error("the confirmation protocol frame matched an afterTool rule")
+	}
+}
+
+func TestNewScriptedModel_RejectsEmptyRule(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(path, []byte(`{"rules":[{"whenMessageContains":"x"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewScriptedModel(path); err == nil {
+		t.Fatal("a rule with neither call nor reply must be rejected at load")
+	}
+}

--- a/infrastructure/agents/scripted_model_test.go
+++ b/infrastructure/agents/scripted_model_test.go
@@ -130,12 +130,49 @@ func TestScriptedModel_ConfirmationFrameIsNotAToolOutcome(t *testing.T) {
 	}
 }
 
-func TestNewScriptedModel_RejectsEmptyRule(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "bad.json")
-	if err := os.WriteFile(path, []byte(`{"rules":[{"whenMessageContains":"x"}]}`), 0o600); err != nil {
+func TestNewScriptedModel_RejectsLooseRules(t *testing.T) {
+	for name, script := range map[string]string{
+		"neither call nor reply": `{"rules":[{"whenMessageContains":"x"}]}`,
+		"multiple triggers":      `{"rules":[{"whenMessageContains":"x","afterTool":"t","reply":"y"}]}`,
+		"call plus reply":        `{"rules":[{"whenMessageContains":"x","call":{"tool":"t"},"reply":"y"}]}`,
+		"call plus replyFromToolOutput": `{"rules":[` +
+			`{"afterTool":"t","call":{"tool":"u"},"replyFromToolOutput":true}]}`,
+		"replyFromToolOutput without a tool trigger": `{"rules":[{"replyFromToolOutput":true}]}`,
+	} {
+		path := filepath.Join(t.TempDir(), "bad.json")
+		if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := NewScriptedModel(path); err == nil {
+			t.Errorf("%s must be rejected at load", name)
+		}
+	}
+
+	// replyFromToolOutput triggered by a failure is a legitimate shape.
+	path := filepath.Join(t.TempDir(), "good.json")
+	script := `{"rules":[{"afterToolFailed":"t","replyFromToolOutput":true}]}`
+	if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := NewScriptedModel(path); err == nil {
-		t.Fatal("a rule with neither call nor reply must be rejected at load")
+	if _, err := NewScriptedModel(path); err != nil {
+		t.Errorf("afterToolFailed with replyFromToolOutput must load: %v", err)
+	}
+}
+
+func TestFencedJSONArgs_NestedObjects(t *testing.T) {
+	// The closing fence anchors the regex, so backtracking must carry the
+	// capture past nested closing braces to the object's real end.
+	args := fencedJSONArgs("import this\n```json\n" +
+		`{"statement": {"fileName": "march.csv"}, "interpretations": [{"line": 1, "meta": {"x": 2}}]}` +
+		"\n```")
+	if args == nil {
+		t.Fatal("a fenced object with nested objects must parse")
+	}
+	statement, ok := args["statement"].(map[string]any)
+	if !ok || statement["fileName"] != "march.csv" {
+		t.Errorf("nested object truncated: %v", args)
+	}
+	if _, ok := args["interpretations"]; !ok {
+		t.Errorf("trailing keys after the nested object were lost: %v", args)
 	}
 }

--- a/infrastructure/database/gorm/provider.go
+++ b/infrastructure/database/gorm/provider.go
@@ -137,7 +137,11 @@ func DialectorForDSN(dsn string) gorm.Dialector {
 //   - journal_mode(WAL) lets the workers' feed reads run concurrently with a
 //     write transaction instead of blocking on it.
 //   - busy_timeout makes a writer wait for the lock instead of failing
-//     immediately with "database is locked".
+//     immediately with "database is locked". It is generous (15s) because a
+//     background subscriber's write can queue behind another subscriber
+//     whose handler is LLM-latency-bound (memory consolidation extracts
+//     facts via a model call between reads and its write) — 5s left the
+//     checkpoint write timing out under that load.
 //   - _txlock=immediate takes the write lock at BEGIN so concurrent writers
 //     serialize cleanly via busy_timeout rather than erroring on a deferred
 //     lock upgrade mid-transaction.
@@ -153,7 +157,7 @@ func sqliteDSNWithWorkerPragmas(dsn string) string {
 	}
 	pragmas := []struct{ key, param string }{
 		{"journal_mode", "_pragma=journal_mode(WAL)"},
-		{"busy_timeout", "_pragma=busy_timeout(5000)"},
+		{"busy_timeout", "_pragma=busy_timeout(15000)"},
 		{"_txlock", "_txlock=immediate"},
 	}
 	sep := "?"

--- a/infrastructure/database/gorm/provider_pragma_test.go
+++ b/infrastructure/database/gorm/provider_pragma_test.go
@@ -26,7 +26,7 @@ func TestSqliteDSNWithWorkerPragmas(t *testing.T) {
 	t.Run("adds all pragmas to a bare file DSN", func(t *testing.T) {
 		got := sqliteDSNWithWorkerPragmas("weos.db")
 		for _, want := range []string{
-			"_pragma=journal_mode(WAL)", "_pragma=busy_timeout(5000)", "_txlock=immediate",
+			"_pragma=journal_mode(WAL)", "_pragma=busy_timeout(15000)", "_txlock=immediate",
 		} {
 			if !strings.Contains(got, want) {
 				t.Errorf("expected %q in %q", want, got)
@@ -48,7 +48,7 @@ func TestSqliteDSNWithWorkerPragmas(t *testing.T) {
 			t.Errorf("should preserve existing params, got %q", got)
 		}
 		// The missing pragmas are still appended with '&'.
-		if !strings.Contains(got, "_pragma=busy_timeout(5000)") ||
+		if !strings.Contains(got, "_pragma=busy_timeout(15000)") ||
 			!strings.Contains(got, "_txlock=immediate") {
 			t.Errorf("expected missing pragmas appended, got %q", got)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -298,7 +298,7 @@ type LLMConfig struct {
 	GeminiAPIKey string
 
 	// GeminiModel is the Gemini model ID to use.
-	// Default: "gemini-2.0-flash"
+	// Default: "gemini-2.5-flash"
 	GeminiModel string
 }
 
@@ -346,7 +346,7 @@ func Default() Config {
 		},
 		SessionSecret: "change-me-in-production",
 		LLM: LLMConfig{
-			GeminiModel: "gemini-2.0-flash",
+			GeminiModel: "gemini-2.5-flash",
 		},
 		OAuth: OAuthConfig{
 			DynamicRegistration: false,

--- a/internal/mcp/agent_toolset.go
+++ b/internal/mcp/agent_toolset.go
@@ -63,7 +63,9 @@ func NewAgentToolset(ctx context.Context, server *mcp.Server, cfg AgentToolsetCo
 	if err != nil {
 		return nil, fmt.Errorf("wrap MCP server as agent toolset: %w", err)
 	}
-	return ts, nil
+	// Approve-with-edits: a confirmation payload replaces the confirmed
+	// call's arguments (stock mcptoolset would re-run the original ones).
+	return EditedArgsToolset(ts), nil
 }
 
 // AgentToolsetFactory returns a factory that opens a fresh toolset session

--- a/internal/mcp/edited_args_toolset.go
+++ b/internal/mcp/edited_args_toolset.go
@@ -1,0 +1,117 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package mcp
+
+import (
+	"fmt"
+
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/tool"
+	"google.golang.org/genai"
+)
+
+// functionTool is the method set the ADK flow drives a runnable tool
+// through (structurally identical to ADK's internal FunctionTool — that
+// interface lives in an internal package, so it is restated here).
+type functionTool interface {
+	tool.Tool
+	Declaration() *genai.FunctionDeclaration
+	Run(ctx agent.Context, args any) (map[string]any, error)
+}
+
+// requestProcessor mirrors ADK's internal RequestProcessor: tools implement
+// it to pack their declarations into the outgoing LLM request.
+type requestProcessor interface {
+	ProcessRequest(ctx agent.Context, req *model.LLMRequest) error
+}
+
+// EditedArgsToolset wraps a toolset so that approving a pending confirmation
+// with a payload substitutes that payload for the tool call's arguments
+// (approve-with-edits): what executes is exactly what the user submitted,
+// never the model's proposal. Stock ADK re-runs a confirmed call with its
+// original arguments and ignores ToolConfirmation.Payload entirely.
+func EditedArgsToolset(ts tool.Toolset) tool.Toolset {
+	return &editedArgsToolset{inner: ts}
+}
+
+type editedArgsToolset struct {
+	inner tool.Toolset
+}
+
+func (s *editedArgsToolset) Name() string { return s.inner.Name() }
+
+func (s *editedArgsToolset) Tools(ctx agent.ReadonlyContext) ([]tool.Tool, error) {
+	tools, err := s.inner.Tools(ctx)
+	if err != nil {
+		return nil, err
+	}
+	wrapped := make([]tool.Tool, len(tools))
+	for i, t := range tools {
+		// Only runnable, request-packing tools (every mcptoolset tool) can
+		// carry a confirmation; anything else passes through untouched.
+		if ft, ok := t.(interface {
+			functionTool
+			requestProcessor
+		}); ok {
+			wrapped[i] = &editedArgsTool{ft}
+			continue
+		}
+		wrapped[i] = t
+	}
+	return wrapped, nil
+}
+
+// editedArgsTool delegates everything to the wrapped tool except Run, which
+// substitutes user-edited arguments from an approved confirmation's payload.
+type editedArgsTool struct {
+	inner interface {
+		functionTool
+		requestProcessor
+	}
+}
+
+func (t *editedArgsTool) Name() string                            { return t.inner.Name() }
+func (t *editedArgsTool) Description() string                     { return t.inner.Description() }
+func (t *editedArgsTool) IsLongRunning() bool                     { return t.inner.IsLongRunning() }
+func (t *editedArgsTool) Declaration() *genai.FunctionDeclaration { return t.inner.Declaration() }
+
+func (t *editedArgsTool) ProcessRequest(ctx agent.Context, req *model.LLMRequest) error {
+	return t.inner.ProcessRequest(ctx, req)
+}
+
+func (t *editedArgsTool) Run(ctx agent.Context, args any) (map[string]any, error) {
+	conf := ctx.ToolConfirmation()
+	if conf == nil || !conf.Confirmed || conf.Payload == nil {
+		// No confirmation in play (the wrapped tool decides whether to
+		// request one), a rejection (the wrapped tool fails the call), or a
+		// plain approval (original arguments run unchanged).
+		return t.inner.Run(ctx, args)
+	}
+	// The payload has round-tripped through JSON (the confirmation event is
+	// stored in the durable session), so an object arrives as
+	// map[string]any. Anything else fails the call: the user asked for
+	// edits, so silently running the model-proposed arguments instead would
+	// execute something they did not approve.
+	edited, ok := conf.Payload.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf(
+			"tool %q: confirmation payload must be a JSON object of tool arguments, got %T",
+			t.Name(), conf.Payload,
+		)
+	}
+	return t.inner.Run(ctx, edited)
+}

--- a/internal/mcp/edited_args_toolset_test.go
+++ b/internal/mcp/edited_args_toolset_test.go
@@ -1,0 +1,190 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package mcp
+
+import (
+	"reflect"
+	"testing"
+
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/tool"
+	"google.golang.org/adk/v2/tool/toolconfirmation"
+	"google.golang.org/genai"
+)
+
+// confirmationContext is an agent context carrying a canned confirmation,
+// the state the ADK flow sets when it re-runs a confirmed call.
+type confirmationContext struct {
+	agent.ContextMock
+	conf *toolconfirmation.ToolConfirmation
+}
+
+func (c *confirmationContext) ToolConfirmation() *toolconfirmation.ToolConfirmation { return c.conf }
+
+// recordingTool captures the args Run receives, standing in for a wrapped
+// mcptoolset tool.
+type recordingTool struct {
+	gotArgs   any
+	ranTimes  int
+	processed bool
+}
+
+func (r *recordingTool) Name() string        { return "save_interpretation" }
+func (r *recordingTool) Description() string { return "saves" }
+func (r *recordingTool) IsLongRunning() bool { return false }
+func (r *recordingTool) Declaration() *genai.FunctionDeclaration {
+	return &genai.FunctionDeclaration{Name: r.Name()}
+}
+func (r *recordingTool) ProcessRequest(agent.Context, *model.LLMRequest) error {
+	r.processed = true
+	return nil
+}
+func (r *recordingTool) Run(_ agent.Context, args any) (map[string]any, error) {
+	r.ranTimes++
+	r.gotArgs = args
+	return map[string]any{"output": "ok"}, nil
+}
+
+// plainTool implements only tool.Tool — the wrapper must pass it through.
+type plainTool struct{}
+
+func (plainTool) Name() string        { return "plain" }
+func (plainTool) Description() string { return "not runnable" }
+func (plainTool) IsLongRunning() bool { return false }
+
+// stubToolset serves a fixed tool list.
+type stubToolset struct{ tools []tool.Tool }
+
+func (stubToolset) Name() string                                       { return "stub" }
+func (s stubToolset) Tools(agent.ReadonlyContext) ([]tool.Tool, error) { return s.tools, nil }
+
+func wrappedRecordingTool(t *testing.T) (functionTool, *recordingTool) {
+	t.Helper()
+	inner := &recordingTool{}
+	tools, err := EditedArgsToolset(stubToolset{tools: []tool.Tool{inner}}).Tools(&testAgentContext{})
+	if err != nil {
+		t.Fatalf("Tools: %v", err)
+	}
+	ft, ok := tools[0].(functionTool)
+	if !ok {
+		t.Fatalf("wrapped tool is not runnable: %T", tools[0])
+	}
+	return ft, inner
+}
+
+func TestEditedArgsToolset_ApprovalWithPayloadSubstitutesArgs(t *testing.T) {
+	wrapped, inner := wrappedRecordingTool(t)
+	edited := map[string]any{"interpretations": []any{"user-edited"}}
+
+	_, err := wrapped.Run(&confirmationContext{
+		conf: &toolconfirmation.ToolConfirmation{Confirmed: true, Payload: edited},
+	}, map[string]any{"interpretations": []any{"model-proposed"}})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !reflect.DeepEqual(inner.gotArgs, edited) {
+		t.Errorf("tool ran with %v, want the user-edited payload %v", inner.gotArgs, edited)
+	}
+}
+
+func TestEditedArgsToolset_PlainApprovalRunsOriginalArgs(t *testing.T) {
+	wrapped, inner := wrappedRecordingTool(t)
+	original := map[string]any{"interpretations": []any{"model-proposed"}}
+
+	_, err := wrapped.Run(&confirmationContext{
+		conf: &toolconfirmation.ToolConfirmation{Confirmed: true},
+	}, original)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !reflect.DeepEqual(inner.gotArgs, original) {
+		t.Errorf("tool ran with %v, want the original args %v", inner.gotArgs, original)
+	}
+}
+
+func TestEditedArgsToolset_NoConfirmationPassesThrough(t *testing.T) {
+	wrapped, inner := wrappedRecordingTool(t)
+	original := map[string]any{"key": "value"}
+
+	if _, err := wrapped.Run(&confirmationContext{}, original); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !reflect.DeepEqual(inner.gotArgs, original) {
+		t.Errorf("tool ran with %v, want %v", inner.gotArgs, original)
+	}
+}
+
+func TestEditedArgsToolset_RejectionIgnoresPayload(t *testing.T) {
+	wrapped, inner := wrappedRecordingTool(t)
+	original := map[string]any{"interpretations": []any{"model-proposed"}}
+
+	// The wrapped tool owns rejection semantics (it fails the call); the
+	// wrapper must not substitute on a rejection.
+	if _, err := wrapped.Run(&confirmationContext{
+		conf: &toolconfirmation.ToolConfirmation{Confirmed: false, Payload: map[string]any{"x": 1}},
+	}, original); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !reflect.DeepEqual(inner.gotArgs, original) {
+		t.Errorf("tool ran with %v, want the original args %v", inner.gotArgs, original)
+	}
+}
+
+func TestEditedArgsToolset_NonObjectPayloadFailsClosed(t *testing.T) {
+	wrapped, inner := wrappedRecordingTool(t)
+
+	_, err := wrapped.Run(&confirmationContext{
+		conf: &toolconfirmation.ToolConfirmation{Confirmed: true, Payload: []any{"not", "an", "object"}},
+	}, map[string]any{"interpretations": []any{"model-proposed"}})
+	if err == nil {
+		t.Fatal("a non-object payload must fail the call, not fall back to the model-proposed args")
+	}
+	if inner.ranTimes != 0 {
+		t.Errorf("tool executed %d times despite a malformed payload", inner.ranTimes)
+	}
+}
+
+func TestEditedArgsToolset_DelegatesDeclarationAndProcessRequest(t *testing.T) {
+	wrapped, inner := wrappedRecordingTool(t)
+
+	if got := wrapped.Declaration().Name; got != "save_interpretation" {
+		t.Errorf("Declaration().Name = %q", got)
+	}
+	rp, ok := wrapped.(requestProcessor)
+	if !ok {
+		t.Fatal("wrapper must keep the tool packable into LLM requests")
+	}
+	if err := rp.ProcessRequest(&confirmationContext{}, nil); err != nil {
+		t.Fatalf("ProcessRequest: %v", err)
+	}
+	if !inner.processed {
+		t.Error("ProcessRequest did not reach the wrapped tool")
+	}
+}
+
+func TestEditedArgsToolset_NonRunnableToolsPassThrough(t *testing.T) {
+	tools, err := EditedArgsToolset(stubToolset{tools: []tool.Tool{plainTool{}}}).Tools(&testAgentContext{})
+	if err != nil {
+		t.Fatalf("Tools: %v", err)
+	}
+	if _, isWrapped := tools[0].(*editedArgsTool); isWrapped {
+		t.Error("a tool without Run/ProcessRequest must pass through unwrapped")
+	}
+	if tools[0].Name() != "plain" {
+		t.Errorf("tool = %q", tools[0].Name())
+	}
+}

--- a/web/admin/composables/useAgentApi.ts
+++ b/web/admin/composables/useAgentApi.ts
@@ -103,14 +103,28 @@ async function streamAgentEvents(
   }
 }
 
+export interface AgentTurnOptions {
+  // Converse with one named skill directly (built as the turn's root agent,
+  // no coordinator routing). A confirmation must repeat the skill the paused
+  // turn ran with. Payload on an approval replaces the pending tool call's
+  // arguments wholesale (approve-with-edits).
+  skill?: string
+  payload?: Record<string, unknown>
+}
+
+function skillQuery(skill?: string): string {
+  return skill ? `?skill=${encodeURIComponent(skill)}` : ''
+}
+
 export function useAgentApi() {
   function sendMessage(
     conversationId: string,
     message: string,
     onEvent: (e: AgentEvent) => void,
+    opts: AgentTurnOptions = {},
   ) {
     return streamAgentEvents(
-      `/api/agent/conversations/${encodeURIComponent(conversationId)}/messages`,
+      `/api/agent/conversations/${encodeURIComponent(conversationId)}/messages${skillQuery(opts.skill)}`,
       { message },
       onEvent,
     )
@@ -121,10 +135,13 @@ export function useAgentApi() {
     callId: string,
     confirmed: boolean,
     onEvent: (e: AgentEvent) => void,
+    opts: AgentTurnOptions = {},
   ) {
+    const body: Record<string, unknown> = { confirmed }
+    if (opts.payload !== undefined) body.payload = opts.payload
     return streamAgentEvents(
-      `/api/agent/conversations/${encodeURIComponent(conversationId)}/confirmations/${encodeURIComponent(callId)}`,
-      { confirmed },
+      `/api/agent/conversations/${encodeURIComponent(conversationId)}/confirmations/${encodeURIComponent(callId)}${skillQuery(opts.skill)}`,
+      body,
       onEvent,
     )
   }


### PR DESCRIPTION
## What

(Also closes #420 — see the scripted-model section below.)

Two additive HITL/orchestrator enhancements for wepala/finexity#123 (agentic statement import):

1. **Approve-with-edits** (closes #417): `POST .../confirmations/:callID` accepts an optional `payload` object alongside `confirmed`; an approved call executes with the payload as its arguments instead of the model-proposed ones.
2. **Direct skill invocation** (closes #419): an optional `?skill=<name>` on the message + confirmation endpoints builds that skill as the turn's root agent instead of the coordinator, so a client's screen flow stays deterministic while riding the orchestrator's HITL loop.

## How

**Approve-with-edits**
- `api/handlers/agent_handler.go` — Confirm body widens to `{"confirmed": bool, "payload": {...}}`; payload optional, must be a JSON object; an explicit `null` is a 400 (raw-JSON binding), never a silent fallback to model args.
- `application/agents/orchestrator.go` — a non-nil payload rides the confirmation `FunctionResponse.Response`; ADK v2.0.0 unmarshals it into `ToolConfirmation.Payload` (verified — no ADK change needed), durable in the session.
- `internal/mcp/edited_args_toolset.go` — `EditedArgsToolset` (applied in `NewAgentToolset`): on a confirmed call with a non-nil payload, substitute it for the args before `CallTool`. Fail-closed: a non-object payload fails the call.

**Direct skill invocation**
- `application/agents/skill_agent.go` — `BuildSkillRootAgent`: builds a skill as a conversation root with delegation mode forced to `ModeChat` (a root `ModeTask` agent would self-install `finish_task` with no parent to consume it — empty-turn risk).
- `application/agents/orchestrator.go` — `ConverseStream`/`ResumeConfirmation` gain a `skill` param; `rootFor` picks the skill root or the coordinator; unknown skill = clear error.
- `api/handlers/agent_handler.go` — `?skill=` query param on both endpoints (the resume rebuilds the same root, so the client resends it).
- `web/admin/composables/useAgentApi.ts` — optional `{skill, payload}` options for parity.

## Semantics

| Call | Result |
|---|---|
| `{"confirmed": true}` | original args run (unchanged) |
| `{"confirmed": true, "payload": {...}}` | payload runs as the args |
| `{"confirmed": false, ...}` | rejected; payload ignored (unchanged) |
| payload not a JSON object / explicit null | 400 at the API; failed call at the toolset — fail closed |
| no `?skill=` | coordinator routing, unchanged |
| `?skill=x`, x loaded | x is the turn's root; no coordinator |
| `?skill=x`, x unknown | clear error on the stream |

The mutating gate (confirmation required for any tool not `ReadOnlyHint`) is untouched.

## Testing

- `go test ./...` green (the `web` embed test needs `web/dist` built — pre-existing, unrelated).
- New coverage: handler payload pass-through / nil / non-object / explicit-null 400; skill param threading + omitted-param default; toolset substitution semantics (5 cases) + declaration/ProcessRequest delegation; `buildSkillRoot` (root has no sub-agents, full turn emits done) + unknown-skill / no-skills errors.
- `go vet` + `gofmt` clean (local golangci-lint binary panics on this toolchain — environmental; CI's pinned lint will run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Addendum: scripted agent model (closes #420)

`WEOS_AGENT_SCRIPT=<path>.json` swaps the orchestrator's Gemini model for a rule-driven scripted one (`infrastructure/agents/scripted_model.go`): a matching user message emits a scripted tool call (args from a fenced ```json block in the message, or fixed), a tool's function response triggers a scripted reply or chained call, everything else falls to a default reply. Confirmation protocol frames never match afterTool rules. Everything except the model's judgment is the real pipeline — which is the point: downstream agent-loop e2e scenarios (wepala/finexity#126) run with no key, no network, no spend. Test-only; the provider logs a loud warning when active.