### PR TITLE
fix(agents): make coordinator→skill routing work through the standard runner

### DIFF
--- a/application/agents/orchestrator.go
+++ b/application/agents/orchestrator.go
@@ -512,8 +512,12 @@ func (o *Orchestrator) buildSkillRoot(ctx context.Context, name string) (agent.A
 }
 
 // buildRoot assembles the coordinator with one sub-agent per loaded skill.
-// It is rebuilt per turn from the live registry, which is what makes skill
-// changes take effect immediately; construction is cheap (no network).
+// The sub-agents are Chat-mode transfer targets (BuildSkillSubAgent), so the
+// coordinator routes to them via ADK's in-process transfer_to_agent — not the
+// dynamic-node RunNode path a task/single_turn sub-agent would need but the
+// standard runner cannot provide for a Chat root. It is rebuilt per turn from
+// the live registry, which is what makes skill changes take effect
+// immediately; construction is cheap (no network).
 func (o *Orchestrator) buildRoot(ctx context.Context) (agent.Agent, error) {
 	o.mu.RLock()
 	skills := o.skills
@@ -543,7 +547,7 @@ func (o *Orchestrator) buildRoot(ctx context.Context) (agent.Agent, error) {
 			o.logger.Info(ctx, "agent-skill model override not yet supported; using the default model",
 				"skill", def.Name, "model", def.Model)
 		}
-		sub, err := BuildSkillAgent(def, o.model, ts)
+		sub, err := BuildSkillSubAgent(def, o.model, ts)
 		if err != nil {
 			// One bad skill must not take the agent down; the registry
 			// already validated, so this is defensive.

--- a/application/agents/orchestrator_test.go
+++ b/application/agents/orchestrator_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"iter"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/wepala/weos/v3/domain/entities"
@@ -39,6 +40,69 @@ func (s scriptedLLM) GenerateContent(
 			},
 		}, nil)
 	}
+}
+
+// reachSkillLLM plays a live model routing one free request from the
+// coordinator to a single skill sub-agent. On the coordinator's first turn it
+// records the function names it was offered (so the test can assert HOW routing
+// is wired), then routes using whatever it was given: it calls a task-tool
+// named after the skill if one is offered (the RunNode-dispatch path), else it
+// transfers via transfer_to_agent (the Chat sub-agent path). Once it is the
+// sub-agent's turn it answers with text so the turn terminates.
+type reachSkillLLM struct {
+	target     string
+	calls      atomic.Int32
+	firstOffer []string // function names offered on the coordinator's first turn
+}
+
+func (*reachSkillLLM) Name() string { return "reach-skill-scripted" }
+func (m *reachSkillLLM) GenerateContent(
+	_ context.Context, req *model.LLMRequest, _ bool,
+) iter.Seq2[*model.LLMResponse, error] {
+	first := m.calls.Add(1) == 1
+	if first {
+		m.firstOffer = offeredFunctions(req)
+	}
+	return func(yield func(*model.LLMResponse, error) bool) {
+		part := &genai.Part{Text: "here is what we know"}
+		if first {
+			if contains(m.firstOffer, m.target) {
+				part = &genai.Part{FunctionCall: &genai.FunctionCall{Name: m.target}}
+			} else {
+				part = &genai.Part{FunctionCall: &genai.FunctionCall{
+					Name: "transfer_to_agent",
+					Args: map[string]any{"agent_name": m.target},
+				}}
+			}
+		}
+		yield(&model.LLMResponse{
+			Content: &genai.Content{Role: genai.RoleModel, Parts: []*genai.Part{part}},
+		}, nil)
+	}
+}
+
+// offeredFunctions returns the names of the function declarations offered to the
+// model in the request.
+func offeredFunctions(req *model.LLMRequest) []string {
+	if req == nil || req.Config == nil {
+		return nil
+	}
+	var names []string
+	for _, tl := range req.Config.Tools {
+		for _, fd := range tl.FunctionDeclarations {
+			names = append(names, fd.Name)
+		}
+	}
+	return names
+}
+
+func contains(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestOrchestrator_NotConfigured(t *testing.T) {
@@ -91,6 +155,44 @@ func TestOrchestrator_BuildRootSkipsBrokenSkill(t *testing.T) {
 	}
 	if len(root.SubAgents()) != 1 || root.SubAgents()[0].Name() != "good" {
 		t.Fatalf("expected only the good skill, got %v", root.SubAgents())
+	}
+}
+
+// A free question with no pinned skill routes through the coordinator, which
+// must reach a skill by TRANSFER — not by a task-tool named after the skill.
+// The task-tool path dispatches the skill through workflow.RunNode, which the
+// standard runner runs outside any dynamic node; that is what broke free-form
+// chat in the field ("RunNode called outside a dynamic node"). This asserts the
+// wiring directly (offer transfer_to_agent, not a skill-named task-tool) and
+// that the routed turn completes — both fail if a skill sub-agent regresses to
+// its declared task/single_turn mode.
+func TestOrchestrator_CoordinatorReachesSkillByTransfer(t *testing.T) {
+	m := &reachSkillLLM{target: "researcher"}
+	o := NewOrchestrator(m, session.InMemoryService(), testLogger{})
+	o.SetSkillSource(func(context.Context) ([]entities.SkillDefinition, error) {
+		return []entities.SkillDefinition{
+			// Declared task mode on purpose: the coordinator must still reach it
+			// by transfer (as a Chat sub-agent), not the RunNode task-tool path.
+			{SchemaVersion: 1, Name: "researcher", Description: "answers questions about the graph",
+				Instructions: "i", Mode: entities.SkillModeTask},
+		}, nil
+	})
+
+	var types []string
+	// Empty skill = the coordinator (the hub) decides where to route.
+	if err := o.ConverseStream(context.Background(), "c1", "u1", "what do we know?", "",
+		func(e entities.AgentEvent) { types = append(types, e.Type) }); err != nil {
+		t.Fatalf("coordinator turn failed: %v", err)
+	}
+	if len(types) == 0 || types[len(types)-1] != entities.AgentEventDone {
+		t.Errorf("event types = %v, want a done-terminated turn", types)
+	}
+	if !contains(m.firstOffer, "transfer_to_agent") {
+		t.Errorf("coordinator must route by transfer, but did not offer transfer_to_agent; offered %v", m.firstOffer)
+	}
+	if contains(m.firstOffer, "researcher") {
+		t.Errorf("coordinator offered a task-tool named after the skill (the workflow.RunNode dispatch "+
+			"path); skill sub-agents must be transfer targets. offered %v", m.firstOffer)
 	}
 }
 

--- a/application/agents/skill_agent.go
+++ b/application/agents/skill_agent.go
@@ -103,18 +103,24 @@ var widgetResponseSchema = &genai.Schema{
 	Required: []string{"widgets"},
 }
 
-// BuildSkillAgent turns a validated skill definition into a runnable ADK
-// agent. The shared toolset is filtered down to the skill's allowlist, and
-// the declared mode maps to the ADK delegation mode that governs how an
-// orchestrator hands work to the skill. The definition is data — this
-// factory is the only place a skill becomes code, which is what lets
-// projects add skills without recompiling.
-func BuildSkillAgent(def entities.SkillDefinition, m model.LLM, toolset tool.Toolset) (agent.Agent, error) {
-	mode := llmagent.ModeTask
-	if def.Mode == entities.SkillModeSingleTurn {
-		mode = llmagent.ModeSingleTurn
-	}
-	return buildSkillAgent(def, m, toolset, mode)
+// BuildSkillSubAgent turns a validated skill definition into a coordinator
+// sub-agent: a Chat-mode LlmAgent the coordinator reaches via ADK's in-process
+// transfer_to_agent, which is exactly what the coordinator's brief promises
+// ("route each request to the sub-agent ... by transferring to it").
+//
+// The declared task/single_turn mode is deliberately NOT applied here. A
+// task/single_turn sub-agent is installed on the parent as a tool that
+// dispatches it through workflow.RunNode, and RunNode only works inside an
+// enclosing dynamic node. The runner executes a Chat root directly
+// (runner.Run → rootAgent.Run) with no dynamic node in scope, so that
+// delegation fails at the first transfer with ErrInvalidRunNodeContext
+// ("RunNode called outside a dynamic node"). Chat sub-agents transfer
+// in-process and need no dynamic node, so routing works through the same
+// runner. The declared mode is preserved on the definition for a future
+// workflow-node execution path; today every reachable skill runs as Chat
+// (a directly-invoked root does too — see BuildSkillRootAgent).
+func BuildSkillSubAgent(def entities.SkillDefinition, m model.LLM, toolset tool.Toolset) (agent.Agent, error) {
+	return buildSkillAgent(def, m, toolset, llmagent.ModeChat)
 }
 
 // BuildSkillRootAgent builds the skill as a conversation's root agent (the

--- a/application/agents/skill_agent_test.go
+++ b/application/agents/skill_agent_test.go
@@ -31,21 +31,25 @@ func skillDef() entities.SkillDefinition {
 	}
 }
 
-func TestBuildSkillAgent(t *testing.T) {
-	a, err := BuildSkillAgent(skillDef(), fakeLLM{}, nil)
+func TestBuildSkillSubAgent(t *testing.T) {
+	a, err := BuildSkillSubAgent(skillDef(), fakeLLM{}, nil)
 	if err != nil {
-		t.Fatalf("BuildSkillAgent: %v", err)
+		t.Fatalf("BuildSkillSubAgent: %v", err)
 	}
 	if a.Name() != "researcher" {
 		t.Errorf("agent name = %q, want researcher", a.Name())
 	}
 }
 
-func TestBuildSkillAgent_SingleTurnMode(t *testing.T) {
+// A sub-agent is always a Chat transfer target — the declared task/single_turn
+// mode is overridden, not applied — so a single_turn-declared skill still
+// builds (as a Chat sub-agent) rather than the RunNode-dispatched node that
+// would fail delegation at runtime.
+func TestBuildSkillSubAgent_OverridesDeclaredMode(t *testing.T) {
 	def := skillDef()
 	def.Mode = entities.SkillModeSingleTurn
-	if _, err := BuildSkillAgent(def, fakeLLM{}, nil); err != nil {
-		t.Fatalf("BuildSkillAgent single_turn: %v", err)
+	if _, err := BuildSkillSubAgent(def, fakeLLM{}, nil); err != nil {
+		t.Fatalf("BuildSkillSubAgent single_turn: %v", err)
 	}
 }
 
@@ -68,10 +72,10 @@ func TestSkillToolNames_IncludesMemoryDefaults(t *testing.T) {
 	}
 }
 
-func TestBuildSkillAgent_RejectsInvalidDefinition(t *testing.T) {
+func TestBuildSkillSubAgent_RejectsInvalidDefinition(t *testing.T) {
 	def := skillDef()
 	def.Instructions = ""
-	_, err := BuildSkillAgent(def, fakeLLM{}, nil)
+	_, err := BuildSkillSubAgent(def, fakeLLM{}, nil)
 	if err == nil || !strings.Contains(err.Error(), "invalid skill definition") {
 		t.Fatalf("expected invalid-definition error, got: %v", err)
 	}

--- a/infrastructure/agents/scripted_model.go
+++ b/infrastructure/agents/scripted_model.go
@@ -226,9 +226,31 @@ func (s *scriptedModel) respond(req *model.LLMRequest, rule *scriptRule, toolOut
 	}}
 }
 
+// Cross-agent context echoes. When the coordinator transfers to a skill
+// sub-agent, ADK narrates the parent's tool activity into the sub-agent's
+// request as plain USER-role text ("For context:" followed by
+// "[parent] called tool `x` with parameters: …" / "[parent] `x` tool
+// returned result: …") — there is no FunctionResponse part on the
+// sub-agent's side. Without recognizing these, a scripted hub handoff is
+// invisible: afterTool rules can't fire (no tool moment) and the echo text
+// shadows the real user message for whenMessageContains/argsFromMessageJSON.
+var (
+	ctxEchoCall   = regexp.MustCompile("^\\[[^\\]]+\\] called tool `[^`]+` with parameters: ")
+	ctxEchoResult = regexp.MustCompile("(?s)^\\[[^\\]]+\\] `([^`]+)` tool returned result: (.*)$")
+)
+
+// isContextEchoNoise reports echo lines that carry no decision signal (the
+// framing line and the call echo — the RESULT echo is the tool moment and
+// is handled in latestMoment).
+func isContextEchoNoise(text string) bool {
+	return strings.TrimSpace(text) == "For context:" || ctxEchoCall.MatchString(text)
+}
+
 // latestMoment scans the request tail: the name (and response map) of the
 // tool whose function response arrived last (skipping the confirmation
-// protocol's own frames), or the latest user text.
+// protocol's own frames), or the latest user text. A cross-agent result
+// echo counts as that tool's moment, so a scripted sub-agent can continue
+// a hub handoff with an afterTool rule (e.g. afterTool transfer_to_agent).
 func latestMoment(req *model.LLMRequest) (lastTool, lastText string, toolOutput map[string]any) {
 	if req == nil {
 		return "", "", nil
@@ -256,6 +278,16 @@ func latestMoment(req *model.LLMRequest) (lastTool, lastText string, toolOutput 
 				return p.FunctionResponse.Name, "", p.FunctionResponse.Response
 			}
 			if p.Text != "" && c.Role == genai.RoleUser {
+				if m := ctxEchoResult.FindStringSubmatch(p.Text); m != nil {
+					// A parent agent's tool outcome, narrated as text: the
+					// sub-agent's view of e.g. the transfer that reached it.
+					var resp map[string]any
+					_ = json.Unmarshal([]byte(strings.TrimSpace(m[2])), &resp)
+					return m[1], "", resp
+				}
+				if isContextEchoNoise(p.Text) {
+					continue
+				}
 				return "", p.Text, nil
 			}
 		}
@@ -274,7 +306,9 @@ func isAwaitingConfirmation(response map[string]any) bool {
 	return strings.Contains(errText, "requires confirmation")
 }
 
-// latestUserText returns the most recent user-authored text content.
+// latestUserText returns the most recent user-authored text content,
+// skipping cross-agent context echoes — after a hub transfer the actual
+// user message (and its fenced args) sits behind ADK's narration lines.
 func latestUserText(req *model.LLMRequest) string {
 	if req == nil {
 		return ""
@@ -285,7 +319,8 @@ func latestUserText(req *model.LLMRequest) string {
 			continue
 		}
 		for j := len(c.Parts) - 1; j >= 0; j-- {
-			if p := c.Parts[j]; p != nil && p.Text != "" {
+			if p := c.Parts[j]; p != nil && p.Text != "" &&
+				!isContextEchoNoise(p.Text) && !ctxEchoResult.MatchString(p.Text) {
 				return p.Text
 			}
 		}

--- a/infrastructure/agents/scripted_model_test.go
+++ b/infrastructure/agents/scripted_model_test.go
@@ -176,3 +176,67 @@ func TestFencedJSONArgs_NestedObjects(t *testing.T) {
 		t.Errorf("trailing keys after the nested object were lost: %v", args)
 	}
 }
+
+// After a coordinator transfer, ADK narrates the parent's tool activity to
+// the sub-agent as USER-role text ("For context:" + call/result echoes) —
+// there is no FunctionResponse on the sub-agent's side. The scripted model
+// must treat the result echo as that tool's moment (so afterTool rules can
+// continue a hub handoff) and must NOT let the echoes shadow the real user
+// message for argsFromMessageJSON.
+func TestScriptedModel_HubTransferEchoIsAToolMoment(t *testing.T) {
+	m := scriptedFromString(t, `{
+	  "rules": [
+	    {"whenMessageContains": "import the statement",
+	     "call": {"tool": "transfer_to_agent", "args": {"agent_name": "statement_import"}}},
+	    {"afterTool": "transfer_to_agent",
+	     "call": {"tool": "check_duplicate_import", "argsFromMessageJSON": true}},
+	    {"reply": "Nothing scripted for that."}
+	  ]
+	}`)
+
+	// The sub-agent's request, exactly as the runner shapes it post-transfer.
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: genai.RoleUser, Parts: []*genai.Part{{Text: "Please import the statement I'm handing you.\n```json\n{\"fileName\":\"march.csv\"}\n```"}}},
+		{Role: genai.RoleUser, Parts: []*genai.Part{
+			{Text: "For context:"},
+			{Text: "[weos_coordinator] called tool `transfer_to_agent` with parameters: {\"agent_name\":\"statement_import\"}"},
+		}},
+		{Role: genai.RoleUser, Parts: []*genai.Part{
+			{Text: "For context:"},
+			{Text: "[weos_coordinator] `transfer_to_agent` tool returned result: {}"},
+		}},
+	}}
+
+	resp := oneResponse(t, m, req)
+	call := resp.Content.Parts[0].FunctionCall
+	if call == nil || call.Name != "check_duplicate_import" {
+		t.Fatalf("expected the afterTool transfer rule to fire check_duplicate_import, got %+v", resp.Content.Parts[0])
+	}
+	if call.Args["fileName"] != "march.csv" {
+		t.Errorf("args = %v, want the ORIGINAL user message's fenced JSON (echoes must not shadow it)", call.Args)
+	}
+}
+
+// The result echo carries the tool's outcome; a narrated error must count as
+// a failed moment so afterToolFailed rules (not afterTool) match it.
+func TestScriptedModel_HubTransferEchoErrorIsAFailedMoment(t *testing.T) {
+	m := scriptedFromString(t, `{
+	  "rules": [
+	    {"afterTool": "transfer_to_agent", "reply": "transferred"},
+	    {"afterToolFailed": "transfer_to_agent", "reply": "transfer failed"},
+	    {"reply": "Nothing scripted for that."}
+	  ]
+	}`)
+
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: genai.RoleUser, Parts: []*genai.Part{{Text: "hi"}}},
+		{Role: genai.RoleUser, Parts: []*genai.Part{
+			{Text: "[weos_coordinator] `transfer_to_agent` tool returned result: {\"error\":\"tool 'transfer_to_agent' not found.\"}"},
+		}},
+	}}
+
+	resp := oneResponse(t, m, req)
+	if text := resp.Content.Parts[0].Text; !strings.Contains(text, "transfer failed") {
+		t.Errorf("reply = %q, want the afterToolFailed branch", text)
+	}
+}


### PR DESCRIPTION
## Why

Free-form chat to the in-app orchestrator was failing whenever the coordinator tried to reach a skill. Two distinct breakages, both on the hub-transfer path:

1. **`RunNode called outside a dynamic node`** — skill sub-agents were built in their declared `task`/`single_turn` mode. A task/single_turn sub-agent is installed on the parent as a tool that dispatches through `workflow.RunNode`, which only works inside an enclosing dynamic node. The standard runner executes a Chat root directly (`runner.Run → rootAgent.Run`) with no dynamic node in scope, so the very first transfer failed.

2. **Scripted model went blind after a transfer** — when the coordinator transfers to a sub-agent, ADK narrates the parent's tool activity into the sub-agent's request as plain **USER-role text** (`For context:` + `[parent] called tool ...` / `... tool returned result: ...`), with no `FunctionResponse` part. The scripted model didn't recognize these echoes, so `afterTool` rules couldn't fire (no tool moment) and the echo text shadowed the real user message for `whenMessageContains` / `argsFromMessageJSON`.

## What

- **`orchestrator.go` / `skill_agent.go`** — the coordinator now builds skill sub-agents via the new `BuildSkillSubAgent`, which forces `ModeChat` so skills are reached by in-process `transfer_to_agent` instead of the RunNode task-tool path. The declared `task`/`single_turn` mode is preserved on the definition for a future workflow-node execution path; today every reachable skill runs as Chat (a directly-invoked root already did).
- **`scripted_model.go`** — recognizes cross-agent context echoes: a result echo now counts as that tool's moment (so a scripted sub-agent can continue a hub handoff with an `afterTool` rule), narrated errors count as failed moments (`afterToolFailed`), and the framing/call-echo noise lines are skipped so the real user message and its fenced args still drive `argsFromMessageJSON`.

## Tests

- `TestOrchestrator_CoordinatorReachesSkillByTransfer` — a `task`-declared skill must still be reached by `transfer_to_agent`, not a skill-named task-tool, and the routed turn completes.
- `TestBuildSkillSubAgent_OverridesDeclaredMode` — a `single_turn`-declared skill builds as a Chat sub-agent.
- `TestScriptedModel_HubTransferEchoIsAToolMoment` / `..._EchoErrorIsAFailedMoment` — the transfer echo is a tool moment (and error a failed moment), and echoes don't shadow the original user message's fenced JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)