### PR TITLE
feat(oauth): restrict OAuth login to an identity allowlist (OAUTH_ALLOWED_EMAILS)

### DIFF
--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -290,7 +290,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		asHandler := weosoauth.AuthorizationServerMetadata(baseURL, appCfg.OAuth.DynamicRegistration)
 		regHandler := weosoauth.RegisterClient(clientRepo, appCfg.OAuth.DynamicRegistration)
 		authzHandler := weosoauth.Authorize(authService, sessionStore, clientRepo, codeRepo, logger, baseURL)
-		cbHandler := weosoauth.Callback(authService, sessionStore, codeRepo, accountRepo, logger, baseURL)
+		cbHandler := weosoauth.Callback(authService, sessionStore, codeRepo, accountRepo, logger, baseURL, appCfg.OAuth.AllowedEmails)
 		tokHandler := weosoauth.Token(jwtService, codeRepo, refreshRepo, agentRepo, accountRepo, logger)
 
 		e.Pre(func(next echo.HandlerFunc) echo.HandlerFunc {

--- a/internal/config/allowlist_test.go
+++ b/internal/config/allowlist_test.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseAllowedEmails(t *testing.T) {
+	got := parseAllowedEmails(" Akeem@Example.com , second@EXAMPLE.com ,, ")
+	want := []string{"akeem@example.com", "second@example.com"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseAllowedEmails = %v, want %v", got, want)
+	}
+}
+
+func TestLoadFromEnvironment_OAuthAllowedEmails(t *testing.T) {
+	t.Setenv("OAUTH_ALLOWED_EMAILS", "akeem@example.com, Second@Example.com")
+
+	cfg := Default()
+	cfg.LoadFromEnvironment()
+
+	want := []string{"akeem@example.com", "second@example.com"}
+	if !reflect.DeepEqual(cfg.OAuth.AllowedEmails, want) {
+		t.Fatalf("AllowedEmails = %v, want %v", cfg.OAuth.AllowedEmails, want)
+	}
+}
+
+func TestLoadFromEnvironment_OAuthAllowedEmails_NotSet(t *testing.T) {
+	cfg := Default()
+	cfg.LoadFromEnvironment()
+
+	if len(cfg.OAuth.AllowedEmails) != 0 {
+		t.Fatalf("expected no AllowedEmails by default, got %v", cfg.OAuth.AllowedEmails)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,11 +72,30 @@ type OAuthConfig struct {
 	JWTSigningKey       string // PEM-encoded RSA private key, or "auto" to generate ephemeral key
 	DynamicRegistration bool   // Enable OAuth Dynamic Client Registration (RFC 7591)
 
+	// AllowedEmails, when non-empty, restricts OAuth login to identities whose
+	// verified email is in this list (case-insensitive). The /oauth/callback
+	// rejects anyone else before an account is created; empty (the default)
+	// allows any authenticated user. Set via OAUTH_ALLOWED_EMAILS (comma-separated).
+	AllowedEmails []string
+
 	// DefaultProvider is the provider used by /api/auth/login when the
 	// caller doesn't pass a provider query param (the admin SPA does
 	// this). Empty means "auto-pick from the configured registry" —
 	// see DefaultOAuthProvider below.
 	DefaultProvider string
+}
+
+// parseAllowedEmails splits a comma-separated OAUTH_ALLOWED_EMAILS value into a
+// normalized allowlist: each entry trimmed and lowercased, blanks dropped.
+func parseAllowedEmails(raw string) []string {
+	parts := strings.Split(raw, ",")
+	emails := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if e := strings.ToLower(strings.TrimSpace(p)); e != "" {
+			emails = append(emails, e)
+		}
+	}
+	return emails
 }
 
 // SMTPConfig holds configuration for outbound email via SMTP.
@@ -511,6 +530,10 @@ func (c *Config) LoadFromEnvironment() {
 		if enabled, err := strconv.ParseBool(dynReg); err == nil {
 			c.OAuth.DynamicRegistration = enabled
 		}
+	}
+
+	if allowed := os.Getenv("OAUTH_ALLOWED_EMAILS"); allowed != "" {
+		c.OAuth.AllowedEmails = parseAllowedEmails(allowed)
 	}
 
 	if provider := os.Getenv("OAUTH_DEFAULT_PROVIDER"); provider != "" {

--- a/internal/oauth/allowlist_test.go
+++ b/internal/oauth/allowlist_test.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package oauth
+
+import "testing"
+
+func TestEmailAllowed(t *testing.T) {
+	allow := []string{"akeem@example.com", "second@example.com"}
+	cases := []struct {
+		name  string
+		email string
+		want  bool
+	}{
+		{"first entry", "akeem@example.com", true},
+		{"second entry", "second@example.com", true},
+		{"not listed", "stranger@example.com", false},
+		{"empty email", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := emailAllowed(tc.email, allow); got != tc.want {
+				t.Fatalf("emailAllowed(%q) = %v, want %v", tc.email, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/oauth/callback.go
+++ b/internal/oauth/callback.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/wepala/weos/v3/domain/entities"
@@ -35,6 +36,9 @@ import (
 // This handler completes the Google OAuth exchange, resolves the user identity,
 // updates the pending authorization code with the agent/account IDs, and
 // redirects back to the MCP client's redirect_uri with the authorization code.
+//
+// When allowedEmails is non-empty, an identity whose email is not in the list is
+// rejected before any account is created, so the server admits only known users.
 func Callback(
 	authService authapp.AuthenticationService,
 	sessionStore sessions.Store,
@@ -42,6 +46,7 @@ func Callback(
 	accountRepo authrepos.AccountRepository,
 	logger entities.Logger,
 	baseURL string,
+	allowedEmails []string,
 ) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		ctx := c.Request().Context()
@@ -121,6 +126,23 @@ func Callback(
 				map[string]string{"error": "server_error"})
 		}
 
+		// Enforce the identity allowlist (when configured) BEFORE resolving the
+		// agent, so a non-permitted user never gets a persisted account. The email
+		// comes from the provider's userinfo endpoint (a server-to-server call),
+		// so we trust Google's consumer-account invariant that this address is
+		// owned by the authenticated user. If a provider without that invariant is
+		// ever added behind this gate, also require an email_verified claim.
+		if len(allowedEmails) > 0 {
+			email := strings.ToLower(strings.TrimSpace(authResult.UserInfo.Email))
+			if !emailAllowed(email, allowedEmails) {
+				logger.Warn(ctx, "oauth callback: identity not in allowlist",
+					"email", email)
+				return c.JSON(http.StatusForbidden,
+					map[string]string{"error": "access_denied",
+						"error_description": "this account is not permitted to access this server"})
+			}
+		}
+
 		agent, _, account, err := authService.FindOrCreateAgent(
 			ctx, authResult.UserInfo)
 		if err != nil {
@@ -182,4 +204,16 @@ func Callback(
 
 		return c.Redirect(http.StatusFound, redirectURL.String())
 	}
+}
+
+// emailAllowed reports whether email (already normalized to lowercase) is present
+// in the allowlist. The caller guards against an empty allowlist, which means
+// "no restriction".
+func emailAllowed(email string, allowed []string) bool {
+	for _, a := range allowed {
+		if a == email {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/oauth/callback_test.go
+++ b/internal/oauth/callback_test.go
@@ -1,0 +1,158 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package oauth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
+	authentities "github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo/v4"
+)
+
+// fakeGateAuthService stubs only the two AuthenticationService methods the
+// callback reaches on the OAuth path: ExchangeCode (returns a fixed identity)
+// and FindOrCreateAgent (records that it ran, then errors so the handler stops
+// right after the gate without needing real entities). Every other interface
+// method is inherited from the nil embedded interface and is never called here.
+type fakeGateAuthService struct {
+	authapp.AuthenticationService
+	email             string
+	findOrCreateCalls int
+}
+
+func (f *fakeGateAuthService) ExchangeCode(ctx context.Context, code, codeVerifier, provider, redirectURI string) (*authapp.AuthResult, error) {
+	return &authapp.AuthResult{UserInfo: authapp.UserInfo{Email: f.email}}, nil
+}
+
+func (f *fakeGateAuthService) FindOrCreateAgent(ctx context.Context, userInfo authapp.UserInfo) (*authentities.Agent, *authentities.Credential, *authentities.Account, error) {
+	f.findOrCreateCalls++
+	return nil, nil, nil, errors.New("stop after gate")
+}
+
+// gateSessionStore returns a session pre-populated with a valid pending-flow
+// state so the callback reaches the allowlist gate.
+type gateSessionStore struct{ code, state string }
+
+func (s *gateSessionStore) Get(r *http.Request, name string) (*sessions.Session, error) {
+	sess := sessions.NewSession(s, name)
+	sess.Values["oauth_code"] = s.code
+	sess.Values["oauth_code_verifier"] = "verifier"
+	sess.Values["oauth_state"] = s.state
+	return sess, nil
+}
+
+func (s *gateSessionStore) New(r *http.Request, name string) (*sessions.Session, error) {
+	return s.Get(r, name)
+}
+
+func (s *gateSessionStore) Save(r *http.Request, w http.ResponseWriter, sess *sessions.Session) error {
+	return nil
+}
+
+// newGateHandler wires a Callback handler to in-memory fakes with a real pending
+// authorization code, and returns the handler plus the handles a test asserts on.
+func newGateHandler(t *testing.T, email string, allowlist []string) (echo.HandlerFunc, *fakeGateAuthService, AuthCodeRepository, string, string) {
+	t.Helper()
+	db := setupTestDB(t)
+	codeRepo := NewAuthCodeRepository(db)
+	code := &OAuthAuthorizationCode{
+		ClientID:            "client-1",
+		RedirectURI:         "https://client.example/cb",
+		CodeChallenge:       "challenge",
+		CodeChallengeMethod: "S256",
+		Status:              StatusPending,
+	}
+	mustNoErr(t, codeRepo.Create(context.Background(), code), "create pending code")
+
+	state := "state-123"
+	auth := &fakeGateAuthService{email: email}
+	store := &gateSessionStore{code: code.Code, state: state}
+	h := Callback(auth, store, codeRepo, nil, noopLogger{}, "https://twin.example", allowlist)
+	return h, auth, codeRepo, code.Code, state
+}
+
+func runCallback(t *testing.T, h echo.HandlerFunc, state string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?state="+state+"&code=google-code", nil)
+	rec := httptest.NewRecorder()
+	if err := h(echo.New().NewContext(req, rec)); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	return rec
+}
+
+func TestCallback_Allowlist_DeniesUnlistedEmail(t *testing.T) {
+	t.Parallel()
+	h, auth, codeRepo, code, state := newGateHandler(t, "stranger@example.com", []string{"akeem@example.com"})
+
+	rec := runCallback(t, h, state)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "access_denied") {
+		t.Errorf("body should contain access_denied: %s", rec.Body.String())
+	}
+	if auth.findOrCreateCalls != 0 {
+		t.Errorf("FindOrCreateAgent ran %d times; a denied identity must never get an account", auth.findOrCreateCalls)
+	}
+	// The code must stay pending — never advanced to issued for a denied user.
+	found, err := codeRepo.FindByCode(context.Background(), code)
+	mustNoErr(t, err, "find code after deny")
+	if found.Status != StatusPending {
+		t.Errorf("code status = %q, want still %q", found.Status, StatusPending)
+	}
+}
+
+func TestCallback_Allowlist_AdmitsListedEmail(t *testing.T) {
+	t.Parallel()
+	h, auth, _, _, state := newGateHandler(t, "akeem@example.com", []string{"akeem@example.com"})
+
+	runCallback(t, h, state)
+
+	if auth.findOrCreateCalls != 1 {
+		t.Errorf("a listed email must pass the gate through to FindOrCreateAgent; calls=%d", auth.findOrCreateCalls)
+	}
+}
+
+func TestCallback_Allowlist_IsCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	h, auth, _, _, state := newGateHandler(t, "Akeem@Example.COM", []string{"akeem@example.com"})
+
+	runCallback(t, h, state)
+
+	if auth.findOrCreateCalls != 1 {
+		t.Errorf("a mixed-case listed email must be admitted; calls=%d", auth.findOrCreateCalls)
+	}
+}
+
+func TestCallback_NoAllowlist_AdmitsAnyIdentity(t *testing.T) {
+	t.Parallel()
+	h, auth, _, _, state := newGateHandler(t, "anyone@example.com", nil)
+
+	runCallback(t, h, state)
+
+	if auth.findOrCreateCalls != 1 {
+		t.Errorf("with no allowlist the gate must be skipped and anyone admitted; calls=%d", auth.findOrCreateCalls)
+	}
+}

--- a/tests/e2e/notification_inbox_test.go
+++ b/tests/e2e/notification_inbox_test.go
@@ -144,7 +144,7 @@ func (w *notificationWorld) aRunningApplication() error {
 
 	// The notifications preset is AutoInstall: app.Start already created the
 	// notification type at boot (no opt-in install), so the inbox is present
-	// for every service — which is exactly the always-on behaviour under test.
+	// for every service — which is exactly the always-on behavior under test.
 
 	// The same inbox routes serve.go registers, behind SoftAuth so the
 	// X-Dev-Agent header selects which seeded user is the caller.


### PR DESCRIPTION
## What

Adds `OAUTH_ALLOWED_EMAILS` — a comma-separated allowlist that, when set, makes `/oauth/callback` reject any upstream identity whose email is not on the list. The check runs **before** `FindOrCreateAgent`, so a non-permitted user never gets a persisted agent/account. Empty (the default) preserves today's behavior of admitting any authenticated user.

## Why

A single-user deployment that exposes its MCP endpoint over the public internet (e.g. behind a Cloudflare tunnel) needs to pin access to its owner's identity. Relying on the upstream IdP's mode isn't enough: a Google **External/Published** consent screen lets *any* Google account complete the flow, and weos then auto-creates an account for them. This gate makes "only these identities" a server-side guarantee, independent of the IdP.

Driven by `wepala/mini-me-weos#17` (exposing the digital twin to claude.ai as a custom connector) — but it's a general single-tenant hardening knob, so it lands here in core.

## How

- `config`: new `OAuthConfig.AllowedEmails []string`, parsed from `OAUTH_ALLOWED_EMAILS` at load (trim + lowercase, blanks dropped).
- `oauth.Callback`: takes `allowedEmails`; when non-empty, rejects a non-listed email with `403 access_denied` before account creation. Case-insensitive.
- `serve`: passes `appCfg.OAuth.AllowedEmails` through.

## Tests

- `internal/config`: `OAUTH_ALLOWED_EMAILS` parsing + normalization, and the unset default (nil).
- `internal/oauth`: `emailAllowed` membership.
- `go build`, `go vet`, `gofmt`, and `go test ./internal/oauth/... ./internal/config/...` all green.

## Compatibility

Fully backward-compatible: unset ⇒ `AllowedEmails` is empty ⇒ the gate is skipped and behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)