### PR TITLE
feat(agents): let RunAgent apply a process-wide runner PluginConfig (downstream observability)

### DIFF
--- a/application/agents/runner.go
+++ b/application/agents/runner.go
@@ -32,6 +32,22 @@ const (
 	DefaultAppName = "WeOS"
 )
 
+// runnerPlugins is an optional, process-wide runner plugin config applied to
+// every RunAgent invocation. Its intended use is an observability/telemetry
+// plugin (e.g. one that records each LLM request/response payload for tracing).
+// The zero value means no plugins — the default. Set once at startup via
+// SetRunnerPlugins, before any agent runs.
+var runnerPlugins runner.PluginConfig
+
+// SetRunnerPlugins registers a runner plugin config that RunAgent applies to
+// every agent run. Downstream services call this once at startup to install an
+// observability plugin (e.g. exporting LLM payloads to a tracing backend);
+// passing the zero value clears it. Not safe to call concurrently with agent
+// runs — treat it as start-up-only configuration.
+func SetRunnerPlugins(pc runner.PluginConfig) {
+	runnerPlugins = pc
+}
+
 // responseSchemaKeyType is the context key for an optional per-run response schema.
 type responseSchemaKeyType struct{}
 
@@ -82,6 +98,7 @@ func RunAgent(
 		AppName:        appName,
 		Agent:          a,
 		SessionService: sessionService,
+		PluginConfig:   runnerPlugins,
 	})
 	if err != nil {
 		return "", fmt.Errorf("create runner: %w", err)

--- a/application/agents/runner_plugins_test.go
+++ b/application/agents/runner_plugins_test.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package agents
+
+import (
+	"testing"
+	"time"
+
+	"google.golang.org/adk/v2/runner"
+)
+
+// SetRunnerPlugins installs the process-wide plugin config RunAgent applies to
+// every run; the zero value clears it.
+func TestSetRunnerPlugins(t *testing.T) {
+	t.Cleanup(func() { SetRunnerPlugins(runner.PluginConfig{}) })
+
+	if runnerPlugins.CloseTimeout != 0 || runnerPlugins.Plugins != nil {
+		t.Fatalf("expected no plugins by default, got %+v", runnerPlugins)
+	}
+	SetRunnerPlugins(runner.PluginConfig{CloseTimeout: 5 * time.Second})
+	if runnerPlugins.CloseTimeout != 5*time.Second {
+		t.Errorf("SetRunnerPlugins did not install the config: %+v", runnerPlugins)
+	}
+	SetRunnerPlugins(runner.PluginConfig{})
+	if runnerPlugins.CloseTimeout != 0 {
+		t.Errorf("the zero value should clear the plugins, got %+v", runnerPlugins)
+	}
+}


### PR DESCRIPTION
## What

Add a `SetRunnerPlugins` seam so a downstream service can install an adk/v2 **runner plugin** that `application/agents.RunAgent` then applies to every agent run.

`RunAgent` builds the adk/v2 runner internally (`runner.New(runner.Config{...})`), so a downstream had no way to attach a `runner.PluginConfig`. This adds a process-wide, start-up-only setter:

```go
agents.SetRunnerPlugins(pc runner.PluginConfig) // call once at startup; zero value = no plugins (default)
```

`RunAgent` passes the registered config into `runner.Config.PluginConfig`. Default behavior is unchanged (zero value → no plugins).

## Why

adk/v2 is OpenTelemetry-instrumented, but its built-in spans carry only metadata (model, token counts, latency) — **not** the LLM request/response payloads. To capture "what was actually sent to the model", you attach a runner plugin (e.g. the Langfuse plugin from `adk-utils-go`, which enriches `generate_content` spans with the payloads). That plugin rides on `runner.Config.PluginConfig`, which only `RunAgent` can set. This seam lets any weos service opt into agent payload tracing without forking `RunAgent`.

First consumer: finexity wires the Langfuse plugin behind `LANGFUSE_*` env vars (separate PR).

## Notes
- Mirrors the "global provider, set once at startup" pattern OTel itself uses; documented as start-up-only (not safe to set concurrently with runs).
- Scoped to `RunAgent`; the chat `Orchestrator` builds its own runner and is untouched here.

## Test
`go build ./application/agents/...`, `go test ./application/agents/...` green; added `TestSetRunnerPlugins`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
