### PR TITLE
feat(worker): reproject — replay the feed through the synchronous projections (#442)

### DIFF
--- a/application/event_handlers.go
+++ b/application/event_handlers.go
@@ -62,12 +62,25 @@ func subscribeResourceTypeHandlers(
 			); err != nil {
 				return err
 			}
-			if err := repo.Save(ctx, entity); err != nil {
-				return err
+			// Replay-idempotent (a handler constraint, and `worker reproject`
+			// re-runs this handler over history): a row that already exists
+			// for this aggregate converges via Update instead of failing
+			// Save's unique constraints. A genuinely conflicting row (same
+			// slug, different aggregate) still fails Save loudly.
+			_, findErr := repo.FindByID(ctx, env.AggregateID)
+			switch {
+			case findErr == nil:
+				if err := repo.Update(ctx, entity); err != nil {
+					return err
+				}
+			case errors.Is(findErr, repositories.ErrNotFound):
+				if err := repo.Save(ctx, entity); err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("projection read failed: %w", findErr)
 			}
 			// ensureProjection is idempotent (CREATE TABLE IF NOT EXISTS).
-			// If it fails and the event is retried, repo.Save will fail with a
-			// duplicate key, which the event dispatcher treats as already-processed.
 			if err := ensureProjection(ctx, repo, projMgr, p.Slug, p.Schema, p.Context); err != nil {
 				logger.Error(ctx, "failed to ensure projection for type",
 					"slug", p.Slug, "error", err)
@@ -298,7 +311,20 @@ func handleResourcePublished(
 		// Reverse-reference display-value propagation runs asynchronously in the
 		// "display-values" subscriber group (see peripheral_groups.go), so it no
 		// longer adds latency to — or can fail — the user's write.
-		return repo.Save(ctx, entity)
+		//
+		// Replay-idempotent (a handler constraint, and `worker reproject`
+		// re-runs this handler over history): if the canonical row already
+		// exists, converge through the Update path — its projection writes
+		// upsert — instead of failing Save's plain inserts.
+		_, findErr := repo.FindByID(ctx, env.AggregateID)
+		switch {
+		case findErr == nil:
+			return repo.Update(ctx, entity)
+		case errors.Is(findErr, repositories.ErrNotFound):
+			return repo.Save(ctx, entity)
+		default:
+			return fmt.Errorf("projection read failed: %w", findErr)
+		}
 	}
 
 	// Update: read existing resource for fields not in the transaction events.

--- a/application/event_handlers.go
+++ b/application/event_handlers.go
@@ -65,9 +65,14 @@ func subscribeResourceTypeHandlers(
 			// Replay-idempotent (a handler constraint, and `worker reproject`
 			// re-runs this handler over history): a row that already exists
 			// for this aggregate converges via Update instead of failing
-			// Save's unique constraints. A genuinely conflicting row (same
-			// slug, different aggregate) still fails Save loudly.
-			_, findErr := repo.FindByID(ctx, env.AggregateID)
+			// Save's unique constraints. The probe must see soft-deleted rows
+			// too — a history holding ResourceType.Deleted leaves one behind,
+			// and Save would hit those constraints. Update resurrects it
+			// (full-field save clears deleted_at); replaying the Deleted
+			// event re-deletes, so the run still converges. A genuinely
+			// conflicting row (same slug, different aggregate) still fails
+			// Save loudly.
+			_, findErr := repo.FindByIDIncludingDeleted(ctx, env.AggregateID)
 			switch {
 			case findErr == nil:
 				if err := repo.Update(ctx, entity); err != nil {

--- a/application/install_preset_test.go
+++ b/application/install_preset_test.go
@@ -45,6 +45,12 @@ func (r *installTestTypeRepo) FindByID(_ context.Context, id string) (*entities.
 	return nil, fmt.Errorf("resource type %q: %w", id, repositories.ErrNotFound)
 }
 
+func (r *installTestTypeRepo) FindByIDIncludingDeleted(
+	ctx context.Context, id string,
+) (*entities.ResourceType, error) {
+	return r.FindByID(ctx, id)
+}
+
 func (r *installTestTypeRepo) FindAll(
 	_ context.Context, _ string, _ int,
 ) (repositories.PaginatedResponse[*entities.ResourceType], error) {
@@ -359,6 +365,11 @@ func (r *failingTypeRepo) FindBySlug(context.Context, string) (*entities.Resourc
 }
 func (r *failingTypeRepo) Save(context.Context, *entities.ResourceType) error { return nil }
 func (r *failingTypeRepo) FindByID(context.Context, string) (*entities.ResourceType, error) {
+	return nil, r.err
+}
+func (r *failingTypeRepo) FindByIDIncludingDeleted(
+	context.Context, string,
+) (*entities.ResourceType, error) {
 	return nil, r.err
 }
 func (r *failingTypeRepo) FindAll(

--- a/application/link_activation_test.go
+++ b/application/link_activation_test.go
@@ -38,6 +38,11 @@ func (r *listingTypeRepo) Save(context.Context, *entities.ResourceType) error { 
 func (r *listingTypeRepo) FindByID(context.Context, string) (*entities.ResourceType, error) {
 	return nil, repositories.ErrNotFound
 }
+func (r *listingTypeRepo) FindByIDIncludingDeleted(
+	context.Context, string,
+) (*entities.ResourceType, error) {
+	return nil, repositories.ErrNotFound
+}
 func (r *listingTypeRepo) FindBySlug(_ context.Context, slug string) (*entities.ResourceType, error) {
 	for _, s := range r.slugs {
 		if s == slug {

--- a/application/oxigraph_handler_test.go
+++ b/application/oxigraph_handler_test.go
@@ -143,6 +143,11 @@ func (r *kgTypeRepo) FindByID(_ context.Context, _ string) (*entities.ResourceTy
 	}
 	return r.rt, nil
 }
+func (r *kgTypeRepo) FindByIDIncludingDeleted(
+	ctx context.Context, id string,
+) (*entities.ResourceType, error) {
+	return r.FindByID(ctx, id)
+}
 func (r *kgTypeRepo) FindBySlug(_ context.Context, _ string) (*entities.ResourceType, error) {
 	return r.rt, nil
 }

--- a/application/reproject.go
+++ b/application/reproject.go
@@ -1,0 +1,209 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/wepala/weos/v3/domain/entities"
+	gormprov "github.com/wepala/weos/v3/infrastructure/database/gorm"
+	"github.com/wepala/weos/v3/infrastructure/events"
+	"github.com/wepala/weos/v3/infrastructure/logging"
+	"github.com/wepala/weos/v3/internal/config"
+
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
+	"go.uber.org/fx"
+)
+
+// This file is the replay rail for the SYNCHRONOUS projections (issue #442).
+//
+// The critical read models — resource types, canonical resources, triples,
+// and the per-type projection tables — are written inline at commit time
+// (subscribeEventHandlers) so the SPA gets read-your-writes. That dispatcher
+// only ever sees events the moment THIS process commits them, which means an
+// event store that arrived by other means (pericarp export → import, a
+// restored backup) has a full history and empty projections, and nothing to
+// rebuild them: `worker checkpoint reset` covers only the checkpointed
+// background groups. Reproject closes that gap by streaming the global feed
+// through the very same handler set the write path uses.
+//
+// Deliberately NOT built on application.Module: constructing the full module
+// runs ensureBuiltInResourceTypes at start, which decides "does this type
+// exist" from the projection tables — empty on exactly the store reproject
+// exists to fix — and would append brand-new ResourceType.Created events
+// (fresh IDs, duplicate slugs) into the imported history before replay runs
+// (issue #443). ReprojectModule assembles only what replay needs.
+//
+// Also deliberately NOT a SubscriberGroup: Manager.Start launches every
+// registered group as a live loop, and these projections are already written
+// synchronously on every commit — a live duplicate would double-write, and
+// its GetEventsByTransactionID reads could observe a transaction whose
+// per-aggregate appends haven't all landed yet. Replay must stay a one-shot,
+// operator-invoked pass.
+
+// ReprojectRuntime bundles what Reproject needs; populate it from an fx app
+// built with ReprojectModule.
+type ReprojectRuntime struct {
+	fx.In
+	EventStore domain.EventStore
+	Dispatcher *domain.EventDispatcher
+	Logger     entities.Logger
+}
+
+// ReprojectModule is the narrow assembly behind `worker reproject`: config,
+// logging, the gorm DB, the event store (undecorated — a one-shot replay has
+// no background subscribers to wake), the four projection dependencies, and a
+// fresh dispatcher wired with ONLY the synchronous projection handlers.
+func ReprojectModule(cfg config.Config) fx.Option {
+	return fx.Module("reproject",
+		fx.Provide(func() config.Config { return cfg }),
+		fx.Provide(logging.ProvideZapLogger),
+		fx.Provide(logging.ProvideLogger),
+		fx.Provide(events.ProvideEventDispatcher),
+		fx.Provide(gormprov.ProvideGormDB),
+		fx.Provide(gormprov.ProvideEventStore),
+		fx.Provide(gormprov.ProvideResourceTypeRepository),
+		fx.Provide(gormprov.ProvideProjectionManager),
+		fx.Provide(gormprov.ProvideResourceRepository),
+		fx.Provide(gormprov.ProvideTripleRepository),
+		fx.Invoke(subscribeEventHandlers),
+	)
+}
+
+// ReprojectOptions tune a replay run.
+type ReprojectOptions struct {
+	// AfterPosition resumes a run: only events with a global Position
+	// strictly greater are replayed. 0 replays everything. The handlers are
+	// idempotent (upserts / IF NOT EXISTS), so re-running from 0 after an
+	// interruption is safe — merely wasteful.
+	AfterPosition int64
+	// BatchSize is events per ReadAfter call; <= 0 uses 500.
+	BatchSize int
+}
+
+// ReprojectResult reports what a replay run did.
+type ReprojectResult struct {
+	Dispatched   int   // events replayed through the projection handlers
+	Skipped      int   // events with no synchronous projection handler
+	LastPosition int64 // last successfully processed global position
+	Head         int64 // feed head captured at the start of the run
+}
+
+// Reproject streams the event store's global feed, in position order, through
+// the synchronous projection handlers. The head is captured once up front so
+// the run terminates even against a concurrently-writing server (writes after
+// the snapshot already projected inline via the live path) — though the
+// intended use is the runbook's: server stopped, freshly imported store.
+func Reproject(ctx context.Context, rt ReprojectRuntime, opts ReprojectOptions) (ReprojectResult, error) {
+	batch := opts.BatchSize
+	if batch <= 0 {
+		batch = 500
+	}
+	res := ReprojectResult{LastPosition: opts.AfterPosition}
+
+	head, err := rt.EventStore.HeadPosition(ctx)
+	if err != nil {
+		return res, fmt.Errorf("reproject: head position: %w", err)
+	}
+	res.Head = head
+
+	pos := opts.AfterPosition
+	for pos < head {
+		envs, err := rt.EventStore.ReadAfter(ctx, pos, batch)
+		if err != nil {
+			return res, fmt.Errorf("reproject: read after position %d: %w", pos, err)
+		}
+		if len(envs) == 0 {
+			break
+		}
+		for i := range envs {
+			env := envs[i]
+			if env.Position > head {
+				// Written after our snapshot — the live path projected it.
+				pos = head
+				break
+			}
+			pos = env.Position
+			typed, handled, convErr := typedForReplay(env)
+			if convErr != nil {
+				return res, fmt.Errorf(
+					"reproject: stopped at position %d (%s on %s): %w — fix the cause, then resume with --after-position %d",
+					env.Position, env.EventType, env.AggregateID, convErr, res.LastPosition)
+			}
+			if !handled {
+				res.Skipped++
+				res.LastPosition = env.Position
+				continue
+			}
+			if err := rt.Dispatcher.Dispatch(ctx, typed); err != nil {
+				return res, fmt.Errorf(
+					"reproject: stopped at position %d (%s on %s): %w — fix the cause, then resume with --after-position %d",
+					env.Position, env.EventType, env.AggregateID, err, res.LastPosition)
+			}
+			res.Dispatched++
+			res.LastPosition = env.Position
+		}
+		rt.Logger.Info(ctx, "reproject: progress",
+			"position", pos, "head", head, "dispatched", res.Dispatched, "skipped", res.Skipped)
+	}
+	return res, nil
+}
+
+// typedForReplay converts a store-loaded envelope (payload deserialized as
+// map[string]any) into the typed envelope the synchronous handlers expect.
+// Subscribe[T]'s wrapper does a plain env.Payload.(T) assertion — it performs
+// no conversion — so replay must hand it the concrete VALUE type. Events with
+// no synchronous handler return handled=false and are skipped (the
+// checkpointed groups own them, with their own replay rail).
+func typedForReplay(env domain.EventEnvelope[any]) (domain.EventEnvelope[any], bool, error) {
+	switch env.EventType {
+	case "ResourceType.Created":
+		return retype[entities.ResourceTypeCreated](env)
+	case "ResourceType.Updated":
+		return retype[entities.ResourceTypeUpdated](env)
+	case "ResourceType.Deleted":
+		return retype[entities.ResourceTypeDeleted](env)
+	case "Resource.Published":
+		return retype[entities.ResourcePublished](env)
+	case "Resource.Deleted":
+		return retype[entities.ResourceDeleted](env)
+	case "Triple.Created":
+		return retype[entities.TripleCreated](env)
+	case "Triple.Deleted":
+		return retype[entities.TripleDeleted](env)
+	default:
+		return env, false, nil
+	}
+}
+
+// retype JSON-round-trips the deserialized payload into T. Untagged event
+// structs (PascalCase map keys) and tagged ones (BasicTripleEvent's lowercase
+// keys) both survive: encoding/json matches field names case-insensitively
+// and tags exactly.
+func retype[T any](env domain.EventEnvelope[any]) (domain.EventEnvelope[any], bool, error) {
+	raw, err := json.Marshal(env.Payload)
+	if err != nil {
+		return env, false, fmt.Errorf("re-marshal payload: %w", err)
+	}
+	var payload T
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return env, false, fmt.Errorf("decode payload as %T: %w", payload, err)
+	}
+	env.Payload = payload
+	return env, true, nil
+}

--- a/application/reproject_test.go
+++ b/application/reproject_test.go
@@ -230,6 +230,67 @@ func TestReproject_IsIdempotent(t *testing.T) {
 	}
 }
 
+// seedDeletedTypeHistory appends a type that was created and then deleted —
+// the history shape that leaves a soft-deleted resource_types row behind
+// after one replay pass.
+func (e *reprojectTestEnv) seedDeletedTypeHistory(t testing.TB) {
+	t.Helper()
+	ctx := context.Background()
+
+	events := []domain.EventEnvelope[any]{
+		{
+			ID:          "evt-rt-d1",
+			AggregateID: "urn:type:draft",
+			EventType:   "ResourceType.Created",
+			Payload: entities.ResourceTypeCreated{
+				Name: "Draft", Slug: "draft", Description: "a draft",
+				Context:   json.RawMessage(`{"@vocab":"https://example.com/ns#"}`),
+				Schema:    json.RawMessage(`{"type":"object","properties":{"title":{"type":"string"}}}`),
+				Timestamp: time.Now().UTC(),
+			},
+			Created:    time.Now().UTC(),
+			SequenceNo: 1,
+		},
+		{
+			ID:          "evt-rt-d2",
+			AggregateID: "urn:type:draft",
+			EventType:   "ResourceType.Deleted",
+			Payload:     entities.ResourceTypeDeleted{}.With(),
+			Created:     time.Now().UTC(),
+			SequenceNo:  2,
+		},
+	}
+	for _, env := range events {
+		if err := e.rt.EventStore.Append(ctx, env.AggregateID, env.SequenceNo-1, env); err != nil {
+			t.Fatalf("append %s: %v", env.EventType, err)
+		}
+	}
+}
+
+// A history that deletes a type leaves a soft-deleted row after the first
+// pass. The Created handler's existence probe must see that row (FindByID
+// filters deleted_at) or the second pass fails Save on the primary key.
+func TestReproject_IsIdempotentOverDeletedTypeHistory(t *testing.T) {
+	env := newReprojectTestEnv(t)
+	env.seedDeletedTypeHistory(t)
+
+	if _, err := Reproject(context.Background(), env.rt, ReprojectOptions{}); err != nil {
+		t.Fatalf("first reproject: %v", err)
+	}
+	if _, err := Reproject(context.Background(), env.rt, ReprojectOptions{}); err != nil {
+		t.Fatalf("second reproject over soft-deleted type: %v", err)
+	}
+
+	if n := env.count(t, `SELECT COUNT(*) FROM resource_types WHERE slug = 'draft'`); n != 1 {
+		t.Errorf("resource_types rows for 'draft' = %d, want 1", n)
+	}
+	if n := env.count(t,
+		`SELECT COUNT(*) FROM resource_types WHERE slug = 'draft' AND deleted_at IS NOT NULL`,
+	); n != 1 {
+		t.Errorf("expected the 'draft' row to converge soft-deleted after replay")
+	}
+}
+
 func TestReproject_ResumesAfterPosition(t *testing.T) {
 	env := newReprojectTestEnv(t)
 	env.seedImportedHistory(t)

--- a/application/reproject_test.go
+++ b/application/reproject_test.go
@@ -1,0 +1,292 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/internal/config"
+
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
+	"go.uber.org/fx"
+	"gorm.io/gorm"
+)
+
+// reprojectTestEnv builds the REAL reproject runtime — the same narrow fx
+// assembly `worker reproject` uses — against a scratch file-backed SQLite DB
+// (file-backed, not :memory:, so every pooled connection sees the same
+// database). Events are appended straight to the store, which is exactly the
+// state a pericarp import produces: full history, empty projections, payloads
+// deserializing as map[string]any.
+type reprojectTestEnv struct {
+	rt  ReprojectRuntime
+	db  *gorm.DB
+	app *fx.App
+}
+
+func newReprojectTestEnv(t testing.TB) *reprojectTestEnv {
+	t.Helper()
+	dsn := filepath.Join(t.TempDir(), "reproject_test.db") +
+		"?_pragma=busy_timeout(10000)&_pragma=journal_mode(WAL)&_txlock=immediate"
+
+	env := &reprojectTestEnv{}
+	env.app = fx.New(
+		fx.NopLogger,
+		ReprojectModule(config.Config{DatabaseDSN: dsn}),
+		fx.Populate(&env.rt),
+		fx.Populate(&env.db),
+	)
+	startCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+	defer cancel()
+	if err := env.app.Start(startCtx); err != nil {
+		t.Fatalf("start reproject runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		defer stopCancel()
+		_ = env.app.Stop(stopCtx)
+	})
+	return env
+}
+
+// seedImportedHistory writes the shape of a real twin's history for one
+// resource type and one resource, using the exact payload structs the write
+// path emits (the store serializes them; ReadAfter then yields
+// map[string]any — the imported-store shape reproject must handle):
+//
+//	pos 1  ResourceType.Created  (type "note")
+//	pos 2  Resource.Created      ┐
+//	pos 3  Triple.Created        ├ one transaction (tx-1)
+//	pos 4  Resource.Published    ┘
+//	pos 5  Custom.Ignored        (no synchronous handler — must be skipped)
+func (e *reprojectTestEnv) seedImportedHistory(t testing.TB) {
+	t.Helper()
+	ctx := context.Background()
+
+	schema := json.RawMessage(`{"type":"object","properties":{"title":{"type":"string"}}}`)
+	ldCtx := json.RawMessage(`{"@vocab":"https://example.com/ns#"}`)
+
+	rtCreated := domain.EventEnvelope[any]{
+		ID:          "evt-rt-1",
+		AggregateID: "urn:type:note",
+		EventType:   "ResourceType.Created",
+		Payload: entities.ResourceTypeCreated{
+			Name: "Note", Slug: "note", Description: "a note",
+			Context: ldCtx, Schema: schema, Timestamp: time.Now().UTC(),
+		},
+		Created:    time.Now().UTC(),
+		SequenceNo: 1,
+	}
+	if err := e.rt.EventStore.Append(ctx, rtCreated.AggregateID, 0, rtCreated); err != nil {
+		t.Fatalf("append ResourceType.Created: %v", err)
+	}
+
+	data := json.RawMessage(`{"@id":"urn:note:abc","@type":"note","title":"hello"}`)
+	resourceEvents := []domain.EventEnvelope[any]{
+		{
+			ID:          "evt-r-1",
+			AggregateID: "urn:note:abc",
+			EventType:   "Resource.Created",
+			Payload: map[string]any{
+				"TypeSlug":  "note",
+				"Data":      json.RawMessage(data),
+				"CreatedBy": "urn:agent:test",
+				"AccountID": "",
+				"Timestamp": time.Now().UTC().Format(time.RFC3339Nano),
+			},
+			Created:       time.Now().UTC(),
+			SequenceNo:    1,
+			TransactionID: "tx-1",
+		},
+		{
+			ID:          "evt-t-1",
+			AggregateID: "urn:note:abc",
+			EventType:   "Triple.Created",
+			Payload: entities.TripleCreated{}.With(
+				"urn:note:abc", "relatesTo", "urn:note:def", "",
+			),
+			Created:       time.Now().UTC(),
+			SequenceNo:    2,
+			TransactionID: "tx-1",
+		},
+		{
+			ID:          "evt-p-1",
+			AggregateID: "urn:note:abc",
+			EventType:   "Resource.Published",
+			Payload:     entities.ResourcePublished{}.With("note", ""),
+			Created:     time.Now().UTC(),
+			SequenceNo:  3,
+
+			TransactionID: "tx-1",
+		},
+	}
+	for _, env := range resourceEvents {
+		if err := e.rt.EventStore.Append(ctx, env.AggregateID, env.SequenceNo-1, env); err != nil {
+			t.Fatalf("append %s: %v", env.EventType, err)
+		}
+	}
+
+	ignored := domain.EventEnvelope[any]{
+		ID:          "evt-x-1",
+		AggregateID: "agg-ignored",
+		EventType:   "Custom.Ignored",
+		Payload:     map[string]any{"n": 1},
+		Created:     time.Now().UTC(),
+		SequenceNo:  1,
+	}
+	if err := e.rt.EventStore.Append(ctx, ignored.AggregateID, 0, ignored); err != nil {
+		t.Fatalf("append Custom.Ignored: %v", err)
+	}
+}
+
+func (e *reprojectTestEnv) count(t testing.TB, query string, args ...any) int64 {
+	t.Helper()
+	var n int64
+	if err := e.db.Raw(query, args...).Scan(&n).Error; err != nil {
+		t.Fatalf("count %q: %v", query, err)
+	}
+	return n
+}
+
+func TestReproject_MaterializesSynchronousProjections(t *testing.T) {
+	env := newReprojectTestEnv(t)
+	env.seedImportedHistory(t)
+
+	// The imported-store premise: history present, projections empty.
+	if n := env.count(t, `SELECT COUNT(*) FROM resource_types`); n != 0 {
+		t.Fatalf("expected empty resource_types before reproject, got %d", n)
+	}
+
+	res, err := Reproject(context.Background(), env.rt, ReprojectOptions{})
+	if err != nil {
+		t.Fatalf("reproject: %v", err)
+	}
+
+	// ResourceType.Created + Triple.Created + Resource.Published are handled;
+	// Resource.Created (folded in via the Published handler's transaction
+	// read) and Custom.Ignored are not.
+	if res.Dispatched != 3 {
+		t.Errorf("dispatched = %d, want 3", res.Dispatched)
+	}
+	if res.Skipped != 2 {
+		t.Errorf("skipped = %d, want 2", res.Skipped)
+	}
+	if res.LastPosition != res.Head {
+		t.Errorf("last position %d != head %d", res.LastPosition, res.Head)
+	}
+
+	if n := env.count(t, `SELECT COUNT(*) FROM resource_types WHERE slug = 'note'`); n != 1 {
+		t.Errorf("resource_types rows for 'note' = %d, want 1", n)
+	}
+	if n := env.count(t, `SELECT COUNT(*) FROM resources WHERE id = 'urn:note:abc'`); n != 1 {
+		t.Errorf("resources rows for urn:note:abc = %d, want 1", n)
+	}
+	if n := env.count(t,
+		`SELECT COUNT(*) FROM triples WHERE subject = 'urn:note:abc' AND predicate = 'relatesTo'`,
+	); n != 1 {
+		t.Errorf("triples rows = %d, want 1", n)
+	}
+}
+
+func TestReproject_IsIdempotent(t *testing.T) {
+	env := newReprojectTestEnv(t)
+	env.seedImportedHistory(t)
+
+	if _, err := Reproject(context.Background(), env.rt, ReprojectOptions{}); err != nil {
+		t.Fatalf("first reproject: %v", err)
+	}
+	res2, err := Reproject(context.Background(), env.rt, ReprojectOptions{})
+	if err != nil {
+		t.Fatalf("second reproject: %v", err)
+	}
+	if res2.Dispatched != 3 {
+		t.Errorf("second run dispatched = %d, want 3", res2.Dispatched)
+	}
+
+	if n := env.count(t, `SELECT COUNT(*) FROM resource_types WHERE slug = 'note'`); n != 1 {
+		t.Errorf("resource_types rows after re-run = %d, want 1", n)
+	}
+	if n := env.count(t, `SELECT COUNT(*) FROM resources WHERE id = 'urn:note:abc'`); n != 1 {
+		t.Errorf("resources rows after re-run = %d, want 1", n)
+	}
+}
+
+func TestReproject_ResumesAfterPosition(t *testing.T) {
+	env := newReprojectTestEnv(t)
+	env.seedImportedHistory(t)
+
+	head, err := env.rt.EventStore.HeadPosition(context.Background())
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+	res, err := Reproject(context.Background(), env.rt, ReprojectOptions{AfterPosition: head})
+	if err != nil {
+		t.Fatalf("reproject: %v", err)
+	}
+	if res.Dispatched != 0 || res.Skipped != 0 {
+		t.Errorf("resume at head replayed %d/%d events, want 0/0", res.Dispatched, res.Skipped)
+	}
+}
+
+func TestTypedForReplay_ConvertsStoreShapedPayloads(t *testing.T) {
+	cases := []struct {
+		eventType string
+		payload   map[string]any
+		want      any
+	}{
+		{
+			// Untagged struct: store maps carry PascalCase keys.
+			eventType: "ResourceType.Deleted",
+			payload:   map[string]any{"Timestamp": "2026-07-28T00:00:00Z"},
+			want:      entities.ResourceTypeDeleted{},
+		},
+		{
+			// Tagged embed (BasicTripleEvent): store maps carry json-tag keys.
+			eventType: "Triple.Created",
+			payload:   map[string]any{"subject": "urn:a:1", "predicate": "p", "object": "urn:b:2"},
+			want:      entities.TripleCreated{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.eventType, func(t *testing.T) {
+			env := domain.EventEnvelope[any]{EventType: tc.eventType, Payload: tc.payload}
+			typed, handled, err := typedForReplay(env)
+			if err != nil {
+				t.Fatalf("typedForReplay: %v", err)
+			}
+			if !handled {
+				t.Fatal("expected event to be handled")
+			}
+			if fmt.Sprintf("%T", typed.Payload) != fmt.Sprintf("%T", tc.want) {
+				t.Fatalf("payload type = %T, want %T", typed.Payload, tc.want)
+			}
+			if tr, ok := typed.Payload.(entities.TripleCreated); ok && tr.Subject != "urn:a:1" {
+				t.Errorf("triple subject = %q, want urn:a:1", tr.Subject)
+			}
+		})
+	}
+
+	env := domain.EventEnvelope[any]{EventType: "Custom.Ignored", Payload: map[string]any{"n": 1}}
+	if _, handled, err := typedForReplay(env); handled || err != nil {
+		t.Fatalf("unhandled event: handled=%v err=%v, want false/nil", handled, err)
+	}
+}

--- a/application/resource_behaviors_test.go
+++ b/application/resource_behaviors_test.go
@@ -30,6 +30,11 @@ func (r *stubTypeRepo) Save(context.Context, *entities.ResourceType) error { ret
 func (r *stubTypeRepo) FindByID(context.Context, string) (*entities.ResourceType, error) {
 	return nil, errors.New("not implemented")
 }
+func (r *stubTypeRepo) FindByIDIncludingDeleted(
+	context.Context, string,
+) (*entities.ResourceType, error) {
+	return nil, errors.New("not implemented")
+}
 func (r *stubTypeRepo) FindAll(
 	_ context.Context, _ string, _ int,
 ) (repositories.PaginatedResponse[*entities.ResourceType], error) {

--- a/domain/repositories/resource_type_repository.go
+++ b/domain/repositories/resource_type_repository.go
@@ -28,6 +28,10 @@ var ErrNotFound = errors.New("not found")
 type ResourceTypeRepository interface {
 	Save(ctx context.Context, entity *entities.ResourceType) error
 	FindByID(ctx context.Context, id string) (*entities.ResourceType, error)
+	// FindByIDIncludingDeleted also matches soft-deleted rows. Projection
+	// replay needs it: ResourceType.Created must converge via Update when a
+	// row exists in any state, or Save hits its unique constraints.
+	FindByIDIncludingDeleted(ctx context.Context, id string) (*entities.ResourceType, error)
 	FindBySlug(ctx context.Context, slug string) (*entities.ResourceType, error)
 	FindAll(ctx context.Context, cursor string, limit int) (PaginatedResponse[*entities.ResourceType], error)
 	Update(ctx context.Context, entity *entities.ResourceType) error

--- a/infrastructure/database/gorm/resource_type_repository.go
+++ b/infrastructure/database/gorm/resource_type_repository.go
@@ -72,6 +72,23 @@ func (r *ResourceTypeRepository) FindByID(
 	return model.ToResourceType()
 }
 
+// FindByIDIncludingDeleted also matches soft-deleted rows, for projection
+// replay's existence probe (see ResourceTypeRepository interface docs).
+func (r *ResourceTypeRepository) FindByIDIncludingDeleted(
+	ctx context.Context, id string,
+) (*entities.ResourceType, error) {
+	var model models.ResourceType
+	err := r.db.WithContext(ctx).
+		Where("id = ?", id).First(&model).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("resource type %q: %w", id, repositories.ErrNotFound)
+		}
+		return nil, fmt.Errorf("failed to find resource type: %w", err)
+	}
+	return model.ToResourceType()
+}
+
 func (r *ResourceTypeRepository) FindBySlug(
 	ctx context.Context, slug string,
 ) (*entities.ResourceType, error) {

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -86,6 +86,29 @@ server stopped (or the affected group otherwise idle).`,
 	RunE: runWorkerCheckpointReset,
 }
 
+var workerReprojectCmd = &cobra.Command{
+	Use:   "reproject",
+	Short: "Replay the event feed through the synchronous projections (resource types, resources, triples)",
+	Long: `Streams the whole event history, in global position order, through the same
+synchronous projection handlers the write path uses, materializing the
+resource-type, canonical-resource, and triple read models — including the
+per-type projection tables.
+
+This is the rebuild rail for projections that "checkpoint reset" cannot reach:
+those handlers run inline at commit time and have no checkpoint. Its intended
+use is an event store that arrived without its projections — a pericarp
+export/import migration, a restored backup — where the history is complete but
+every synchronous read model is empty.
+
+Run it with the server STOPPED: a live server is writing the same tables. The
+handlers are idempotent, so an interrupted run can simply be re-run (or resumed
+with --after-position from the position the error message reports). Events
+owned by the checkpointed background groups are skipped here — rebuild those
+with "worker checkpoint reset <subscriber>" as usual.`,
+	Args: cobra.NoArgs,
+	RunE: runWorkerReproject,
+}
+
 func init() {
 	workerParkedListCmd.Flags().String("subscriber", "", "limit to a single subscriber")
 	workerParkedCmd.AddCommand(workerParkedListCmd, workerParkedReplayCmd)
@@ -93,8 +116,54 @@ func init() {
 	workerCheckpointResetCmd.Flags().Bool("truncate", false, "clear the subscriber's projection before replay")
 	workerCheckpointCmd.AddCommand(workerCheckpointResetCmd)
 
-	workerCmd.AddCommand(workerParkedCmd, workerCheckpointCmd)
+	workerReprojectCmd.Flags().Int64("after-position", 0, "resume: replay only events after this global position")
+	workerReprojectCmd.Flags().Int("batch-size", 500, "events read per batch")
+
+	workerCmd.AddCommand(workerParkedCmd, workerCheckpointCmd, workerReprojectCmd)
 	rootCmd.AddCommand(workerCmd)
+}
+
+// runWorkerReproject drives application.Reproject over a deliberately NARROW
+// fx graph (application.ReprojectModule), not withWorkerManager's full
+// application.Module: the full module runs ensureBuiltInResourceTypes at
+// start, which decides type existence from the projection tables — empty on
+// exactly the freshly-imported store reproject exists to fix — and would
+// append duplicate built-in ResourceType.Created events (fresh IDs) into the
+// imported history before replay ever ran (#443).
+func runWorkerReproject(cmd *cobra.Command, _ []string) error {
+	after, _ := cmd.Flags().GetInt64("after-position")
+	batch, _ := cmd.Flags().GetInt("batch-size")
+	appCfg := GetConfig().Config
+
+	var rt application.ReprojectRuntime
+	app := fx.New(
+		fx.NopLogger,
+		application.ReprojectModule(appCfg),
+		fx.Populate(&rt),
+	)
+
+	startCtx, startCancel := context.WithTimeout(cmd.Context(), fx.DefaultTimeout)
+	defer startCancel()
+	if err := app.Start(startCtx); err != nil {
+		return fmt.Errorf("failed to start reproject runtime: %w", err)
+	}
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		defer stopCancel()
+		_ = app.Stop(stopCtx)
+	}()
+
+	res, err := application.Reproject(cmd.Context(), rt, application.ReprojectOptions{
+		AfterPosition: after,
+		BatchSize:     batch,
+	})
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(os.Stdout,
+		"reprojected %d events (%d skipped) through positions %d..%d\n",
+		res.Dispatched, res.Skipped, after, res.LastPosition)
+	return nil
 }
 
 // withWorkerManager builds the application graph, hands the worker Manager to


### PR DESCRIPTION
Implements #442: `worker reproject` streams the event store's global feed, in position order, through the same synchronous projection handlers the write path uses — the rebuild rail for the read models `checkpoint reset` cannot reach (resource types, canonical resources, triples, per-type projection tables). Target scenario: an event store that arrived without its projections — a pericarp export→import migration (akeemphilbert/pericarp#67), a restored backup.

## Design decisions

- **Narrow fx assembly (`application.ReprojectModule`), not `application.Module`** — the full module's `ensureBuiltInResourceTypes` decides type existence from the projection tables, which are empty on exactly the store reproject exists to fix, and would append duplicate built-in `ResourceType.Created` events (fresh KSUIDs) into the imported history before replay ran. That pre-existing hazard is filed separately as #443.
- **Not a `SubscriberGroup`** — `Manager.Start` launches every registered group as a live loop; these projections are already written inline at every commit, so a live duplicate would double-write and its `GetEventsByTransactionID` reads could observe a mid-commit transaction (per-aggregate appends aren't atomic across the tx).
- **Bounded + resumable** — `HeadPosition` is captured once so the run terminates even against a concurrent writer (whose writes project inline anyway); failures report the exact `--after-position` to resume from; handlers are idempotent so re-running from 0 is safe.
- **Payload conversion** — store-loaded envelopes carry `map[string]any` payloads, and `Subscribe[T]`'s wrapper does a plain type assertion; replay JSON-round-trips each handled event into its concrete `entities.*` type (covers untagged PascalCase structs and the json-tagged `BasicTripleEvent` embed).
- **Handler idempotency closed for real** — `ResourceType.Created` and `Resource.Published`'s create path did plain INSERTs and violated the stated handlers-must-be-idempotent constraint under replay; both now converge via the Update path when the row exists (`SaveTriple` was already `FirstOrCreate`). A genuinely conflicting row (same slug, different aggregate) still fails loudly.

## Testing

`application/reproject_test.go` runs the real narrow fx assembly against file-backed SQLite: full replay materializes `resource_types`/`resources`/`triples` from a bare history (transaction-grouped create + triple + publish, exercising `buildStateFromTransaction`), a second run converges identically, resume-at-head replays nothing, unhandled event types are skipped, and payload conversion is covered for tagged + untagged structs. `go test -race ./application/... ./internal/cli/...` green; `golangci-lint run` 0 issues.

## Downstream

First consumer is mini-me's per-user GCP deployment (wepala/mini-me#68, wepala/mini-me-weos#21): event seeding of a deployed twin works end-to-end except imported events never surfaced in the app — `worker reproject` is the missing step; the seeding flow wires it in once this lands.

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)