### PR TITLE
feat(core): per-call BehaviorScratch + EnsureTable canonical backfill

### DIFF
--- a/application/behavior_scratch.go
+++ b/application/behavior_scratch.go
@@ -1,0 +1,58 @@
+package application
+
+import (
+	"context"
+	"sync"
+)
+
+// BehaviorScratch is a per-call scratch bag a ResourceBehavior can use to pass
+// data between hook phases of the SAME Create/Update call. For example, a
+// BeforeCreate hook can strip a field out of the payload (so it never reaches
+// schema validation or the projection) and stash it here for that same call's
+// AfterCreate hook to consume once the entity has an ID.
+//
+// Why this exists rather than a field on the behavior: behaviors are
+// process-wide singletons shared across concurrent Create/Update calls, so
+// per-call state cannot live on the behavior itself without racing. The scratch
+// is seeded fresh on the context at the top of each Create/Update, so every hook
+// in one call shares one scratch and different calls never see each other's.
+type BehaviorScratch struct {
+	mu     sync.Mutex
+	values map[string]any
+}
+
+// Set stores v under key, overwriting any previous value. Safe for concurrent
+// use, though within a single call hooks run sequentially.
+func (b *BehaviorScratch) Set(key string, v any) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.values == nil {
+		b.values = make(map[string]any)
+	}
+	b.values[key] = v
+}
+
+// Get returns the value stored under key and whether it was present.
+func (b *BehaviorScratch) Get(key string) (any, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	v, ok := b.values[key]
+	return v, ok
+}
+
+type behaviorScratchKey struct{}
+
+// ScratchFromContext returns the scratch bag seeded for the current
+// Create/Update call, or nil if there is none. It is nil when called outside a
+// resource-service Create/Update (e.g. from a List or a direct repository
+// access), so callers must nil-check before use.
+func ScratchFromContext(ctx context.Context) *BehaviorScratch {
+	s, _ := ctx.Value(behaviorScratchKey{}).(*BehaviorScratch)
+	return s
+}
+
+// withBehaviorScratch seeds a fresh scratch bag on ctx. Called once near the top
+// of Create and Update so every behavior hook in that call shares one scratch.
+func withBehaviorScratch(ctx context.Context) context.Context {
+	return context.WithValue(ctx, behaviorScratchKey{}, &BehaviorScratch{})
+}

--- a/application/behavior_scratch_test.go
+++ b/application/behavior_scratch_test.go
@@ -1,0 +1,69 @@
+package application
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestBehaviorScratch_SetGetRoundTrip(t *testing.T) {
+	var s BehaviorScratch
+	s.Set("stripped", 42)
+
+	got, ok := s.Get("stripped")
+	if !ok {
+		t.Fatal("expected key to be present")
+	}
+	if got != 42 {
+		t.Fatalf("got %v, want 42", got)
+	}
+
+	if _, ok := s.Get("missing"); ok {
+		t.Fatal("expected missing key to be absent")
+	}
+}
+
+func TestScratchFromContext_BareContextReturnsNil(t *testing.T) {
+	if s := ScratchFromContext(context.Background()); s != nil {
+		t.Fatalf("expected nil scratch on bare context, got %v", s)
+	}
+}
+
+func TestScratchFromContext_SeededIsUsable(t *testing.T) {
+	ctx := withBehaviorScratch(context.Background())
+	s := ScratchFromContext(ctx)
+	if s == nil {
+		t.Fatal("expected seeded scratch, got nil")
+	}
+	s.Set("k", "v")
+	if got, ok := ScratchFromContext(ctx).Get("k"); !ok || got != "v" {
+		t.Fatalf("expected round-trip through context, got %v ok=%v", got, ok)
+	}
+}
+
+func TestWithBehaviorScratch_CallsAreIndependent(t *testing.T) {
+	ctx1 := withBehaviorScratch(context.Background())
+	ScratchFromContext(ctx1).Set("shared", "call-1")
+
+	ctx2 := withBehaviorScratch(context.Background())
+	if _, ok := ScratchFromContext(ctx2).Get("shared"); ok {
+		t.Fatal("second call's scratch must not see the first call's data")
+	}
+}
+
+func TestBehaviorScratch_ConcurrentUseIsRaceFree(t *testing.T) {
+	var s BehaviorScratch
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func(n int) {
+			defer wg.Done()
+			s.Set("key", n)
+		}(i)
+		go func() {
+			defer wg.Done()
+			s.Get("key")
+		}()
+	}
+	wg.Wait()
+}

--- a/application/resource_service.go
+++ b/application/resource_service.go
@@ -244,6 +244,11 @@ func (s *resourceService) Create(
 	if err != nil {
 		return nil, err
 	}
+	// Seed a per-call scratch bag so a behavior's BeforeCreate can stash data
+	// (e.g. a field it strips from the payload) for this same call's
+	// AfterCreate to consume; behaviors are shared singletons so this cannot
+	// live on the behavior itself.
+	ctx = withBehaviorScratch(ctx)
 	rt, err := s.typeRepo.FindBySlug(ctx, cmd.TypeSlug)
 	if err != nil {
 		return nil, fmt.Errorf("resource type %q not found: %w", cmd.TypeSlug, err)
@@ -523,6 +528,9 @@ func (s *resourceService) Update(
 	if err != nil {
 		return nil, err
 	}
+	// Seed a per-call scratch bag shared by every behavior hook in this update
+	// (see withBehaviorScratch / BehaviorScratch for why per-call, not per-behavior).
+	ctx = withBehaviorScratch(ctx)
 	entity, err := s.repo.FindByID(ctx, cmd.ID)
 	if err != nil {
 		return nil, err

--- a/application/resource_service_scratch_test.go
+++ b/application/resource_service_scratch_test.go
@@ -1,0 +1,164 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
+
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
+)
+
+// scratchRoundtripRepo is a ResourceRepository whose only live method is
+// FindByID (the sole repo call Update makes before commit). Everything else
+// panics via the embedded interface so an unexpected call fails loudly.
+type scratchRoundtripRepo struct {
+	repositories.ResourceRepository
+	entity *entities.Resource
+}
+
+func (r *scratchRoundtripRepo) FindByID(_ context.Context, _ string) (*entities.Resource, error) {
+	return r.entity, nil
+}
+
+// scratchRoundtripTripleRepo returns no existing triples so reconcileTriples on
+// the update path is a clean no-op.
+type scratchRoundtripTripleRepo struct {
+	repositories.TripleRepository
+}
+
+func (r *scratchRoundtripTripleRepo) FindBySubject(
+	_ context.Context, _ string,
+) ([]repositories.Triple, error) {
+	return nil, nil
+}
+
+// scratchBehavior stashes a sentinel in the per-call scratch during its Before
+// hook and records, in its After hook, whether the same sentinel came back —
+// proving the scratch seeded at the top of Create/Update is the one every hook
+// of that call shares. Create and Update use distinct sentinels so a rail can't
+// accidentally pass by reading the other rail's value.
+type scratchBehavior struct {
+	entities.DefaultBehavior
+
+	createSentinel string
+	updateSentinel string
+
+	afterCreateSaw string
+	afterCreateOK  bool
+	afterUpdateSaw string
+	afterUpdateOK  bool
+}
+
+func (b *scratchBehavior) BeforeCreate(
+	ctx context.Context, data json.RawMessage, _ *entities.ResourceType,
+) (json.RawMessage, error) {
+	if s := ScratchFromContext(ctx); s != nil {
+		s.Set("sentinel", b.createSentinel)
+	}
+	return data, nil
+}
+
+func (b *scratchBehavior) AfterCreate(ctx context.Context, _ *entities.Resource) error {
+	if s := ScratchFromContext(ctx); s != nil {
+		v, ok := s.Get("sentinel")
+		b.afterCreateOK = ok
+		if sv, isStr := v.(string); isStr {
+			b.afterCreateSaw = sv
+		}
+	}
+	return nil
+}
+
+func (b *scratchBehavior) BeforeUpdate(
+	ctx context.Context, _ *entities.Resource, data json.RawMessage, _ *entities.ResourceType,
+) (json.RawMessage, error) {
+	if s := ScratchFromContext(ctx); s != nil {
+		s.Set("sentinel", b.updateSentinel)
+	}
+	return data, nil
+}
+
+func (b *scratchBehavior) AfterUpdate(ctx context.Context, _ *entities.Resource) error {
+	if s := ScratchFromContext(ctx); s != nil {
+		v, ok := s.Get("sentinel")
+		b.afterUpdateOK = ok
+		if sv, isStr := v.(string); isStr {
+			b.afterUpdateSaw = sv
+		}
+	}
+	return nil
+}
+
+// TestResourceService_ScratchRoundtripAcrossHooks drives the REAL Create and
+// Update rails end-to-end (behavior hooks → schema validation → UoW commit) and
+// asserts a behavior's Before hook and After hook of the same call see one
+// shared scratch — the contract BehaviorScratch exists to provide.
+func TestResourceService_ScratchRoundtripAcrossHooks(t *testing.T) {
+	t.Parallel()
+
+	rt := makeTestRT("scratch-thing", json.RawMessage(`{"@vocab":"https://schema.org/"}`))
+	behavior := &scratchBehavior{
+		createSentinel: "from-before-create",
+		updateSentinel: "from-before-update",
+	}
+
+	svc := &resourceService{
+		repo: &scratchRoundtripRepo{
+			entity: restoredResource(t, "urn:scratch-thing:1", "scratch-thing"),
+		},
+		typeRepo:   &stubTypeRepo{types: map[string]*entities.ResourceType{"scratch-thing": rt}},
+		tripleRepo: &scratchRoundtripTripleRepo{},
+		eventStore: &stubEventStore{},
+		dispatcher: domain.NewEventDispatcher(),
+		logger:     noopLogger{},
+		behaviors:  ResourceBehaviorRegistry{"scratch-thing": behavior},
+	}
+
+	ctx := context.Background()
+
+	if _, err := svc.Create(ctx, CreateResourceCommand{
+		TypeSlug: "scratch-thing",
+		Data:     json.RawMessage(`{"name":"test"}`),
+	}); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if !behavior.afterCreateOK {
+		t.Fatal("AfterCreate saw no scratch value — the create rail's hooks did not share a scratch")
+	}
+	if behavior.afterCreateSaw != behavior.createSentinel {
+		t.Errorf("AfterCreate saw %q, want the BeforeCreate sentinel %q",
+			behavior.afterCreateSaw, behavior.createSentinel)
+	}
+
+	if _, err := svc.Update(ctx, UpdateResourceCommand{
+		ID:   "urn:scratch-thing:1",
+		Data: json.RawMessage(`{"name":"updated"}`),
+	}); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if !behavior.afterUpdateOK {
+		t.Fatal("AfterUpdate saw no scratch value — the update rail's hooks did not share a scratch")
+	}
+	if behavior.afterUpdateSaw != behavior.updateSentinel {
+		t.Errorf("AfterUpdate saw %q, want the BeforeUpdate sentinel %q",
+			behavior.afterUpdateSaw, behavior.updateSentinel)
+	}
+}

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -155,6 +155,11 @@ func (pm *projectionManager) EnsureTable(
 			}
 		}
 	}
+	// Cache the table as healthy BEFORE backfilling — backfillFromCanonical
+	// reads this entry (via HasColumn) to decide which extracted keys map to
+	// real columns. If the backfill then errors we invalidate the entry below,
+	// so the lazy HasProjectionTable path re-runs EnsureTable next call rather
+	// than trusting a table that never got its pre-existing rows filled.
 	pm.tables.Store(slug, tableInfo{name: tableName, context: ldContext, columns: colSet})
 	if parentSlug := jsonld.SubClassOf(ldContext); parentSlug != "" {
 		pm.parentOf.Store(slug, parentSlug)
@@ -168,8 +173,22 @@ func (pm *projectionManager) EnsureTable(
 	// work when a type's projection table is created after resources of that type
 	// already exist (e.g. a preset installed, or a lazily-created table for a type
 	// whose rows were written before EnsureTable first ran for it).
-	if err := pm.backfillFromCanonical(ctx, slug, tableName, ldContext); err != nil {
-		return fmt.Errorf("failed to backfill projection table %q: %w", tableName, err)
+	skipped, err := pm.backfillFromCanonical(ctx, slug, tableName, ldContext)
+	if err != nil {
+		// A backfill query failure (not a per-row skip — those are tolerated
+		// below) means we can't vouch for this table's completeness. Drop the
+		// cache entry so the lazy HasProjectionTable path retries instead of
+		// caching a half-filled table as healthy for the process lifetime.
+		pm.tables.Delete(slug)
+		return fmt.Errorf("failed to backfill projection table %q (skipped %d rows before failure): %w",
+			tableName, skipped, err)
+	}
+	if skipped > 0 {
+		// Partial backfill: the healthy rows are in, but some legacy rows could
+		// not be projected. Surface the count so an operator can find and repair
+		// them; the per-row cause was logged as each was skipped.
+		pm.logger.Warn(ctx, "projection backfill completed with skipped rows",
+			"table", tableName, "slug", slug, "skipped", skipped)
 	}
 	return nil
 }
@@ -180,10 +199,23 @@ const backfillBatchSize = 500
 
 // backfillFromCanonical populates the projection table with any canonical
 // `resources` rows of type slug that have no matching projection row yet. It
-// scans in batches (LIMIT backfillBatchSize) using a NOT EXISTS anti-join —
-// supported identically by SQLite and Postgres — so each round shrinks the
-// candidate set until none remain. In steady state the first round returns
-// nothing and the function is a no-op.
+// walks the canonical rows in keyset order (ORDER BY id, cursor id > lastID)
+// using a NOT EXISTS anti-join — supported identically by SQLite and Postgres.
+// In steady state the first round's anti-join returns nothing and the function
+// is a no-op.
+//
+// Keyset (not shrink-by-anti-join) pagination is deliberate: a row that fails
+// to insert is skipped rather than aborting the batch (see below), but a
+// skipped row still has no projection row, so a shrink-by-anti-join scan would
+// hand it back on every subsequent round and spin forever on a full batch of
+// poisoned rows. Advancing a cursor past each batch's last id guarantees every
+// canonical row is visited exactly once and the walk terminates.
+//
+// Per-row inserts that fail (e.g. a legacy payload whose value violates a
+// column constraint) are logged and skipped, not fatal, so one poisoned row
+// can't starve every healthy row behind it. The count of skipped rows is
+// returned so EnsureTable can surface it to operators. A returned error means
+// a batch-level query failure (the scan itself), which is not tolerated.
 //
 // Rows are inserted with ON CONFLICT (id) DO NOTHING so a row written
 // concurrently by the synchronous save path is never clobbered. Display columns
@@ -193,28 +225,32 @@ const backfillBatchSize = 500
 // lookup's account-scope dependencies.
 func (pm *projectionManager) backfillFromCanonical(
 	ctx context.Context, slug, tableName string, ldContext json.RawMessage,
-) error {
+) (int, error) {
 	// No canonical store means nothing to backfill. In production the resources
 	// table is always migrated before any type is ensured; this guard keeps the
 	// path a clean no-op for callers (and tests) that ensure tables in isolation.
 	if !pm.db.Migrator().HasTable("resources") {
-		return nil
+		return 0, nil
 	}
 
 	antiJoin := fmt.Sprintf(
 		"NOT EXISTS (SELECT 1 FROM %s p WHERE p.id = resources.id)", tableName)
 
+	skipped := 0
+	lastID := ""
 	for {
-		var batch []models.Resource
-		if err := pm.db.WithContext(ctx).
+		q := pm.db.WithContext(ctx).
 			Where("type_slug = ? AND deleted_at IS NULL", slug).
-			Where(antiJoin).
-			Limit(backfillBatchSize).
-			Find(&batch).Error; err != nil {
-			return err
+			Where(antiJoin)
+		if lastID != "" {
+			q = q.Where("resources.id > ?", lastID)
+		}
+		var batch []models.Resource
+		if err := q.Order("resources.id").Limit(backfillBatchSize).Find(&batch).Error; err != nil {
+			return skipped, err
 		}
 		if len(batch) == 0 {
-			return nil
+			return skipped, nil
 		}
 
 		for i := range batch {
@@ -244,12 +280,18 @@ func (pm *projectionManager) backfillFromCanonical(
 					Columns:   []clause.Column{{Name: "id"}},
 					DoNothing: true,
 				}).Create(row).Error; err != nil {
-				return fmt.Errorf("failed to backfill row %q into %s: %w", res.ID, tableName, err)
+				// Skip the poisoned row, keep going. The keyset cursor advances
+				// past it below so it won't be re-scanned into an infinite loop.
+				pm.logger.Warn(ctx, "projection backfill skipping row after insert failure",
+					"id", res.ID, "table", tableName, "error", err)
+				skipped++
+				continue
 			}
 		}
 
+		lastID = batch[len(batch)-1].ID
 		if len(batch) < backfillBatchSize {
-			return nil
+			return skipped, nil
 		}
 	}
 }

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -33,6 +33,7 @@ import (
 	"github.com/jinzhu/inflection"
 	"go.uber.org/fx"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type columnDef struct {
@@ -161,7 +162,96 @@ func (pm *projectionManager) EnsureTable(
 		pm.parentOf.Delete(slug)
 	}
 	pm.registerReverseReferences(slug, schema)
+
+	// Backfill any canonical rows that predate this projection table. In steady
+	// state the anti-join returns nothing, so this is a cheap no-op; it only does
+	// work when a type's projection table is created after resources of that type
+	// already exist (e.g. a preset installed, or a lazily-created table for a type
+	// whose rows were written before EnsureTable first ran for it).
+	if err := pm.backfillFromCanonical(ctx, slug, tableName, ldContext); err != nil {
+		return fmt.Errorf("failed to backfill projection table %q: %w", tableName, err)
+	}
 	return nil
+}
+
+// backfillBatchSize bounds each backfill scan so a type with a large canonical
+// backlog is filled in bounded rounds rather than one unbounded query.
+const backfillBatchSize = 500
+
+// backfillFromCanonical populates the projection table with any canonical
+// `resources` rows of type slug that have no matching projection row yet. It
+// scans in batches (LIMIT backfillBatchSize) using a NOT EXISTS anti-join —
+// supported identically by SQLite and Postgres — so each round shrinks the
+// candidate set until none remain. In steady state the first round returns
+// nothing and the function is a no-op.
+//
+// Rows are inserted with ON CONFLICT (id) DO NOTHING so a row written
+// concurrently by the synchronous save path is never clobbered. Display columns
+// are deliberately left unpopulated — a NULL display is a documented-tolerated
+// state (see populateDisplayColumns) that self-heals on the next write or
+// triple-propagation event — which also keeps this path free of the display
+// lookup's account-scope dependencies.
+func (pm *projectionManager) backfillFromCanonical(
+	ctx context.Context, slug, tableName string, ldContext json.RawMessage,
+) error {
+	// No canonical store means nothing to backfill. In production the resources
+	// table is always migrated before any type is ensured; this guard keeps the
+	// path a clean no-op for callers (and tests) that ensure tables in isolation.
+	if !pm.db.Migrator().HasTable("resources") {
+		return nil
+	}
+
+	antiJoin := fmt.Sprintf(
+		"NOT EXISTS (SELECT 1 FROM %s p WHERE p.id = resources.id)", tableName)
+
+	for {
+		var batch []models.Resource
+		if err := pm.db.WithContext(ctx).
+			Where("type_slug = ? AND deleted_at IS NULL", slug).
+			Where(antiJoin).
+			Limit(backfillBatchSize).
+			Find(&batch).Error; err != nil {
+			return err
+		}
+		if len(batch) == 0 {
+			return nil
+		}
+
+		for i := range batch {
+			res := &batch[i]
+			row := map[string]any{
+				"id":          res.ID,
+				"type_slug":   res.TypeSlug,
+				"status":      res.Status,
+				"created_by":  res.CreatedBy,
+				"account_id":  res.AccountID,
+				"sequence_no": res.SequenceNo,
+				"created_at":  res.CreatedAt,
+			}
+			// ExtractFlatColumns understands both legacy flat and @graph payloads.
+			ExtractFlatColumns(json.RawMessage(res.Data), ldContext, row)
+			// Drop keys with no column on this table (mirrors dropMissingColumns).
+			for col := range row {
+				if standardColumnNames[col] {
+					continue
+				}
+				if !pm.HasColumn(slug, col) {
+					delete(row, col)
+				}
+			}
+			if err := pm.db.WithContext(ctx).Table(tableName).
+				Clauses(clause.OnConflict{
+					Columns:   []clause.Column{{Name: "id"}},
+					DoNothing: true,
+				}).Create(row).Error; err != nil {
+				return fmt.Errorf("failed to backfill row %q into %s: %w", res.ID, tableName, err)
+			}
+		}
+
+		if len(batch) < backfillBatchSize {
+			return nil
+		}
+	}
 }
 
 // HasProjectionTable reports whether a projection table exists. Cached entries are not

--- a/infrastructure/database/gorm/projection_manager_test.go
+++ b/infrastructure/database/gorm/projection_manager_test.go
@@ -972,3 +972,149 @@ func TestEnsureTable_ReconcilesBaseColumnsOnPreexistingTable(t *testing.T) {
 		t.Fatalf("projection write still fails after reconciliation: %v", err)
 	}
 }
+
+// insertCanonicalResource writes a row straight into the canonical resources
+// table, bypassing the projection path — used to simulate rows that predate a
+// projection table's creation.
+func insertCanonicalResource(t *testing.T, db *gorm.DB, r models.Resource) {
+	t.Helper()
+	if err := db.Create(&r).Error; err != nil {
+		t.Fatalf("failed to insert canonical resource %q: %v", r.ID, err)
+	}
+}
+
+func TestEnsureTable_BackfillsPreexistingCanonicalRows(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	if err := db.AutoMigrate(&models.Resource{}); err != nil {
+		t.Fatalf("failed to migrate resources: %v", err)
+	}
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	// Canonical rows written BEFORE the projection table exists. Legacy
+	// flat-format payload (no @graph wrapper) on purpose.
+	insertCanonicalResource(t, db, models.Resource{
+		ID: "rec-1", TypeSlug: "recipe", Status: "active",
+		CreatedBy: "u1", AccountID: "acct-1", SequenceNo: 1,
+		CreatedAt: time.Now(),
+		Data:      `{"@id":"rec-1","@type":"Recipe","name":"Chili","servings":4}`,
+	})
+	insertCanonicalResource(t, db, models.Resource{
+		ID: "rec-2", TypeSlug: "recipe", Status: "active",
+		CreatedBy: "u1", AccountID: "acct-1", SequenceNo: 2,
+		CreatedAt: time.Now(),
+		Data:      `{"@id":"rec-2","@type":"Recipe","name":"Soup","servings":2}`,
+	})
+
+	schema := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"name": {"type": "string"},
+			"servings": {"type": "integer"}
+		}
+	}`)
+	if err := pm.EnsureTable(ctx, "recipe", schema, nil); err != nil {
+		t.Fatalf("EnsureTable failed: %v", err)
+	}
+
+	var rows []map[string]any
+	if err := db.Table("recipes").Order("id").Find(&rows).Error; err != nil {
+		t.Fatalf("failed to read recipes projection: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 backfilled rows, got %d", len(rows))
+	}
+	if rows[0]["name"] != "Chili" {
+		t.Errorf("row 0 name = %v, want Chili", rows[0]["name"])
+	}
+	// sqlite returns integer columns as int64.
+	if got := rows[0]["servings"]; got != int64(4) {
+		t.Errorf("row 0 servings = %v (%T), want 4", got, got)
+	}
+	if rows[0]["type_slug"] != "recipe" || rows[0]["account_id"] != "acct-1" {
+		t.Errorf("row 0 base columns wrong: %+v", rows[0])
+	}
+}
+
+func TestEnsureTable_BackfillDoesNotClobberExistingRow(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	if err := db.AutoMigrate(&models.Resource{}); err != nil {
+		t.Fatalf("failed to migrate resources: %v", err)
+	}
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	insertCanonicalResource(t, db, models.Resource{
+		ID: "rec-1", TypeSlug: "recipe", Status: "active",
+		CreatedBy: "u1", AccountID: "acct-1", SequenceNo: 1,
+		CreatedAt: time.Now(),
+		Data:      `{"@id":"rec-1","@type":"Recipe","name":"Chili"}`,
+	})
+
+	schema := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`)
+	if err := pm.EnsureTable(ctx, "recipe", schema, nil); err != nil {
+		t.Fatalf("first EnsureTable failed: %v", err)
+	}
+
+	// Simulate a divergent projection row (e.g. a later synchronous write).
+	if err := db.Table("recipes").Where("id = ?", "rec-1").
+		Update("name", "Chili (updated)").Error; err != nil {
+		t.Fatalf("failed to update projection row: %v", err)
+	}
+
+	// Re-run EnsureTable: the anti-join must exclude the already-projected row,
+	// and ON CONFLICT DO NOTHING must never overwrite it back to the canonical value.
+	if err := pm.EnsureTable(ctx, "recipe", schema, nil); err != nil {
+		t.Fatalf("second EnsureTable failed: %v", err)
+	}
+
+	var row map[string]any
+	if err := db.Table("recipes").Where("id = ?", "rec-1").Take(&row).Error; err != nil {
+		t.Fatalf("failed to read row: %v", err)
+	}
+	if row["name"] != "Chili (updated)" {
+		t.Errorf("backfill clobbered existing row: name = %v, want %q", row["name"], "Chili (updated)")
+	}
+}
+
+func TestEnsureTable_BackfillSkipsSoftDeletedRows(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	if err := db.AutoMigrate(&models.Resource{}); err != nil {
+		t.Fatalf("failed to migrate resources: %v", err)
+	}
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	ctx := context.Background()
+
+	deleted := time.Now()
+	insertCanonicalResource(t, db, models.Resource{
+		ID: "rec-live", TypeSlug: "recipe", Status: "active",
+		CreatedBy: "u1", AccountID: "acct-1", SequenceNo: 1,
+		CreatedAt: time.Now(),
+		Data:      `{"@id":"rec-live","@type":"Recipe","name":"Live"}`,
+	})
+	insertCanonicalResource(t, db, models.Resource{
+		ID: "rec-gone", TypeSlug: "recipe", Status: "active",
+		CreatedBy: "u1", AccountID: "acct-1", SequenceNo: 2,
+		CreatedAt: time.Now(), DeletedAt: &deleted,
+		Data:      `{"@id":"rec-gone","@type":"Recipe","name":"Gone"}`,
+	})
+
+	schema := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`)
+	if err := pm.EnsureTable(ctx, "recipe", schema, nil); err != nil {
+		t.Fatalf("EnsureTable failed: %v", err)
+	}
+
+	var rows []map[string]any
+	if err := db.Table("recipes").Find(&rows).Error; err != nil {
+		t.Fatalf("failed to read recipes projection: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected only the live row backfilled, got %d rows", len(rows))
+	}
+	if rows[0]["id"] != "rec-live" {
+		t.Errorf("expected rec-live, got %v", rows[0]["id"])
+	}
+}

--- a/infrastructure/database/gorm/projection_manager_test.go
+++ b/infrastructure/database/gorm/projection_manager_test.go
@@ -18,6 +18,7 @@ package gorm
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -1116,5 +1117,140 @@ func TestEnsureTable_BackfillSkipsSoftDeletedRows(t *testing.T) {
 	}
 	if rows[0]["id"] != "rec-live" {
 		t.Errorf("expected rec-live, got %v", rows[0]["id"])
+	}
+}
+
+// TestEnsureTable_BackfillSkipsPoisonedRowAndContinues pins the per-row
+// resilience: one legacy row whose data trips a column constraint is logged
+// and skipped, the surrounding healthy rows still backfill, and the skip count
+// is surfaced through EnsureTable's log — a single poisoned row must never
+// starve the rest of the backlog.
+func TestEnsureTable_BackfillSkipsPoisonedRowAndContinues(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	if err := db.AutoMigrate(&models.Resource{}); err != nil {
+		t.Fatalf("failed to migrate resources: %v", err)
+	}
+
+	// Pre-create the projection table with a CHECK on servings so a legacy row
+	// carrying an out-of-range value fails its insert while its neighbours don't.
+	// CREATE ... IF NOT EXISTS inside EnsureTable is a no-op against this table,
+	// and addMissingColumns fills in the rest (name) idempotently.
+	if err := db.Exec(`CREATE TABLE recipes (
+		id TEXT PRIMARY KEY, type_slug TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'active',
+		created_by TEXT, account_id TEXT, sequence_no INTEGER,
+		created_at DATETIME, updated_at DATETIME,
+		servings INTEGER CHECK (servings <= 100))`).Error; err != nil {
+		t.Fatalf("failed to pre-create recipes table: %v", err)
+	}
+
+	logger := &recordingLogger{}
+	pm := &projectionManager{db: db, logger: logger}
+	ctx := context.Background()
+
+	insertCanonicalResource(t, db, models.Resource{
+		ID: "rec-1", TypeSlug: "recipe", Status: "active",
+		CreatedBy: "u1", AccountID: "acct-1", SequenceNo: 1, CreatedAt: time.Now(),
+		Data: `{"@id":"rec-1","@type":"Recipe","name":"Chili","servings":4}`,
+	})
+	insertCanonicalResource(t, db, models.Resource{
+		ID: "rec-2-poison", TypeSlug: "recipe", Status: "active",
+		CreatedBy: "u1", AccountID: "acct-1", SequenceNo: 2, CreatedAt: time.Now(),
+		Data: `{"@id":"rec-2-poison","@type":"Recipe","name":"Banquet","servings":999}`,
+	})
+	insertCanonicalResource(t, db, models.Resource{
+		ID: "rec-3", TypeSlug: "recipe", Status: "active",
+		CreatedBy: "u1", AccountID: "acct-1", SequenceNo: 3, CreatedAt: time.Now(),
+		Data: `{"@id":"rec-3","@type":"Recipe","name":"Soup","servings":2}`,
+	})
+
+	schema := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"name": {"type": "string"},
+			"servings": {"type": "integer"}
+		}
+	}`)
+	// A skipped row is tolerated: EnsureTable must NOT return an error for it.
+	if err := pm.EnsureTable(ctx, "recipe", schema, nil); err != nil {
+		t.Fatalf("EnsureTable should tolerate a skipped row, got: %v", err)
+	}
+
+	var rows []map[string]any
+	if err := db.Table("recipes").Order("id").Find(&rows).Error; err != nil {
+		t.Fatalf("failed to read recipes projection: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected the 2 healthy rows backfilled, got %d: %+v", len(rows), rows)
+	}
+	got := map[string]bool{}
+	for _, r := range rows {
+		got[r["id"].(string)] = true
+	}
+	if !got["rec-1"] || !got["rec-3"] {
+		t.Errorf("expected rec-1 and rec-3 backfilled, got %v", got)
+	}
+	if got["rec-2-poison"] {
+		t.Error("poisoned row should not have been projected")
+	}
+
+	// The partial-fill count must reach EnsureTable's operator-facing log.
+	sawPartial := false
+	for _, w := range logger.warns {
+		if strings.Contains(w, "completed with skipped rows") {
+			sawPartial = true
+		}
+	}
+	if !sawPartial {
+		t.Errorf("expected a 'completed with skipped rows' warning, got warns=%v", logger.warns)
+	}
+}
+
+// TestEnsureTable_FailedBackfillLeavesHasProjectionTableRetrying pins the
+// cache-ordering fix: a backfill that errors at the query level (not a per-row
+// skip) must invalidate the cached table entry so the lazy HasProjectionTable
+// path retries on the next call instead of trusting a table whose pre-existing
+// rows were never filled. A stale, healthy-looking cache entry would suppress
+// every future backfill attempt for the process lifetime.
+func TestEnsureTable_FailedBackfillLeavesHasProjectionTableRetrying(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+
+	// resource_types row so the lazy HasProjectionTable path can re-run EnsureTable.
+	if err := db.AutoMigrate(&models.ResourceType{}); err != nil {
+		t.Fatalf("failed to migrate resource_types: %v", err)
+	}
+	db.Create(&models.ResourceType{
+		ID: "1", Name: "Recipe", Slug: "recipe", Status: "active",
+		Schema: `{"type":"object","properties":{"name":{"type":"string"}}}`,
+	})
+
+	// A resources table that exists (so the HasTable guard passes) but lacks
+	// deleted_at, so the backfill scan's WHERE deleted_at IS NULL errors. This
+	// stands in for any transient query-level backfill failure.
+	if err := db.Exec(`CREATE TABLE resources (
+		id TEXT PRIMARY KEY, type_slug TEXT, status TEXT,
+		created_by TEXT, account_id TEXT, sequence_no INTEGER,
+		created_at DATETIME, data TEXT)`).Error; err != nil {
+		t.Fatalf("failed to create broken resources table: %v", err)
+	}
+
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	schema := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`)
+
+	// First EnsureTable fails on the backfill scan and must not leave a cached entry.
+	if err := pm.EnsureTable(context.Background(), "recipe", schema, nil); err == nil {
+		t.Fatal("expected EnsureTable to fail on the broken backfill scan")
+	}
+	if _, ok := pm.tables.Load("recipe"); ok {
+		t.Fatal("failed backfill poisoned the cache: the tables entry must be invalidated so it retries")
+	}
+
+	// Repair the resources table; the retry via the lazy path must now succeed.
+	if err := db.Exec(`ALTER TABLE resources ADD COLUMN deleted_at DATETIME`).Error; err != nil {
+		t.Fatalf("failed to repair resources table: %v", err)
+	}
+	if !pm.HasProjectionTable("recipe") {
+		t.Fatal("HasProjectionTable should retry EnsureTable and succeed once the failure cleared")
 	}
 }

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -290,7 +290,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		asHandler := weosoauth.AuthorizationServerMetadata(baseURL, appCfg.OAuth.DynamicRegistration)
 		regHandler := weosoauth.RegisterClient(clientRepo, appCfg.OAuth.DynamicRegistration)
 		authzHandler := weosoauth.Authorize(authService, sessionStore, clientRepo, codeRepo, logger, baseURL)
-		cbHandler := weosoauth.Callback(authService, sessionStore, codeRepo, accountRepo, logger, baseURL)
+		cbHandler := weosoauth.Callback(authService, sessionStore, codeRepo, accountRepo, logger, baseURL, appCfg.OAuth.AllowedEmails)
 		tokHandler := weosoauth.Token(jwtService, codeRepo, refreshRepo, agentRepo, accountRepo, logger)
 
 		e.Pre(func(next echo.HandlerFunc) echo.HandlerFunc {

--- a/internal/config/allowlist_test.go
+++ b/internal/config/allowlist_test.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseAllowedEmails(t *testing.T) {
+	got := parseAllowedEmails(" Akeem@Example.com , second@EXAMPLE.com ,, ")
+	want := []string{"akeem@example.com", "second@example.com"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseAllowedEmails = %v, want %v", got, want)
+	}
+}
+
+func TestLoadFromEnvironment_OAuthAllowedEmails(t *testing.T) {
+	t.Setenv("OAUTH_ALLOWED_EMAILS", "akeem@example.com, Second@Example.com")
+
+	cfg := Default()
+	cfg.LoadFromEnvironment()
+
+	want := []string{"akeem@example.com", "second@example.com"}
+	if !reflect.DeepEqual(cfg.OAuth.AllowedEmails, want) {
+		t.Fatalf("AllowedEmails = %v, want %v", cfg.OAuth.AllowedEmails, want)
+	}
+}
+
+func TestLoadFromEnvironment_OAuthAllowedEmails_NotSet(t *testing.T) {
+	cfg := Default()
+	cfg.LoadFromEnvironment()
+
+	if len(cfg.OAuth.AllowedEmails) != 0 {
+		t.Fatalf("expected no AllowedEmails by default, got %v", cfg.OAuth.AllowedEmails)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,11 +72,30 @@ type OAuthConfig struct {
 	JWTSigningKey       string // PEM-encoded RSA private key, or "auto" to generate ephemeral key
 	DynamicRegistration bool   // Enable OAuth Dynamic Client Registration (RFC 7591)
 
+	// AllowedEmails, when non-empty, restricts OAuth login to identities whose
+	// verified email is in this list (case-insensitive). The /oauth/callback
+	// rejects anyone else before an account is created; empty (the default)
+	// allows any authenticated user. Set via OAUTH_ALLOWED_EMAILS (comma-separated).
+	AllowedEmails []string
+
 	// DefaultProvider is the provider used by /api/auth/login when the
 	// caller doesn't pass a provider query param (the admin SPA does
 	// this). Empty means "auto-pick from the configured registry" —
 	// see DefaultOAuthProvider below.
 	DefaultProvider string
+}
+
+// parseAllowedEmails splits a comma-separated OAUTH_ALLOWED_EMAILS value into a
+// normalized allowlist: each entry trimmed and lowercased, blanks dropped.
+func parseAllowedEmails(raw string) []string {
+	parts := strings.Split(raw, ",")
+	emails := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if e := strings.ToLower(strings.TrimSpace(p)); e != "" {
+			emails = append(emails, e)
+		}
+	}
+	return emails
 }
 
 // SMTPConfig holds configuration for outbound email via SMTP.
@@ -511,6 +530,10 @@ func (c *Config) LoadFromEnvironment() {
 		if enabled, err := strconv.ParseBool(dynReg); err == nil {
 			c.OAuth.DynamicRegistration = enabled
 		}
+	}
+
+	if allowed := os.Getenv("OAUTH_ALLOWED_EMAILS"); allowed != "" {
+		c.OAuth.AllowedEmails = parseAllowedEmails(allowed)
 	}
 
 	if provider := os.Getenv("OAUTH_DEFAULT_PROVIDER"); provider != "" {

--- a/internal/oauth/allowlist_test.go
+++ b/internal/oauth/allowlist_test.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package oauth
+
+import "testing"
+
+func TestEmailAllowed(t *testing.T) {
+	allow := []string{"akeem@example.com", "second@example.com"}
+	cases := []struct {
+		name  string
+		email string
+		want  bool
+	}{
+		{"first entry", "akeem@example.com", true},
+		{"second entry", "second@example.com", true},
+		{"not listed", "stranger@example.com", false},
+		{"empty email", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := emailAllowed(tc.email, allow); got != tc.want {
+				t.Fatalf("emailAllowed(%q) = %v, want %v", tc.email, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/oauth/callback.go
+++ b/internal/oauth/callback.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/wepala/weos/v3/domain/entities"
@@ -35,6 +36,9 @@ import (
 // This handler completes the Google OAuth exchange, resolves the user identity,
 // updates the pending authorization code with the agent/account IDs, and
 // redirects back to the MCP client's redirect_uri with the authorization code.
+//
+// When allowedEmails is non-empty, an identity whose email is not in the list is
+// rejected before any account is created, so the server admits only known users.
 func Callback(
 	authService authapp.AuthenticationService,
 	sessionStore sessions.Store,
@@ -42,6 +46,7 @@ func Callback(
 	accountRepo authrepos.AccountRepository,
 	logger entities.Logger,
 	baseURL string,
+	allowedEmails []string,
 ) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		ctx := c.Request().Context()
@@ -121,6 +126,23 @@ func Callback(
 				map[string]string{"error": "server_error"})
 		}
 
+		// Enforce the identity allowlist (when configured) BEFORE resolving the
+		// agent, so a non-permitted user never gets a persisted account. The email
+		// comes from the provider's userinfo endpoint (a server-to-server call),
+		// so we trust Google's consumer-account invariant that this address is
+		// owned by the authenticated user. If a provider without that invariant is
+		// ever added behind this gate, also require an email_verified claim.
+		if len(allowedEmails) > 0 {
+			email := strings.ToLower(strings.TrimSpace(authResult.UserInfo.Email))
+			if !emailAllowed(email, allowedEmails) {
+				logger.Warn(ctx, "oauth callback: identity not in allowlist",
+					"email", email)
+				return c.JSON(http.StatusForbidden,
+					map[string]string{"error": "access_denied",
+						"error_description": "this account is not permitted to access this server"})
+			}
+		}
+
 		agent, _, account, err := authService.FindOrCreateAgent(
 			ctx, authResult.UserInfo)
 		if err != nil {
@@ -182,4 +204,16 @@ func Callback(
 
 		return c.Redirect(http.StatusFound, redirectURL.String())
 	}
+}
+
+// emailAllowed reports whether email (already normalized to lowercase) is present
+// in the allowlist. The caller guards against an empty allowlist, which means
+// "no restriction".
+func emailAllowed(email string, allowed []string) bool {
+	for _, a := range allowed {
+		if a == email {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/oauth/callback_test.go
+++ b/internal/oauth/callback_test.go
@@ -1,0 +1,158 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package oauth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
+	authentities "github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo/v4"
+)
+
+// fakeGateAuthService stubs only the two AuthenticationService methods the
+// callback reaches on the OAuth path: ExchangeCode (returns a fixed identity)
+// and FindOrCreateAgent (records that it ran, then errors so the handler stops
+// right after the gate without needing real entities). Every other interface
+// method is inherited from the nil embedded interface and is never called here.
+type fakeGateAuthService struct {
+	authapp.AuthenticationService
+	email             string
+	findOrCreateCalls int
+}
+
+func (f *fakeGateAuthService) ExchangeCode(ctx context.Context, code, codeVerifier, provider, redirectURI string) (*authapp.AuthResult, error) {
+	return &authapp.AuthResult{UserInfo: authapp.UserInfo{Email: f.email}}, nil
+}
+
+func (f *fakeGateAuthService) FindOrCreateAgent(ctx context.Context, userInfo authapp.UserInfo) (*authentities.Agent, *authentities.Credential, *authentities.Account, error) {
+	f.findOrCreateCalls++
+	return nil, nil, nil, errors.New("stop after gate")
+}
+
+// gateSessionStore returns a session pre-populated with a valid pending-flow
+// state so the callback reaches the allowlist gate.
+type gateSessionStore struct{ code, state string }
+
+func (s *gateSessionStore) Get(r *http.Request, name string) (*sessions.Session, error) {
+	sess := sessions.NewSession(s, name)
+	sess.Values["oauth_code"] = s.code
+	sess.Values["oauth_code_verifier"] = "verifier"
+	sess.Values["oauth_state"] = s.state
+	return sess, nil
+}
+
+func (s *gateSessionStore) New(r *http.Request, name string) (*sessions.Session, error) {
+	return s.Get(r, name)
+}
+
+func (s *gateSessionStore) Save(r *http.Request, w http.ResponseWriter, sess *sessions.Session) error {
+	return nil
+}
+
+// newGateHandler wires a Callback handler to in-memory fakes with a real pending
+// authorization code, and returns the handler plus the handles a test asserts on.
+func newGateHandler(t *testing.T, email string, allowlist []string) (echo.HandlerFunc, *fakeGateAuthService, AuthCodeRepository, string, string) {
+	t.Helper()
+	db := setupTestDB(t)
+	codeRepo := NewAuthCodeRepository(db)
+	code := &OAuthAuthorizationCode{
+		ClientID:            "client-1",
+		RedirectURI:         "https://client.example/cb",
+		CodeChallenge:       "challenge",
+		CodeChallengeMethod: "S256",
+		Status:              StatusPending,
+	}
+	mustNoErr(t, codeRepo.Create(context.Background(), code), "create pending code")
+
+	state := "state-123"
+	auth := &fakeGateAuthService{email: email}
+	store := &gateSessionStore{code: code.Code, state: state}
+	h := Callback(auth, store, codeRepo, nil, noopLogger{}, "https://twin.example", allowlist)
+	return h, auth, codeRepo, code.Code, state
+}
+
+func runCallback(t *testing.T, h echo.HandlerFunc, state string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?state="+state+"&code=google-code", nil)
+	rec := httptest.NewRecorder()
+	if err := h(echo.New().NewContext(req, rec)); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	return rec
+}
+
+func TestCallback_Allowlist_DeniesUnlistedEmail(t *testing.T) {
+	t.Parallel()
+	h, auth, codeRepo, code, state := newGateHandler(t, "stranger@example.com", []string{"akeem@example.com"})
+
+	rec := runCallback(t, h, state)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "access_denied") {
+		t.Errorf("body should contain access_denied: %s", rec.Body.String())
+	}
+	if auth.findOrCreateCalls != 0 {
+		t.Errorf("FindOrCreateAgent ran %d times; a denied identity must never get an account", auth.findOrCreateCalls)
+	}
+	// The code must stay pending — never advanced to issued for a denied user.
+	found, err := codeRepo.FindByCode(context.Background(), code)
+	mustNoErr(t, err, "find code after deny")
+	if found.Status != StatusPending {
+		t.Errorf("code status = %q, want still %q", found.Status, StatusPending)
+	}
+}
+
+func TestCallback_Allowlist_AdmitsListedEmail(t *testing.T) {
+	t.Parallel()
+	h, auth, _, _, state := newGateHandler(t, "akeem@example.com", []string{"akeem@example.com"})
+
+	runCallback(t, h, state)
+
+	if auth.findOrCreateCalls != 1 {
+		t.Errorf("a listed email must pass the gate through to FindOrCreateAgent; calls=%d", auth.findOrCreateCalls)
+	}
+}
+
+func TestCallback_Allowlist_IsCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	h, auth, _, _, state := newGateHandler(t, "Akeem@Example.COM", []string{"akeem@example.com"})
+
+	runCallback(t, h, state)
+
+	if auth.findOrCreateCalls != 1 {
+		t.Errorf("a mixed-case listed email must be admitted; calls=%d", auth.findOrCreateCalls)
+	}
+}
+
+func TestCallback_NoAllowlist_AdmitsAnyIdentity(t *testing.T) {
+	t.Parallel()
+	h, auth, _, _, state := newGateHandler(t, "anyone@example.com", nil)
+
+	runCallback(t, h, state)
+
+	if auth.findOrCreateCalls != 1 {
+		t.Errorf("with no allowlist the gate must be skipped and anyone admitted; calls=%d", auth.findOrCreateCalls)
+	}
+}


### PR DESCRIPTION
Housekeeping merge, requested by Akeem: brings the BehaviorScratch work (per-call scratch + EnsureTable canonical backfill and its hardening) onto v3. The branch's allowlist half already landed via #440, so this nets to the scratch/backfill files only (+713 across 6 files; verified locally: clean merge, `go build ./...` OK, `go test -race ./application/ ./infrastructure/database/gorm/` green).

Context: mini-me has been pinning this branch's tip (5feee2e) as a pseudo-version because `cmd/mini-me` depends on `application.ScratchFromContext` — with reproject (#444) it moved to a pushed integration merge (`integration/behavior-scratch-plus-v3`). Landing this on v3 lets mini-me re-pin to mainline and retires that integration branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)