### PR TITLE
fix(db): dialect-gated write serialization for SQLite (eliminate SQLITE_BUSY under subscriber load)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
 	github.com/casbin/gorm-adapter/v3 v3.41.0
 	github.com/cucumber/godog v0.15.1
+	github.com/glebarez/go-sqlite v1.22.0
 	github.com/glebarez/sqlite v1.11.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/gorilla/sessions v1.4.0
@@ -72,7 +73,6 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
-	github.com/glebarez/go-sqlite v1.22.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/infrastructure/database/gorm/provider.go
+++ b/infrastructure/database/gorm/provider.go
@@ -137,14 +137,14 @@ func DialectorForDSN(dsn string) gorm.Dialector {
 	if config.IsPostgresDSN(dsn) {
 		return postgres.Open(dsn)
 	}
-	inner := sqlite.Open(sqliteDSNWithWorkerPragmas(dsn))
+	augmented := sqliteDSNWithWorkerPragmas(dsn)
 	if strings.Contains(dsn, ":memory:") || strings.Contains(dsn, "mode=memory") {
 		// In-memory databases are single-connection and unique per DSN;
 		// keying a shared gate on ":memory:" would serialize unrelated test
 		// databases against each other. Skip the gate, same as the pragmas.
-		return inner
+		return sqlite.Open(augmented)
 	}
-	return gatedSQLiteDialector{Dialector: inner, dsn: dsn}
+	return newGatedSQLiteDialector(augmented, dsn)
 }
 
 // sqliteDSNWithWorkerPragmas augments a file-based SQLite DSN with the pragmas

--- a/infrastructure/database/gorm/provider.go
+++ b/infrastructure/database/gorm/provider.go
@@ -85,9 +85,19 @@ func ProvideGormDB(params struct {
 		return GormDBResult{}, fmt.Errorf("failed to get underlying sql.DB: %w", err)
 	}
 
-	// Configure connection pool (only meaningful for PostgreSQL)
-	sqlDB.SetMaxIdleConns(10)
-	sqlDB.SetMaxOpenConns(100)
+	// Configure the connection pool per dialect. PostgreSQL has real MVCC
+	// concurrency and keeps its large pool. SQLite keeps a small pool for
+	// concurrent readers (WAL); writers are serialized by the write gate (see
+	// sqlite_write_gate.go), not by pool size — the pool must stay above one
+	// connection, because a single shared connection forces reads and boot to
+	// queue behind background subscriber writes (the #425 regression).
+	if params.Config.IsPostgres() {
+		sqlDB.SetMaxIdleConns(10)
+		sqlDB.SetMaxOpenConns(100)
+	} else {
+		sqlDB.SetMaxIdleConns(5)
+		sqlDB.SetMaxOpenConns(10)
+	}
 
 	models := []any{
 		&weosmodels.ResourceType{},
@@ -117,16 +127,24 @@ func ProvideGormDB(params struct {
 }
 
 // DialectorForDSN detects the database driver from the DSN the same way the
-// main DB provider does: PostgreSQL DSNs start with "host=" or contain a
-// postgres:// URI; everything else is treated as SQLite (file path or file:
-// URI, with the worker pragmas applied). Consumers that need their own GORM
-// connection to the configured database (e.g. the ADK session service) use
-// this so driver selection never diverges.
+// main DB provider does: PostgreSQL DSNs (per config.IsPostgresDSN) get the
+// postgres driver untouched; everything else is treated as SQLite (file path
+// or file: URI, with the worker pragmas applied and the write gate installed).
+// Consumers that need their own GORM connection to the configured database
+// (e.g. the ADK session service) use this so driver selection — and write
+// serialization — never diverges.
 func DialectorForDSN(dsn string) gorm.Dialector {
-	if strings.HasPrefix(dsn, "host=") || strings.Contains(dsn, "postgres://") || strings.Contains(dsn, "postgresql://") {
+	if config.IsPostgresDSN(dsn) {
 		return postgres.Open(dsn)
 	}
-	return sqlite.Open(sqliteDSNWithWorkerPragmas(dsn))
+	inner := sqlite.Open(sqliteDSNWithWorkerPragmas(dsn))
+	if strings.Contains(dsn, ":memory:") || strings.Contains(dsn, "mode=memory") {
+		// In-memory databases are single-connection and unique per DSN;
+		// keying a shared gate on ":memory:" would serialize unrelated test
+		// databases against each other. Skip the gate, same as the pragmas.
+		return inner
+	}
+	return gatedSQLiteDialector{Dialector: inner, dsn: dsn}
 }
 
 // sqliteDSNWithWorkerPragmas augments a file-based SQLite DSN with the pragmas

--- a/infrastructure/database/gorm/provider.go
+++ b/infrastructure/database/gorm/provider.go
@@ -90,7 +90,8 @@ func ProvideGormDB(params struct {
 	// concurrent readers (WAL); writers are serialized by the write gate (see
 	// sqlite_write_gate.go), not by pool size — the pool must stay above one
 	// connection, because a single shared connection forces reads and boot to
-	// queue behind background subscriber writes (the #425 regression).
+	// queue behind background subscriber writes (the regression that sank the
+	// unmerged #425).
 	if params.Config.IsPostgres() {
 		sqlDB.SetMaxIdleConns(10)
 		sqlDB.SetMaxOpenConns(100)

--- a/infrastructure/database/gorm/resource_repository.go
+++ b/infrastructure/database/gorm/resource_repository.go
@@ -30,6 +30,7 @@ import (
 	"github.com/wepala/weos/v3/pkg/identity"
 	"github.com/wepala/weos/v3/pkg/utils"
 
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/subscriptions"
 	"go.uber.org/fx"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -105,6 +106,20 @@ func ProvideResourceRepository(params struct {
 	}, nil
 }
 
+// writeDB returns the gorm handle a resource write must use. When a
+// subscriber's batch transaction is in the context (pericarp injects it via
+// HandlerContext), the write joins that transaction so it runs on the same
+// connection — otherwise, under SQLite, a handler write on a pooled
+// connection deadlocks against the batch's own write lock. Outside a batch
+// (request-path writes) TxFromContext is nil and we fall back to the pooled
+// handle. Same contract as projectionManager.writeDB.
+func (r *ResourceRepository) writeDB(ctx context.Context) *gorm.DB {
+	if tx := subscriptions.TxFromContext(ctx); tx != nil {
+		return tx.WithContext(ctx)
+	}
+	return r.db.WithContext(ctx)
+}
+
 // Save persists a resource to the canonical table and all projection tables.
 // Projection writes are not transactional by design: projections are eventually-consistent
 // read models that can be rebuilt from the event store. A partial failure leaves the
@@ -114,7 +129,7 @@ func (r *ResourceRepository) Save(
 ) error {
 	// Always save to the generic resources table (canonical store).
 	model := models.FromResource(entity)
-	if err := r.db.WithContext(ctx).Create(model).Error; err != nil {
+	if err := r.writeDB(ctx).Create(model).Error; err != nil {
 		return fmt.Errorf("failed to save resource: %w", err)
 	}
 	// Also save to the projection table (denormalized read model) if one exists.
@@ -156,7 +171,7 @@ func (r *ResourceRepository) saveToProjection(
 	r.dropMissingColumns(targetSlug, row)
 	r.populateDisplayColumns(ctx, targetSlug, row,
 		buildLookupScope(entity.AccountID(), entity.CreatedBy()))
-	if err := r.db.WithContext(ctx).Table(tableName).Create(row).Error; err != nil {
+	if err := r.writeDB(ctx).Table(tableName).Create(row).Error; err != nil {
 		return fmt.Errorf("failed to save resource to projection %s: %w", tableName, err)
 	}
 	return nil
@@ -193,7 +208,7 @@ func (r *ResourceRepository) updateProjectionBySlug(
 		}
 	}
 
-	err := r.db.WithContext(ctx).Table(tableName).
+	err := r.writeDB(ctx).Table(tableName).
 		Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "id"}},
 			DoUpdates: clause.AssignmentColumns(updateCols),
@@ -1270,7 +1285,7 @@ func (r *ResourceRepository) UpdateData(
 	if sequenceNo > 0 {
 		updates["sequence_no"] = sequenceNo
 	}
-	if err := r.db.WithContext(ctx).Model(&models.Resource{}).
+	if err := r.writeDB(ctx).Model(&models.Resource{}).
 		Where("id = ?", id).Updates(updates).Error; err != nil {
 		return fmt.Errorf("failed to update resource data: %w", err)
 	}
@@ -1326,7 +1341,7 @@ func (r *ResourceRepository) updateDataInProjection(
 	if len(row) == 0 {
 		return nil
 	}
-	result := r.db.WithContext(ctx).Table(tableName).
+	result := r.writeDB(ctx).Table(tableName).
 		Where("id = ?", id).Updates(row)
 	if result.Error != nil {
 		return fmt.Errorf("failed to update projection data in %s: %w", tableName, result.Error)
@@ -1340,7 +1355,7 @@ func (r *ResourceRepository) Update(
 ) error {
 	// Always update the generic resources table.
 	model := models.FromResource(entity)
-	if err := r.db.WithContext(ctx).Save(model).Error; err != nil {
+	if err := r.writeDB(ctx).Save(model).Error; err != nil {
 		return fmt.Errorf("failed to update resource: %w", err)
 	}
 	// Also update the projection table if one exists.
@@ -1363,7 +1378,7 @@ func (r *ResourceRepository) Update(
 
 func (r *ResourceRepository) Delete(ctx context.Context, id string) error {
 	// Always delete from the generic resources table.
-	err := r.db.WithContext(ctx).Where("id = ?", id).Delete(&models.Resource{}).Error
+	err := r.writeDB(ctx).Where("id = ?", id).Delete(&models.Resource{}).Error
 	if err != nil {
 		return fmt.Errorf("failed to delete resource: %w", err)
 	}
@@ -1392,7 +1407,7 @@ func (r *ResourceRepository) deleteFromProjectionTable(
 	ctx context.Context, id, targetSlug string,
 ) error {
 	tableName := r.projMgr.TableName(targetSlug)
-	err := r.db.WithContext(ctx).Table(tableName).
+	err := r.writeDB(ctx).Table(tableName).
 		Where("id = ?", id).Delete(map[string]any{}).Error
 	if err != nil {
 		return fmt.Errorf("failed to delete resource from %s: %w", tableName, err)

--- a/infrastructure/database/gorm/resource_repository_tx_test.go
+++ b/infrastructure/database/gorm/resource_repository_tx_test.go
@@ -1,0 +1,102 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package gorm
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/wepala/weos/v3/infrastructure/models"
+
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/subscriptions"
+)
+
+// TestResourceWrite_JoinsBatchTransaction pins the same contract for
+// ResourceRepository that TestProjectionWrite_JoinsBatchTransaction pins for
+// the projection manager: a resource write invoked from inside a subscriber
+// handler must run through the batch transaction pericarp puts in the context
+// (writeDB → subscriptions.TxFromContext), NOT through the pooled *gorm.DB.
+// On SQLite a pooled-connection write blocks on the batch's own write lock
+// until busy_timeout, then errors "database is locked" — a self-deadlock
+// inside the subscriber goroutine. Reverting writeDB to r.db reintroduces
+// exactly that; this test catches it.
+func TestResourceWrite_JoinsBatchTransaction(t *testing.T) {
+	db := newWALTestDB(t)
+	if err := db.AutoMigrate(&models.Resource{}); err != nil {
+		t.Fatalf("auto-migrate resources: %v", err)
+	}
+	const id = "urn:widget:tx-guardrail"
+	if err := db.Create(&models.Resource{ID: id, TypeSlug: "widget", Data: "{}"}).Error; err != nil {
+		t.Fatalf("seed resource: %v", err)
+	}
+
+	repo := &ResourceRepository{
+		db:      db,
+		projMgr: &projectionManager{db: db, logger: &testLogger{}},
+		logger:  &testLogger{},
+	}
+
+	cps, err := subscriptions.NewGormCheckpointStore(db)
+	if err != nil {
+		t.Fatalf("new checkpoint store: %v", err)
+	}
+	batch, acquired, err := cps.Acquire(context.Background(), "resource-guardrail")
+	if err != nil || !acquired {
+		t.Fatalf("acquire batch: acquired=%v err=%v", acquired, err)
+	}
+	defer func() { _ = batch.Rollback() }()
+	handlerCtx := batch.HandlerContext(context.Background())
+
+	// Must not deadlock: pre-fix (writing through r.db) this takes a second
+	// pooled connection and blocks on the batch's write lock until
+	// busy_timeout, then errors "database is locked".
+	done := make(chan error, 1)
+	go func() {
+		done <- repo.Delete(handlerCtx, id)
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("resource write inside the batch transaction failed "+
+				"(deadlock regression — write did not join the batch tx): %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("resource write blocked inside the batch transaction " +
+			"(deadlock regression — write did not join the batch tx)")
+	}
+
+	// Routing proof: the delete lives in the still-open batch transaction, so
+	// a pooled read must still see the row before commit.
+	var preCommit int64
+	if err := db.Model(&models.Resource{}).Where("id = ?", id).Count(&preCommit).Error; err != nil {
+		t.Fatalf("pre-commit count: %v", err)
+	}
+	if preCommit != 1 {
+		t.Fatalf("pre-commit pooled read found %d rows, want 1 (write leaked outside the batch tx)", preCommit)
+	}
+
+	if err := batch.Commit(context.Background(), 1); err != nil {
+		t.Fatalf("commit batch: %v", err)
+	}
+	var postCommit int64
+	if err := db.Model(&models.Resource{}).Where("id = ?", id).Count(&postCommit).Error; err != nil {
+		t.Fatalf("post-commit count: %v", err)
+	}
+	if postCommit != 0 {
+		t.Fatalf("post-commit read found %d rows, want 0", postCommit)
+	}
+}

--- a/infrastructure/database/gorm/sqlite_write_gate.go
+++ b/infrastructure/database/gorm/sqlite_write_gate.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -28,6 +29,7 @@ import (
 
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/subscriptions"
 	gosqlite "github.com/glebarez/go-sqlite"
+	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 )
 
@@ -155,27 +157,32 @@ func isSQLiteBusy(err error) bool {
 	return errors.As(err, &e) && e.Code()&0xff == sqliteBusyCode
 }
 
-// gatedSQLiteDialector decorates the glebarez dialector so Initialize swaps
-// the raw *sql.DB ConnPool for the write-gated wrapper. Wrapping inside the
-// dialector (not after gorm.Open) means every caller of DialectorForDSN gets
-// the gate — nothing opts in, nothing can forget to.
-type gatedSQLiteDialector struct {
-	gorm.Dialector
-	dsn string
-}
-
-func (d gatedSQLiteDialector) Initialize(db *gorm.DB) error {
-	if err := d.Dialector.Initialize(db); err != nil {
-		return err
+// newGatedSQLiteDialector opens the raw *sql.DB itself and hands the glebarez
+// dialector a pre-wrapped ConnPool via its Conn field (its Initialize then
+// skips sql.Open and installs the Conn as-is). Building the concrete
+// *sqlite.Dialector — rather than decorating the gorm.Dialector interface —
+// keeps its full method set visible to gorm's optional-interface assertions:
+// an interface-embedding wrapper hides SavePoint/RollbackTo
+// (SavePointerDialectorInterface) and Translate (ErrorTranslator), which
+// breaks every savepoint (pericarp brackets each subscriber handler attempt
+// in one) with "unsupported driver".
+//
+// augmentedDSN carries the worker pragmas; rawDSN keys the per-file gate.
+func newGatedSQLiteDialector(augmentedDSN, rawDSN string) gorm.Dialector {
+	sqlDB, err := sql.Open(sqlite.DriverName, augmentedDSN)
+	if err != nil {
+		// Effectively unreachable: the driver is registered by the
+		// glebarez/go-sqlite import above, and sql.Open defers DSN parsing
+		// to connection time. Degrade to the ungated dialector (stderr only:
+		// stdout carries the MCP stdio protocol) rather than panic.
+		fmt.Fprintf(os.Stderr, "weos: sqlite write gate disabled: %v\n", err)
+		return sqlite.Open(augmentedDSN)
 	}
-	sqlDB, ok := db.ConnPool.(*sql.DB)
-	if !ok {
-		// A pre-supplied Conn or a wrapping gorm config (e.g. PrepareStmt)
-		// got here first; leave it alone rather than double-wrap.
-		return nil
+	return &sqlite.Dialector{
+		DriverName: sqlite.DriverName,
+		DSN:        augmentedDSN,
+		Conn:       &gatedConnPool{db: sqlDB, gate: writeGateFor(rawDSN)},
 	}
-	db.ConnPool = &gatedConnPool{db: sqlDB, gate: writeGateFor(d.dsn)}
-	return nil
 }
 
 // gatedConnPool implements gorm.ConnPool over the raw *sql.DB. Reads and

--- a/infrastructure/database/gorm/sqlite_write_gate.go
+++ b/infrastructure/database/gorm/sqlite_write_gate.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -31,6 +32,8 @@ import (
 	gosqlite "github.com/glebarez/go-sqlite"
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"gorm.io/gorm/schema"
 )
 
 // SQLite allows one writer per database file. With _txlock=immediate every
@@ -49,6 +52,13 @@ import (
 // means every consumer of the shared *gorm.DB — weos repositories, pericarp's
 // event store, checkpoint store and parking lot, and the ADK session store's
 // independent handle — inherits it without opting in.
+//
+// Invariant for subscriber handlers: writes made while a batch transaction is
+// open must join it via subscriptions.TxFromContext (see the writeDB helpers
+// on projectionManager and ResourceRepository). A handler write that opens a
+// fresh transaction instead bypasses the gate (see BeginTx) and contends with
+// its own batch inside SQLite — a bounded busy_timeout failure rather than a
+// wedge, but still a failure.
 
 const (
 	// sqliteBusyCode is SQLite's primary result code for "database is locked"
@@ -64,6 +74,13 @@ const (
 	// up to busyRetryMaxDelay.
 	busyRetryInitialDelay = 50 * time.Millisecond
 	busyRetryMaxDelay     = 2 * time.Second
+
+	// writeGateWarnAfter is how long a writer may queue at the gate before a
+	// warning is emitted (stderr — the logger doesn't exist when the dialector
+	// is built, and stdout carries the MCP stdio protocol). A healthy gate
+	// holds for milliseconds; a wait this long means a holder is stuck or an
+	// LLM-latency-bound batch is monopolizing the writer slot.
+	writeGateWarnAfter = 10 * time.Second
 )
 
 // writeGate is a binary semaphore serializing write-intent transactions on
@@ -81,8 +98,25 @@ func (g *writeGate) Lock(ctx context.Context) error {
 	select {
 	case g.ch <- struct{}{}:
 		return nil
-	case <-ctx.Done():
-		return ctx.Err()
+	default:
+	}
+	// Slow path: the gate is held. Warn once if the wait runs long — silence
+	// here would make a stuck holder look like a slow query — and wrap a
+	// cancellation so the operator can tell "died queued at the write gate"
+	// from an ordinary timeout.
+	warn := time.NewTimer(writeGateWarnAfter)
+	defer warn.Stop()
+	for {
+		select {
+		case g.ch <- struct{}{}:
+			return nil
+		case <-ctx.Done():
+			return fmt.Errorf("queued at the sqlite write gate: %w", ctx.Err())
+		case <-warn.C:
+			fmt.Fprintf(os.Stderr,
+				"weos: sqlite write gate: writer queued for over %s — the current holder is stuck or long-running\n",
+				writeGateWarnAfter)
+		}
 	}
 }
 
@@ -173,10 +207,10 @@ func newGatedSQLiteDialector(augmentedDSN, rawDSN string) gorm.Dialector {
 	if err != nil {
 		// Effectively unreachable: the driver is registered by the
 		// glebarez/go-sqlite import above, and sql.Open defers DSN parsing
-		// to connection time. Degrade to the ungated dialector (stderr only:
-		// stdout carries the MCP stdio protocol) rather than panic.
-		fmt.Fprintf(os.Stderr, "weos: sqlite write gate disabled: %v\n", err)
-		return sqlite.Open(augmentedDSN)
+		// to connection time. Fail fast at gorm.Open rather than silently
+		// degrade to an ungated pool — a working-but-ungated database would
+		// reintroduce the SQLITE_BUSY class this gate exists to eliminate.
+		return failingDialector{err: fmt.Errorf("sqlite write gate: open %q: %w", rawDSN, err)}
 	}
 	return &sqlite.Dialector{
 		DriverName: sqlite.DriverName,
@@ -184,6 +218,20 @@ func newGatedSQLiteDialector(augmentedDSN, rawDSN string) gorm.Dialector {
 		Conn:       &gatedConnPool{db: sqlDB, gate: writeGateFor(rawDSN)},
 	}
 }
+
+// failingDialector surfaces a construction error through gorm.Open (which
+// calls Initialize first and returns its error before any other method is
+// used). The remaining gorm.Dialector methods are dead stubs.
+type failingDialector struct{ err error }
+
+func (d failingDialector) Name() string                                        { return "sqlite" }
+func (d failingDialector) Initialize(*gorm.DB) error                           { return d.err }
+func (d failingDialector) Migrator(*gorm.DB) gorm.Migrator                     { return nil }
+func (d failingDialector) DataTypeOf(*schema.Field) string                     { return "" }
+func (d failingDialector) DefaultValueOf(*schema.Field) clause.Expression      { return nil }
+func (d failingDialector) BindVarTo(clause.Writer, *gorm.Statement, any)       {}
+func (d failingDialector) QuoteTo(clause.Writer, string)                       {}
+func (d failingDialector) Explain(sql string, vars ...any) string              { return sql }
 
 // gatedConnPool implements gorm.ConnPool over the raw *sql.DB. Reads and
 // non-transactional statements delegate straight through — they never queue.
@@ -229,9 +277,11 @@ func (p *gatedConnPool) GetDBConn() (*sql.DB, error) {
 // attaches it via HandlerContext; detected with TxFromContext) bypasses the
 // gate: the batch's own BeginTx acquired it higher up this goroutine's call
 // stack, and re-acquiring a non-reentrant semaphore would deadlock. The
-// bypassed Begin still contends with the batch inside SQLite itself — that
-// nested-write hazard is fixed at its root in pericarp (Append joining the
-// ambient transaction), not here.
+// bypassed Begin still contends with the batch inside SQLite itself, bounded
+// by busy_timeout — the bypass's only job is to keep that contention from
+// becoming a permanent gate deadlock. The root fix (pericarp's Append joining
+// the ambient transaction) ships separately in akeemphilbert/pericarp#58 and
+// takes effect once weos pins a release containing it.
 func (p *gatedConnPool) BeginTx(ctx context.Context, opts *sql.TxOptions) (gorm.ConnPool, error) {
 	if subscriptions.TxFromContext(ctx) != nil {
 		tx, err := p.db.BeginTx(ctx, opts)
@@ -248,7 +298,9 @@ func (p *gatedConnPool) BeginTx(ctx context.Context, opts *sql.TxOptions) (gorm.
 		p.gate.Unlock()
 		return nil, err
 	}
-	return &gatedTx{tx: tx, gate: p.gate}, nil
+	gt := &gatedTx{tx: tx, gate: p.gate}
+	runtime.SetFinalizer(gt, finalizeLeakedGatedTx)
+	return gt, nil
 }
 
 // beginWithBusyRetry retries BeginTx on SQLITE_BUSY with doubling backoff,
@@ -274,7 +326,11 @@ func (p *gatedConnPool) beginWithBusyRetry(ctx context.Context, opts *sql.TxOpti
 		select {
 		case <-time.After(delay):
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			// Keep the BUSY that drove us into backoff visible — a bare
+			// ctx.Err() is indistinguishable from a slow query.
+			return nil, fmt.Errorf(
+				"begin sqlite write transaction: %w (interrupted after %d attempts; last SQLITE_BUSY: %v)",
+				ctx.Err(), attempt, lastErr)
 		}
 		delay *= 2
 		if delay > busyRetryMaxDelay {
@@ -289,16 +345,37 @@ func (p *gatedConnPool) beginWithBusyRetry(ctx context.Context, opts *sql.TxOpti
 // gatedTx wraps the write transaction and releases the gate exactly once, on
 // whichever of Commit/Rollback runs first. A nil gate means the transaction
 // was begun via the ambient-batch bypass and holds nothing.
+//
+// A wrapper that becomes unreachable without either being called would hold
+// the gate forever — a silent, process-wide write wedge (strictly worse than
+// the pre-gate behavior, where a leaked transaction surfaced as loud BUSY
+// errors and self-healed at busy_timeout). BeginTx therefore arms a finalizer
+// as a loud last resort: it rolls the inner transaction back, releases the
+// gate, and reports the leak on stderr.
 type gatedTx struct {
-	tx   *sql.Tx
-	gate *writeGate
-	once sync.Once
+	tx       *sql.Tx
+	gate     *writeGate
+	released atomic.Bool
 }
 
 func (t *gatedTx) release() {
-	if t.gate != nil {
-		t.once.Do(t.gate.Unlock)
+	if t.gate != nil && t.released.CompareAndSwap(false, true) {
+		t.gate.Unlock()
 	}
+}
+
+// finalizeLeakedGatedTx is the last-resort release for a gated transaction
+// that was dropped without Commit/Rollback (e.g. a panic between gorm's begin
+// and commit callbacks, recovered upstream). Rollback on an already-finished
+// inner transaction returns sql.ErrTxDone harmlessly.
+func finalizeLeakedGatedTx(t *gatedTx) {
+	if t.gate == nil || t.released.Load() {
+		return
+	}
+	fmt.Fprintln(os.Stderr,
+		"weos: sqlite write gate: transaction leaked without Commit/Rollback; rolling back and releasing the gate")
+	_ = t.tx.Rollback()
+	t.release()
 }
 
 func (t *gatedTx) Commit() error {

--- a/infrastructure/database/gorm/sqlite_write_gate.go
+++ b/infrastructure/database/gorm/sqlite_write_gate.go
@@ -1,0 +1,325 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package gorm
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/subscriptions"
+	gosqlite "github.com/glebarez/go-sqlite"
+	"gorm.io/gorm"
+)
+
+// SQLite allows one writer per database file. With _txlock=immediate every
+// transaction takes the write lock at BEGIN, so N goroutines beginning
+// transactions on separate pooled connections race the file lock inside
+// SQLite — and the loser of a lock-upgrade race fails *immediately* with
+// SQLITE_BUSY, before busy_timeout is even consulted (#421). The write gate
+// moves that queue into Go: at most one write transaction is in flight per
+// database file, waiters queue on a semaphore (ctx-cancellable, inspectable
+// in a goroutine dump), and in-process SQLITE_BUSY becomes structurally
+// impossible. Reads never touch the gate — only BeginTx acquires it — so a
+// write burst cannot starve reads or server boot the way the reverted
+// MaxOpenConns(1) approach did (#425).
+//
+// The gate is installed at the gorm.ConnPool seam by DialectorForDSN, which
+// means every consumer of the shared *gorm.DB — weos repositories, pericarp's
+// event store, checkpoint store and parking lot, and the ADK session store's
+// independent handle — inherits it without opting in.
+
+const (
+	// sqliteBusyCode is SQLite's primary result code for "database is locked"
+	// (SQLITE_BUSY). Stable since SQLite 3.0.
+	sqliteBusyCode = 5
+
+	// busyRetryMaxAttempts bounds the retry-on-BUSY loop in BeginTx. Retry is
+	// belt-and-suspenders for contention the gate cannot see (another process,
+	// or a second in-process pool on the same file).
+	busyRetryMaxAttempts = 5
+
+	// busyRetryInitialDelay is the first retry delay; it doubles per attempt
+	// up to busyRetryMaxDelay.
+	busyRetryInitialDelay = 50 * time.Millisecond
+	busyRetryMaxDelay     = 2 * time.Second
+)
+
+// writeGate is a binary semaphore serializing write-intent transactions on
+// one SQLite file. Lock is context-aware so a queued writer honors its
+// caller's deadline/cancellation instead of waiting indefinitely.
+type writeGate struct {
+	ch chan struct{}
+}
+
+func newWriteGate() *writeGate {
+	return &writeGate{ch: make(chan struct{}, 1)}
+}
+
+func (g *writeGate) Lock(ctx context.Context) error {
+	select {
+	case g.ch <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (g *writeGate) Unlock() {
+	<-g.ch
+}
+
+// writeGates shares one gate per canonical database file, so two *gorm.DB
+// handles opened on the same file (the main DB and the ADK session store when
+// AGENT_SESSION_DSN is unset) serialize against each other, while distinct
+// files get independent gates — matching SQLite's own per-file locking.
+var (
+	writeGatesMu sync.Mutex
+	writeGates   = map[string]*writeGate{}
+)
+
+func writeGateFor(dsn string) *writeGate {
+	key := sqliteFileKey(dsn)
+	writeGatesMu.Lock()
+	defer writeGatesMu.Unlock()
+	if g, ok := writeGates[key]; ok {
+		return g
+	}
+	g := newWriteGate()
+	writeGates[key] = g
+	return g
+}
+
+// sqliteFileKey canonicalizes a SQLite DSN to its file path (best-effort: no
+// symlink resolution — two spellings resolving to one inode via symlinks
+// would get separate gates, which today's single-DSN configuration never
+// produces).
+func sqliteFileKey(dsn string) string {
+	p := strings.TrimPrefix(dsn, "file:")
+	if i := strings.IndexByte(p, '?'); i >= 0 {
+		p = p[:i]
+	}
+	if abs, err := filepath.Abs(p); err == nil {
+		return abs
+	}
+	return p
+}
+
+// busyRetryObserver is a test seam: when set (SetBusyRetryObserver), it is
+// called once per gated BeginTx attempt with the attempt number and its
+// outcome. Production leaves it nil.
+var busyRetryObserver atomic.Pointer[func(attempt int, err error)]
+
+// SetBusyRetryObserver installs a hook called once per gated BeginTx attempt
+// (err is nil on the attempt that succeeded). Test seam for asserting retry
+// behavior end to end; pass nil to clear.
+func SetBusyRetryObserver(fn func(attempt int, err error)) {
+	if fn == nil {
+		busyRetryObserver.Store(nil)
+		return
+	}
+	busyRetryObserver.Store(&fn)
+}
+
+func notifyBusyObserver(attempt int, err error) {
+	if fn := busyRetryObserver.Load(); fn != nil {
+		(*fn)(attempt, err)
+	}
+}
+
+// isSQLiteBusy reports whether err is (or wraps) a glebarez/go-sqlite error
+// whose primary result code is SQLITE_BUSY (extended codes like
+// SQLITE_BUSY_SNAPSHOT share the low byte). This is the only error class the
+// retry loop treats as transient.
+func isSQLiteBusy(err error) bool {
+	var e *gosqlite.Error
+	return errors.As(err, &e) && e.Code()&0xff == sqliteBusyCode
+}
+
+// gatedSQLiteDialector decorates the glebarez dialector so Initialize swaps
+// the raw *sql.DB ConnPool for the write-gated wrapper. Wrapping inside the
+// dialector (not after gorm.Open) means every caller of DialectorForDSN gets
+// the gate — nothing opts in, nothing can forget to.
+type gatedSQLiteDialector struct {
+	gorm.Dialector
+	dsn string
+}
+
+func (d gatedSQLiteDialector) Initialize(db *gorm.DB) error {
+	if err := d.Dialector.Initialize(db); err != nil {
+		return err
+	}
+	sqlDB, ok := db.ConnPool.(*sql.DB)
+	if !ok {
+		// A pre-supplied Conn or a wrapping gorm config (e.g. PrepareStmt)
+		// got here first; leave it alone rather than double-wrap.
+		return nil
+	}
+	db.ConnPool = &gatedConnPool{db: sqlDB, gate: writeGateFor(d.dsn)}
+	return nil
+}
+
+// gatedConnPool implements gorm.ConnPool over the raw *sql.DB. Reads and
+// non-transactional statements delegate straight through — they never queue.
+// Only BeginTx (gorm.ConnPoolBeginner) acquires the gate, and it holds zero
+// pool connections while waiting.
+type gatedConnPool struct {
+	db   *sql.DB
+	gate *writeGate
+}
+
+func (p *gatedConnPool) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	return p.db.PrepareContext(ctx, query)
+}
+
+func (p *gatedConnPool) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	return p.db.ExecContext(ctx, query, args...)
+}
+
+func (p *gatedConnPool) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return p.db.QueryContext(ctx, query, args...)
+}
+
+func (p *gatedConnPool) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return p.db.QueryRowContext(ctx, query, args...)
+}
+
+// Ping keeps gorm.Open's automatic connectivity check working.
+func (p *gatedConnPool) Ping() error {
+	return p.db.Ping()
+}
+
+// GetDBConn satisfies gorm's GetDBConnector so db.DB() (pool sizing, stats)
+// still resolves the real *sql.DB through the wrapper.
+func (p *gatedConnPool) GetDBConn() (*sql.DB, error) {
+	return p.db, nil
+}
+
+// BeginTx implements gorm.ConnPoolBeginner: gorm's Begin() routes every
+// transaction — explicit Transaction(...) calls and the implicit one wrapping
+// each Create/Update/Delete — through here.
+//
+// A handler already running inside a subscriber's batch transaction (pericarp
+// attaches it via HandlerContext; detected with TxFromContext) bypasses the
+// gate: the batch's own BeginTx acquired it higher up this goroutine's call
+// stack, and re-acquiring a non-reentrant semaphore would deadlock. The
+// bypassed Begin still contends with the batch inside SQLite itself — that
+// nested-write hazard is fixed at its root in pericarp (Append joining the
+// ambient transaction), not here.
+func (p *gatedConnPool) BeginTx(ctx context.Context, opts *sql.TxOptions) (gorm.ConnPool, error) {
+	if subscriptions.TxFromContext(ctx) != nil {
+		tx, err := p.db.BeginTx(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		return &gatedTx{tx: tx}, nil
+	}
+	if err := p.gate.Lock(ctx); err != nil {
+		return nil, err
+	}
+	tx, err := p.beginWithBusyRetry(ctx, opts)
+	if err != nil {
+		p.gate.Unlock()
+		return nil, err
+	}
+	return &gatedTx{tx: tx, gate: p.gate}, nil
+}
+
+// beginWithBusyRetry retries BeginTx on SQLITE_BUSY with doubling backoff,
+// bounded at busyRetryMaxAttempts. Any other error surfaces on the first
+// attempt. The gate is already held, so BUSY here means contention the gate
+// cannot see: another process on the file, or a second in-process pool.
+func (p *gatedConnPool) beginWithBusyRetry(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	delay := busyRetryInitialDelay
+	var lastErr error
+	for attempt := 1; attempt <= busyRetryMaxAttempts; attempt++ {
+		tx, err := p.db.BeginTx(ctx, opts)
+		notifyBusyObserver(attempt, err)
+		if err == nil {
+			return tx, nil
+		}
+		if !isSQLiteBusy(err) {
+			return nil, err
+		}
+		lastErr = err
+		if attempt == busyRetryMaxAttempts {
+			break
+		}
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		delay *= 2
+		if delay > busyRetryMaxDelay {
+			delay = busyRetryMaxDelay
+		}
+	}
+	return nil, fmt.Errorf(
+		"begin sqlite write transaction: gave up after %d attempts: %w",
+		busyRetryMaxAttempts, lastErr)
+}
+
+// gatedTx wraps the write transaction and releases the gate exactly once, on
+// whichever of Commit/Rollback runs first. A nil gate means the transaction
+// was begun via the ambient-batch bypass and holds nothing.
+type gatedTx struct {
+	tx   *sql.Tx
+	gate *writeGate
+	once sync.Once
+}
+
+func (t *gatedTx) release() {
+	if t.gate != nil {
+		t.once.Do(t.gate.Unlock)
+	}
+}
+
+func (t *gatedTx) Commit() error {
+	defer t.release()
+	return t.tx.Commit()
+}
+
+func (t *gatedTx) Rollback() error {
+	defer t.release()
+	return t.tx.Rollback()
+}
+
+func (t *gatedTx) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	return t.tx.PrepareContext(ctx, query)
+}
+
+func (t *gatedTx) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	return t.tx.ExecContext(ctx, query, args...)
+}
+
+func (t *gatedTx) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return t.tx.QueryContext(ctx, query, args...)
+}
+
+func (t *gatedTx) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return t.tx.QueryRowContext(ctx, query, args...)
+}
+
+func (t *gatedTx) StmtContext(ctx context.Context, stmt *sql.Stmt) *sql.Stmt {
+	return t.tx.StmtContext(ctx, stmt)
+}

--- a/infrastructure/database/gorm/sqlite_write_gate.go
+++ b/infrastructure/database/gorm/sqlite_write_gate.go
@@ -39,14 +39,16 @@ import (
 // SQLite allows one writer per database file. With _txlock=immediate every
 // transaction takes the write lock at BEGIN, so N goroutines beginning
 // transactions on separate pooled connections race the file lock inside
-// SQLite — and the loser of a lock-upgrade race fails *immediately* with
-// SQLITE_BUSY, before busy_timeout is even consulted (#421). The write gate
-// moves that queue into Go: at most one write transaction is in flight per
-// database file, waiters queue on a semaphore (ctx-cancellable, inspectable
-// in a goroutine dump), and in-process SQLITE_BUSY becomes structurally
-// impossible. Reads never touch the gate — only BeginTx acquires it — so a
-// write burst cannot starve reads or server boot the way the reverted
-// MaxOpenConns(1) approach did (#425).
+// SQLite — and the loser of that lock-upgrade/deadlock-avoidance race fails
+// *immediately* with SQLITE_BUSY, before busy_timeout is even consulted
+// (#421). The write gate moves that queue into Go: at most one write
+// transaction is in flight per database file, waiters queue on a semaphore
+// (ctx-cancellable, inspectable in a goroutine dump), and SQLITE_BUSY becomes
+// structurally impossible between gated writers (connections opened outside
+// DialectorForDSN, or another process, can still produce it — the bounded
+// retry below covers those). Reads never touch the gate — only BeginTx
+// acquires it — so a write burst cannot starve reads or server boot the way
+// the rejected MaxOpenConns(1) approach did (#425, closed unmerged).
 //
 // The gate is installed at the gorm.ConnPool seam by DialectorForDSN, which
 // means every consumer of the shared *gorm.DB — weos repositories, pericarp's
@@ -67,7 +69,7 @@ const (
 
 	// busyRetryMaxAttempts bounds the retry-on-BUSY loop in BeginTx. Retry is
 	// belt-and-suspenders for contention the gate cannot see (another process,
-	// or a second in-process pool on the same file).
+	// or a connection to the same file opened outside DialectorForDSN).
 	busyRetryMaxAttempts = 5
 
 	// busyRetryInitialDelay is the first retry delay; it doubles per attempt
@@ -224,14 +226,14 @@ func newGatedSQLiteDialector(augmentedDSN, rawDSN string) gorm.Dialector {
 // used). The remaining gorm.Dialector methods are dead stubs.
 type failingDialector struct{ err error }
 
-func (d failingDialector) Name() string                                        { return "sqlite" }
-func (d failingDialector) Initialize(*gorm.DB) error                           { return d.err }
-func (d failingDialector) Migrator(*gorm.DB) gorm.Migrator                     { return nil }
-func (d failingDialector) DataTypeOf(*schema.Field) string                     { return "" }
-func (d failingDialector) DefaultValueOf(*schema.Field) clause.Expression      { return nil }
-func (d failingDialector) BindVarTo(clause.Writer, *gorm.Statement, any)       {}
-func (d failingDialector) QuoteTo(clause.Writer, string)                       {}
-func (d failingDialector) Explain(sql string, vars ...any) string              { return sql }
+func (d failingDialector) Name() string                                   { return "sqlite" }
+func (d failingDialector) Initialize(*gorm.DB) error                      { return d.err }
+func (d failingDialector) Migrator(*gorm.DB) gorm.Migrator                { return nil }
+func (d failingDialector) DataTypeOf(*schema.Field) string                { return "" }
+func (d failingDialector) DefaultValueOf(*schema.Field) clause.Expression { return nil }
+func (d failingDialector) BindVarTo(clause.Writer, *gorm.Statement, any)  {}
+func (d failingDialector) QuoteTo(clause.Writer, string)                  {}
+func (d failingDialector) Explain(sql string, vars ...any) string         { return sql }
 
 // gatedConnPool implements gorm.ConnPool over the raw *sql.DB. Reads and
 // non-transactional statements delegate straight through — they never queue.
@@ -306,7 +308,8 @@ func (p *gatedConnPool) BeginTx(ctx context.Context, opts *sql.TxOptions) (gorm.
 // beginWithBusyRetry retries BeginTx on SQLITE_BUSY with doubling backoff,
 // bounded at busyRetryMaxAttempts. Any other error surfaces on the first
 // attempt. The gate is already held, so BUSY here means contention the gate
-// cannot see: another process on the file, or a second in-process pool.
+// cannot see: another process on the file, or a connection opened outside
+// DialectorForDSN.
 func (p *gatedConnPool) beginWithBusyRetry(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
 	delay := busyRetryInitialDelay
 	var lastErr error
@@ -347,11 +350,12 @@ func (p *gatedConnPool) beginWithBusyRetry(ctx context.Context, opts *sql.TxOpti
 // was begun via the ambient-batch bypass and holds nothing.
 //
 // A wrapper that becomes unreachable without either being called would hold
-// the gate forever — a silent, process-wide write wedge (strictly worse than
-// the pre-gate behavior, where a leaked transaction surfaced as loud BUSY
-// errors and self-healed at busy_timeout). BeginTx therefore arms a finalizer
-// as a loud last resort: it rolls the inner transaction back, releases the
-// gate, and reports the leak on stderr.
+// the gate forever — a silent, process-wide write wedge. (Pre-gate, a leaked
+// transaction pinned its connection and SQLite's write lock just as
+// indefinitely, but every competing writer failed loudly at busy_timeout;
+// the gate must not turn that into silence.) BeginTx therefore arms a
+// finalizer as a loud last resort: it rolls the inner transaction back,
+// releases the gate, and reports the leak on stderr.
 type gatedTx struct {
 	tx       *sql.Tx
 	gate     *writeGate

--- a/infrastructure/database/gorm/sqlite_write_gate_test.go
+++ b/infrastructure/database/gorm/sqlite_write_gate_test.go
@@ -1,0 +1,356 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package gorm
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type gateTestRow struct {
+	ID   uint `gorm:"primarykey"`
+	Name string
+}
+
+func openGatedTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dsn := filepath.Join(t.TempDir(), "gate_test.db")
+	db, err := gorm.Open(DialectorForDSN(dsn), gormConfig())
+	if err != nil {
+		t.Fatalf("open gated db: %v", err)
+	}
+	if err := db.AutoMigrate(&gateTestRow{}); err != nil {
+		t.Fatalf("auto-migrate: %v", err)
+	}
+	return db
+}
+
+// TestWriteGate_MutualExclusion proves at most one holder at a time and that
+// waiters proceed after release.
+func TestWriteGate_MutualExclusion(t *testing.T) {
+	g := newWriteGate()
+	var inGate, maxSeen int32
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Go(func() {
+			if err := g.Lock(context.Background()); err != nil {
+				t.Errorf("lock: %v", err)
+				return
+			}
+			n := atomic.AddInt32(&inGate, 1)
+			for {
+				m := atomic.LoadInt32(&maxSeen)
+				if n <= m || atomic.CompareAndSwapInt32(&maxSeen, m, n) {
+					break
+				}
+			}
+			time.Sleep(time.Millisecond)
+			atomic.AddInt32(&inGate, -1)
+			g.Unlock()
+		})
+	}
+	wg.Wait()
+	if got := atomic.LoadInt32(&maxSeen); got != 1 {
+		t.Fatalf("expected at most 1 concurrent holder, saw %d", got)
+	}
+}
+
+func TestWriteGate_LockHonorsContext(t *testing.T) {
+	g := newWriteGate()
+	if err := g.Lock(context.Background()); err != nil {
+		t.Fatalf("initial lock: %v", err)
+	}
+	defer g.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if err := g.Lock(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected DeadlineExceeded while queued, got %v", err)
+	}
+}
+
+// TestGatedDB_ConcurrentWriteBurst is the in-package regression for the #421
+// failure: many goroutines writing transactionally at once must all land with
+// zero "database is locked" errors.
+func TestGatedDB_ConcurrentWriteBurst(t *testing.T) {
+	db := openGatedTestDB(t)
+
+	const writers = 20
+	errs := make(chan error, writers)
+	var wg sync.WaitGroup
+	for i := range writers {
+		wg.Go(func() {
+			errs <- db.Transaction(func(tx *gorm.DB) error {
+				return tx.Create(&gateTestRow{Name: fmt.Sprintf("row-%d", i)}).Error
+			})
+		})
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent write failed: %v", err)
+		}
+	}
+
+	var count int64
+	if err := db.Model(&gateTestRow{}).Count(&count).Error; err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != writers {
+		t.Fatalf("expected %d rows, got %d", writers, count)
+	}
+}
+
+// TestGatedDB_ReadsPassWhileWriteHeld: a SELECT must complete while a write
+// transaction holds the gate — reads never queue on it.
+func TestGatedDB_ReadsPassWhileWriteHeld(t *testing.T) {
+	db := openGatedTestDB(t)
+	if err := db.Create(&gateTestRow{Name: "seed"}).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	tx := db.Begin()
+	if tx.Error != nil {
+		t.Fatalf("begin: %v", tx.Error)
+	}
+	if err := tx.Create(&gateTestRow{Name: "in-flight"}).Error; err != nil {
+		t.Fatalf("create in tx: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		var rows []gateTestRow
+		done <- db.Find(&rows).Error
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("read during held write: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("read blocked behind the write gate")
+	}
+
+	if err := tx.Commit().Error; err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+}
+
+// TestGatedDB_SecondWriterQueuesUntilCommit: a second write transaction waits
+// for the first to finish instead of failing with SQLITE_BUSY.
+func TestGatedDB_SecondWriterQueuesUntilCommit(t *testing.T) {
+	db := openGatedTestDB(t)
+
+	tx := db.Begin()
+	if tx.Error != nil {
+		t.Fatalf("begin: %v", tx.Error)
+	}
+
+	second := make(chan error, 1)
+	go func() {
+		second <- db.Transaction(func(inner *gorm.DB) error {
+			return inner.Create(&gateTestRow{Name: "queued"}).Error
+		})
+	}()
+
+	select {
+	case err := <-second:
+		t.Fatalf("second writer finished while gate was held (err=%v)", err)
+	case <-time.After(200 * time.Millisecond):
+		// still queued — expected
+	}
+
+	if err := tx.Commit().Error; err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	select {
+	case err := <-second:
+		if err != nil {
+			t.Fatalf("queued writer failed after release: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("queued writer never proceeded after commit")
+	}
+}
+
+// TestIsSQLiteBusy_RealDriverError manufactures genuine BUSY contention with
+// two raw connections (the driver's error fields are unexported, so a real
+// collision is the only honest way to produce one).
+func TestIsSQLiteBusy_RealDriverError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "busy_test.db")
+	holder, err := sql.Open("sqlite", path+"?_pragma=journal_mode(WAL)&_txlock=immediate")
+	if err != nil {
+		t.Fatalf("open holder: %v", err)
+	}
+	defer holder.Close()
+	contender, err := sql.Open("sqlite", path+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(0)&_txlock=immediate")
+	if err != nil {
+		t.Fatalf("open contender: %v", err)
+	}
+	defer contender.Close()
+
+	if _, err := holder.Exec("CREATE TABLE t (id INTEGER PRIMARY KEY)"); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	holdTx, err := holder.Begin()
+	if err != nil {
+		t.Fatalf("holder begin: %v", err)
+	}
+	defer func() { _ = holdTx.Rollback() }()
+
+	_, busyErr := contender.Begin()
+	if busyErr == nil {
+		t.Fatal("expected the contender's BEGIN IMMEDIATE to fail while the lock is held")
+	}
+	if !isSQLiteBusy(busyErr) {
+		t.Fatalf("isSQLiteBusy(%v) = false, want true", busyErr)
+	}
+	if isSQLiteBusy(errors.New("some other failure")) {
+		t.Fatal("isSQLiteBusy misclassified a generic error")
+	}
+}
+
+// TestBeginWithBusyRetry_BoundedGiveUp holds the file lock past the whole
+// retry budget and asserts the gate gives up after exactly
+// busyRetryMaxAttempts attempts with a wrapped BUSY error.
+func TestBeginWithBusyRetry_BoundedGiveUp(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "giveup_test.db")
+	holder, err := sql.Open("sqlite", path+"?_pragma=journal_mode(WAL)&_txlock=immediate")
+	if err != nil {
+		t.Fatalf("open holder: %v", err)
+	}
+	defer holder.Close()
+	if _, err := holder.Exec("CREATE TABLE t (id INTEGER PRIMARY KEY)"); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	pooled, err := sql.Open("sqlite", path+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(0)&_txlock=immediate")
+	if err != nil {
+		t.Fatalf("open pooled: %v", err)
+	}
+	defer pooled.Close()
+	pool := &gatedConnPool{db: pooled, gate: newWriteGate()}
+
+	var attempts int32
+	SetBusyRetryObserver(func(attempt int, err error) {
+		atomic.AddInt32(&attempts, 1)
+	})
+	defer SetBusyRetryObserver(nil)
+
+	holdTx, err := holder.Begin()
+	if err != nil {
+		t.Fatalf("holder begin: %v", err)
+	}
+	defer func() { _ = holdTx.Rollback() }()
+
+	_, beginErr := pool.BeginTx(context.Background(), nil)
+	if beginErr == nil {
+		t.Fatal("expected BeginTx to give up while the lock is held")
+	}
+	wantMsg := fmt.Sprintf("gave up after %d attempts", busyRetryMaxAttempts)
+	if !strings.Contains(beginErr.Error(), wantMsg) {
+		t.Fatalf("error %q does not contain %q", beginErr.Error(), wantMsg)
+	}
+	if got := atomic.LoadInt32(&attempts); got != busyRetryMaxAttempts {
+		t.Fatalf("expected %d attempts, observed %d", busyRetryMaxAttempts, got)
+	}
+}
+
+// TestBeginWithBusyRetry_TransientBusyRecovers releases the external lock
+// partway through the retry budget and asserts the write lands after more
+// than one attempt.
+func TestBeginWithBusyRetry_TransientBusyRecovers(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "transient_test.db")
+	holder, err := sql.Open("sqlite", path+"?_pragma=journal_mode(WAL)&_txlock=immediate")
+	if err != nil {
+		t.Fatalf("open holder: %v", err)
+	}
+	defer holder.Close()
+	if _, err := holder.Exec("CREATE TABLE t (id INTEGER PRIMARY KEY)"); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	pooled, err := sql.Open("sqlite", path+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(0)&_txlock=immediate")
+	if err != nil {
+		t.Fatalf("open pooled: %v", err)
+	}
+	defer pooled.Close()
+	pool := &gatedConnPool{db: pooled, gate: newWriteGate()}
+
+	var attempts int32
+	SetBusyRetryObserver(func(attempt int, err error) {
+		atomic.AddInt32(&attempts, 1)
+	})
+	defer SetBusyRetryObserver(nil)
+
+	holdTx, err := holder.Begin()
+	if err != nil {
+		t.Fatalf("holder begin: %v", err)
+	}
+	go func() {
+		time.Sleep(120 * time.Millisecond) // past attempt 1 (+50ms) and into attempt 2's window
+		_ = holdTx.Rollback()
+	}()
+
+	tx, beginErr := pool.BeginTx(context.Background(), nil)
+	if beginErr != nil {
+		t.Fatalf("expected the write to land once the lock released, got %v", beginErr)
+	}
+	committer, ok := tx.(interface{ Rollback() error })
+	if !ok {
+		t.Fatalf("returned tx %T does not support Rollback", tx)
+	}
+	_ = committer.Rollback()
+
+	if got := atomic.LoadInt32(&attempts); got < 2 {
+		t.Fatalf("expected more than one attempt, observed %d", got)
+	}
+}
+
+// TestGatedDialector_MemoryDSNSkipsGate: in-memory databases keep the plain
+// dialector (a shared ":memory:" gate would serialize unrelated databases).
+func TestGatedDialector_MemoryDSNSkipsGate(t *testing.T) {
+	if _, ok := DialectorForDSN(":memory:").(gatedSQLiteDialector); ok {
+		t.Fatal(":memory: DSN should not be write-gated")
+	}
+	if _, ok := DialectorForDSN("file.db").(gatedSQLiteDialector); !ok {
+		t.Fatal("file DSN should be write-gated")
+	}
+}
+
+// TestWriteGateFor_SharedPerFile: same file (different DSN spellings) shares
+// one gate; different files get independent gates.
+func TestWriteGateFor_SharedPerFile(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "one.db")
+	if writeGateFor(a) != writeGateFor("file:"+a+"?_pragma=busy_timeout(100)") {
+		t.Fatal("same file should share one gate")
+	}
+	if writeGateFor(a) == writeGateFor(filepath.Join(dir, "two.db")) {
+		t.Fatal("different files should have independent gates")
+	}
+}

--- a/infrastructure/database/gorm/sqlite_write_gate_test.go
+++ b/infrastructure/database/gorm/sqlite_write_gate_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/subscriptions"
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 )
@@ -279,6 +280,19 @@ func TestBeginWithBusyRetry_BoundedGiveUp(t *testing.T) {
 	if got := atomic.LoadInt32(&attempts); got != busyRetryMaxAttempts {
 		t.Fatalf("expected %d attempts, observed %d", busyRetryMaxAttempts, got)
 	}
+
+	// The failed begin must release the gate: once the external lock drops,
+	// the next writer goes straight through instead of wedging.
+	if err := holdTx.Rollback(); err != nil {
+		t.Fatalf("release external lock: %v", err)
+	}
+	tx, err := pool.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("gate leaked by the failed begin — follow-up BeginTx errored: %v", err)
+	}
+	if rb, ok := tx.(interface{ Rollback() error }); ok {
+		_ = rb.Rollback()
+	}
 }
 
 // TestBeginWithBusyRetry_TransientBusyRecovers releases the external lock
@@ -329,6 +343,105 @@ func TestBeginWithBusyRetry_TransientBusyRecovers(t *testing.T) {
 
 	if got := atomic.LoadInt32(&attempts); got < 2 {
 		t.Fatalf("expected more than one attempt, observed %d", got)
+	}
+}
+
+// TestGatedDB_AmbientBatchTxBypassesGate pins the self-deadlock guard for
+// handlers that begin a NEW transaction from inside a subscriber batch (the
+// consolidation path: handler → ResourceService → UnitOfWork → event store
+// Append). The batch's own BeginTx holds the gate, so without the
+// TxFromContext bypass the nested Begin would queue on the gate its own call
+// stack holds — a permanent, app-wide write wedge. With the bypass it reaches
+// SQLite instead and fails fast with BUSY (bounded by the DSN's busy_timeout)
+// until pericarp's Append learns to join the ambient transaction
+// (akeemphilbert/pericarp#58).
+func TestGatedDB_AmbientBatchTxBypassesGate(t *testing.T) {
+	dsn := filepath.Join(t.TempDir(), "ambient_test.db") + "?_pragma=busy_timeout(200)"
+	db, err := gorm.Open(DialectorForDSN(dsn), gormConfig())
+	if err != nil {
+		t.Fatalf("open gated db: %v", err)
+	}
+	if err := db.AutoMigrate(&gateTestRow{}); err != nil {
+		t.Fatalf("auto-migrate: %v", err)
+	}
+
+	cps, err := subscriptions.NewGormCheckpointStore(db)
+	if err != nil {
+		t.Fatalf("new checkpoint store: %v", err)
+	}
+	// Acquire goes through the gated pool: the batch now holds the gate AND
+	// SQLite's write lock.
+	batch, acquired, err := cps.Acquire(context.Background(), "ambient-bypass")
+	if err != nil || !acquired {
+		t.Fatalf("acquire batch: acquired=%v err=%v", acquired, err)
+	}
+	defer func() { _ = batch.Rollback() }()
+	handlerCtx := batch.HandlerContext(context.Background())
+
+	// A new transaction from inside the batch must NOT hang on the gate. It
+	// bypasses it, contends with the batch inside SQLite, and surfaces BUSY
+	// after the 200ms busy_timeout — a bounded error, not a wedge.
+	done := make(chan error, 1)
+	go func() {
+		done <- db.WithContext(handlerCtx).Transaction(func(tx *gorm.DB) error {
+			return tx.Create(&gateTestRow{Name: "nested"}).Error
+		})
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("nested transaction unexpectedly succeeded while the batch holds the write lock")
+		}
+		if !isSQLiteBusy(err) {
+			t.Fatalf("expected a bounded SQLITE_BUSY from the bypassed begin, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("nested transaction hung — the ambient-batch bypass regressed into a gate self-deadlock")
+	}
+
+	// Ending the batch releases the gate; ordinary writes must flow again.
+	if err := batch.Rollback(); err != nil {
+		t.Fatalf("rollback batch: %v", err)
+	}
+	if err := db.Create(&gateTestRow{Name: "after"}).Error; err != nil {
+		t.Fatalf("write after batch release: %v", err)
+	}
+}
+
+// TestGatedDB_RollbackReleasesGate: a rolled-back transaction must free the
+// gate for queued writers — rollbacks are routine (failed Transaction
+// callbacks, constraint violations), and a leaked slot is a permanent wedge.
+func TestGatedDB_RollbackReleasesGate(t *testing.T) {
+	db := openGatedTestDB(t)
+
+	tx := db.Begin()
+	if tx.Error != nil {
+		t.Fatalf("begin: %v", tx.Error)
+	}
+
+	second := make(chan error, 1)
+	go func() {
+		second <- db.Transaction(func(inner *gorm.DB) error {
+			return inner.Create(&gateTestRow{Name: "after-rollback"}).Error
+		})
+	}()
+	select {
+	case err := <-second:
+		t.Fatalf("second writer finished while gate was held (err=%v)", err)
+	case <-time.After(200 * time.Millisecond):
+		// still queued — expected
+	}
+
+	if err := tx.Rollback().Error; err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	select {
+	case err := <-second:
+		if err != nil {
+			t.Fatalf("queued writer failed after rollback released the gate: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("queued writer never proceeded after rollback — gate leaked")
 	}
 }
 

--- a/infrastructure/database/gorm/sqlite_write_gate_test.go
+++ b/infrastructure/database/gorm/sqlite_write_gate_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 )
 
@@ -332,13 +333,57 @@ func TestBeginWithBusyRetry_TransientBusyRecovers(t *testing.T) {
 }
 
 // TestGatedDialector_MemoryDSNSkipsGate: in-memory databases keep the plain
-// dialector (a shared ":memory:" gate would serialize unrelated databases).
+// dialector (a shared ":memory:" gate would serialize unrelated databases);
+// file DSNs get the concrete glebarez dialector with a gated Conn preset —
+// concrete so gorm still sees SavePoint/RollbackTo/Translate.
 func TestGatedDialector_MemoryDSNSkipsGate(t *testing.T) {
-	if _, ok := DialectorForDSN(":memory:").(gatedSQLiteDialector); ok {
+	if d, ok := DialectorForDSN(":memory:").(*sqlite.Dialector); ok && d.Conn != nil {
 		t.Fatal(":memory: DSN should not be write-gated")
 	}
-	if _, ok := DialectorForDSN("file.db").(gatedSQLiteDialector); !ok {
-		t.Fatal("file DSN should be write-gated")
+	d, ok := DialectorForDSN("file.db").(*sqlite.Dialector)
+	if !ok {
+		t.Fatalf("file DSN should produce the concrete glebarez dialector, got %T", DialectorForDSN("file.db"))
+	}
+	if _, ok := d.Conn.(*gatedConnPool); !ok {
+		t.Fatalf("file DSN should be write-gated, Conn is %T", d.Conn)
+	}
+	if _, ok := DialectorForDSN("file.db").(gorm.SavePointerDialectorInterface); !ok {
+		t.Fatal("gated dialector must keep SavePoint/RollbackTo visible (subscriber batches depend on savepoints)")
+	}
+}
+
+// TestGatedDB_SavepointsWork pins the regression the interface-embedding
+// wrapper caused: pericarp brackets every subscriber handler attempt in a
+// savepoint, so SAVEPOINT/ROLLBACK TO must work on a gated transaction.
+func TestGatedDB_SavepointsWork(t *testing.T) {
+	db := openGatedTestDB(t)
+
+	tx := db.Begin()
+	if tx.Error != nil {
+		t.Fatalf("begin: %v", tx.Error)
+	}
+	if err := tx.SavePoint("sp1").Error; err != nil {
+		t.Fatalf("savepoint on a gated tx: %v", err)
+	}
+	if err := tx.Create(&gateTestRow{Name: "discarded"}).Error; err != nil {
+		t.Fatalf("create after savepoint: %v", err)
+	}
+	if err := tx.RollbackTo("sp1").Error; err != nil {
+		t.Fatalf("rollback to savepoint: %v", err)
+	}
+	if err := tx.Create(&gateTestRow{Name: "kept"}).Error; err != nil {
+		t.Fatalf("create after rollback-to: %v", err)
+	}
+	if err := tx.Commit().Error; err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	var names []string
+	if err := db.Model(&gateTestRow{}).Pluck("name", &names).Error; err != nil {
+		t.Fatalf("pluck: %v", err)
+	}
+	if len(names) != 1 || names[0] != "kept" {
+		t.Fatalf("expected only the post-savepoint row to survive, got %v", names)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -174,9 +174,9 @@ type WorkerConfig struct {
 
 // IsPostgresDSN reports whether dsn targets PostgreSQL — a "host=" libpq DSN
 // or a postgres(ql):// URI. Everything else is treated as SQLite. This is the
-// single dialect predicate: the GORM provider's driver selection
-// (DialectorForDSN) and the worker runtime's wake-mechanism choice both call
-// it, so driver decisions never diverge between consumers.
+// single dialect predicate — every DSN-driven driver decision (e.g. the GORM
+// provider's DialectorForDSN, the worker runtime's wake-mechanism choice)
+// must call it so those decisions never diverge between consumers.
 func IsPostgresDSN(dsn string) bool {
 	return strings.HasPrefix(dsn, "host=") ||
 		strings.Contains(dsn, "postgres://") ||

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -172,14 +172,20 @@ type WorkerConfig struct {
 	LagLogInterval time.Duration
 }
 
-// IsPostgres reports whether the configured DSN targets PostgreSQL. Mirrors the
-// driver detection in the GORM provider so the worker runtime can choose the
-// right wake mechanism (Postgres LISTEN/NOTIFY vs in-process notifier).
-func (c Config) IsPostgres() bool {
-	dsn := c.DatabaseDSN
+// IsPostgresDSN reports whether dsn targets PostgreSQL — a "host=" libpq DSN
+// or a postgres(ql):// URI. Everything else is treated as SQLite. This is the
+// single dialect predicate: the GORM provider's driver selection
+// (DialectorForDSN) and the worker runtime's wake-mechanism choice both call
+// it, so driver decisions never diverge between consumers.
+func IsPostgresDSN(dsn string) bool {
 	return strings.HasPrefix(dsn, "host=") ||
 		strings.Contains(dsn, "postgres://") ||
 		strings.Contains(dsn, "postgresql://")
+}
+
+// IsPostgres reports whether the configured DSN targets PostgreSQL.
+func (c Config) IsPostgres() bool {
+	return IsPostgresDSN(c.DatabaseDSN)
 }
 
 // OxigraphConfig holds configuration for the optional Oxigraph knowledge-graph

--- a/tests/e2e/features/postgres_write_concurrency.feature
+++ b/tests/e2e/features/postgres_write_concurrency.feature
@@ -1,0 +1,20 @@
+@wip @postgres
+Feature: PostgreSQL write concurrency is untouched by SQLite serialization
+  As an operator running WeOS on PostgreSQL
+  I want the connection pool to stay concurrent and the busy-retry to stay inert
+  So that the SQLite write-serialization fix never slows down or alters PostgreSQL
+
+  Background:
+    Given a clean WeOS instance backed by a PostgreSQL database
+    And the "tasks" preset is installed
+
+  Scenario: Concurrent PostgreSQL writes are not serialized
+    When 10 "task" resources are created concurrently within one second
+    Then every create succeeds
+    And more than one database connection served the writes at the same time
+
+  Scenario: A failing PostgreSQL write is not retried by the busy handler
+    Given the next write to the database fails with a non-recoverable error
+    When I create a "project" named "Client onboarding"
+    Then the create fails
+    And the write was attempted exactly once

--- a/tests/e2e/features/sqlite_write_serialization.feature
+++ b/tests/e2e/features/sqlite_write_serialization.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: SQLite write bursts queue instead of failing with database-is-locked
   As an operator running WeOS on SQLite
   I want concurrent writes to queue for the database instead of erroring

--- a/tests/e2e/features/sqlite_write_serialization.feature
+++ b/tests/e2e/features/sqlite_write_serialization.feature
@@ -1,0 +1,46 @@
+@wip
+Feature: SQLite write bursts queue instead of failing with database-is-locked
+  As an operator running WeOS on SQLite
+  I want concurrent writes to queue for the database instead of erroring
+  So that a burst of request and subscriber-checkpoint writes always lands
+  while reads and server boot stay responsive
+
+  Background:
+    Given a clean WeOS instance backed by a file-based SQLite database
+    And the "tasks" preset is installed
+
+  Scenario: A concurrent write burst lands without database-is-locked errors
+    Given the checkpointed subscribers "lexical-index", "event-references" and "display-values" are running
+    When 10 "task" resources are created concurrently within one second
+    Then every create succeeds
+    And no "database is locked" error is logged during the burst
+
+  Scenario: Subscriber checkpoints survive a write burst
+    Given the checkpointed subscribers "lexical-index", "event-references" and "display-values" are running
+    When 10 "task" resources are created concurrently within one second
+    And the subscribers finish processing the burst
+    Then each subscriber's checkpoint has advanced past every event in the burst
+
+  Scenario: The server boots healthy while subscribers replay an event backlog
+    Given the event store holds a backlog of 200 events no subscriber has processed
+    When the server is restarted
+    Then the health endpoint reports healthy within 5 seconds of boot
+    And every subscriber eventually processes the backlog
+
+  Scenario: Reads are served while a write burst is in flight
+    Given a "project" named "Client onboarding" exists
+    When a sustained burst of concurrent writes is in flight
+    And I fetch the project "Client onboarding" during the burst
+    Then the read succeeds while the burst is still in flight
+
+  Scenario: A transient database-is-locked failure is retried until the write lands
+    Given the next write to the database transiently fails with SQLITE_BUSY
+    When I create a "project" named "Client onboarding"
+    Then the create succeeds
+    And the write was attempted more than once
+
+  Scenario: A database that stays locked surfaces an error instead of retrying forever
+    Given the database stays locked for longer than the retry budget allows
+    When I create a "project" named "Client onboarding"
+    Then the create fails with a database-locked error
+    And the write gave up after a bounded number of attempts

--- a/tests/e2e/postgres_write_concurrency_test.go
+++ b/tests/e2e/postgres_write_concurrency_test.go
@@ -1,0 +1,260 @@
+package e2e
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/application/presets"
+	"github.com/wepala/weos/v3/internal/config"
+
+	pericarpdomain "github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
+	"github.com/cucumber/godog"
+	"go.uber.org/fx"
+)
+
+// TestPostgresWriteConcurrency proves the SQLite write-serialization fix
+// (feature #426) leaves the PostgreSQL path untouched: the connection pool
+// stays concurrent and the busy-retry never engages. It requires a real
+// PostgreSQL database supplied via TEST_POSTGRES_DSN and cleanly skips
+// otherwise. Filter on demand with:
+// GODOG_TAGS=@wip go test ./tests/e2e/ -run TestPostgresWriteConcurrency -v
+func TestPostgresWriteConcurrency(t *testing.T) {
+	if os.Getenv("TEST_POSTGRES_DSN") == "" {
+		t.Skip("TEST_POSTGRES_DSN not set — postgres write-concurrency scenarios skipped")
+	}
+	tags := "~@wip"
+	if override := os.Getenv("GODOG_TAGS"); override != "" {
+		tags = override
+	}
+	suite := godog.TestSuite{
+		Name:                "postgres-write-concurrency",
+		ScenarioInitializer: initPostgresWriteConcurrencyScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"features/postgres_write_concurrency.feature"},
+			Tags:     tags,
+			Strict:   true,
+			TestingT: t,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("postgres write-concurrency acceptance scenarios failed")
+	}
+}
+
+// armedEventStore decorates the pericarp event store so a single scenario can
+// force one write to fail with a permanent (non-BUSY) error and count how many
+// times the write was attempted. It proves the PostgreSQL path does not retry.
+type armedEventStore struct {
+	pericarpdomain.EventStore
+	armed       atomic.Bool
+	appendCalls atomic.Int64
+}
+
+func (s *armedEventStore) Append(ctx context.Context, aggregateID string, expectedVersion int,
+	events ...pericarpdomain.EventEnvelope[any]) error {
+	s.appendCalls.Add(1)
+	if s.armed.Load() {
+		// A non-recoverable error (not SQLITE_BUSY): the busy-retry must ignore
+		// it entirely, so the write is attempted exactly once.
+		return fmt.Errorf("permanent write failure: non-recoverable")
+	}
+	return s.EventStore.Append(ctx, aggregateID, expectedVersion, events...)
+}
+
+// pgWorld boots the full application against a real PostgreSQL database. Each
+// scenario boots a fresh app; the assertions are independent of any residual
+// data (concurrent-connection sampling and the armed-append count), and the
+// preset install is idempotent, so no per-scenario schema teardown is needed.
+type pgWorld struct {
+	app       *fx.App
+	rs        application.ResourceService
+	rts       application.ResourceTypeService
+	sqlDB     *sql.DB
+	failStore *armedEventStore
+
+	createErrs []error
+	createErr  error
+	maxInUse   int64
+}
+
+func initPostgresWriteConcurrencyScenario(sc *godog.ScenarioContext) {
+	w := &pgWorld{failStore: &armedEventStore{}}
+
+	sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		w.teardown()
+		return ctx, nil
+	})
+
+	sc.Step(`^a clean WeOS instance backed by a PostgreSQL database$`, w.aCleanInstance)
+	sc.Step(`^the "([^"]*)" preset is installed$`, w.presetInstalled)
+	sc.Step(`^(\d+) "([^"]*)" resources are created concurrently within one second$`, w.createConcurrently)
+	sc.Step(`^every create succeeds$`, w.everyCreateSucceeds)
+	sc.Step(`^more than one database connection served the writes at the same time$`, w.moreThanOneConnection)
+	sc.Step(`^the next write to the database fails with a non-recoverable error$`, w.nextWriteFailsPermanently)
+	sc.Step(`^I create a "([^"]*)" named "([^"]*)"$`, w.iCreateResourceNamed)
+	sc.Step(`^the create fails$`, w.theCreateFails)
+	sc.Step(`^the write was attempted exactly once$`, w.writeAttemptedExactlyOnce)
+}
+
+// --- Background ---
+
+func (w *pgWorld) aCleanInstance() error {
+	cfg := config.Default()
+	cfg.DatabaseDSN = os.Getenv("TEST_POSTGRES_DSN")
+	cfg.LogLevel = "error"
+
+	var rs application.ResourceService
+	var rts application.ResourceTypeService
+	var sqlDB *sql.DB
+
+	app := fx.New(
+		fx.NopLogger,
+		application.Module(cfg, presets.NewDefaultRegistry()),
+		// Wrap the event store so the failing-write scenario can arm a single
+		// permanent Append failure and count attempts. Inert until armed.
+		fx.Decorate(func(inner pericarpdomain.EventStore) pericarpdomain.EventStore {
+			w.failStore.EventStore = inner
+			return w.failStore
+		}),
+		fx.Populate(&rs, &rts, &sqlDB),
+	)
+	startCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+	defer cancel()
+	if err := app.Start(startCtx); err != nil {
+		return fmt.Errorf("failed to start app: %w", err)
+	}
+	w.app = app
+	w.rs = rs
+	w.rts = rts
+	w.sqlDB = sqlDB
+	return nil
+}
+
+func (w *pgWorld) presetInstalled(ctx context.Context, name string) error {
+	if w.rts == nil {
+		return fmt.Errorf("application not booted")
+	}
+	if _, err := w.rts.InstallPreset(ctx, name, true); err != nil {
+		return fmt.Errorf("failed to install %q preset: %w", name, err)
+	}
+	return nil
+}
+
+// --- Concurrency ---
+
+func (w *pgWorld) createConcurrently(count int, typeSlug string) error {
+	var maxInUse atomic.Int64
+	stop := make(chan struct{})
+	var sampler sync.WaitGroup
+	sampler.Add(1)
+	go func() {
+		defer sampler.Done()
+		ticker := time.NewTicker(time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				inUse := int64(w.sqlDB.Stats().InUse)
+				for {
+					cur := maxInUse.Load()
+					if inUse <= cur || maxInUse.CompareAndSwap(cur, inUse) {
+						break
+					}
+				}
+			}
+		}
+	}()
+
+	errs := make([]error, count)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < count; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			errs[i] = w.createResource(context.Background(), typeSlug, fmt.Sprintf("Burst %s %02d", typeSlug, i))
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(stop)
+	sampler.Wait()
+
+	w.createErrs = errs
+	w.maxInUse = maxInUse.Load()
+	return nil
+}
+
+func (w *pgWorld) everyCreateSucceeds() error {
+	for i, err := range w.createErrs {
+		if err != nil {
+			return fmt.Errorf("create %d of %d failed: %w", i, len(w.createErrs), err)
+		}
+	}
+	return nil
+}
+
+func (w *pgWorld) moreThanOneConnection() error {
+	if w.maxInUse <= 1 {
+		return fmt.Errorf("expected more than one connection in use during the burst, peak was %d", w.maxInUse)
+	}
+	return nil
+}
+
+// --- Non-recoverable failure is not retried ---
+
+func (w *pgWorld) nextWriteFailsPermanently() error {
+	w.failStore.appendCalls.Store(0)
+	w.failStore.armed.Store(true)
+	return nil
+}
+
+func (w *pgWorld) iCreateResourceNamed(typeSlug, name string) error {
+	w.failStore.appendCalls.Store(0)
+	w.createErr = w.createResource(context.Background(), typeSlug, name)
+	return nil
+}
+
+func (w *pgWorld) theCreateFails() error {
+	if w.createErr == nil {
+		return fmt.Errorf("expected the create to fail, but it succeeded")
+	}
+	return nil
+}
+
+func (w *pgWorld) writeAttemptedExactlyOnce() error {
+	if n := w.failStore.appendCalls.Load(); n != 1 {
+		return fmt.Errorf("expected the write to be attempted exactly once, got %d attempts", n)
+	}
+	return nil
+}
+
+// --- Helpers ---
+
+func (w *pgWorld) createResource(ctx context.Context, typeSlug, name string) error {
+	data := json.RawMessage(fmt.Sprintf(`{"name":%q}`, name))
+	_, err := w.rs.Create(ctx, application.CreateResourceCommand{TypeSlug: typeSlug, Data: data})
+	return err
+}
+
+func (w *pgWorld) teardown() {
+	w.failStore.armed.Store(false)
+	if w.app != nil {
+		stopCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		defer cancel()
+		_ = w.app.Stop(stopCtx)
+		w.app = nil
+	}
+}

--- a/tests/e2e/postgres_write_concurrency_test.go
+++ b/tests/e2e/postgres_write_concurrency_test.go
@@ -22,10 +22,12 @@ import (
 
 // TestPostgresWriteConcurrency proves the SQLite write-serialization fix
 // (feature #426) leaves the PostgreSQL path untouched: the connection pool
-// stays concurrent and the busy-retry never engages. It requires a real
-// PostgreSQL database supplied via TEST_POSTGRES_DSN and cleanly skips
-// otherwise. Filter on demand with:
-// GODOG_TAGS=@wip go test ./tests/e2e/ -run TestPostgresWriteConcurrency -v
+// stays concurrent, and a failing write is attempted exactly once — no retry
+// layer engages anywhere above the driver (on Postgres the gated pool and its
+// BUSY retry don't exist at all). It requires a real PostgreSQL database
+// supplied via TEST_POSTGRES_DSN and cleanly skips otherwise. The feature is
+// @wip until it has run against a real Postgres:
+// GODOG_TAGS=@wip TEST_POSTGRES_DSN=... go test ./tests/e2e/ -run TestPostgresWriteConcurrency -v
 func TestPostgresWriteConcurrency(t *testing.T) {
 	if os.Getenv("TEST_POSTGRES_DSN") == "" {
 		t.Skip("TEST_POSTGRES_DSN not set — postgres write-concurrency scenarios skipped")
@@ -51,8 +53,11 @@ func TestPostgresWriteConcurrency(t *testing.T) {
 }
 
 // armedEventStore decorates the pericarp event store so a single scenario can
-// force one write to fail with a permanent (non-BUSY) error and count how many
-// times the write was attempted. It proves the PostgreSQL path does not retry.
+// force one write to fail with a permanent error and count how many times the
+// write was attempted. Injecting at the store (application) layer pins that no
+// application-level retry wraps a failing Postgres write; the ConnPool-level
+// BUSY retry is out of reach of this fault by construction — and absent
+// entirely on Postgres, which is the point.
 type armedEventStore struct {
 	pericarpdomain.EventStore
 	armed       atomic.Bool
@@ -63,8 +68,8 @@ func (s *armedEventStore) Append(ctx context.Context, aggregateID string, expect
 	events ...pericarpdomain.EventEnvelope[any]) error {
 	s.appendCalls.Add(1)
 	if s.armed.Load() {
-		// A non-recoverable error (not SQLITE_BUSY): the busy-retry must ignore
-		// it entirely, so the write is attempted exactly once.
+		// A permanent failure: nothing above the driver may retry it, so the
+		// write is attempted exactly once.
 		return fmt.Errorf("permanent write failure: non-recoverable")
 	}
 	return s.EventStore.Append(ctx, aggregateID, expectedVersion, events...)

--- a/tests/e2e/sqlite_write_serialization_test.go
+++ b/tests/e2e/sqlite_write_serialization_test.go
@@ -38,8 +38,8 @@ import (
 // (feature #426): an in-process write gate serializes SQLite write transactions
 // so a concurrent burst queues instead of failing with "database is locked",
 // while reads and server boot stay responsive and a genuinely stuck database
-// still surfaces a bounded-retry error. Filter on demand with:
-// GODOG_TAGS=@wip go test ./tests/e2e/ -run TestSQLiteWriteSerialization -v
+// still surfaces a bounded-retry error. The feature is promoted (no @wip), so
+// the default suite runs it: go test ./tests/e2e/ -run TestSQLiteWriteSerialization -v
 func TestSQLiteWriteSerialization(t *testing.T) {
 	tags := "~@wip"
 	if override := os.Getenv("GODOG_TAGS"); override != "" {
@@ -62,8 +62,10 @@ func TestSQLiteWriteSerialization(t *testing.T) {
 }
 
 // burstSubscribers are the checkpointed subscriber groups the write-burst
-// scenarios expect to be running on file-based SQLite (all three register
-// unconditionally on SQLite — lexical-index because glebarez ships FTS5).
+// scenarios expect on file-based SQLite. event-references and display-values
+// always register; lexical-index registers when the FTS5 index activates,
+// which glebarez's unconditional FTS5 support makes effectively always true
+// here (the subscribersRunning step verifies all three by name regardless).
 var burstSubscribers = []string{"lexical-index", "event-references", "display-values"}
 
 // sqliteWriteWorld boots the full application against a file-backed SQLite

--- a/tests/e2e/sqlite_write_serialization_test.go
+++ b/tests/e2e/sqlite_write_serialization_test.go
@@ -1,0 +1,611 @@
+package e2e
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wepala/weos/v3/api/handlers"
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/application/presets"
+	"github.com/wepala/weos/v3/domain/entities"
+	weosgorm "github.com/wepala/weos/v3/infrastructure/database/gorm"
+	"github.com/wepala/weos/v3/infrastructure/logging"
+	"github.com/wepala/weos/v3/internal/config"
+
+	pericarpdomain "github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/subscriptions"
+	"github.com/cucumber/godog"
+	_ "github.com/glebarez/go-sqlite" // registers the "sqlite" database/sql driver for the lock-holding connection
+	"github.com/labstack/echo/v4"
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// TestSQLiteWriteSerialization runs the write-gate acceptance scenarios
+// (feature #426): an in-process write gate serializes SQLite write transactions
+// so a concurrent burst queues instead of failing with "database is locked",
+// while reads and server boot stay responsive and a genuinely stuck database
+// still surfaces a bounded-retry error. Filter on demand with:
+// GODOG_TAGS=@wip go test ./tests/e2e/ -run TestSQLiteWriteSerialization -v
+func TestSQLiteWriteSerialization(t *testing.T) {
+	tags := "~@wip"
+	if override := os.Getenv("GODOG_TAGS"); override != "" {
+		tags = override
+	}
+	suite := godog.TestSuite{
+		Name:                "sqlite-write-serialization",
+		ScenarioInitializer: initSQLiteWriteSerializationScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"features/sqlite_write_serialization.feature"},
+			Tags:     tags,
+			Strict:   true,
+			TestingT: t,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("sqlite write-serialization acceptance scenarios failed")
+	}
+}
+
+// burstSubscribers are the checkpointed subscriber groups the write-burst
+// scenarios expect to be running on file-based SQLite (all three register
+// unconditionally on SQLite — lexical-index because glebarez ships FTS5).
+var burstSubscribers = []string{"lexical-index", "event-references", "display-values"}
+
+// sqliteWriteWorld boots the full application against a file-backed SQLite
+// database and drives it the way the feature's scenarios describe: concurrent
+// bursts through the service layer, checkpoint polling for the async
+// subscribers, a health server for the restart scenario, and a second raw
+// connection to simulate external write-lock contention.
+type sqliteWriteWorld struct {
+	tmpDir string
+	dbPath string
+	dsn    string
+
+	app         *fx.App
+	rs          application.ResourceService
+	rts         application.ResourceTypeService
+	eventStore  pericarpdomain.EventStore
+	checkpoints subscriptions.CheckpointStore
+	manager     *application.Manager
+
+	// observerLogger replaces the app's entities.Logger so the "database is
+	// locked" assertion can inspect everything the app (and its workers) logged.
+	observerLogger entities.Logger
+	logs           *observer.ObservedLogs
+
+	healthServer *httptest.Server
+	restartAt    time.Time
+
+	resources      map[string]string // name -> URN, for the read-during-burst scenario
+	createErrs     []error           // per-goroutine results of the concurrent burst
+	createErr      error             // result of a single create (retry / lock scenarios)
+	headAfterBurst int64
+
+	// sustained-burst control (reads-are-served-during-a-burst scenario).
+	burstStop       chan struct{}
+	burstWG         sync.WaitGroup
+	burstActive     atomic.Bool
+	readErr         error
+	readDuringBurst bool
+
+	// busy-retry observation (transient-BUSY and stays-locked scenarios).
+	busyAttempts atomic.Int64
+	rawLockDB    *sql.DB
+	rawLockTx    *sql.Tx
+	rawLockOnce  sync.Once
+}
+
+func initSQLiteWriteSerializationScenario(sc *godog.ScenarioContext) {
+	w := &sqliteWriteWorld{resources: map[string]string{}}
+
+	sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		w.teardown()
+		return ctx, nil
+	})
+
+	sc.Step(`^a clean WeOS instance backed by a file-based SQLite database$`, w.aCleanInstance)
+	sc.Step(`^the "([^"]*)" preset is installed$`, w.presetInstalled)
+	sc.Step(`^the checkpointed subscribers "([^"]*)", "([^"]*)" and "([^"]*)" are running$`, w.subscribersRunning)
+	sc.Step(`^(\d+) "([^"]*)" resources are created concurrently within one second$`, w.createConcurrently)
+	sc.Step(`^every create succeeds$`, w.everyCreateSucceeds)
+	sc.Step(`^no "([^"]*)" error is logged during the burst$`, w.noErrorLoggedDuringBurst)
+	sc.Step(`^the subscribers finish processing the burst$`, w.subscribersFinishBurst)
+	sc.Step(`^each subscriber's checkpoint has advanced past every event in the burst$`, w.checkpointsAdvancedPastBurst)
+	sc.Step(`^the event store holds a backlog of (\d+) events no subscriber has processed$`, w.backlogOfEvents)
+	sc.Step(`^the server is restarted$`, w.serverRestarted)
+	sc.Step(`^the health endpoint reports healthy within (\d+) seconds of boot$`, w.healthyWithinSeconds)
+	sc.Step(`^every subscriber eventually processes the backlog$`, w.everySubscriberProcessesBacklog)
+	sc.Step(`^a "([^"]*)" named "([^"]*)" exists$`, w.aResourceNamedExists)
+	sc.Step(`^a sustained burst of concurrent writes is in flight$`, w.sustainedBurstInFlight)
+	sc.Step(`^I fetch the project "([^"]*)" during the burst$`, w.fetchProjectDuringBurst)
+	sc.Step(`^the read succeeds while the burst is still in flight$`, w.readSucceedsWhileBurst)
+	sc.Step(`^the next write to the database transiently fails with SQLITE_BUSY$`, w.nextWriteTransientlyBusy)
+	sc.Step(`^I create a "([^"]*)" named "([^"]*)"$`, w.iCreateResourceNamed)
+	sc.Step(`^the create succeeds$`, w.theCreateSucceeds)
+	sc.Step(`^the write was attempted more than once$`, w.writeAttemptedMoreThanOnce)
+	sc.Step(`^the database stays locked for longer than the retry budget allows$`, w.databaseStaysLocked)
+	sc.Step(`^the create fails with a database-locked error$`, w.createFailsWithLockedError)
+	sc.Step(`^the write gave up after a bounded number of attempts$`, w.writeGaveUpBounded)
+}
+
+// --- Background ---
+
+func (w *sqliteWriteWorld) aCleanInstance() error {
+	dir, err := os.MkdirTemp("", "weos-sqlite-write-e2e-")
+	if err != nil {
+		return err
+	}
+	w.tmpDir = dir
+	w.dbPath = filepath.Join(dir, "test.db")
+	// A fast busy_timeout keeps the BUSY-retry scenarios quick. The provider
+	// preserves any pragma already present in the DSN, so this 100ms wins over
+	// the 15s worker default (sqliteDSNWithWorkerPragmas).
+	w.dsn = w.dbPath + "?_pragma=busy_timeout(100)"
+
+	// Capture at Info level: the production logger emits Info and above, and a
+	// database-locked failure surfaces as an Error entry — both are recorded.
+	core, logs := observer.New(zapcore.InfoLevel)
+	w.logs = logs
+	w.observerLogger = logging.NewZapLogger(zap.New(core))
+
+	// The clean instance boots with workers OFF; the "subscribers are running"
+	// step brings them up, and the backlog scenario seeds against this quiet
+	// process before restarting it with workers on.
+	return w.bootApp(false)
+}
+
+// bootApp (re)starts the fx application on the world's fixed DSN. The database
+// file persists across reboots, so the preset and any seeded data survive a
+// workers-off -> workers-on transition.
+func (w *sqliteWriteWorld) bootApp(runWorkers bool) error {
+	w.stopApp()
+	cfg := config.Default()
+	cfg.DatabaseDSN = w.dsn
+	cfg.LogLevel = "error"
+	cfg.Worker.RunInProcess = runWorkers
+
+	var rs application.ResourceService
+	var rts application.ResourceTypeService
+	var es pericarpdomain.EventStore
+	var cp subscriptions.CheckpointStore
+	var mgr *application.Manager
+
+	app := fx.New(
+		fx.NopLogger,
+		application.Module(cfg, presets.NewDefaultRegistry()),
+		fx.Decorate(func(entities.Logger) entities.Logger { return w.observerLogger }),
+		fx.Populate(&rs, &rts, &es, &cp, &mgr),
+	)
+	startCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+	defer cancel()
+	if err := app.Start(startCtx); err != nil {
+		return fmt.Errorf("failed to start app: %w", err)
+	}
+	w.app = app
+	w.rs = rs
+	w.rts = rts
+	w.eventStore = es
+	w.checkpoints = cp
+	w.manager = mgr
+	return nil
+}
+
+func (w *sqliteWriteWorld) presetInstalled(ctx context.Context, name string) error {
+	if w.rts == nil {
+		return fmt.Errorf("application not booted")
+	}
+	if _, err := w.rts.InstallPreset(ctx, name, true); err != nil {
+		return fmt.Errorf("failed to install %q preset: %w", name, err)
+	}
+	return nil
+}
+
+func (w *sqliteWriteWorld) subscribersRunning(a, b, c string) error {
+	// Bring the process up with background subscribers enabled. The preset and
+	// any prior writes persist in the same database file across the reboot.
+	if err := w.bootApp(true); err != nil {
+		return err
+	}
+	have := map[string]bool{}
+	for _, n := range w.manager.Names() {
+		have[n] = true
+	}
+	for _, want := range []string{a, b, c} {
+		if !have[want] {
+			return fmt.Errorf("subscriber %q is not registered (have %v)", want, w.manager.Names())
+		}
+	}
+	return nil
+}
+
+// --- Concurrent burst ---
+
+func (w *sqliteWriteWorld) createConcurrently(count int, typeSlug string) error {
+	errs := make([]error, count)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < count; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start // release all goroutines together so the writes truly race
+			errs[i] = w.createResource(context.Background(), typeSlug, fmt.Sprintf("Burst %s %02d", typeSlug, i))
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	w.createErrs = errs
+
+	head, err := w.eventStore.HeadPosition(context.Background())
+	if err != nil {
+		return fmt.Errorf("read event store head after burst: %w", err)
+	}
+	w.headAfterBurst = head
+	return nil
+}
+
+func (w *sqliteWriteWorld) everyCreateSucceeds() error {
+	for i, err := range w.createErrs {
+		if err != nil {
+			return fmt.Errorf("create %d of %d failed: %w", i, len(w.createErrs), err)
+		}
+	}
+	return nil
+}
+
+func (w *sqliteWriteWorld) noErrorLoggedDuringBurst(phrase string) error {
+	needles := []string{strings.ToLower(phrase), "sqlite_busy"}
+	for _, e := range w.logs.All() {
+		hay := strings.ToLower(e.Message)
+		for k, v := range e.ContextMap() {
+			hay += " " + strings.ToLower(k) + " " + strings.ToLower(fmt.Sprint(v))
+		}
+		for _, needle := range needles {
+			if strings.Contains(hay, needle) {
+				return fmt.Errorf("a log entry surfaced a locked-database error: %q %v", e.Message, e.ContextMap())
+			}
+		}
+	}
+	for i, err := range w.createErrs {
+		if err == nil {
+			continue
+		}
+		msg := strings.ToLower(err.Error())
+		for _, needle := range needles {
+			if strings.Contains(msg, needle) {
+				return fmt.Errorf("create %d returned a locked-database error: %w", i, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (w *sqliteWriteWorld) subscribersFinishBurst() error {
+	return w.waitCheckpointsAtLeast(context.Background(), w.headAfterBurst, 15*time.Second)
+}
+
+func (w *sqliteWriteWorld) checkpointsAdvancedPastBurst() error {
+	return w.waitCheckpointsAtLeast(context.Background(), w.headAfterBurst, 15*time.Second)
+}
+
+// waitCheckpointsAtLeast polls every burst subscriber's checkpoint until each
+// has advanced to or past head, or the timeout elapses.
+func (w *sqliteWriteWorld) waitCheckpointsAtLeast(ctx context.Context, head int64, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		status := make([]string, 0, len(burstSubscribers))
+		behind := false
+		for _, name := range burstSubscribers {
+			pos, err := w.checkpoints.Position(ctx, name)
+			if err != nil {
+				return fmt.Errorf("read checkpoint %q: %w", name, err)
+			}
+			status = append(status, fmt.Sprintf("%s=%d", name, pos))
+			if pos < head {
+				behind = true
+			}
+		}
+		if !behind {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("subscribers did not reach the burst head %d within %s: %s",
+				head, timeout, strings.Join(status, " "))
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// --- Restart / backlog ---
+
+func (w *sqliteWriteWorld) backlogOfEvents(count int) error {
+	ctx := context.Background()
+	for i := 0; i < count; i++ {
+		if err := w.createResource(ctx, "task", fmt.Sprintf("Backlog Task %03d", i)); err != nil {
+			return fmt.Errorf("seed backlog task %d: %w", i, err)
+		}
+	}
+	head, err := w.eventStore.HeadPosition(ctx)
+	if err != nil {
+		return fmt.Errorf("read event store head after seeding backlog: %w", err)
+	}
+	w.headAfterBurst = head
+	// Stop this workers-off process but keep the database file so the restart
+	// replays the backlog no subscriber has yet consumed.
+	w.stopApp()
+	return nil
+}
+
+func (w *sqliteWriteWorld) serverRestarted() error {
+	// Measure "within N seconds of boot" from just before the process starts.
+	w.restartAt = time.Now()
+	if err := w.bootApp(true); err != nil {
+		return err
+	}
+	e := echo.New()
+	e.HideBanner = true
+	e.GET("/api/health", handlers.HealthHandler)
+	w.healthServer = httptest.NewServer(e)
+	return nil
+}
+
+func (w *sqliteWriteWorld) healthyWithinSeconds(seconds int) error {
+	if w.healthServer == nil {
+		return fmt.Errorf("no health server is running")
+	}
+	budget := time.Duration(seconds) * time.Second
+	deadline := w.restartAt.Add(budget)
+	url := w.healthServer.URL + "/api/health"
+	for {
+		resp, err := http.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				if elapsed := time.Since(w.restartAt); elapsed > budget {
+					return fmt.Errorf("health became ready in %s, over the %s budget", elapsed, budget)
+				}
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("health endpoint did not report healthy within %s of boot", budget)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func (w *sqliteWriteWorld) everySubscriberProcessesBacklog() error {
+	return w.waitCheckpointsAtLeast(context.Background(), w.headAfterBurst, 30*time.Second)
+}
+
+// --- Reads during a burst ---
+
+func (w *sqliteWriteWorld) aResourceNamedExists(typeSlug, name string) error {
+	data := json.RawMessage(fmt.Sprintf(`{"name":%q}`, name))
+	res, err := w.rs.Create(context.Background(), application.CreateResourceCommand{TypeSlug: typeSlug, Data: data})
+	if err != nil {
+		return fmt.Errorf("failed to create %s %q: %w", typeSlug, name, err)
+	}
+	w.resources[name] = res.GetID()
+	return nil
+}
+
+func (w *sqliteWriteWorld) sustainedBurstInFlight() error {
+	w.startBurst()
+	return nil
+}
+
+func (w *sqliteWriteWorld) fetchProjectDuringBurst(name string) error {
+	id, ok := w.resources[name]
+	if !ok {
+		return fmt.Errorf("no known resource named %q", name)
+	}
+	// Record that the burst was active at read time; reads bypass the write
+	// gate, so the fetch should return without waiting on the write queue.
+	w.readDuringBurst = w.burstActive.Load()
+	_, w.readErr = w.rs.GetByID(context.Background(), id)
+	return nil
+}
+
+func (w *sqliteWriteWorld) readSucceedsWhileBurst() error {
+	if !w.readDuringBurst {
+		return fmt.Errorf("the read was not issued while a burst was active")
+	}
+	if !w.burstActive.Load() {
+		return fmt.Errorf("the burst ended before the read could be validated as in-flight")
+	}
+	err := w.readErr
+	w.stopBurst()
+	if err != nil {
+		return fmt.Errorf("the read failed while the burst was in flight: %w", err)
+	}
+	return nil
+}
+
+func (w *sqliteWriteWorld) startBurst() {
+	w.burstStop = make(chan struct{})
+	w.burstActive.Store(true)
+	for i := 0; i < 8; i++ {
+		w.burstWG.Add(1)
+		go func(id int) {
+			defer w.burstWG.Done()
+			for c := 0; ; c++ {
+				select {
+				case <-w.burstStop:
+					return
+				default:
+				}
+				_ = w.createResource(context.Background(), "task", fmt.Sprintf("Sustained %d-%d", id, c))
+			}
+		}(i)
+	}
+}
+
+func (w *sqliteWriteWorld) stopBurst() {
+	if w.burstStop == nil {
+		return
+	}
+	close(w.burstStop)
+	w.burstWG.Wait()
+	w.burstActive.Store(false)
+	w.burstStop = nil
+}
+
+// --- Busy-retry / stays-locked ---
+
+func (w *sqliteWriteWorld) nextWriteTransientlyBusy() error {
+	w.observeBusyRetries()
+	// Hold the write lock from a second connection, then release it well inside
+	// the retry budget so a retried BeginTx eventually lands.
+	return w.holdWriteLock(250 * time.Millisecond)
+}
+
+func (w *sqliteWriteWorld) databaseStaysLocked() error {
+	w.observeBusyRetries()
+	// Hold the lock past the whole retry budget; teardown releases it after the
+	// create has failed.
+	return w.holdWriteLock(0)
+}
+
+func (w *sqliteWriteWorld) iCreateResourceNamed(typeSlug, name string) error {
+	w.busyAttempts.Store(0)
+	w.createErr = w.createResource(context.Background(), typeSlug, name)
+	return nil
+}
+
+func (w *sqliteWriteWorld) theCreateSucceeds() error {
+	if w.createErr != nil {
+		return fmt.Errorf("expected the create to succeed, got: %w", w.createErr)
+	}
+	return nil
+}
+
+func (w *sqliteWriteWorld) writeAttemptedMoreThanOnce() error {
+	if n := w.busyAttempts.Load(); n <= 1 {
+		return fmt.Errorf("expected more than one write attempt, got %d", n)
+	}
+	return nil
+}
+
+func (w *sqliteWriteWorld) createFailsWithLockedError() error {
+	if w.createErr == nil {
+		return fmt.Errorf("expected the create to fail with a database-locked error, but it succeeded")
+	}
+	if !strings.Contains(strings.ToLower(w.createErr.Error()), "lock") {
+		return fmt.Errorf("expected a database-locked error, got: %w", w.createErr)
+	}
+	return nil
+}
+
+func (w *sqliteWriteWorld) writeGaveUpBounded() error {
+	if w.createErr == nil {
+		return fmt.Errorf("expected the create to fail after exhausting its retries")
+	}
+	if !strings.Contains(w.createErr.Error(), "gave up after 5 attempts") {
+		return fmt.Errorf("expected a bounded 'gave up after 5 attempts' error, got: %w", w.createErr)
+	}
+	if n := w.busyAttempts.Load(); n != 5 {
+		return fmt.Errorf("expected exactly 5 write attempts, got %d", n)
+	}
+	return nil
+}
+
+func (w *sqliteWriteWorld) observeBusyRetries() {
+	w.busyAttempts.Store(0)
+	weosgorm.SetBusyRetryObserver(func(int, error) { w.busyAttempts.Add(1) })
+}
+
+// holdWriteLock opens a second raw connection to the same database file and
+// holds SQLite's single write lock via a BEGIN IMMEDIATE transaction. When
+// release > 0 the lock is dropped after that delay from a goroutine; otherwise
+// it is held until teardown.
+func (w *sqliteWriteWorld) holdWriteLock(release time.Duration) error {
+	raw, err := sql.Open("sqlite", w.dbPath+"?_pragma=busy_timeout(0)&_txlock=immediate")
+	if err != nil {
+		return fmt.Errorf("open lock-holding connection: %w", err)
+	}
+	raw.SetMaxOpenConns(1)
+	if _, err := raw.Exec(`CREATE TABLE IF NOT EXISTS _write_lock_probe (x INTEGER)`); err != nil {
+		_ = raw.Close()
+		return fmt.Errorf("create lock-probe table: %w", err)
+	}
+	tx, err := raw.BeginTx(context.Background(), nil) // BEGIN IMMEDIATE takes the write lock
+	if err != nil {
+		_ = raw.Close()
+		return fmt.Errorf("begin lock-holding transaction: %w", err)
+	}
+	if _, err := tx.Exec(`INSERT INTO _write_lock_probe (x) VALUES (1)`); err != nil {
+		_ = tx.Rollback()
+		_ = raw.Close()
+		return fmt.Errorf("write inside lock-holding transaction: %w", err)
+	}
+	w.rawLockDB = raw
+	w.rawLockTx = tx
+	if release > 0 {
+		go func() {
+			time.Sleep(release)
+			w.releaseLock()
+		}()
+	}
+	return nil
+}
+
+func (w *sqliteWriteWorld) releaseLock() {
+	w.rawLockOnce.Do(func() {
+		if w.rawLockTx != nil {
+			_ = w.rawLockTx.Rollback()
+		}
+	})
+}
+
+// --- Shared helpers ---
+
+func (w *sqliteWriteWorld) createResource(ctx context.Context, typeSlug, name string) error {
+	data := json.RawMessage(fmt.Sprintf(`{"name":%q}`, name))
+	_, err := w.rs.Create(ctx, application.CreateResourceCommand{TypeSlug: typeSlug, Data: data})
+	return err
+}
+
+func (w *sqliteWriteWorld) stopApp() {
+	if w.app == nil {
+		return
+	}
+	stopCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+	defer cancel()
+	_ = w.app.Stop(stopCtx)
+	w.app = nil
+}
+
+func (w *sqliteWriteWorld) teardown() {
+	w.stopBurst()
+	w.releaseLock()
+	if w.rawLockDB != nil {
+		_ = w.rawLockDB.Close()
+		w.rawLockDB = nil
+	}
+	weosgorm.SetBusyRetryObserver(nil)
+	if w.healthServer != nil {
+		w.healthServer.Close()
+		w.healthServer = nil
+	}
+	w.stopApp()
+	if w.tmpDir != "" {
+		_ = os.RemoveAll(w.tmpDir)
+		w.tmpDir = ""
+	}
+}

--- a/tests/e2e/sqlite_write_serialization_test.go
+++ b/tests/e2e/sqlite_write_serialization_test.go
@@ -100,6 +100,7 @@ type sqliteWriteWorld struct {
 	burstStop       chan struct{}
 	burstWG         sync.WaitGroup
 	burstActive     atomic.Bool
+	burstSucceeded  atomic.Int64
 	readErr         error
 	readDuringBurst bool
 
@@ -171,9 +172,13 @@ func (w *sqliteWriteWorld) aCleanInstance() error {
 
 // bootApp (re)starts the fx application on the world's fixed DSN. The database
 // file persists across reboots, so the preset and any seeded data survive a
-// workers-off -> workers-on transition.
+// workers-off -> workers-on transition. A failed stop of the previous app is a
+// step failure, not a shrug: its workers would keep writing alongside the new
+// app and corrupt whatever the scenario asserts next.
 func (w *sqliteWriteWorld) bootApp(runWorkers bool) error {
-	w.stopApp()
+	if err := w.stopApp(); err != nil {
+		return fmt.Errorf("stop previous app before reboot: %w", err)
+	}
 	cfg := config.Default()
 	cfg.DatabaseDSN = w.dsn
 	cfg.LogLevel = "error"
@@ -434,6 +439,11 @@ func (w *sqliteWriteWorld) readSucceedsWhileBurst() error {
 	if err != nil {
 		return fmt.Errorf("the read failed while the burst was in flight: %w", err)
 	}
+	// The premise must hold: a "sustained burst" where every write failed
+	// would make the read assertion vacuous.
+	if w.burstSucceeded.Load() == 0 {
+		return fmt.Errorf("no burst write succeeded — the sustained-burst premise did not hold")
+	}
 	return nil
 }
 
@@ -450,7 +460,10 @@ func (w *sqliteWriteWorld) startBurst() {
 					return
 				default:
 				}
-				_ = w.createResource(context.Background(), "task", fmt.Sprintf("Sustained %d-%d", id, c))
+				if err := w.createResource(context.Background(), "task",
+					fmt.Sprintf("Sustained %d-%d", id, c)); err == nil {
+					w.burstSucceeded.Add(1)
+				}
 			}
 		}(i)
 	}
@@ -496,8 +509,10 @@ func (w *sqliteWriteWorld) theCreateSucceeds() error {
 }
 
 func (w *sqliteWriteWorld) writeAttemptedMoreThanOnce() error {
-	if n := w.busyAttempts.Load(); n <= 1 {
-		return fmt.Errorf("expected more than one write attempt, got %d", n)
+	// At least one BUSY-failed attempt plus the eventual success means the
+	// write was attempted more than once.
+	if n := w.busyAttempts.Load(); n < 1 {
+		return fmt.Errorf("expected at least one retried (BUSY-failed) attempt, got %d", n)
 	}
 	return nil
 }
@@ -520,14 +535,23 @@ func (w *sqliteWriteWorld) writeGaveUpBounded() error {
 		return fmt.Errorf("expected a bounded 'gave up after 5 attempts' error, got: %w", w.createErr)
 	}
 	if n := w.busyAttempts.Load(); n != 5 {
-		return fmt.Errorf("expected exactly 5 write attempts, got %d", n)
+		return fmt.Errorf("expected exactly 5 BUSY-failed attempts, got %d", n)
 	}
 	return nil
 }
 
+// observeBusyRetries counts only FAILED begin attempts. Successful begins
+// notify the observer too, and one resource create issues several gated
+// transactions (event append, canonical save, projection writes) — counting
+// those would make "attempted more than once" pass even with the retry loop
+// deleted.
 func (w *sqliteWriteWorld) observeBusyRetries() {
 	w.busyAttempts.Store(0)
-	weosgorm.SetBusyRetryObserver(func(int, error) { w.busyAttempts.Add(1) })
+	weosgorm.SetBusyRetryObserver(func(_ int, err error) {
+		if err != nil {
+			w.busyAttempts.Add(1)
+		}
+	})
 }
 
 // holdWriteLock opens a second raw connection to the same database file and
@@ -581,14 +605,15 @@ func (w *sqliteWriteWorld) createResource(ctx context.Context, typeSlug, name st
 	return err
 }
 
-func (w *sqliteWriteWorld) stopApp() {
+func (w *sqliteWriteWorld) stopApp() error {
 	if w.app == nil {
-		return
+		return nil
 	}
 	stopCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
 	defer cancel()
-	_ = w.app.Stop(stopCtx)
+	err := w.app.Stop(stopCtx)
 	w.app = nil
+	return err
 }
 
 func (w *sqliteWriteWorld) teardown() {
@@ -603,7 +628,7 @@ func (w *sqliteWriteWorld) teardown() {
 		w.healthServer.Close()
 		w.healthServer = nil
 	}
-	w.stopApp()
+	_ = w.stopApp()
 	if w.tmpDir != "" {
 		_ = os.RemoveAll(w.tmpDir)
 		w.tmpDir = ""


### PR DESCRIPTION
Closes #426.

## What

A write burst — request-path event appends plus subscriber checkpoint writes — races `BEGIN IMMEDIATE` across pooled connections, and the loser fails **immediately** with `SQLITE_BUSY` (the lock-upgrade/deadlock-avoidance class `busy_timeout` never covers; diagnosis in #421). This PR serializes SQLite write transactions in Go instead of letting them collide inside SQLite:

- **Write gate at the gorm ConnPool seam** (`sqlite_write_gate.go`, installed by `DialectorForDSN`): at most one write transaction in flight per database file; waiters queue on a ctx-cancellable semaphore holding zero pool connections. Reads never touch the gate. Because pericarp's event store, checkpoint store, and parking lot share the same `*gorm.DB` — and the ADK session store goes through `DialectorForDSN` too — every writer inherits the gate without opting in.
- **Bounded retry-on-BUSY** in the gated `BeginTx` (typed driver error code 5, no string matching; 5 attempts, doubling backoff): belt-and-suspenders for contention the gate can't see (other processes, out-of-gate connections). Structurally absent on PostgreSQL.
- **Dialect-aware pool**: PostgreSQL keeps `10/100` untouched; SQLite gets `5/10` — above one connection, avoiding the boot-starvation that sank the unmerged #425.
- **Ambient-batch-transaction handling**: writes made inside a subscriber batch join it (`ResourceRepository.writeDB`, mirroring the projection manager); a nested `BeginTx` from a batch context bypasses the gate so it can't self-deadlock (bounded BUSY instead — root fix in pericarp, below).
- **Leak hardening** (from review): a gated transaction dropped without Commit/Rollback is rolled back and released by a finalizer with a loud stderr report; writers queued >10s warn once; ctx cancellations are wrapped so "died at the write gate" is distinguishable from a slow query; `sql.Open` failure fails fast instead of silently degrading to an ungated pool.
- `config.IsPostgresDSN` is now the single dialect predicate (was duplicated).

## Acceptance contract (ATDD)

`tests/e2e/features/sqlite_write_serialization.feature` — 6 scenarios (burst lands with no locked errors, checkpoints survive, boots healthy with a 200-event backlog, reads served mid-burst, transient BUSY retried, bounded give-up) — **all green and promoted** into the default suite with full godog step definitions.

`tests/e2e/features/postgres_write_concurrency.feature` — 2 scenarios pinning Postgres untouched; env-gated behind `TEST_POSTGRES_DSN` and still `@wip` until run against a real Postgres (no Postgres exists in CI or this environment; promoting unverified scenarios would be dishonest).

Unit regression pins: gate mutual exclusion, queue-until-commit/rollback-release, give-up-releases-gate, real-driver BUSY classification, savepoints through the gate (pericarp brackets every handler attempt in one), ambient-bypass no-self-deadlock, and `TestResourceWrite_JoinsBatchTransaction` mirroring the existing projection-manager guardrail.

## Cross-repo (acceptance criterion 4)

The subscriber checkpoint write participates via the shared gated handle (the "both sides route through the same serialized writer" option). Additionally, companion PR **akeemphilbert/pericarp#58** (open, tests green) memoizes the per-cycle `ensure()` INSERT (halves checkpoint write volume) and makes `Append` join an ambient batch transaction via savepoints — the root fix for the consolidation nested-append self-wait. After it merges and tags `v1.0.0-beta.2`, weos bumps its pin in a one-line follow-up; nothing here depends on it.

## Verification

CI does not run on v3-targeted PRs (`ci.yml` triggers on main/develop only), so the gate was run locally: `go test -race ./...` green across every package except the **pre-existing** `web/TestStaticFS_DefaultEmbed` failure, which fails identically on a clean `v3` checkout (tracked `web/dist/` ships only `PLACEHOLDER`, no `index.html` — worth its own ticket); `make lint` 0 issues; `go vet` clean.

## Out of scope (per the ticket)

PostgreSQL behavior (untouched, pinned by the @wip feature); LLM-latency-bound consolidation writes (the gate makes their cost visible but unchanged in kind); a second in-process pool pointed at the same file via `AGENT_SESSION_DSN` shares the gate through the per-file registry when the DSN matches the main DB (the default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)