### PR TITLE
fix(db): pin SQLite to a single-connection pool (weos#421)

### DIFF
--- a/infrastructure/database/gorm/provider.go
+++ b/infrastructure/database/gorm/provider.go
@@ -85,9 +85,22 @@ func ProvideGormDB(params struct {
 		return GormDBResult{}, fmt.Errorf("failed to get underlying sql.DB: %w", err)
 	}
 
-	// Configure connection pool (only meaningful for PostgreSQL)
-	sqlDB.SetMaxIdleConns(10)
-	sqlDB.SetMaxOpenConns(100)
+	// Configure the connection pool by dialect. SQLite has ONE writer: a
+	// pool of many connections doesn't parallelize writes, it just makes
+	// them collide — the event-sourcing subscribers' checkpoint writes and
+	// a request's resource write then fail with SQLITE_BUSY that busy_timeout
+	// can't clear (a checkpoint upgrade against a pool-held lock returns
+	// immediately). Pinning SQLite to a single connection serializes every
+	// access through Go's sql pool instead, which removes the contention
+	// outright (WAL keeps reads cheap). PostgreSQL has real concurrency, so
+	// it keeps the larger pool.
+	if isPostgresDSN(dsn) {
+		sqlDB.SetMaxIdleConns(10)
+		sqlDB.SetMaxOpenConns(100)
+	} else {
+		sqlDB.SetMaxIdleConns(1)
+		sqlDB.SetMaxOpenConns(1)
+	}
 
 	models := []any{
 		&weosmodels.ResourceType{},
@@ -123,10 +136,19 @@ func ProvideGormDB(params struct {
 // connection to the configured database (e.g. the ADK session service) use
 // this so driver selection never diverges.
 func DialectorForDSN(dsn string) gorm.Dialector {
-	if strings.HasPrefix(dsn, "host=") || strings.Contains(dsn, "postgres://") || strings.Contains(dsn, "postgresql://") {
+	if isPostgresDSN(dsn) {
 		return postgres.Open(dsn)
 	}
 	return sqlite.Open(sqliteDSNWithWorkerPragmas(dsn))
+}
+
+// isPostgresDSN reports whether the DSN names a PostgreSQL database; anything
+// else is treated as SQLite. One predicate so pool sizing and driver
+// selection can never disagree about the dialect.
+func isPostgresDSN(dsn string) bool {
+	return strings.HasPrefix(dsn, "host=") ||
+		strings.Contains(dsn, "postgres://") ||
+		strings.Contains(dsn, "postgresql://")
 }
 
 // sqliteDSNWithWorkerPragmas augments a file-based SQLite DSN with the pragmas

--- a/infrastructure/database/gorm/provider_pragma_test.go
+++ b/infrastructure/database/gorm/provider_pragma_test.go
@@ -16,8 +16,12 @@
 package gorm
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/wepala/weos/v3/internal/config"
+	"go.uber.org/fx"
 )
 
 func TestSqliteDSNWithWorkerPragmas(t *testing.T) {
@@ -61,4 +65,40 @@ func TestSqliteDSNWithWorkerPragmas(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestIsPostgresDSN(t *testing.T) {
+	postgres := []string{
+		"host=localhost user=x dbname=y",
+		"postgres://u:p@localhost:5432/db",
+		"postgresql://u:p@localhost/db",
+	}
+	for _, dsn := range postgres {
+		if !isPostgresDSN(dsn) {
+			t.Errorf("%q should be detected as PostgreSQL", dsn)
+		}
+	}
+	sqlite := []string{"/tmp/app.db", "file:app.db?cache=shared", ":memory:", "app.db"}
+	for _, dsn := range sqlite {
+		if isPostgresDSN(dsn) {
+			t.Errorf("%q should be treated as SQLite", dsn)
+		}
+	}
+}
+
+func TestProvideGormDB_SqlitePoolIsSingleConnection(t *testing.T) {
+	// SQLite has one writer; the pool must be pinned to a single connection
+	// so subscriber checkpoint writes and request writes serialize instead of
+	// colliding on SQLITE_BUSY.
+	dsn := filepath.Join(t.TempDir(), "pool.db")
+	res, err := ProvideGormDB(struct {
+		fx.In
+		Config config.Config
+	}{Config: config.Config{DatabaseDSN: dsn}})
+	if err != nil {
+		t.Fatalf("ProvideGormDB: %v", err)
+	}
+	if got := res.SQLDB.Stats().MaxOpenConnections; got != 1 {
+		t.Errorf("SQLite MaxOpenConnections = %d, want 1", got)
+	}
 }


### PR DESCRIPTION
## Bug

Confirming a transaction in finexity floods the logs with:

```
subscriber batch failed  subscriber=lexical-index   error=failed to acquire checkpoint: ... database is locked (5) (SQLITE_BUSY)
subscriber batch failed  subscriber=event-references error=... database is locked (SQLITE_BUSY)
subscriber batch failed  subscriber=display-values  error=... database is locked (SQLITE_BUSY)
could not create user-override rule for correction  error=... database is locked (SQLITE_BUSY)
```

## Root cause

The pool was hardcoded `SetMaxOpenConns(100)` — with a comment admitting it's *"only meaningful for PostgreSQL"* but applying it unconditionally. SQLite has a **single writer**; a 100-connection pool doesn't parallelize writes, it makes them **collide**. When a confirm fires a burst of events, the three event-sourcing subscribers' checkpoint writes and the request's rule write all contend, and the losers get immediate `SQLITE_BUSY` — which `busy_timeout` can't clear, because a checkpoint-row upgrade against a lock another pool connection holds returns BUSY straight away.

## Fix

Dialect-aware pool: **SQLite → `MaxOpenConns(1)`** (every access serializes through Go's `sql` pool — no concurrent writers, no contention; WAL keeps reads cheap), PostgreSQL keeps the 100-connection pool. Extracted `isPostgresDSN` so pool sizing and driver selection can't disagree. Tests cover the predicate and that a SQLite DSN yields a single-connection pool. The application package (subscribers/checkpoints) passes unchanged.

This is the follow-through on wepala/weos#421 (busy_timeout + AGENT_SESSION_DSN reduced it; single-writer pinning removes it).

**Needs a `v3.0.1-alpha8` tag after merge** for finexity PR #139 to pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)