### PR TITLE
ci: run CI on v3 pushes and PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, v3 ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, develop, v3 ]
 
 jobs:
   # web/dist is not checked in; //go:embed all:dist requires it to exist,


### PR DESCRIPTION
## Summary
- Add `v3` to the `push` and `pull_request` branch filters in `.github/workflows/ci.yml`

`v3` is the default/integration branch, but the CI workflow only fired for `main`/`develop` — so v3-targeted PRs (and merges into v3) got zero build/test/lint checks. This surfaced on #440, where a lint failure only appeared because the PR briefly targeted `main` before being retargeted.

Since `pull_request` workflows evaluate from the merge ref, CI should fire on this PR itself, proving the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)