### PR TITLE
fix(projection): reconcile base columns on a pre-existing table

### DIFF
--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -112,6 +112,17 @@ func (pm *projectionManager) EnsureTable(
 		return fmt.Errorf("failed to ensure projection table %q: %w", tableName, err)
 	}
 
+	// Reconcile the base columns even when the table already existed. The
+	// CREATE above lists them, but CREATE ... IF NOT EXISTS is a no-op on a
+	// table another owner made first — e.g. pericarp auth's `agents` table,
+	// which the ValueFlows `agent` type's projection shares by name — so
+	// without this a projection write to that table fails on the first
+	// missing base column (account_id). addMissingColumns is idempotent
+	// (HasColumn-guarded), so this is a cheap ALTER only when needed.
+	if err := pm.addMissingColumns(ctx, tableName, pm.baseColumnDefs()); err != nil {
+		return fmt.Errorf("failed to ensure base columns on %q: %w", tableName, err)
+	}
+
 	if err := pm.addMissingColumns(ctx, tableName, columns); err != nil {
 		return fmt.Errorf("failed to add columns to %q: %w", tableName, err)
 	}
@@ -577,6 +588,28 @@ func (pm *projectionManager) EnsureExistingTables(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+// baseColumnDefs are the system columns every projection row carries. They
+// match the non-PK base columns createTableIfNotExists lists, but are typed
+// nullable here on purpose: ADD COLUMN can't introduce NOT NULL without a
+// default on a populated table, and the writer always supplies these values.
+// (id is the primary key and can't be ALTER-added, so it is omitted — a
+// table missing its primary key is not a case this reconciliation targets.)
+func (pm *projectionManager) baseColumnDefs() []columnDef {
+	ts := "DATETIME"
+	if pm.db.Name() == "postgres" {
+		ts = "TIMESTAMP WITH TIME ZONE"
+	}
+	return []columnDef{
+		{Name: "type_slug", SQLType: "TEXT"},
+		{Name: "status", SQLType: "TEXT"},
+		{Name: "created_by", SQLType: "TEXT"},
+		{Name: "account_id", SQLType: "TEXT"},
+		{Name: "sequence_no", SQLType: "INTEGER"},
+		{Name: "created_at", SQLType: ts},
+		{Name: "updated_at", SQLType: ts},
+	}
 }
 
 func (pm *projectionManager) createTableIfNotExists(ctx context.Context, tableName string, columns []columnDef) error {

--- a/infrastructure/database/gorm/projection_manager_test.go
+++ b/infrastructure/database/gorm/projection_manager_test.go
@@ -936,3 +936,39 @@ func TestRegisterLink_CoexistsWithSchemaReference(t *testing.T) {
 		t.Errorf("expected targets {project, user}, got %+v", targets)
 	}
 }
+
+// TestEnsureTable_ReconcilesBaseColumnsOnPreexistingTable covers the pericarp
+// collision: another owner (auth) created the `agents` table first, with no
+// base columns. EnsureTable for the ValueFlows `agent` type must ALTER the
+// base columns in, or the projection write fails on account_id.
+func TestEnsureTable_ReconcilesBaseColumnsOnPreexistingTable(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+
+	// Stand in for pericarp auth's agents table: present, but only its own
+	// columns — none of the projection base columns.
+	if err := db.Exec(`CREATE TABLE agents (
+		id text PRIMARY KEY, name text NOT NULL,
+		agent_type text NOT NULL DEFAULT 'foaf:Person',
+		status text NOT NULL DEFAULT 'active', created_at datetime)`).Error; err != nil {
+		t.Fatalf("failed to seed pre-existing agents table: %v", err)
+	}
+
+	schema := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`)
+	if err := pm.EnsureTable(context.Background(), "agent", schema, nil); err != nil {
+		t.Fatalf("EnsureTable failed: %v", err)
+	}
+
+	for _, col := range []string{"type_slug", "created_by", "account_id", "sequence_no"} {
+		if !db.Migrator().HasColumn("agents", col) {
+			t.Errorf("base column %q was not reconciled onto the pre-existing table", col)
+		}
+	}
+
+	// The write that used to fail must now succeed.
+	if err := db.Exec(`INSERT INTO agents (id, type_slug, status, created_by, account_id, sequence_no, name)
+		VALUES ('urn:agent:1', 'agent', 'active', 'urn:user:1', 'urn:account:1', 1, 'Acme')`).Error; err != nil {
+		t.Fatalf("projection write still fails after reconciliation: %v", err)
+	}
+}


### PR DESCRIPTION
## Bug

Approving a statement in finexity (epic wepala/finexity#123) throws:

```
SQL logic error: table agents has no column named account_id (1)
```

## Root cause — a table-name collision

The `agents` table is owned by **pericarp auth** (`AgentModel.TableName() == "agents"`, fixed schema: `id, name, agent_type, status, created_at`). The finance preset's ValueFlows **`agent` resource type** pluralizes to the same `agents` table.

`EnsureTable` builds the projection with `CREATE TABLE IF NOT EXISTS agents (…)` — which lists all the base columns — but auth migrates its table first, so the `CREATE` is a **no-op** and the base columns are never made. `addMissingColumns` then adds only the schema's *data* columns (`note`, `image`), never the base columns. The first projection write of an `agent` resource (a confirmed counterparty) fails on `account_id`.

Reproduces on a **fresh** `finexity seed`, not just stale DBs: every other projection table has `account_id`; only `agents` (the collision) lacks it.

## Fix

`EnsureTable` now runs `addMissingColumns` for the base columns too, so a pre-existing table is reconciled with a cheap, idempotent (HasColumn-guarded) `ALTER`. Base columns are typed nullable — `ADD COLUMN` can't add `NOT NULL` without a default on a populated table, and the writer always supplies the values. This **self-heals existing databases** on next boot and makes fresh installs correct. Regression test covers the pericarp-collision shape.

Verified against finexity via go.work: fresh seed now creates `agents` with the base columns and the previously-failing insert succeeds.

**Needs a `v3.0.1-alpha7` tag after merge** so finexity PR #139 can pin it (the epic's e2e never materialized an `agent` resource, which is the coverage gap that let this ship — a follow-up on the finexity side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)