### PR TITLE
fix(presets): reach provisioned databases when a preset schema gains a property (#379)

### DIFF
--- a/application/builtin_resource_types.go
+++ b/application/builtin_resource_types.go
@@ -59,6 +59,34 @@ func ensureBuiltInResourceTypes(params struct {
 			params.Logger.Info(ctx, "seeded built-in fixture data",
 				"slug", slug, "count", count)
 		}
+		// InstallPreset above skips types that already exist, so a preset that
+		// gained a property in this build would never reach a database
+		// provisioned by an earlier one — the stored schema would stay stale and
+		// every write to the new field would be silently dropped (issue #379).
+		// Reconcile merges those additions in; it deliberately does NOT overwrite
+		// a stored type's name, description, context or status, and refuses any
+		// non-additive divergence rather than guessing.
+		//
+		// A reconcile failure is logged, not fatal: the types are installed and
+		// serviceable, and failing the boot over a projection column that most
+		// requests don't touch would be a worse outcome than running with it
+		// missing and the warning on the record.
+		reconciled, rErr := params.TypeSvc.ReconcilePresetSchemas(ctx, preset.Name)
+		if rErr != nil {
+			params.Logger.Error(ctx, "failed to reconcile built-in preset schema",
+				"preset", preset.Name, "error", rErr)
+		}
+		if reconciled == nil {
+			continue
+		}
+		for _, slug := range reconciled.Updated {
+			params.Logger.Info(ctx, "reconciled built-in resource type schema", "slug", slug)
+		}
+		for slug, conflicts := range reconciled.Refused {
+			params.Logger.Warn(ctx,
+				"built-in resource type left unchanged: preset schema diverges non-additively",
+				"preset", preset.Name, "slug", slug, "conflictingProperties", conflicts)
+		}
 	}
 	// InstallPreset already reconciles after each install, but presets install
 	// one at a time in the loop above — if preset B depends on preset A's

--- a/application/builtin_resource_types.go
+++ b/application/builtin_resource_types.go
@@ -115,14 +115,13 @@ func reconcilePresetSchemas(
 		logger.Info(ctx, "reconciled resource type schema from preset",
 			"preset", presetName, "slug", slug)
 	}
-	for slug, conflicts := range reconciled.Refused {
-		// Name the blocked additive properties alongside the conflict: refusal
-		// is all-or-nothing, so those are the properties whose writes are still
-		// being dropped, and a conflict list alone never reveals them.
+	for slug, held := range reconciled.Refused {
+		// Held at their stored definition, not applied. The type's additive
+		// properties still landed, so this is a narrower warning than it used to
+		// be: only these properties need an operator decision.
 		logger.Warn(ctx,
-			"resource type left unchanged: preset schema diverges non-additively",
-			"preset", presetName, "slug", slug, "conflictingProperties", conflicts,
-			"blockedAdditions", reconciled.BlockedAdditions[slug])
+			"resource type properties held at their stored definition: preset diverges non-additively",
+			"preset", presetName, "slug", slug, "heldProperties", held)
 	}
 	for slug, reason := range reconciled.Failed {
 		logger.Error(ctx,

--- a/application/builtin_resource_types.go
+++ b/application/builtin_resource_types.go
@@ -38,6 +38,14 @@ func ensureBuiltInResourceTypes(params struct {
 }) error {
 	ctx := context.Background()
 	for _, preset := range params.Registry.List() {
+		// The schema reconcile runs for EVERY registered preset, not just the
+		// auto-installed ones. Only two presets in the tree set AutoInstall, so
+		// gating the reconcile on it would leave issue #379 unfixed for every
+		// preset an operator installs on demand — including any shipped by a
+		// private registrar. A preset type that isn't installed in this database
+		// is a no-op inside the reconcile, so running it unconditionally is safe.
+		reconcilePresetSchemas(ctx, params.TypeSvc, params.Logger, preset.Name)
+
 		if !preset.AutoInstall {
 			continue
 		}
@@ -59,34 +67,6 @@ func ensureBuiltInResourceTypes(params struct {
 			params.Logger.Info(ctx, "seeded built-in fixture data",
 				"slug", slug, "count", count)
 		}
-		// InstallPreset above skips types that already exist, so a preset that
-		// gained a property in this build would never reach a database
-		// provisioned by an earlier one — the stored schema would stay stale and
-		// every write to the new field would be silently dropped (issue #379).
-		// Reconcile merges those additions in; it deliberately does NOT overwrite
-		// a stored type's name, description, context or status, and refuses any
-		// non-additive divergence rather than guessing.
-		//
-		// A reconcile failure is logged, not fatal: the types are installed and
-		// serviceable, and failing the boot over a projection column that most
-		// requests don't touch would be a worse outcome than running with it
-		// missing and the warning on the record.
-		reconciled, rErr := params.TypeSvc.ReconcilePresetSchemas(ctx, preset.Name)
-		if rErr != nil {
-			params.Logger.Error(ctx, "failed to reconcile built-in preset schema",
-				"preset", preset.Name, "error", rErr)
-		}
-		if reconciled == nil {
-			continue
-		}
-		for _, slug := range reconciled.Updated {
-			params.Logger.Info(ctx, "reconciled built-in resource type schema", "slug", slug)
-		}
-		for slug, conflicts := range reconciled.Refused {
-			params.Logger.Warn(ctx,
-				"built-in resource type left unchanged: preset schema diverges non-additively",
-				"preset", preset.Name, "slug", slug, "conflictingProperties", conflicts)
-		}
 	}
 	// InstallPreset already reconciles after each install, but presets install
 	// one at a time in the loop above — if preset B depends on preset A's
@@ -107,4 +87,51 @@ func ensureBuiltInResourceTypes(params struct {
 		}
 	}
 	return nil
+}
+
+// reconcilePresetSchemas merges a preset's additive schema changes into the
+// types already stored in this database and reports every outcome that means
+// data is still being dropped (issue #379).
+//
+// A reconcile failure is logged, not fatal. That is a deliberate asymmetry with
+// the terminal LinkActivator reconcile above, which does fail startup: link
+// activation is all-or-nothing for a whole deployment, whereas a per-type
+// schema failure is contained to that type, and refusing to boot the entire
+// service over one type would take a running system down to fix a subset of
+// writes. Every failing type is named in the log instead — the operator signal
+// that was missing before this existed.
+func reconcilePresetSchemas(
+	ctx context.Context, svc ResourceTypeService, logger entities.Logger, presetName string,
+) {
+	reconciled, err := svc.ReconcilePresetSchemas(ctx, presetName)
+	if err != nil {
+		logger.Error(ctx, "failed to reconcile preset schema",
+			"preset", presetName, "error", err)
+	}
+	if reconciled == nil {
+		return
+	}
+	for _, slug := range reconciled.Updated {
+		logger.Info(ctx, "reconciled resource type schema from preset",
+			"preset", presetName, "slug", slug)
+	}
+	for slug, conflicts := range reconciled.Refused {
+		// Name the blocked additive properties alongside the conflict: refusal
+		// is all-or-nothing, so those are the properties whose writes are still
+		// being dropped, and a conflict list alone never reveals them.
+		logger.Warn(ctx,
+			"resource type left unchanged: preset schema diverges non-additively",
+			"preset", presetName, "slug", slug, "conflictingProperties", conflicts,
+			"blockedAdditions", reconciled.BlockedAdditions[slug])
+	}
+	for slug, reason := range reconciled.Failed {
+		logger.Error(ctx,
+			"resource type NOT reconciled: writes to its new properties will be dropped",
+			"preset", presetName, "slug", slug, "reason", reason)
+	}
+	for _, slug := range reconciled.NoSchema {
+		logger.Warn(ctx,
+			"preset type declares no JSON Schema: its projection has only base columns",
+			"preset", presetName, "slug", slug)
+	}
 }

--- a/application/event_handlers_test.go
+++ b/application/event_handlers_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/wepala/weos/v3/domain/entities"
 	"github.com/wepala/weos/v3/domain/repositories"
+	"github.com/wepala/weos/v3/pkg/utils"
 
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
 )
@@ -19,13 +20,45 @@ type stubProjMgr struct {
 	tables         map[string]bool
 	ancestorMap    map[string][]string
 	reverseRefs    map[string][]repositories.ReverseReference
+	columns        map[string]map[string]bool
 	fkUpdates      []fkUpdate
 	updateErr      error
 }
 
-func (s *stubProjMgr) EnsureTable(_ context.Context, slug string, _, _ json.RawMessage) error {
+func (s *stubProjMgr) EnsureTable(_ context.Context, slug string, schema, _ json.RawMessage) error {
 	s.ensuredSlugs = append(s.ensuredSlugs, slug)
-	return s.ensureTableErr
+	if s.ensureTableErr != nil {
+		// A failed EnsureTable adds no columns. Modeling that is what lets a
+		// test prove the reconcile refuses to report success when the column
+		// never landed (issue #379).
+		return s.ensureTableErr
+	}
+	s.recordColumns(slug, schema)
+	return nil
+}
+
+// recordColumns mirrors the real projection manager closely enough for
+// HasColumn to mean something: each schema property becomes a snake_case
+// column on the slug's table.
+func (s *stubProjMgr) recordColumns(slug string, schema json.RawMessage) {
+	if len(schema) == 0 {
+		return
+	}
+	var doc struct {
+		Properties map[string]json.RawMessage `json:"properties"`
+	}
+	if err := json.Unmarshal(schema, &doc); err != nil {
+		return
+	}
+	if s.columns == nil {
+		s.columns = map[string]map[string]bool{}
+	}
+	if s.columns[slug] == nil {
+		s.columns[slug] = map[string]bool{}
+	}
+	for name := range doc.Properties {
+		s.columns[slug][utils.CamelToSnake(name)] = true
+	}
 }
 
 func (s *stubProjMgr) HasProjectionTable(slug string) bool {
@@ -69,7 +102,7 @@ func (s *stubProjMgr) AncestorSlugs(slug string) []string {
 	return s.ancestorMap[slug]
 }
 
-func (s *stubProjMgr) HasColumn(_, _ string) bool { return false }
+func (s *stubProjMgr) HasColumn(slug, column string) bool { return s.columns[slug][column] }
 
 func (s *stubProjMgr) RegisterLink(_ context.Context, _ repositories.LinkReference) error {
 	return nil

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -105,6 +105,18 @@ type InstallPresetResult struct {
 	Warnings  []string       `json:"warnings,omitempty"`
 }
 
+// ReconcilePresetResult reports the outcome of an additive schema reconcile
+// (issue #379) across one preset's types. Refused holds the types whose preset
+// schema diverged non-additively, keyed by slug and listing the offending
+// property names — those types were left untouched and need an operator
+// decision. Types the preset declares but that aren't installed are absent
+// entirely; creating them is InstallPreset's job, not this one's.
+type ReconcilePresetResult struct {
+	Updated   []string            `json:"updated,omitempty"`
+	Unchanged []string            `json:"unchanged,omitempty"`
+	Refused   map[string][]string `json:"refused,omitempty"`
+}
+
 // presetMatchesResourceType reports whether the preset's definition matches
 // the stored type. Slug is equal by construction (the lookup key); Status is
 // carried over on update and so is deliberately not compared.

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -110,10 +110,15 @@ type InstallPresetResult struct {
 // aren't installed are absent entirely; creating them is InstallPreset's job,
 // not this one's.
 //
-// Every category other than Unchanged means writes to at least one property are
-// still being dropped, so each is reported separately rather than folded
-// together — a reconcile that quietly does nothing is the failure mode this
-// whole change exists to end.
+// The categories are reported separately rather than folded together because
+// they demand different responses — a reconcile that quietly does nothing is
+// the failure mode this whole change exists to end:
+//
+//   - Failed and NoSchema mean writes to at least one property ARE still being
+//     dropped. Both are urgent.
+//   - Refused means a property definition diverged and is being held safely at
+//     its stored form. The column already exists and writes to it still land;
+//     what needs an operator is the divergence itself, not data loss.
 type ReconcilePresetResult struct {
 	// Updated lists types whose stored schema was rewritten AND whose new
 	// columns were confirmed present afterwards.

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -106,15 +106,38 @@ type InstallPresetResult struct {
 }
 
 // ReconcilePresetResult reports the outcome of an additive schema reconcile
-// (issue #379) across one preset's types. Refused holds the types whose preset
-// schema diverged non-additively, keyed by slug and listing the offending
-// property names — those types were left untouched and need an operator
-// decision. Types the preset declares but that aren't installed are absent
-// entirely; creating them is InstallPreset's job, not this one's.
+// (issue #379) across one preset's types. Types the preset declares but that
+// aren't installed are absent entirely; creating them is InstallPreset's job,
+// not this one's.
+//
+// Every category other than Unchanged means writes to at least one property are
+// still being dropped, so each is reported separately rather than folded
+// together — a reconcile that quietly does nothing is the failure mode this
+// whole change exists to end.
 type ReconcilePresetResult struct {
-	Updated   []string            `json:"updated,omitempty"`
-	Unchanged []string            `json:"unchanged,omitempty"`
-	Refused   map[string][]string `json:"refused,omitempty"`
+	// Updated lists types whose stored schema was rewritten AND whose new
+	// columns were confirmed present afterwards.
+	Updated []string `json:"updated,omitempty"`
+	// Unchanged lists types already in sync — the steady-state boot.
+	Unchanged []string `json:"unchanged,omitempty"`
+	// Refused maps a slug to the properties whose definitions diverged
+	// non-additively. The type was left untouched and needs an operator
+	// decision. See BlockedAdditions for what that refusal also cost.
+	Refused map[string][]string `json:"refused,omitempty"`
+	// BlockedAdditions maps a refused slug to the additive properties that were
+	// blocked along with it. Refusal is all-or-nothing, so these are the
+	// properties whose writes are still being silently dropped — the list an
+	// operator actually needs, and the one a "conflicting properties" warning
+	// alone never shows.
+	BlockedAdditions map[string][]string `json:"blockedAdditions,omitempty"`
+	// Failed maps a slug to why its reconcile could not be completed. A type
+	// here is NOT reconciled: either the update errored, or it reported success
+	// while the projection column did not actually appear.
+	Failed map[string]string `json:"failed,omitempty"`
+	// NoSchema lists preset types that declare no JSON Schema at all. Their
+	// projection tables carry only base columns, so every data field is dropped
+	// on write — usually a preset packaging mistake, and never a healthy no-op.
+	NoSchema []string `json:"noSchema,omitempty"`
 }
 
 // presetMatchesResourceType reports whether the preset's definition matches

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -121,15 +121,11 @@ type ReconcilePresetResult struct {
 	// Unchanged lists types already in sync — the steady-state boot.
 	Unchanged []string `json:"unchanged,omitempty"`
 	// Refused maps a slug to the properties whose definitions diverged
-	// non-additively. The type was left untouched and needs an operator
-	// decision. See BlockedAdditions for what that refusal also cost.
+	// non-additively and were therefore HELD at their stored definition. The
+	// type's genuinely additive properties were still merged (refusal is
+	// per-property, not per-type), so a slug can appear here and in Updated at
+	// the same time. Held properties need an operator decision.
 	Refused map[string][]string `json:"refused,omitempty"`
-	// BlockedAdditions maps a refused slug to the additive properties that were
-	// blocked along with it. Refusal is all-or-nothing, so these are the
-	// properties whose writes are still being silently dropped — the list an
-	// operator actually needs, and the one a "conflicting properties" warning
-	// alone never shows.
-	BlockedAdditions map[string][]string `json:"blockedAdditions,omitempty"`
 	// Failed maps a slug to why its reconcile could not be completed. A type
 	// here is NOT reconciled: either the update errored, or it reported success
 	// while the projection column did not actually appear.

--- a/application/preset_schema_reconcile.go
+++ b/application/preset_schema_reconcile.go
@@ -24,26 +24,32 @@ import (
 // schemaReconciliation reports what an additive reconcile would do to one
 // resource type's stored JSON Schema (issue #379).
 //
-// Only Schema is safe to persist, and only when Changed is true. When
-// Conflicts is non-empty the reconcile is refused wholesale — Changed is
-// false and Schema is nil — because a property whose definition changed is a
-// non-additive migration, which is explicitly out of scope and needs an
-// operator decision rather than a silent rewrite.
+// Refusal is per-property, not per-type: a property whose definition changed is
+// held at its stored definition, while every genuinely additive property in the
+// same schema is still merged in. The alternative — refusing the whole type —
+// meant a preset that added `sku` and merely gave an existing property a
+// `description` blocked `sku` too, so the silent-drop this exists to fix
+// persisted for that type on a routine upgrade.
+//
+// Schema is safe to persist whenever Changed is true, including alongside a
+// non-empty Conflicts: the merged schema keeps the STORED definition of every
+// conflicting property, so nothing non-additive is ever applied.
 type schemaReconciliation struct {
 	// Added names the properties present in the preset but absent from the
 	// stored schema. These are what the projection table is missing columns for.
-	// It is populated even when the reconcile is ultimately refused, so a caller
-	// can report which additive properties a refusal also blocked.
 	Added []string
 	// Conflicts names properties present in BOTH schemas whose definitions
-	// differ — a retype or redefinition. Refusing on these is what keeps the
-	// reconcile additive.
+	// differ — a retype or redefinition. These are left at their stored
+	// definition and reported for an operator to resolve; holding them back is
+	// what keeps the reconcile additive.
 	Conflicts []string
 	// Schema is the merged result. Nil unless Changed.
 	Schema json.RawMessage
 	// Changed reports whether the stored schema needs rewriting at all. False
 	// means the boot is a no-op for this type, so no ResourceTypeUpdated event
-	// is emitted and repeated restarts stay quiet.
+	// is emitted and repeated restarts stay quiet. Conflicts alone never make a
+	// schema Changed — there is nothing to write if the only difference is a
+	// property being held back.
 	Changed bool
 }
 
@@ -60,9 +66,11 @@ type schemaReconciliation struct {
 //     addition through the API is indistinguishable from drift; dropping it
 //     would trade one silent data loss for another. Preserving it also stops a
 //     single customization from permanently blocking later preset additions.
-//   - A property in BOTH whose definition differs is a CONFLICT. The whole type
-//     is refused and left untouched for the caller to warn about — that is the
-//     deferred non-additive case (rename/retype/drop).
+//   - A property in BOTH whose definition differs is a CONFLICT: it is HELD at
+//     its stored definition and reported, while the rest of the merge proceeds.
+//     Applying it would be the deferred non-additive case (rename/retype/drop);
+//     refusing the whole type instead would let one cosmetic edit block every
+//     additive property beside it.
 //   - `required` follows the preset, EXCEPT that requirements naming
 //     stored-only properties are carried over. The preset has no opinion about a
 //     property it does not declare, so dropping such an entry would silently
@@ -125,15 +133,10 @@ func reconcileAdditiveSchema(stored, preset json.RawMessage) (schemaReconciliati
 			continue
 		}
 		if !jsonEquivalent(existing, presetDoc.props[name]) {
+			// Held at the stored definition: mergedProps already carries it, so
+			// simply not overwriting is what keeps the merge additive.
 			out.Conflicts = append(out.Conflicts, name)
 		}
-	}
-
-	// A non-additive divergence refuses the whole type. Reporting Schema as nil
-	// makes it impossible for a caller to persist a partially-merged schema.
-	// Added survives so the caller can name what the refusal also blocked.
-	if len(out.Conflicts) > 0 {
-		return out, nil
 	}
 
 	mergedTop, topChanged, err := mergeTopLevel(storedDoc, presetDoc)

--- a/application/preset_schema_reconcile.go
+++ b/application/preset_schema_reconcile.go
@@ -32,6 +32,8 @@ import (
 type schemaReconciliation struct {
 	// Added names the properties present in the preset but absent from the
 	// stored schema. These are what the projection table is missing columns for.
+	// It is populated even when the reconcile is ultimately refused, so a caller
+	// can report which additive properties a refusal also blocked.
 	Added []string
 	// Conflicts names properties present in BOTH schemas whose definitions
 	// differ — a retype or redefinition. Refusing on these is what keeps the
@@ -61,14 +63,26 @@ type schemaReconciliation struct {
 //   - A property in BOTH whose definition differs is a CONFLICT. The whole type
 //     is refused and left untouched for the caller to warn about — that is the
 //     deferred non-additive case (rename/retype/drop).
-//   - Every other top-level keyword (`required`, `type`, `additionalProperties`,
-//     …) follows the PRESET where the preset declares it; stored-only keywords
-//     are preserved. Note this makes `required` authoritative: a property the
-//     preset newly marks required will start failing validation for existing
-//     rows that lack it. That is a deliberate, operator-visible choice.
+//   - `required` follows the preset, EXCEPT that requirements naming
+//     stored-only properties are carried over. The preset has no opinion about a
+//     property it does not declare, so dropping such an entry would silently
+//     weaken a constraint the operator set — the mirror of the property-
+//     preservation rule above. Note the tightening direction is deliberate and
+//     load-bearing: a property the preset newly marks required will start
+//     failing validation for existing rows that lack it.
+//   - Every other top-level keyword (`type`, `additionalProperties`, …) follows
+//     the PRESET where the preset declares it; stored-only keywords are preserved.
 //
 // An absent or empty stored schema adopts the preset's schema wholesale —
 // there is nothing to preserve and nothing that can conflict.
+//
+// SCOPE OF THE CONFLICT CHECK: property definitions are compared verbatim. A
+// schema that reaches its types through indirection — `$ref` into `$defs` or
+// `definitions`, or `allOf`/`patternProperties` — can therefore be retyped
+// without tripping the conflict guard, because the change lands in a top-level
+// keyword the preset simply wins. No preset in the tree uses those keywords
+// today; if one starts to, the conflict check must resolve indirection before
+// it can honestly claim to refuse every non-additive divergence.
 //
 // The merge is idempotent: re-running it against its own output reports
 // Changed=false, which is what keeps a restart from emitting an event per type
@@ -82,66 +96,65 @@ func reconcileAdditiveSchema(stored, preset json.RawMessage) (schemaReconciliati
 		return out, nil
 	}
 
-	presetTop, presetProps, err := splitSchema(preset)
+	presetDoc, err := splitSchema(preset)
 	if err != nil {
 		return out, fmt.Errorf("preset schema: %w", err)
 	}
 
 	if len(stored) == 0 {
-		out.Added = sortedKeys(presetProps)
+		out.Added = sortedKeys(presetDoc.props)
 		out.Schema = preset
 		out.Changed = true
 		return out, nil
 	}
 
-	storedTop, storedProps, err := splitSchema(stored)
+	storedDoc, err := splitSchema(stored)
 	if err != nil {
 		return out, fmt.Errorf("stored schema: %w", err)
 	}
 
-	mergedProps := make(map[string]json.RawMessage, len(storedProps)+len(presetProps))
-	for name, def := range storedProps {
+	mergedProps := make(map[string]json.RawMessage, len(storedDoc.props)+len(presetDoc.props))
+	for name, def := range storedDoc.props {
 		mergedProps[name] = def
 	}
-	for _, name := range sortedKeys(presetProps) {
-		existing, inStored := storedProps[name]
+	for _, name := range sortedKeys(presetDoc.props) {
+		existing, inStored := storedDoc.props[name]
 		if !inStored {
-			mergedProps[name] = presetProps[name]
+			mergedProps[name] = presetDoc.props[name]
 			out.Added = append(out.Added, name)
 			continue
 		}
-		if !jsonEquivalent(existing, presetProps[name]) {
+		if !jsonEquivalent(existing, presetDoc.props[name]) {
 			out.Conflicts = append(out.Conflicts, name)
 		}
 	}
 
 	// A non-additive divergence refuses the whole type. Reporting Schema as nil
 	// makes it impossible for a caller to persist a partially-merged schema.
+	// Added survives so the caller can name what the refusal also blocked.
 	if len(out.Conflicts) > 0 {
 		return out, nil
 	}
 
-	mergedTop := make(map[string]json.RawMessage, len(storedTop)+len(presetTop))
-	for key, val := range storedTop {
-		mergedTop[key] = val
-	}
-	topChanged := false
-	for key, val := range presetTop {
-		if prev, ok := storedTop[key]; !ok || !jsonEquivalent(prev, val) {
-			mergedTop[key] = val
-			topChanged = true
-		}
+	mergedTop, topChanged, err := mergeTopLevel(storedDoc, presetDoc)
+	if err != nil {
+		return out, err
 	}
 
 	if len(out.Added) == 0 && !topChanged {
 		return out, nil
 	}
 
-	propsRaw, err := json.Marshal(mergedProps)
-	if err != nil {
-		return out, fmt.Errorf("failed to marshal merged properties: %w", err)
+	// Only carry a `properties` key if one side actually had one. Writing an
+	// empty object unconditionally would put a keyword in the stored schema
+	// that neither the preset nor the operator declared.
+	if len(mergedProps) > 0 || storedDoc.hadProps || presetDoc.hadProps {
+		propsRaw, mErr := json.Marshal(mergedProps)
+		if mErr != nil {
+			return out, fmt.Errorf("failed to marshal merged properties: %w", mErr)
+		}
+		mergedTop["properties"] = propsRaw
 	}
-	mergedTop["properties"] = propsRaw
 
 	merged, err := json.Marshal(mergedTop)
 	if err != nil {
@@ -152,25 +165,140 @@ func reconcileAdditiveSchema(stored, preset json.RawMessage) (schemaReconciliati
 	return out, nil
 }
 
-// splitSchema decodes a JSON Schema into its top-level keywords (excluding
-// `properties`) and its property map. A schema with no `properties` key yields
-// an empty — not nil — property map so callers can range over it freely.
-//
-// `properties` is separated because it is the only keyword this reconcile
-// merges key-by-key; everything else is compared and replaced whole.
-func splitSchema(raw json.RawMessage) (map[string]json.RawMessage, map[string]json.RawMessage, error) {
-	var top map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &top); err != nil {
-		return nil, nil, fmt.Errorf("not a JSON object: %w", err)
+// mergeTopLevel merges every schema keyword except `properties`: the preset
+// wins where it declares a keyword, stored-only keywords are preserved, and
+// `required` gets the carry-over treatment described on reconcileAdditiveSchema.
+// Reports whether anything actually changed.
+func mergeTopLevel(storedDoc, presetDoc schemaDoc) (map[string]json.RawMessage, bool, error) {
+	merged := make(map[string]json.RawMessage, len(storedDoc.top)+len(presetDoc.top))
+	for key, val := range storedDoc.top {
+		merged[key] = val
 	}
-	props := map[string]json.RawMessage{}
-	if rawProps, ok := top["properties"]; ok {
-		if err := json.Unmarshal(rawProps, &props); err != nil {
-			return nil, nil, fmt.Errorf("`properties` is not a JSON object: %w", err)
+	changed := false
+	for key, val := range presetDoc.top {
+		if key == requiredKeyword {
+			continue // handled below, where stored-only properties are known
+		}
+		if prev, ok := storedDoc.top[key]; !ok || !jsonEquivalent(prev, val) {
+			merged[key] = val
+			changed = true
 		}
 	}
-	delete(top, "properties")
-	return top, props, nil
+
+	requiredRaw, reqChanged, err := mergeRequired(storedDoc, presetDoc)
+	if err != nil {
+		return nil, false, err
+	}
+	if requiredRaw != nil {
+		merged[requiredKeyword] = requiredRaw
+	}
+	return merged, changed || reqChanged, nil
+}
+
+const requiredKeyword = "required"
+
+// mergeRequired computes the reconciled `required` array: the preset's list,
+// plus any stored entry naming a property the preset does not declare.
+//
+// Without that carry-over, a preset whose `required` omits an operator's own
+// property would silently drop that property's requirement — the property is
+// preserved but its constraint is not, leaving a schema neither side authored.
+// Returns a nil slice when the preset declares no `required` at all, meaning
+// "leave whatever is stored alone".
+func mergeRequired(storedDoc, presetDoc schemaDoc) (json.RawMessage, bool, error) {
+	presetRaw, presetDeclares := presetDoc.top[requiredKeyword]
+	if !presetDeclares {
+		return nil, false, nil
+	}
+	presetReq, err := decodeStringArray(presetRaw)
+	if err != nil {
+		return nil, false, fmt.Errorf("preset `required`: %w", err)
+	}
+	storedReq, err := decodeStringArray(storedDoc.top[requiredKeyword])
+	if err != nil {
+		return nil, false, fmt.Errorf("stored `required`: %w", err)
+	}
+
+	seen := make(map[string]bool, len(presetReq))
+	out := make([]string, 0, len(presetReq)+len(storedReq))
+	for _, name := range presetReq {
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	for _, name := range storedReq {
+		if seen[name] {
+			continue
+		}
+		// Only carry over requirements the preset has no opinion about — i.e.
+		// those naming properties it does not declare.
+		if _, presetHas := presetDoc.props[name]; presetHas {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+
+	encoded, err := json.Marshal(out)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to marshal merged `required`: %w", err)
+	}
+	return encoded, !jsonEquivalent(storedDoc.top[requiredKeyword], encoded), nil
+}
+
+// decodeStringArray decodes a JSON string array, tolerating an absent or null
+// value as empty. A non-array (or non-string element) is an error rather than a
+// silent empty, so a malformed `required` can't quietly erase requirements.
+func decodeStringArray(raw json.RawMessage) ([]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var out []string
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("not an array of strings: %w", err)
+	}
+	return out, nil
+}
+
+// schemaDoc is a JSON Schema split into its property map and everything else,
+// because `properties` is the only keyword this reconcile merges key-by-key.
+type schemaDoc struct {
+	top   map[string]json.RawMessage
+	props map[string]json.RawMessage
+	// hadProps records whether the document declared a `properties` keyword at
+	// all, so the merge can avoid inventing one.
+	hadProps bool
+}
+
+// splitSchema decodes a JSON Schema into a schemaDoc. A schema with no
+// `properties` key yields an empty — not nil — property map so callers can
+// range over it freely. A schema that is valid JSON but not an object (`true`,
+// `[1,2]`) is an error; the caller reports it rather than reconciling blind.
+func splitSchema(raw json.RawMessage) (schemaDoc, error) {
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &top); err != nil {
+		return schemaDoc{}, fmt.Errorf("not a JSON object: %w", err)
+	}
+	doc := schemaDoc{top: top, props: map[string]json.RawMessage{}}
+	if doc.top == nil {
+		// The schema decoded as JSON `null`. Treat it as an empty object rather
+		// than persisting `null` back as a schema.
+		doc.top = map[string]json.RawMessage{}
+		return doc, nil
+	}
+	if rawProps, ok := doc.top["properties"]; ok {
+		doc.hadProps = true
+		if err := json.Unmarshal(rawProps, &doc.props); err != nil {
+			return schemaDoc{}, fmt.Errorf("`properties` is not a JSON object: %w", err)
+		}
+		if doc.props == nil {
+			doc.props = map[string]json.RawMessage{}
+		}
+	}
+	delete(doc.top, "properties")
+	return doc, nil
 }
 
 // sortedKeys returns a map's keys in a stable order so Added lists (and the

--- a/application/preset_schema_reconcile.go
+++ b/application/preset_schema_reconcile.go
@@ -1,0 +1,185 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// schemaReconciliation reports what an additive reconcile would do to one
+// resource type's stored JSON Schema (issue #379).
+//
+// Only Schema is safe to persist, and only when Changed is true. When
+// Conflicts is non-empty the reconcile is refused wholesale — Changed is
+// false and Schema is nil — because a property whose definition changed is a
+// non-additive migration, which is explicitly out of scope and needs an
+// operator decision rather than a silent rewrite.
+type schemaReconciliation struct {
+	// Added names the properties present in the preset but absent from the
+	// stored schema. These are what the projection table is missing columns for.
+	Added []string
+	// Conflicts names properties present in BOTH schemas whose definitions
+	// differ — a retype or redefinition. Refusing on these is what keeps the
+	// reconcile additive.
+	Conflicts []string
+	// Schema is the merged result. Nil unless Changed.
+	Schema json.RawMessage
+	// Changed reports whether the stored schema needs rewriting at all. False
+	// means the boot is a no-op for this type, so no ResourceTypeUpdated event
+	// is emitted and repeated restarts stay quiet.
+	Changed bool
+}
+
+// reconcileAdditiveSchema merges a preset's code-defined JSON Schema into the
+// schema currently stored for a resource type, additively.
+//
+// The rules, in the order they matter:
+//
+//   - A property the preset declares and the stored schema lacks is MERGED IN.
+//     This is the whole point: it is what gives the projection table its missing
+//     column on the next EnsureTable pass.
+//   - A property the stored schema has and the preset does not is PRESERVED.
+//     WeOS has no provenance field on ResourceType, so an operator's own
+//     addition through the API is indistinguishable from drift; dropping it
+//     would trade one silent data loss for another. Preserving it also stops a
+//     single customization from permanently blocking later preset additions.
+//   - A property in BOTH whose definition differs is a CONFLICT. The whole type
+//     is refused and left untouched for the caller to warn about — that is the
+//     deferred non-additive case (rename/retype/drop).
+//   - Every other top-level keyword (`required`, `type`, `additionalProperties`,
+//     …) follows the PRESET where the preset declares it; stored-only keywords
+//     are preserved. Note this makes `required` authoritative: a property the
+//     preset newly marks required will start failing validation for existing
+//     rows that lack it. That is a deliberate, operator-visible choice.
+//
+// An absent or empty stored schema adopts the preset's schema wholesale —
+// there is nothing to preserve and nothing that can conflict.
+//
+// The merge is idempotent: re-running it against its own output reports
+// Changed=false, which is what keeps a restart from emitting an event per type
+// per boot.
+func reconcileAdditiveSchema(stored, preset json.RawMessage) (schemaReconciliation, error) {
+	var out schemaReconciliation
+
+	// Nothing declared in code means nothing to add. Never treat an empty
+	// preset schema as an instruction to clear a stored one.
+	if len(preset) == 0 {
+		return out, nil
+	}
+
+	presetTop, presetProps, err := splitSchema(preset)
+	if err != nil {
+		return out, fmt.Errorf("preset schema: %w", err)
+	}
+
+	if len(stored) == 0 {
+		out.Added = sortedKeys(presetProps)
+		out.Schema = preset
+		out.Changed = true
+		return out, nil
+	}
+
+	storedTop, storedProps, err := splitSchema(stored)
+	if err != nil {
+		return out, fmt.Errorf("stored schema: %w", err)
+	}
+
+	mergedProps := make(map[string]json.RawMessage, len(storedProps)+len(presetProps))
+	for name, def := range storedProps {
+		mergedProps[name] = def
+	}
+	for _, name := range sortedKeys(presetProps) {
+		existing, inStored := storedProps[name]
+		if !inStored {
+			mergedProps[name] = presetProps[name]
+			out.Added = append(out.Added, name)
+			continue
+		}
+		if !jsonEquivalent(existing, presetProps[name]) {
+			out.Conflicts = append(out.Conflicts, name)
+		}
+	}
+
+	// A non-additive divergence refuses the whole type. Reporting Schema as nil
+	// makes it impossible for a caller to persist a partially-merged schema.
+	if len(out.Conflicts) > 0 {
+		return out, nil
+	}
+
+	mergedTop := make(map[string]json.RawMessage, len(storedTop)+len(presetTop))
+	for key, val := range storedTop {
+		mergedTop[key] = val
+	}
+	topChanged := false
+	for key, val := range presetTop {
+		if prev, ok := storedTop[key]; !ok || !jsonEquivalent(prev, val) {
+			mergedTop[key] = val
+			topChanged = true
+		}
+	}
+
+	if len(out.Added) == 0 && !topChanged {
+		return out, nil
+	}
+
+	propsRaw, err := json.Marshal(mergedProps)
+	if err != nil {
+		return out, fmt.Errorf("failed to marshal merged properties: %w", err)
+	}
+	mergedTop["properties"] = propsRaw
+
+	merged, err := json.Marshal(mergedTop)
+	if err != nil {
+		return out, fmt.Errorf("failed to marshal merged schema: %w", err)
+	}
+	out.Schema = merged
+	out.Changed = true
+	return out, nil
+}
+
+// splitSchema decodes a JSON Schema into its top-level keywords (excluding
+// `properties`) and its property map. A schema with no `properties` key yields
+// an empty — not nil — property map so callers can range over it freely.
+//
+// `properties` is separated because it is the only keyword this reconcile
+// merges key-by-key; everything else is compared and replaced whole.
+func splitSchema(raw json.RawMessage) (map[string]json.RawMessage, map[string]json.RawMessage, error) {
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &top); err != nil {
+		return nil, nil, fmt.Errorf("not a JSON object: %w", err)
+	}
+	props := map[string]json.RawMessage{}
+	if rawProps, ok := top["properties"]; ok {
+		if err := json.Unmarshal(rawProps, &props); err != nil {
+			return nil, nil, fmt.Errorf("`properties` is not a JSON object: %w", err)
+		}
+	}
+	delete(top, "properties")
+	return top, props, nil
+}
+
+// sortedKeys returns a map's keys in a stable order so Added lists (and the
+// log lines built from them) don't shuffle between runs.
+func sortedKeys(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/application/preset_schema_reconcile_test.go
+++ b/application/preset_schema_reconcile_test.go
@@ -23,7 +23,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/wepala/weos/v3/domain/entities"
+
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
+	"go.uber.org/fx"
 )
 
 // schemaProps decodes a schema's `properties` map so assertions can talk about
@@ -198,6 +201,25 @@ func TestReconcileAdditiveSchema(t *testing.T) {
 		wantChanged: true,
 		wantAdded:   []string{"owner"},
 		wantProps:   []string{"name", "owner"},
+	}, {
+		// A rename is NOT detected: it reads as one property added and one
+		// preserved. Both columns land, the old keeps its data, the new is NULL.
+		// Additively safe, but not a migration — pinned so the ADR can't drift.
+		name:        "a renamed property is added, not migrated",
+		stored:      `{"type":"object","properties":{"name":{"type":"string"},"sku":{"type":"string"}}}`,
+		preset:      `{"type":"object","properties":{"name":{"type":"string"},"stockKeepingUnit":{"type":"string"}}}`,
+		wantChanged: true,
+		wantAdded:   []string{"stockKeepingUnit"},
+		wantProps:   []string{"name", "sku", "stockKeepingUnit"},
+	}, {
+		// Indirection routes around the conflict check: the $ref is identical on
+		// both sides, so the retype hides in $defs, which the preset simply wins.
+		// Documented as a scope limit; pinned so it fails loudly if it changes.
+		name:        "a retype behind $ref is NOT caught as a conflict",
+		stored:      `{"type":"object","$defs":{"P":{"type":"string"}},"properties":{"o":{"$ref":"#/$defs/P"}}}`,
+		preset:      `{"type":"object","$defs":{"P":{"type":"integer"}},"properties":{"o":{"$ref":"#/$defs/P"}}}`,
+		wantChanged: true,
+		wantProps:   []string{"o"},
 	}, {
 		name:        "a schema with no properties key is tolerated",
 		stored:      `{"type":"object"}`,
@@ -839,5 +861,148 @@ func TestReconcilePresetSchemas_HeldPropertyDoesNotBlockAdditions(t *testing.T) 
 	}
 	if sku.Type != "string" {
 		t.Errorf("held property was rewritten: sku.type = %q, want the stored %q", sku.Type, "string")
+	}
+}
+
+// catalogPreset builds a preset whose single type carries the given schema.
+func catalogPreset(autoInstall bool, schema string) PresetDefinition {
+	return PresetDefinition{
+		Name:        "single",
+		AutoInstall: autoInstall,
+		Types: []PresetResourceType{{
+			Name: "Product", Slug: "product", Description: "A product",
+			Context: json.RawMessage(`{"@vocab":"https://schema.org/"}`),
+			Schema:  json.RawMessage(schema),
+		}},
+	}
+}
+
+// TestEnsureBuiltInResourceTypes_ReconcilesNonAutoInstallPresets is the
+// regression guard for the scope of the fix. Only two presets in the tree set
+// AutoInstall, so gating the reconcile on that flag left issue #379 unfixed for
+// every preset an operator installs on demand — including any from a private
+// registrar. Moving the reconcile back under the AutoInstall guard must fail
+// this test.
+func TestEnsureBuiltInResourceTypes_ReconcilesNonAutoInstallPresets(t *testing.T) {
+	t.Parallel()
+	v1 := NewPresetRegistry()
+	v1.MustAdd(catalogPreset(false, `{"type":"object","properties":{"name":{"type":"string"}}}`))
+
+	repo := newInstallTestTypeRepo()
+	rSvc := newFakeResourceSvc()
+	// The operator installed it explicitly at some earlier point.
+	if _, err := makeInstallTestService(repo, rSvc, v1).
+		InstallPreset(context.Background(), "single", false); err != nil {
+		t.Fatalf("initial install: %v", err)
+	}
+
+	// A later build adds a property. The preset is still NOT auto-install.
+	v2 := NewPresetRegistry()
+	v2.MustAdd(catalogPreset(false,
+		`{"type":"object","properties":{"name":{"type":"string"},"sku":{"type":"string"}}}`))
+
+	err := ensureBuiltInResourceTypes(struct {
+		fx.In
+		Registry      *PresetRegistry
+		TypeSvc       ResourceTypeService
+		Logger        entities.Logger
+		LinkActivator *LinkActivator `optional:"true"`
+	}{
+		Registry: v2,
+		TypeSvc:  reconcileTestService(t, repo, rSvc, v2),
+		Logger:   noopLogger{},
+	})
+	if err != nil {
+		t.Fatalf("ensureBuiltInResourceTypes: %v", err)
+	}
+
+	after, aErr := repo.FindBySlug(context.Background(), "product")
+	if aErr != nil {
+		t.Fatalf("FindBySlug: %v", aErr)
+	}
+	if _, ok := schemaProps(t, after.Schema())["sku"]; !ok {
+		t.Fatal("a non-AutoInstall preset's added property never reached the stored schema")
+	}
+}
+
+// TestReconcilePresetSchemas_HeldTypeSettlesAcrossRestarts: a type carrying a
+// held property must still go quiet after its additive changes land. Without
+// this, a schema stuck in permanent divergence would emit a ResourceTypeUpdated
+// on every boot forever — the failure the clean path already guards against.
+func TestReconcilePresetSchemas_HeldTypeSettlesAcrossRestarts(t *testing.T) {
+	t.Parallel()
+	v1 := NewPresetRegistry()
+	v1.MustAdd(catalogPreset(true, `{"type":"object","properties":{"sku":{"type":"string"}}}`))
+	repo := newInstallTestTypeRepo()
+	rSvc := newFakeResourceSvc()
+	if _, err := makeInstallTestService(repo, rSvc, v1).
+		InstallPreset(context.Background(), "single", false); err != nil {
+		t.Fatalf("initial install: %v", err)
+	}
+
+	v2 := NewPresetRegistry()
+	v2.MustAdd(catalogPreset(true,
+		`{"type":"object","properties":{"sku":{"type":"integer"},"gtin":{"type":"string"}}}`))
+
+	d := domain.NewEventDispatcher()
+	pm := &stubProjMgr{}
+	if err := SubscribeResourceTypeHandlers(d, repo, pm, noopLogger{}); err != nil {
+		t.Fatalf("SubscribeResourceTypeHandlers: %v", err)
+	}
+	updateCount := countingUpdateSub(t, d)
+	svc := &resourceTypeService{
+		repo: repo, projMgr: pm, eventStore: &stubEventStore{}, dispatcher: d,
+		registry: v2, logger: noopLogger{}, resourceSvc: rSvc,
+	}
+
+	for i := 0; i < 3; i++ {
+		res, err := svc.ReconcilePresetSchemas(context.Background(), "single")
+		if err != nil {
+			t.Fatalf("reconcile %d: %v", i, err)
+		}
+		// The hold is reported every boot — it stays unresolved until an
+		// operator acts — but it must not keep rewriting the schema.
+		if !sameStrings(res.Refused["product"], []string{"sku"}) {
+			t.Fatalf("boot %d: expected sku held, got %+v", i, res.Refused)
+		}
+		if i > 0 && len(res.Updated) != 0 {
+			t.Fatalf("boot %d rewrote the schema again: %+v", i, res.Updated)
+		}
+	}
+	if *updateCount != 1 {
+		t.Fatalf("expected exactly one ResourceTypeUpdated across three boots, got %d", *updateCount)
+	}
+}
+
+// TestReconcilePresetSchemas_IgnoresColumnlessProperties: some schema property
+// names deliberately yield no projection column of their own. Reporting them as
+// missing would raise a false alarm announcing data loss that isn't happening.
+func TestReconcilePresetSchemas_IgnoresColumnlessProperties(t *testing.T) {
+	t.Parallel()
+	v1 := NewPresetRegistry()
+	v1.MustAdd(catalogPreset(true, `{"type":"object","properties":{"name":{"type":"string"}}}`))
+	repo := newInstallTestTypeRepo()
+	rSvc := newFakeResourceSvc()
+	if _, err := makeInstallTestService(repo, rSvc, v1).
+		InstallPreset(context.Background(), "single", false); err != nil {
+		t.Fatalf("initial install: %v", err)
+	}
+
+	// A later build adds properties the projection deliberately has no column
+	// for: the canonical data blob and a JSON-LD meta-key.
+	v2 := NewPresetRegistry()
+	v2.MustAdd(catalogPreset(true,
+		`{"type":"object","properties":{"name":{"type":"string"},"data":{"type":"string"},"@id":{"type":"string"}}}`))
+
+	res, err := reconcileTestService(t, repo, rSvc, v2).
+		ReconcilePresetSchemas(context.Background(), "single")
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(res.Failed) != 0 {
+		t.Fatalf("columnless properties were reported as a failure: %+v", res.Failed)
+	}
+	if !sameStrings(res.Updated, []string{"product"}) {
+		t.Errorf("expected Updated=[product], got %+v", res)
 	}
 }

--- a/application/preset_schema_reconcile_test.go
+++ b/application/preset_schema_reconcile_test.go
@@ -1,0 +1,564 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
+)
+
+// schemaProps decodes a schema's `properties` map so assertions can talk about
+// property names without depending on key order in the marshaled output.
+func schemaProps(t *testing.T, raw json.RawMessage) map[string]json.RawMessage {
+	t.Helper()
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &top); err != nil {
+		t.Fatalf("schema is not a JSON object: %v", err)
+	}
+	props := map[string]json.RawMessage{}
+	if p, ok := top["properties"]; ok {
+		if err := json.Unmarshal(p, &props); err != nil {
+			t.Fatalf("`properties` is not a JSON object: %v", err)
+		}
+	}
+	return props
+}
+
+// sameStrings compares two string slices, treating nil and empty as equal so a
+// table case can leave an expectation unset.
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestReconcileAdditiveSchema(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		stored        string
+		preset        string
+		wantChanged   bool
+		wantAdded     []string
+		wantConflicts []string
+		// wantProps, when set, lists every property name the merged schema must
+		// carry — the guard that preserved and added properties coexist.
+		wantProps []string
+	}{{
+		name:        "identical schemas are a no-op",
+		stored:      `{"type":"object","properties":{"name":{"type":"string"}}}`,
+		preset:      `{"type":"object","properties":{"name":{"type":"string"}}}`,
+		wantChanged: false,
+	}, {
+		name:        "formatting-only differences are a no-op",
+		stored:      `{"type":"object","properties":{"name":{"type":"string"}}}`,
+		preset:      "{\n \"properties\" : {\"name\":{ \"type\":\"string\" }},\n \"type\":\"object\"\n}",
+		wantChanged: false,
+	}, {
+		name:        "a new property is merged in",
+		stored:      `{"type":"object","properties":{"name":{"type":"string"}}}`,
+		preset:      `{"type":"object","properties":{"name":{"type":"string"},"sku":{"type":"string"}}}`,
+		wantChanged: true,
+		wantAdded:   []string{"sku"},
+		wantProps:   []string{"name", "sku"},
+	}, {
+		name:        "an empty stored schema adopts the preset wholesale",
+		stored:      ``,
+		preset:      `{"type":"object","properties":{"name":{"type":"string"},"sku":{"type":"string"}}}`,
+		wantChanged: true,
+		wantAdded:   []string{"name", "sku"},
+		wantProps:   []string{"name", "sku"},
+	}, {
+		name:        "an empty preset schema never clears the stored one",
+		stored:      `{"type":"object","properties":{"name":{"type":"string"}}}`,
+		preset:      ``,
+		wantChanged: false,
+	}, {
+		// The operator-customization guard: a property only the database knows
+		// about survives, and does not block the preset's own addition.
+		name:        "a stored-only property is preserved alongside a new one",
+		stored:      `{"type":"object","properties":{"name":{"type":"string"},"nickname":{"type":"string"}}}`,
+		preset:      `{"type":"object","properties":{"name":{"type":"string"},"sku":{"type":"string"}}}`,
+		wantChanged: true,
+		wantAdded:   []string{"sku"},
+		wantProps:   []string{"name", "nickname", "sku"},
+	}, {
+		name:        "a property the preset drops is preserved, not removed",
+		stored:      `{"type":"object","properties":{"name":{"type":"string"},"legacy":{"type":"string"}}}`,
+		preset:      `{"type":"object","properties":{"name":{"type":"string"}}}`,
+		wantChanged: false,
+	}, {
+		name:          "a retyped property is refused",
+		stored:        `{"type":"object","properties":{"sku":{"type":"string"}}}`,
+		preset:        `{"type":"object","properties":{"sku":{"type":"integer"}}}`,
+		wantChanged:   false,
+		wantConflicts: []string{"sku"},
+	}, {
+		name:          "a redefined property is refused even when a sibling is additive",
+		stored:        `{"type":"object","properties":{"sku":{"type":"string"}}}`,
+		preset:        `{"type":"object","properties":{"sku":{"type":"string","maxLength":8},"tag":{"type":"string"}}}`,
+		wantChanged:   false,
+		wantConflicts: []string{"sku"},
+	}, {
+		// Akeem's call on issue #379: the preset is authoritative for `required`,
+		// so tightening it applies even though existing rows may then fail
+		// validation on their next write.
+		name:        "a tightened required array follows the preset",
+		stored:      `{"type":"object","required":["name"],"properties":{"name":{"type":"string"}}}`,
+		preset:      `{"type":"object","required":["name","sku"],"properties":{"name":{"type":"string"},"sku":{"type":"string"}}}`,
+		wantChanged: true,
+		wantAdded:   []string{"sku"},
+		wantProps:   []string{"name", "sku"},
+	}, {
+		name:        "a changed top-level keyword alone still counts as a change",
+		stored:      `{"type":"object","additionalProperties":true,"properties":{"name":{"type":"string"}}}`,
+		preset:      `{"type":"object","additionalProperties":false,"properties":{"name":{"type":"string"}}}`,
+		wantChanged: true,
+	}, {
+		name:   "nested object properties compare by value",
+		stored: `{"type":"object","properties":{"addr":{"type":"object","properties":{"city":{"type":"string"}}}}}`,
+		preset: `{"type":"object","properties":{"addr":{"type":"object","properties":{"city":{"type":"string"}}}}}`,
+		//nolint:lll // the schemas above are clearer on one line each
+		wantChanged: false,
+	}, {
+		name:          "a nested object property that changes shape is refused",
+		stored:        `{"type":"object","properties":{"addr":{"type":"object","properties":{"city":{"type":"string"}}}}}`,
+		preset:        `{"type":"object","properties":{"addr":{"type":"object","properties":{"zip":{"type":"string"}}}}}`,
+		wantChanged:   false,
+		wantConflicts: []string{"addr"},
+	}, {
+		name:        "a ref-shaped property is added like any other",
+		stored:      `{"type":"object","properties":{"name":{"type":"string"}}}`,
+		preset:      `{"type":"object","properties":{"name":{"type":"string"},"owner":{"$ref":"#/defs/Person"}}}`,
+		wantChanged: true,
+		wantAdded:   []string{"owner"},
+		wantProps:   []string{"name", "owner"},
+	}, {
+		name:        "a schema with no properties key is tolerated",
+		stored:      `{"type":"object"}`,
+		preset:      `{"type":"object","properties":{"sku":{"type":"string"}}}`,
+		wantChanged: true,
+		wantAdded:   []string{"sku"},
+		wantProps:   []string{"sku"},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := reconcileAdditiveSchema(json.RawMessage(tc.stored), json.RawMessage(tc.preset))
+			if err != nil {
+				t.Fatalf("reconcileAdditiveSchema: %v", err)
+			}
+			if got.Changed != tc.wantChanged {
+				t.Fatalf("Changed = %v, want %v (result %+v)", got.Changed, tc.wantChanged, got)
+			}
+			if tc.wantAdded != nil && !reflect.DeepEqual(got.Added, tc.wantAdded) {
+				t.Errorf("Added = %v, want %v", got.Added, tc.wantAdded)
+			}
+			if !sameStrings(got.Conflicts, tc.wantConflicts) {
+				t.Errorf("Conflicts = %v, want %v", got.Conflicts, tc.wantConflicts)
+			}
+			// A refused reconcile must never hand back a schema a caller could
+			// persist by mistake.
+			if len(tc.wantConflicts) > 0 && got.Schema != nil {
+				t.Errorf("refused reconcile returned a schema: %s", got.Schema)
+			}
+			if !tc.wantChanged {
+				if got.Schema != nil {
+					t.Errorf("unchanged reconcile returned a schema: %s", got.Schema)
+				}
+				return
+			}
+			if tc.wantProps == nil {
+				return
+			}
+			props := schemaProps(t, got.Schema)
+			if len(props) != len(tc.wantProps) {
+				t.Fatalf("merged properties = %v, want exactly %v", sortedKeys(props), tc.wantProps)
+			}
+			for _, name := range tc.wantProps {
+				if _, ok := props[name]; !ok {
+					t.Errorf("merged schema is missing property %q (have %v)", name, sortedKeys(props))
+				}
+			}
+		})
+	}
+}
+
+// TestReconcileAdditiveSchema_Idempotent pins the property that keeps a restart
+// quiet: re-running the merge against its own output reports no change, so no
+// ResourceTypeUpdated event is emitted on the second boot.
+func TestReconcileAdditiveSchema_Idempotent(t *testing.T) {
+	t.Parallel()
+	stored := json.RawMessage(`{"type":"object","required":["name"],"properties":{"name":{"type":"string"}}}`)
+	preset := json.RawMessage(
+		`{"type":"object","required":["name","sku"],"properties":{"name":{"type":"string"},"sku":{"type":"string"}}}`)
+
+	first, err := reconcileAdditiveSchema(stored, preset)
+	if err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	if !first.Changed {
+		t.Fatal("first reconcile should have changed the schema")
+	}
+
+	second, err := reconcileAdditiveSchema(first.Schema, preset)
+	if err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	if second.Changed {
+		t.Fatalf("second reconcile should be a no-op, got %+v", second)
+	}
+}
+
+func TestReconcileAdditiveSchema_MalformedSchemaErrors(t *testing.T) {
+	t.Parallel()
+	valid := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`)
+
+	if _, err := reconcileAdditiveSchema(valid, json.RawMessage(`not json`)); err == nil {
+		t.Error("expected an error for a malformed preset schema")
+	}
+	if _, err := reconcileAdditiveSchema(json.RawMessage(`not json`), valid); err == nil {
+		t.Error("expected an error for a malformed stored schema")
+	}
+	if _, err := reconcileAdditiveSchema(valid, json.RawMessage(`{"properties":"nope"}`)); err == nil {
+		t.Error("expected an error when `properties` is not an object")
+	}
+}
+
+// TestReconcilePresetSchemas_AddsPropertyToInstalledType is the service-level
+// case behind issue #379: a database provisioned by an earlier build, booted
+// against a preset that has since gained a property.
+func TestReconcilePresetSchemas_AddsPropertyToInstalledType(t *testing.T) {
+	t.Parallel()
+	v1 := NewPresetRegistry()
+	v1.MustAdd(testPresetSingle(
+		"Product", "product", "A product",
+		`{"@vocab":"https://schema.org/"}`,
+		`{"type":"object","properties":{"name":{"type":"string"}}}`,
+	))
+
+	repo := newInstallTestTypeRepo()
+	rSvc := newFakeResourceSvc()
+	svc := makeInstallTestService(repo, rSvc, v1)
+	if _, err := svc.InstallPreset(context.Background(), "single", false); err != nil {
+		t.Fatalf("initial install: %v", err)
+	}
+
+	// The next build declares an extra property.
+	v2 := NewPresetRegistry()
+	v2.MustAdd(testPresetSingle(
+		"Product", "product", "A product",
+		`{"@vocab":"https://schema.org/"}`,
+		`{"type":"object","properties":{"name":{"type":"string"},"sku":{"type":"string"}}}`,
+	))
+	svc2 := reconcileTestService(t, repo, rSvc, v2)
+
+	res, err := svc2.ReconcilePresetSchemas(context.Background(), "single")
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(res.Updated) != 1 || res.Updated[0] != "product" {
+		t.Fatalf("expected Updated=[product], got %+v", res)
+	}
+
+	stored, err := repo.FindBySlug(context.Background(), "product")
+	if err != nil {
+		t.Fatalf("FindBySlug: %v", err)
+	}
+	props := schemaProps(t, stored.Schema())
+	if _, ok := props["sku"]; !ok {
+		t.Fatalf("stored schema is missing the added property (have %v)", sortedKeys(props))
+	}
+}
+
+// TestReconcilePresetSchemas_UnchangedEmitsNoEvent covers scenarios 3 and 4 of
+// the acceptance contract: restarting against an unchanged preset must not
+// append a ResourceTypeUpdated per type per boot.
+func TestReconcilePresetSchemas_UnchangedEmitsNoEvent(t *testing.T) {
+	t.Parallel()
+	registry := NewPresetRegistry()
+	registry.MustAdd(testPresetSingle(
+		"Product", "product", "A product",
+		`{"@vocab":"https://schema.org/"}`,
+		`{"type":"object","properties":{"name":{"type":"string"}}}`,
+	))
+
+	repo := newInstallTestTypeRepo()
+	rSvc := newFakeResourceSvc()
+	svc := makeInstallTestService(repo, rSvc, registry)
+	if _, err := svc.InstallPreset(context.Background(), "single", false); err != nil {
+		t.Fatalf("initial install: %v", err)
+	}
+
+	d := domain.NewEventDispatcher()
+	pm := &stubProjMgr{}
+	if err := SubscribeResourceTypeHandlers(d, repo, pm, noopLogger{}); err != nil {
+		t.Fatalf("SubscribeResourceTypeHandlers: %v", err)
+	}
+	updateCount := countingUpdateSub(t, d)
+	svc2 := &resourceTypeService{
+		repo: repo, projMgr: pm, eventStore: &stubEventStore{}, dispatcher: d,
+		registry: registry, logger: noopLogger{}, resourceSvc: rSvc,
+	}
+
+	for i := 0; i < 2; i++ {
+		res, err := svc2.ReconcilePresetSchemas(context.Background(), "single")
+		if err != nil {
+			t.Fatalf("reconcile %d: %v", i, err)
+		}
+		if len(res.Unchanged) != 1 || len(res.Updated) != 0 {
+			t.Fatalf("reconcile %d should be a no-op, got %+v", i, res)
+		}
+	}
+	if *updateCount != 0 {
+		t.Fatalf("expected zero ResourceTypeUpdated events, got %d", *updateCount)
+	}
+}
+
+// TestReconcilePresetSchemas_SettlesAfterOneUpdate is scenario 4 proper: the
+// first boot after a schema change updates once, the next boot is quiet.
+func TestReconcilePresetSchemas_SettlesAfterOneUpdate(t *testing.T) {
+	t.Parallel()
+	v1 := NewPresetRegistry()
+	v1.MustAdd(testPresetSingle(
+		"Product", "product", "A product",
+		`{"@vocab":"https://schema.org/"}`,
+		`{"type":"object","properties":{"name":{"type":"string"}}}`,
+	))
+	repo := newInstallTestTypeRepo()
+	rSvc := newFakeResourceSvc()
+	if _, err := makeInstallTestService(repo, rSvc, v1).
+		InstallPreset(context.Background(), "single", false); err != nil {
+		t.Fatalf("initial install: %v", err)
+	}
+
+	v2 := NewPresetRegistry()
+	v2.MustAdd(testPresetSingle(
+		"Product", "product", "A product",
+		`{"@vocab":"https://schema.org/"}`,
+		`{"type":"object","properties":{"name":{"type":"string"},"sku":{"type":"string"}}}`,
+	))
+
+	d := domain.NewEventDispatcher()
+	pm := &stubProjMgr{}
+	if err := SubscribeResourceTypeHandlers(d, repo, pm, noopLogger{}); err != nil {
+		t.Fatalf("SubscribeResourceTypeHandlers: %v", err)
+	}
+	updateCount := countingUpdateSub(t, d)
+	svc := &resourceTypeService{
+		repo: repo, projMgr: pm, eventStore: &stubEventStore{}, dispatcher: d,
+		registry: v2, logger: noopLogger{}, resourceSvc: rSvc,
+	}
+
+	if _, err := svc.ReconcilePresetSchemas(context.Background(), "single"); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	second, err := svc.ReconcilePresetSchemas(context.Background(), "single")
+	if err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	if len(second.Updated) != 0 || len(second.Unchanged) != 1 {
+		t.Fatalf("second reconcile should be a no-op, got %+v", second)
+	}
+	if *updateCount != 1 {
+		t.Fatalf("expected exactly one ResourceTypeUpdated event, got %d", *updateCount)
+	}
+}
+
+// TestReconcilePresetSchemas_PreservesStoredIdentity is the operator-
+// customization guard: only the schema is reconciled, so a renamed or
+// re-described built-in type keeps its edits across a restart.
+func TestReconcilePresetSchemas_PreservesStoredIdentity(t *testing.T) {
+	t.Parallel()
+	v1 := NewPresetRegistry()
+	v1.MustAdd(testPresetSingle(
+		"Product", "product", "A product",
+		`{"@vocab":"https://schema.org/"}`,
+		`{"type":"object","properties":{"name":{"type":"string"}}}`,
+	))
+	repo := newInstallTestTypeRepo()
+	rSvc := newFakeResourceSvc()
+	svc := makeInstallTestService(repo, rSvc, v1)
+	if _, err := svc.InstallPreset(context.Background(), "single", false); err != nil {
+		t.Fatalf("initial install: %v", err)
+	}
+
+	// The operator renames and re-describes the built-in type.
+	stored, err := repo.FindBySlug(context.Background(), "product")
+	if err != nil {
+		t.Fatalf("FindBySlug: %v", err)
+	}
+	if _, err := svc.Update(context.Background(), UpdateResourceTypeCommand{
+		ID:          stored.GetID(),
+		Name:        "Catalog Item",
+		Slug:        "product",
+		Description: "Our own wording",
+		Status:      stored.Status(),
+		Context:     stored.Context(),
+		Schema:      stored.Schema(),
+	}); err != nil {
+		t.Fatalf("operator update: %v", err)
+	}
+
+	// A later build adds a property.
+	v2 := NewPresetRegistry()
+	v2.MustAdd(testPresetSingle(
+		"Product", "product", "A product",
+		`{"@vocab":"https://schema.org/"}`,
+		`{"type":"object","properties":{"name":{"type":"string"},"sku":{"type":"string"}}}`,
+	))
+	if _, err := reconcileTestService(t, repo, rSvc, v2).
+		ReconcilePresetSchemas(context.Background(), "single"); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	after, err := repo.FindBySlug(context.Background(), "product")
+	if err != nil {
+		t.Fatalf("FindBySlug after reconcile: %v", err)
+	}
+	if after.Name() != "Catalog Item" {
+		t.Errorf("operator's name was clobbered: got %q", after.Name())
+	}
+	if after.Description() != "Our own wording" {
+		t.Errorf("operator's description was clobbered: got %q", after.Description())
+	}
+	if _, ok := schemaProps(t, after.Schema())["sku"]; !ok {
+		t.Error("the preset's added property did not land")
+	}
+}
+
+// TestReconcilePresetSchemas_RefusesNonAdditiveChange pins the deferred case:
+// a retyped property leaves the stored type entirely alone and is reported.
+func TestReconcilePresetSchemas_RefusesNonAdditiveChange(t *testing.T) {
+	t.Parallel()
+	v1 := NewPresetRegistry()
+	v1.MustAdd(testPresetSingle(
+		"Product", "product", "A product",
+		`{"@vocab":"https://schema.org/"}`,
+		`{"type":"object","properties":{"sku":{"type":"string"}}}`,
+	))
+	repo := newInstallTestTypeRepo()
+	rSvc := newFakeResourceSvc()
+	if _, err := makeInstallTestService(repo, rSvc, v1).
+		InstallPreset(context.Background(), "single", false); err != nil {
+		t.Fatalf("initial install: %v", err)
+	}
+
+	v2 := NewPresetRegistry()
+	v2.MustAdd(testPresetSingle(
+		"Product", "product", "A product",
+		`{"@vocab":"https://schema.org/"}`,
+		`{"type":"object","properties":{"sku":{"type":"integer"},"tag":{"type":"string"}}}`,
+	))
+
+	d := domain.NewEventDispatcher()
+	pm := &stubProjMgr{}
+	if err := SubscribeResourceTypeHandlers(d, repo, pm, noopLogger{}); err != nil {
+		t.Fatalf("SubscribeResourceTypeHandlers: %v", err)
+	}
+	updateCount := countingUpdateSub(t, d)
+	svc := &resourceTypeService{
+		repo: repo, projMgr: pm, eventStore: &stubEventStore{}, dispatcher: d,
+		registry: v2, logger: noopLogger{}, resourceSvc: rSvc,
+	}
+
+	res, err := svc.ReconcilePresetSchemas(context.Background(), "single")
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if got := res.Refused["product"]; !reflect.DeepEqual(got, []string{"sku"}) {
+		t.Fatalf("expected Refused[product]=[sku], got %+v", res)
+	}
+	if len(res.Updated) != 0 {
+		t.Errorf("a refused type must not be updated, got %+v", res.Updated)
+	}
+	if *updateCount != 0 {
+		t.Errorf("a refused type must emit no event, got %d", *updateCount)
+	}
+
+	// The additive sibling must NOT have been smuggled in.
+	after, err := repo.FindBySlug(context.Background(), "product")
+	if err != nil {
+		t.Fatalf("FindBySlug: %v", err)
+	}
+	if _, ok := schemaProps(t, after.Schema())["tag"]; ok {
+		t.Error("a refused reconcile partially applied the preset")
+	}
+}
+
+// TestReconcilePresetSchemas_IgnoresUninstalledTypes: creating types is
+// InstallPreset's job, so a preset type absent from this database is skipped
+// rather than conjured into existence by the reconcile pass.
+func TestReconcilePresetSchemas_IgnoresUninstalledTypes(t *testing.T) {
+	t.Parallel()
+	registry := NewPresetRegistry()
+	registry.MustAdd(testPresetSingle(
+		"Product", "product", "A product",
+		`{"@vocab":"https://schema.org/"}`,
+		`{"type":"object","properties":{"name":{"type":"string"}}}`,
+	))
+	repo := newInstallTestTypeRepo()
+	rSvc := newFakeResourceSvc()
+	svc := reconcileTestService(t, repo, rSvc, registry)
+
+	res, err := svc.ReconcilePresetSchemas(context.Background(), "single")
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(res.Updated) != 0 || len(res.Unchanged) != 0 || len(res.Refused) != 0 {
+		t.Fatalf("expected an empty result for an uninstalled type, got %+v", res)
+	}
+	if _, err := repo.FindBySlug(context.Background(), "product"); err == nil {
+		t.Error("reconcile must not create the type")
+	}
+}
+
+func TestReconcilePresetSchemas_UnknownPreset(t *testing.T) {
+	t.Parallel()
+	svc := reconcileTestService(t, newInstallTestTypeRepo(), newFakeResourceSvc(), NewPresetRegistry())
+	if _, err := svc.ReconcilePresetSchemas(context.Background(), "nope"); err == nil {
+		t.Error("expected an error for an unknown preset")
+	}
+}
+
+// reconcileTestService builds a service over an existing repo, standing in for
+// a restart: the database persists, the process (and its dispatcher) is new.
+func reconcileTestService(
+	t *testing.T, repo *installTestTypeRepo, rSvc *fakeResourceSvc, registry *PresetRegistry,
+) ResourceTypeService {
+	t.Helper()
+	d := domain.NewEventDispatcher()
+	pm := &stubProjMgr{}
+	if err := SubscribeResourceTypeHandlers(d, repo, pm, noopLogger{}); err != nil {
+		t.Fatalf("SubscribeResourceTypeHandlers: %v", err)
+	}
+	return &resourceTypeService{
+		repo: repo, projMgr: pm, eventStore: &stubEventStore{}, dispatcher: d,
+		registry: registry, logger: noopLogger{}, resourceSvc: rSvc,
+	}
+}

--- a/application/preset_schema_reconcile_test.go
+++ b/application/preset_schema_reconcile_test.go
@@ -136,11 +136,16 @@ func TestReconcileAdditiveSchema(t *testing.T) {
 		wantChanged:   false,
 		wantConflicts: []string{"sku"},
 	}, {
-		name:          "a redefined property is refused even when a sibling is additive",
+		// Per-property refusal: the conflicting property is held at its stored
+		// definition, but the additive sibling still lands — otherwise one
+		// cosmetic edit would block the whole type and #379 would persist for it.
+		name:          "a held property does not block an additive sibling",
 		stored:        `{"type":"object","properties":{"sku":{"type":"string"}}}`,
 		preset:        `{"type":"object","properties":{"sku":{"type":"string","maxLength":8},"tag":{"type":"string"}}}`,
-		wantChanged:   false,
+		wantChanged:   true,
+		wantAdded:     []string{"tag"},
 		wantConflicts: []string{"sku"},
+		wantProps:     []string{"sku", "tag"},
 	}, {
 		// Akeem's call on issue #379: the preset is authoritative for `required`,
 		// so tightening it applies even though existing rows may then fail
@@ -218,10 +223,17 @@ func TestReconcileAdditiveSchema(t *testing.T) {
 			if !sameStrings(got.Conflicts, tc.wantConflicts) {
 				t.Errorf("Conflicts = %v, want %v", got.Conflicts, tc.wantConflicts)
 			}
-			// A refused reconcile must never hand back a schema a caller could
-			// persist by mistake.
+			// A held property must keep its STORED definition in whatever schema
+			// comes back — that is what keeps the merge additive.
 			if len(tc.wantConflicts) > 0 && got.Schema != nil {
-				t.Errorf("refused reconcile returned a schema: %s", got.Schema)
+				storedProps := schemaProps(t, json.RawMessage(tc.stored))
+				mergedProps := schemaProps(t, got.Schema)
+				for _, name := range tc.wantConflicts {
+					if !jsonEquivalent(storedProps[name], mergedProps[name]) {
+						t.Errorf("held property %q was rewritten: stored %s, merged %s",
+							name, storedProps[name], mergedProps[name])
+					}
+				}
 			}
 			if !tc.wantChanged {
 				if got.Schema != nil {
@@ -491,9 +503,10 @@ func TestReconcilePresetSchemas_PreservesStoredIdentity(t *testing.T) {
 	}
 }
 
-// TestReconcilePresetSchemas_RefusesNonAdditiveChange pins the deferred case:
-// a retyped property leaves the stored type entirely alone and is reported.
-func TestReconcilePresetSchemas_RefusesNonAdditiveChange(t *testing.T) {
+// TestReconcilePresetSchemas_HoldsNonAdditiveChange pins the deferred case: a
+// retyped property keeps its stored definition and is reported, while the rest
+// of the merge proceeds.
+func TestReconcilePresetSchemas_HoldsNonAdditiveChange(t *testing.T) {
 	t.Parallel()
 	v1 := NewPresetRegistry()
 	v1.MustAdd(testPresetSingle(
@@ -533,20 +546,31 @@ func TestReconcilePresetSchemas_RefusesNonAdditiveChange(t *testing.T) {
 	if got := res.Refused["product"]; !reflect.DeepEqual(got, []string{"sku"}) {
 		t.Fatalf("expected Refused[product]=[sku], got %+v", res)
 	}
-	if len(res.Updated) != 0 {
-		t.Errorf("a refused type must not be updated, got %+v", res.Updated)
+	if !sameStrings(res.Updated, []string{"product"}) {
+		t.Errorf("the additive sibling should still be applied, got Updated=%v", res.Updated)
 	}
-	if *updateCount != 0 {
-		t.Errorf("a refused type must emit no event, got %d", *updateCount)
+	if *updateCount != 1 {
+		t.Errorf("expected exactly one ResourceTypeUpdated event, got %d", *updateCount)
 	}
 
-	// The additive sibling must NOT have been smuggled in.
+	// The conflicting property keeps its stored definition even though the
+	// additive sibling landed.
 	after, err := repo.FindBySlug(context.Background(), "product")
 	if err != nil {
 		t.Fatalf("FindBySlug: %v", err)
 	}
-	if _, ok := schemaProps(t, after.Schema())["tag"]; ok {
-		t.Error("a refused reconcile partially applied the preset")
+	props := schemaProps(t, after.Schema())
+	if _, ok := props["tag"]; !ok {
+		t.Error("the additive sibling should have landed alongside the held property")
+	}
+	var sku struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(props["sku"], &sku); err != nil {
+		t.Fatalf("sku is not an object: %v", err)
+	}
+	if sku.Type != "string" {
+		t.Errorf("held property was rewritten: sku.type = %q, want the stored %q", sku.Type, "string")
 	}
 }
 
@@ -758,10 +782,11 @@ func TestReconcilePresetSchemas_ReportsSchemaLessType(t *testing.T) {
 	}
 }
 
-// TestReconcilePresetSchemas_ReportsBlockedAdditions: refusal is all-or-nothing,
-// so an operator needs to know which additive properties went down with the
-// conflict — those are the ones still losing writes.
-func TestReconcilePresetSchemas_ReportsBlockedAdditions(t *testing.T) {
+// TestReconcilePresetSchemas_HeldPropertyDoesNotBlockAdditions: refusal is
+// per-property, so a conflicting definition is held at its stored form while
+// every additive property in the same schema still lands. Under the old
+// all-or-nothing rule these additions were blocked and kept losing writes.
+func TestReconcilePresetSchemas_HeldPropertyDoesNotBlockAdditions(t *testing.T) {
 	t.Parallel()
 	v1 := NewPresetRegistry()
 	v1.MustAdd(testPresetSingle(
@@ -791,7 +816,28 @@ func TestReconcilePresetSchemas_ReportsBlockedAdditions(t *testing.T) {
 	if !sameStrings(res.Refused["product"], []string{"sku"}) {
 		t.Fatalf("expected Refused[product]=[sku], got %+v", res.Refused)
 	}
-	if !sameStrings(res.BlockedAdditions["product"], []string{"brand", "gtin"}) {
-		t.Fatalf("expected BlockedAdditions[product]=[brand gtin], got %+v", res.BlockedAdditions)
+	if !sameStrings(res.Updated, []string{"product"}) {
+		t.Fatalf("the additive properties should still have landed, got Updated=%v", res.Updated)
+	}
+
+	after, err := repo.FindBySlug(context.Background(), "product")
+	if err != nil {
+		t.Fatalf("FindBySlug: %v", err)
+	}
+	props := schemaProps(t, after.Schema())
+	for _, name := range []string{"gtin", "brand"} {
+		if _, ok := props[name]; !ok {
+			t.Errorf("additive property %q did not land (have %v)", name, sortedKeys(props))
+		}
+	}
+	// ...and the conflicting one is still the STORED definition, not the preset's.
+	var sku struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(props["sku"], &sku); err != nil {
+		t.Fatalf("sku is not an object: %v", err)
+	}
+	if sku.Type != "string" {
+		t.Errorf("held property was rewritten: sku.type = %q, want the stored %q", sku.Type, "string")
 	}
 }

--- a/application/preset_schema_reconcile_test.go
+++ b/application/preset_schema_reconcile_test.go
@@ -18,7 +18,9 @@ package application
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
@@ -55,6 +57,20 @@ func sameStrings(a, b []string) bool {
 	return true
 }
 
+// assertRequired checks the merged schema's `required` array exactly.
+func assertRequired(t *testing.T, raw json.RawMessage, want []string) {
+	t.Helper()
+	var doc struct {
+		Required []string `json:"required"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("merged schema is not a JSON object: %v", err)
+	}
+	if !sameStrings(doc.Required, want) {
+		t.Errorf("required = %v, want %v", doc.Required, want)
+	}
+}
+
 func TestReconcileAdditiveSchema(t *testing.T) {
 	t.Parallel()
 
@@ -68,6 +84,8 @@ func TestReconcileAdditiveSchema(t *testing.T) {
 		// wantProps, when set, lists every property name the merged schema must
 		// carry — the guard that preserved and added properties coexist.
 		wantProps []string
+		// wantRequired, when set, is the exact reconciled `required` array.
+		wantRequired []string
 	}{{
 		name:        "identical schemas are a no-op",
 		stored:      `{"type":"object","properties":{"name":{"type":"string"}}}`,
@@ -134,6 +152,24 @@ func TestReconcileAdditiveSchema(t *testing.T) {
 		wantAdded:   []string{"sku"},
 		wantProps:   []string{"name", "sku"},
 	}, {
+		// The preset has no opinion about a property it doesn't declare, so its
+		// `required` list must not silently drop the operator's own requirement.
+		name:         "a stored-only property keeps its requirement",
+		stored:       `{"type":"object","required":["name","nickname"],"properties":{"name":{"type":"string"},"nickname":{"type":"string"}}}`,
+		preset:       `{"type":"object","required":["name"],"properties":{"name":{"type":"string"},"sku":{"type":"string"}}}`,
+		wantChanged:  true,
+		wantAdded:    []string{"sku"},
+		wantProps:    []string{"name", "nickname", "sku"},
+		wantRequired: []string{"name", "nickname"},
+	}, {
+		// ...but a requirement the preset DOES have an opinion about follows the
+		// preset, including when the preset drops it.
+		name:         "a requirement on a preset-declared property follows the preset",
+		stored:       `{"type":"object","required":["name","sku"],"properties":{"name":{"type":"string"},"sku":{"type":"string"}}}`,
+		preset:       `{"type":"object","required":["name"],"properties":{"name":{"type":"string"},"sku":{"type":"string"}}}`,
+		wantChanged:  true,
+		wantRequired: []string{"name"},
+	}, {
 		name:        "a changed top-level keyword alone still counts as a change",
 		stored:      `{"type":"object","additionalProperties":true,"properties":{"name":{"type":"string"}}}`,
 		preset:      `{"type":"object","additionalProperties":false,"properties":{"name":{"type":"string"}}}`,
@@ -195,6 +231,9 @@ func TestReconcileAdditiveSchema(t *testing.T) {
 			}
 			if tc.wantProps == nil {
 				return
+			}
+			if tc.wantRequired != nil {
+				assertRequired(t, got.Schema, tc.wantRequired)
 			}
 			props := schemaProps(t, got.Schema)
 			if len(props) != len(tc.wantProps) {
@@ -560,5 +599,199 @@ func reconcileTestService(
 	return &resourceTypeService{
 		repo: repo, projMgr: pm, eventStore: &stubEventStore{}, dispatcher: d,
 		registry: registry, logger: noopLogger{}, resourceSvc: rSvc,
+	}
+}
+
+// TestReconcilePresetSchemas_FailsWhenColumnDoesNotLand is the guard against
+// announcing success over a silent failure. SimpleUnitOfWork.Commit discards
+// dispatch errors, so Update returns nil even when EnsureTable failed and the
+// column was never added — reporting that type as reconciled would claim the
+// #379 bug is fixed for a type still dropping writes.
+func TestReconcilePresetSchemas_FailsWhenColumnDoesNotLand(t *testing.T) {
+	t.Parallel()
+	v1 := NewPresetRegistry()
+	v1.MustAdd(testPresetSingle(
+		"Product", "product", "A product",
+		`{"@vocab":"https://schema.org/"}`,
+		`{"type":"object","properties":{"name":{"type":"string"}}}`,
+	))
+	repo := newInstallTestTypeRepo()
+	rSvc := newFakeResourceSvc()
+	if _, err := makeInstallTestService(repo, rSvc, v1).
+		InstallPreset(context.Background(), "single", false); err != nil {
+		t.Fatalf("initial install: %v", err)
+	}
+
+	v2 := NewPresetRegistry()
+	v2.MustAdd(testPresetSingle(
+		"Product", "product", "A product",
+		`{"@vocab":"https://schema.org/"}`,
+		`{"type":"object","properties":{"name":{"type":"string"},"sku":{"type":"string"}}}`,
+	))
+
+	// A projection manager that refuses to add columns — the ALTER failing, or
+	// any other reason EnsureTable errors inside the event handler.
+	d := domain.NewEventDispatcher()
+	pm := &stubProjMgr{ensureTableErr: errors.New("ALTER TABLE failed")}
+	if err := SubscribeResourceTypeHandlers(d, repo, pm, noopLogger{}); err != nil {
+		t.Fatalf("SubscribeResourceTypeHandlers: %v", err)
+	}
+	svc := &resourceTypeService{
+		repo: repo, projMgr: pm, eventStore: &stubEventStore{}, dispatcher: d,
+		registry: v2, logger: noopLogger{}, resourceSvc: rSvc,
+	}
+
+	res, err := svc.ReconcilePresetSchemas(context.Background(), "single")
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(res.Updated) != 0 {
+		t.Errorf("must not report Updated when the column never landed, got %+v", res.Updated)
+	}
+	if _, ok := res.Failed["product"]; !ok {
+		t.Fatalf("expected product in Failed, got %+v", res)
+	}
+	if !strings.Contains(res.Failed["product"], "sku") {
+		t.Errorf("failure reason should name the missing column, got %q", res.Failed["product"])
+	}
+}
+
+// TestReconcilePresetSchemas_ContinuesAfterPerTypeFailure: one bad type must
+// not leave every later type in the preset unreconciled and silently dropping
+// writes.
+func TestReconcilePresetSchemas_ContinuesAfterPerTypeFailure(t *testing.T) {
+	t.Parallel()
+	registry := NewPresetRegistry()
+	registry.MustAdd(PresetDefinition{
+		Name: "single",
+		Types: []PresetResourceType{
+			{
+				Name: "Broken", Slug: "broken", Description: "d",
+				Context: json.RawMessage(`{"@vocab":"https://schema.org/"}`),
+				Schema:  json.RawMessage(`{"type":"object","properties":{"a":{"type":"string"}}}`),
+			},
+			{
+				Name: "Healthy", Slug: "healthy", Description: "d",
+				Context: json.RawMessage(`{"@vocab":"https://schema.org/"}`),
+				Schema:  json.RawMessage(`{"type":"object","properties":{"b":{"type":"string"}}}`),
+			},
+		},
+	})
+	repo := newInstallTestTypeRepo()
+	rSvc := newFakeResourceSvc()
+	svc := makeInstallTestService(repo, rSvc, registry)
+	if _, err := svc.InstallPreset(context.Background(), "single", false); err != nil {
+		t.Fatalf("initial install: %v", err)
+	}
+
+	// Corrupt the first type's stored schema so its reconcile errors.
+	broken, err := repo.FindBySlug(context.Background(), "broken")
+	if err != nil {
+		t.Fatalf("FindBySlug: %v", err)
+	}
+	if err := broken.Restore(broken.GetID(), broken.Name(), "broken", broken.Description(),
+		broken.Status(), broken.Context(), json.RawMessage(`"not an object"`),
+		broken.CreatedAt(), 2); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if err := repo.Update(context.Background(), broken); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	// A later build adds a property to BOTH types.
+	v2 := NewPresetRegistry()
+	v2.MustAdd(PresetDefinition{
+		Name: "single",
+		Types: []PresetResourceType{
+			{
+				Name: "Broken", Slug: "broken", Description: "d",
+				Context: json.RawMessage(`{"@vocab":"https://schema.org/"}`),
+				Schema:  json.RawMessage(`{"type":"object","properties":{"a":{"type":"string"},"a2":{"type":"string"}}}`),
+			},
+			{
+				Name: "Healthy", Slug: "healthy", Description: "d",
+				Context: json.RawMessage(`{"@vocab":"https://schema.org/"}`),
+				Schema:  json.RawMessage(`{"type":"object","properties":{"b":{"type":"string"},"b2":{"type":"string"}}}`),
+			},
+		},
+	})
+
+	res, err := reconcileTestService(t, repo, rSvc, v2).
+		ReconcilePresetSchemas(context.Background(), "single")
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if _, ok := res.Failed["broken"]; !ok {
+		t.Errorf("expected broken in Failed, got %+v", res)
+	}
+	if !sameStrings(res.Updated, []string{"healthy"}) {
+		t.Fatalf("the type after the failing one must still be reconciled, got Updated=%v", res.Updated)
+	}
+}
+
+// TestReconcilePresetSchemas_ReportsSchemaLessType: a preset type with no schema
+// projects only base columns, so every field is dropped on write. It must not
+// be filed as a healthy no-op.
+func TestReconcilePresetSchemas_ReportsSchemaLessType(t *testing.T) {
+	t.Parallel()
+	registry := NewPresetRegistry()
+	registry.MustAdd(testPresetSingle(
+		"Product", "product", "A product", `{"@vocab":"https://schema.org/"}`, ``,
+	))
+	repo := newInstallTestTypeRepo()
+	rSvc := newFakeResourceSvc()
+	svc := makeInstallTestService(repo, rSvc, registry)
+	if _, err := svc.InstallPreset(context.Background(), "single", false); err != nil {
+		t.Fatalf("initial install: %v", err)
+	}
+
+	res, err := reconcileTestService(t, repo, rSvc, registry).
+		ReconcilePresetSchemas(context.Background(), "single")
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !sameStrings(res.NoSchema, []string{"product"}) {
+		t.Fatalf("expected NoSchema=[product], got %+v", res)
+	}
+	if len(res.Unchanged) != 0 {
+		t.Errorf("a schema-less type must not be filed as Unchanged, got %v", res.Unchanged)
+	}
+}
+
+// TestReconcilePresetSchemas_ReportsBlockedAdditions: refusal is all-or-nothing,
+// so an operator needs to know which additive properties went down with the
+// conflict — those are the ones still losing writes.
+func TestReconcilePresetSchemas_ReportsBlockedAdditions(t *testing.T) {
+	t.Parallel()
+	v1 := NewPresetRegistry()
+	v1.MustAdd(testPresetSingle(
+		"Product", "product", "A product",
+		`{"@vocab":"https://schema.org/"}`,
+		`{"type":"object","properties":{"sku":{"type":"string"}}}`,
+	))
+	repo := newInstallTestTypeRepo()
+	rSvc := newFakeResourceSvc()
+	if _, err := makeInstallTestService(repo, rSvc, v1).
+		InstallPreset(context.Background(), "single", false); err != nil {
+		t.Fatalf("initial install: %v", err)
+	}
+
+	v2 := NewPresetRegistry()
+	v2.MustAdd(testPresetSingle(
+		"Product", "product", "A product",
+		`{"@vocab":"https://schema.org/"}`,
+		`{"type":"object","properties":{"sku":{"type":"integer"},"gtin":{"type":"string"},"brand":{"type":"string"}}}`,
+	))
+
+	res, err := reconcileTestService(t, repo, rSvc, v2).
+		ReconcilePresetSchemas(context.Background(), "single")
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !sameStrings(res.Refused["product"], []string{"sku"}) {
+		t.Fatalf("expected Refused[product]=[sku], got %+v", res.Refused)
+	}
+	if !sameStrings(res.BlockedAdditions["product"], []string{"brand", "gtin"}) {
+		t.Fatalf("expected BlockedAdditions[product]=[brand gtin], got %+v", res.BlockedAdditions)
 	}
 }

--- a/application/reproject.go
+++ b/application/reproject.go
@@ -153,12 +153,17 @@ func Reproject(ctx context.Context, rt ReprojectRuntime, opts ReprojectOptions) 
 		return res, nil
 	}
 
+	// countSkip is set on pass 1 as well as pass 2. Each pass's accept filter
+	// excludes what the other handles, so an event is only ever counted once —
+	// and a future ResourceType.* event with no synchronous handler would
+	// otherwise fall out of both counters entirely.
 	if err := runReplayPass(ctx, rt, replayPassOptions{
-		label:  "resource-types",
-		head:   head,
-		from:   0,
-		batch:  batch,
-		accept: isResourceTypeEvent,
+		label:     "resource-types",
+		head:      head,
+		from:      0,
+		batch:     batch,
+		accept:    isResourceTypeEvent,
+		countSkip: true,
 	}, &res); err != nil {
 		return res, err
 	}
@@ -174,6 +179,14 @@ func Reproject(ctx context.Context, rt ReprojectRuntime, opts ReprojectOptions) 
 	}, &res); err != nil {
 		return res, err
 	}
+
+	// Both passes reached the head, so the whole feed is processed. Pass 2 only
+	// advances LastPosition on events it accepts, and the last event in the feed
+	// is now commonly a ResourceType.Updated (the startup reconcile appends
+	// one), which would otherwise leave a fully successful run reporting a
+	// LastPosition short of the head — the number an operator would feed back as
+	// --after-position, and the range the CLI prints.
+	res.LastPosition = head
 	return res, nil
 }
 

--- a/application/reproject.go
+++ b/application/reproject.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/wepala/weos/v3/domain/entities"
 	gormprov "github.com/wepala/weos/v3/infrastructure/database/gorm"
@@ -104,11 +105,33 @@ type ReprojectResult struct {
 	Head         int64 // feed head captured at the start of the run
 }
 
-// Reproject streams the event store's global feed, in position order, through
-// the synchronous projection handlers. The head is captured once up front so
-// the run terminates even against a concurrently-writing server (writes after
-// the snapshot already projected inline via the live path) — though the
-// intended use is the runbook's: server stopped, freshly imported store.
+// Reproject streams the event store's global feed through the synchronous
+// projection handlers. The head is captured once up front so the run terminates
+// even against a concurrently-writing server (writes after the snapshot already
+// projected inline via the live path) — though the intended use is the
+// runbook's: server stopped, freshly imported store.
+//
+// The feed is replayed in TWO passes, resource types first, and that ordering
+// is load-bearing (issue #379). A projection write drops any key with no
+// column, deciding that from the column set EnsureTable cached the last time it
+// saw the type's schema. Replaying one strict position order would hand the
+// handlers each type's ORIGINAL schema, project every resource against it, and
+// only then apply the later ResourceType.Updated that added a column — so a
+// column added by a schema change would never be backfilled, and re-running
+// wouldn't help because the ordering is identical every pass. Draining all
+// ResourceType events first brings every type to its final shape before a
+// single resource projects.
+//
+// Pass 1 always starts at the beginning of the feed, ignoring AfterPosition:
+// resuming mid-run must still put the types in their final shape before the
+// remaining resources replay, and re-applying type events is idempotent
+// (EnsureTable is HasColumn-guarded, the repo write converges). Pass 2 is the
+// resumable one, so it alone honors AfterPosition and advances LastPosition.
+//
+// Both passes scan the whole feed — the event store has no server-side type
+// filter — which trades a second read for correctness in an operator-invoked
+// one-shot. Only pass 2 counts Skipped, so an event with no synchronous handler
+// is still counted exactly once.
 func Reproject(ctx context.Context, rt ReprojectRuntime, opts ReprojectOptions) (ReprojectResult, error) {
 	batch := opts.BatchSize
 	if batch <= 0 {
@@ -122,46 +145,128 @@ func Reproject(ctx context.Context, rt ReprojectRuntime, opts ReprojectOptions) 
 	}
 	res.Head = head
 
-	pos := opts.AfterPosition
-	for pos < head {
-		envs, err := rt.EventStore.ReadAfter(ctx, pos, batch)
+	// Nothing left in the feed: resuming at (or past) the head is a no-op. This
+	// guard is what keeps that true now that pass 1 ignores AfterPosition —
+	// without it, a resume at head would still re-dispatch every type event for
+	// no benefit, since pass 2 has no resources left to project against them.
+	if opts.AfterPosition >= head {
+		return res, nil
+	}
+
+	if err := runReplayPass(ctx, rt, replayPassOptions{
+		label:  "resource-types",
+		head:   head,
+		from:   0,
+		batch:  batch,
+		accept: isResourceTypeEvent,
+	}, &res); err != nil {
+		return res, err
+	}
+
+	if err := runReplayPass(ctx, rt, replayPassOptions{
+		label:     "resources",
+		head:      head,
+		from:      opts.AfterPosition,
+		batch:     batch,
+		accept:    func(eventType string) bool { return !isResourceTypeEvent(eventType) },
+		trackLast: true,
+		countSkip: true,
+	}, &res); err != nil {
+		return res, err
+	}
+	return res, nil
+}
+
+// isResourceTypeEvent reports whether an event shapes a resource type (and so
+// belongs to Reproject's first pass) rather than carrying resource data.
+func isResourceTypeEvent(eventType string) bool {
+	return strings.HasPrefix(eventType, "ResourceType.")
+}
+
+// replayPassOptions configures one pass of the feed. accept selects the event
+// types this pass dispatches; everything else is stepped over without being
+// counted, so the two passes together account for each event exactly once.
+type replayPassOptions struct {
+	label  string
+	head   int64
+	from   int64
+	batch  int
+	accept func(eventType string) bool
+	// trackLast advances res.LastPosition, which is the position an operator
+	// resumes from. Only the resumable pass sets it.
+	trackLast bool
+	// countSkip counts events with no synchronous handler. Only one pass sets
+	// it, so a skipped event isn't tallied twice.
+	countSkip bool
+}
+
+func runReplayPass(
+	ctx context.Context, rt ReprojectRuntime, p replayPassOptions, res *ReprojectResult,
+) error {
+	pos := p.from
+	for pos < p.head {
+		envs, err := rt.EventStore.ReadAfter(ctx, pos, p.batch)
 		if err != nil {
-			return res, fmt.Errorf("reproject: read after position %d: %w", pos, err)
+			return fmt.Errorf("reproject(%s): read after position %d: %w", p.label, pos, err)
 		}
 		if len(envs) == 0 {
 			break
 		}
 		for i := range envs {
 			env := envs[i]
-			if env.Position > head {
+			if env.Position > p.head {
 				// Written after our snapshot — the live path projected it.
-				pos = head
+				pos = p.head
 				break
 			}
 			pos = env.Position
-			typed, handled, convErr := typedForReplay(env)
-			if convErr != nil {
-				return res, fmt.Errorf(
-					"reproject: stopped at position %d (%s on %s): %w — fix the cause, then resume with --after-position %d",
-					env.Position, env.EventType, env.AggregateID, convErr, res.LastPosition)
-			}
-			if !handled {
-				res.Skipped++
-				res.LastPosition = env.Position
+			if !p.accept(env.EventType) {
 				continue
 			}
-			if err := rt.Dispatcher.Dispatch(ctx, typed); err != nil {
-				return res, fmt.Errorf(
-					"reproject: stopped at position %d (%s on %s): %w — fix the cause, then resume with --after-position %d",
-					env.Position, env.EventType, env.AggregateID, err, res.LastPosition)
+			if err := dispatchReplayed(ctx, rt, env, p, res); err != nil {
+				return err
 			}
-			res.Dispatched++
+		}
+		rt.Logger.Info(ctx, "reproject: progress", "pass", p.label,
+			"position", pos, "head", p.head, "dispatched", res.Dispatched, "skipped", res.Skipped)
+	}
+	return nil
+}
+
+// dispatchReplayed converts and dispatches one accepted envelope, updating the
+// run's counters. Split out of runReplayPass to keep both within the project's
+// function-length and complexity limits.
+func dispatchReplayed(
+	ctx context.Context, rt ReprojectRuntime,
+	env domain.EventEnvelope[any], p replayPassOptions, res *ReprojectResult,
+) error {
+	typed, handled, convErr := typedForReplay(env)
+	if convErr != nil {
+		return replayStopErr(p.label, env, convErr, res.LastPosition)
+	}
+	if !handled {
+		if p.countSkip {
+			res.Skipped++
+		}
+		if p.trackLast {
 			res.LastPosition = env.Position
 		}
-		rt.Logger.Info(ctx, "reproject: progress",
-			"position", pos, "head", head, "dispatched", res.Dispatched, "skipped", res.Skipped)
+		return nil
 	}
-	return res, nil
+	if err := rt.Dispatcher.Dispatch(ctx, typed); err != nil {
+		return replayStopErr(p.label, env, err, res.LastPosition)
+	}
+	res.Dispatched++
+	if p.trackLast {
+		res.LastPosition = env.Position
+	}
+	return nil
+}
+
+func replayStopErr(label string, env domain.EventEnvelope[any], cause error, resumeFrom int64) error {
+	return fmt.Errorf(
+		"reproject(%s): stopped at position %d (%s on %s): %w — fix the cause, then resume with --after-position %d",
+		label, env.Position, env.EventType, env.AggregateID, cause, resumeFrom)
 }
 
 // typedForReplay converts a store-loaded envelope (payload deserialized as

--- a/application/reproject.go
+++ b/application/reproject.go
@@ -130,8 +130,9 @@ type ReprojectResult struct {
 //
 // Both passes scan the whole feed — the event store has no server-side type
 // filter — which trades a second read for correctness in an operator-invoked
-// one-shot. Only pass 2 counts Skipped, so an event with no synchronous handler
-// is still counted exactly once.
+// one-shot. Both also count Skipped; an event with no synchronous handler is
+// still tallied exactly once because the passes' accept filters partition the
+// feed, so only one pass ever reaches it.
 func Reproject(ctx context.Context, rt ReprojectRuntime, opts ReprojectOptions) (ReprojectResult, error) {
 	batch := opts.BatchSize
 	if batch <= 0 {
@@ -203,8 +204,9 @@ func isResourceTypeEvent(eventType string) bool {
 }
 
 // replayPassOptions configures one pass of the feed. accept selects the event
-// types this pass dispatches; everything else is stepped over without being
-// counted, so the two passes together account for each event exactly once.
+// types this pass handles; everything else is stepped over untouched, and is
+// accounted for by the pass whose filter does accept it — so the passes
+// together see each event exactly once.
 type replayPassOptions struct {
 	label  string
 	head   int64
@@ -214,8 +216,10 @@ type replayPassOptions struct {
 	// trackLast advances res.LastPosition, which is the position an operator
 	// resumes from. Only the resumable pass sets it.
 	trackLast bool
-	// countSkip counts events with no synchronous handler. Only one pass sets
-	// it, so a skipped event isn't tallied twice.
+	// countSkip counts events with no synchronous handler. Every pass sets it:
+	// double-counting is prevented by the accept filters partitioning the feed,
+	// not by leaving it off somewhere. Leaving it off would instead drop an
+	// unhandled event from the totals altogether, since no other pass sees it.
 	countSkip bool
 }
 

--- a/application/reproject.go
+++ b/application/reproject.go
@@ -149,14 +149,20 @@ func Reproject(ctx context.Context, rt ReprojectRuntime, opts ReprojectOptions) 
 	// guard is what keeps that true now that pass 1 ignores AfterPosition —
 	// without it, a resume at head would still re-dispatch every type event for
 	// no benefit, since pass 2 has no resources left to project against them.
+	//
+	// LastPosition reports the head rather than the caller's AfterPosition, so a
+	// no-op run and a complete run agree on the resume point. It also keeps an
+	// over-large AfterPosition from being echoed straight back to the operator.
 	if opts.AfterPosition >= head {
+		res.LastPosition = head
 		return res, nil
 	}
 
-	// countSkip is set on pass 1 as well as pass 2. Each pass's accept filter
-	// excludes what the other handles, so an event is only ever counted once —
-	// and a future ResourceType.* event with no synchronous handler would
-	// otherwise fall out of both counters entirely.
+	// BOTH passes set countSkip. Their accept filters partition the feed, so an
+	// unhandled event is tallied by whichever pass accepts it and therefore
+	// exactly once. Pass 1 needs it because pass 2 never sees ResourceType.*
+	// events: without it, a future ResourceType.* event with no synchronous
+	// handler would fall out of both counters entirely.
 	if err := runReplayPass(ctx, rt, replayPassOptions{
 		label:     "resource-types",
 		head:      head,

--- a/application/reproject_test.go
+++ b/application/reproject_test.go
@@ -351,3 +351,73 @@ func TestTypedForReplay_ConvertsStoreShapedPayloads(t *testing.T) {
 		t.Fatalf("unhandled event: handled=%v err=%v, want false/nil", handled, err)
 	}
 }
+
+// TestReproject_ResumeStillRunsTypePass covers the semantics this file's other
+// resume test can't reach: a resume from a position BELOW the head. Pass 1
+// deliberately ignores AfterPosition so the types reach their final shape
+// before the remaining resources project, while pass 2 honors it.
+func TestReproject_ResumeStillRunsTypePass(t *testing.T) {
+	env := newReprojectTestEnv(t)
+	env.seedImportedHistory(t)
+
+	full, err := Reproject(context.Background(), env.rt, ReprojectOptions{})
+	if err != nil {
+		t.Fatalf("full reproject: %v", err)
+	}
+
+	// Resume from just after the ResourceType.Created at position 1. The type
+	// pass must run again regardless, or the resources replaying in pass 2 would
+	// have no column set to project against.
+	resumed, err := Reproject(context.Background(), env.rt, ReprojectOptions{AfterPosition: 1})
+	if err != nil {
+		t.Fatalf("resumed reproject: %v", err)
+	}
+	if resumed.Dispatched == 0 {
+		t.Fatal("a resume below the head dispatched nothing")
+	}
+	if resumed.LastPosition != full.Head {
+		t.Errorf("resume LastPosition = %d, want head %d", resumed.LastPosition, full.Head)
+	}
+}
+
+// TestReproject_CompleteRunReachesHead pins the number an operator would feed
+// back as --after-position. Pass 2 only advances LastPosition on events it
+// accepts, and the last event in a real feed is commonly a ResourceType.Updated
+// (the startup reconcile appends one), so without the terminal assignment a
+// fully successful run would under-report.
+func TestReproject_CompleteRunReachesHead(t *testing.T) {
+	env := newReprojectTestEnv(t)
+	env.seedImportedHistory(t)
+
+	res, err := Reproject(context.Background(), env.rt, ReprojectOptions{})
+	if err != nil {
+		t.Fatalf("reproject: %v", err)
+	}
+	if res.LastPosition != res.Head {
+		t.Errorf("complete run reported LastPosition %d, want head %d", res.LastPosition, res.Head)
+	}
+}
+
+// TestReproject_CountsEachEventOnce guards the two-pass split: the passes'
+// accept filters partition the feed, so no event may be double-counted or fall
+// out of both counters.
+func TestReproject_CountsEachEventOnce(t *testing.T) {
+	env := newReprojectTestEnv(t)
+	env.seedImportedHistory(t)
+
+	res, err := Reproject(context.Background(), env.rt, ReprojectOptions{})
+	if err != nil {
+		t.Fatalf("reproject: %v", err)
+	}
+	// seedImportedHistory writes 5 events. Two have no synchronous handler of
+	// their own — Custom.Ignored, and Resource.Created (folded in via the
+	// Published handler's transaction read) — so the split must be 3/2 with
+	// every event accounted for exactly once.
+	if got := res.Dispatched + res.Skipped; got != 5 {
+		t.Errorf("Dispatched+Skipped = %d, want 5 (dispatched=%d skipped=%d)",
+			got, res.Dispatched, res.Skipped)
+	}
+	if res.Skipped != 2 {
+		t.Errorf("Skipped = %d, want exactly 2", res.Skipped)
+	}
+}

--- a/application/reproject_test.go
+++ b/application/reproject_test.go
@@ -352,42 +352,117 @@ func TestTypedForReplay_ConvertsStoreShapedPayloads(t *testing.T) {
 	}
 }
 
-// TestReproject_ResumeStillRunsTypePass covers the semantics this file's other
-// resume test can't reach: a resume from a position BELOW the head. Pass 1
-// deliberately ignores AfterPosition so the types reach their final shape
-// before the remaining resources project, while pass 2 honors it.
-func TestReproject_ResumeStillRunsTypePass(t *testing.T) {
+// seedSchemaChangeHistory writes the history shape issue #379 is about: a type
+// created WITHOUT a property, resources written carrying that property anyway,
+// and only then a ResourceType.Updated adding it. Replaying this in one strict
+// position order projects the resources against the old column set and loses
+// the value; the two-pass order is what recovers it.
+//
+//	pos 1  ResourceType.Created   (note, schema {title})
+//	pos 2  ResourceType.Unarchived (no synchronous handler — a ResourceType.*
+//	                                event pass 1 must still count as skipped)
+//	pos 3  Resource.Created       ┐
+//	pos 4  Triple.Created         ├ one transaction (tx-1), data carries `sku`
+//	pos 5  Resource.Published     ┘
+//	pos 6  ResourceType.Updated   (note, schema {title, sku}) — LAST in the feed
+func (e *reprojectTestEnv) seedSchemaChangeHistory(t testing.TB) {
+	t.Helper()
+	ctx := context.Background()
+	ldCtx := json.RawMessage(`{"@vocab":"https://example.com/ns#"}`)
+	oldSchema := json.RawMessage(`{"type":"object","properties":{"title":{"type":"string"}}}`)
+	newSchema := json.RawMessage(
+		`{"type":"object","properties":{"title":{"type":"string"},"sku":{"type":"string"}}}`)
+
+	appendEvt := func(aggregateID, eventType string, payload any, seq int, txID string) {
+		t.Helper()
+		env := domain.EventEnvelope[any]{
+			ID:            fmt.Sprintf("evt-%s-%d", eventType, seq),
+			AggregateID:   aggregateID,
+			EventType:     eventType,
+			Payload:       payload,
+			Created:       time.Now().UTC(),
+			SequenceNo:    seq,
+			TransactionID: txID,
+		}
+		if err := e.rt.EventStore.Append(ctx, aggregateID, seq-1, env); err != nil {
+			t.Fatalf("append %s: %v", eventType, err)
+		}
+	}
+
+	appendEvt("urn:type:note", "ResourceType.Created", entities.ResourceTypeCreated{
+		Name: "Note", Slug: "note", Description: "a note",
+		Context: ldCtx, Schema: oldSchema, Timestamp: time.Now().UTC(),
+	}, 1, "")
+	// A ResourceType.* event typedForReplay does not handle. Pass 2's accept
+	// filter excludes it, so only pass 1 can account for it.
+	appendEvt("urn:type:note", "ResourceType.Unarchived", map[string]any{"n": 1}, 2, "")
+
+	data := json.RawMessage(`{"@id":"urn:note:abc","@type":"note","title":"hello","sku":"BC-100"}`)
+	appendEvt("urn:note:abc", "Resource.Created", map[string]any{
+		"TypeSlug": "note", "Data": data, "CreatedBy": "urn:agent:test", "AccountID": "",
+		"Timestamp": time.Now().UTC().Format(time.RFC3339Nano),
+	}, 1, "tx-1")
+	appendEvt("urn:note:abc", "Triple.Created",
+		entities.TripleCreated{}.With("urn:note:abc", "relatesTo", "urn:note:def", ""), 2, "tx-1")
+	appendEvt("urn:note:abc", "Resource.Published",
+		entities.ResourcePublished{}.With("note", ""), 3, "tx-1")
+
+	appendEvt("urn:type:note", "ResourceType.Updated", entities.ResourceTypeUpdated{
+		Name: "Note", Slug: "note", Description: "a note", Status: "active",
+		Context: ldCtx, Schema: newSchema, Timestamp: time.Now().UTC(),
+	}, 3, "")
+}
+
+// TestReproject_BackfillsColumnAddedAfterTheRows is the unit-level guard for the
+// two-pass order. Replaying in one position order applies the type's ORIGINAL
+// schema, projects the resources against it, and only then the update that adds
+// `sku` — so the column stays NULL. Draining type events first recovers it.
+func TestReproject_BackfillsColumnAddedAfterTheRows(t *testing.T) {
 	env := newReprojectTestEnv(t)
-	env.seedImportedHistory(t)
+	env.seedSchemaChangeHistory(t)
 
-	full, err := Reproject(context.Background(), env.rt, ReprojectOptions{})
-	if err != nil {
-		t.Fatalf("full reproject: %v", err)
+	if _, err := Reproject(context.Background(), env.rt, ReprojectOptions{}); err != nil {
+		t.Fatalf("reproject: %v", err)
 	}
-
-	// Resume from just after the ResourceType.Created at position 1. The type
-	// pass must run again regardless, or the resources replaying in pass 2 would
-	// have no column set to project against.
-	resumed, err := Reproject(context.Background(), env.rt, ReprojectOptions{AfterPosition: 1})
-	if err != nil {
-		t.Fatalf("resumed reproject: %v", err)
-	}
-	if resumed.Dispatched == 0 {
-		t.Fatal("a resume below the head dispatched nothing")
-	}
-	if resumed.LastPosition != full.Head {
-		t.Errorf("resume LastPosition = %d, want head %d", resumed.LastPosition, full.Head)
+	if n := env.count(t,
+		`SELECT COUNT(*) FROM notes WHERE id = 'urn:note:abc' AND sku = 'BC-100'`,
+	); n != 1 {
+		t.Errorf("sku was not backfilled onto the projection row (matching rows = %d)", n)
 	}
 }
 
-// TestReproject_CompleteRunReachesHead pins the number an operator would feed
-// back as --after-position. Pass 2 only advances LastPosition on events it
-// accepts, and the last event in a real feed is commonly a ResourceType.Updated
-// (the startup reconcile appends one), so without the terminal assignment a
-// fully successful run would under-report.
+// TestReproject_ResumeStillRunsTypePass pins that pass 1 ignores AfterPosition.
+// Resuming past the type events must STILL bring the type to its final shape,
+// or the resources replaying in pass 2 project against a column set that was
+// never established.
+func TestReproject_ResumeStillRunsTypePass(t *testing.T) {
+	env := newReprojectTestEnv(t)
+	env.seedSchemaChangeHistory(t)
+
+	// Resume from position 2 — past both type events that precede the
+	// resources. Only pass 1 replaying from the start of the feed can give the
+	// projection its table and its `sku` column.
+	res, err := Reproject(context.Background(), env.rt, ReprojectOptions{AfterPosition: 2})
+	if err != nil {
+		t.Fatalf("resumed reproject: %v", err)
+	}
+	if res.LastPosition != res.Head {
+		t.Errorf("resume LastPosition = %d, want head %d", res.LastPosition, res.Head)
+	}
+	if n := env.count(t,
+		`SELECT COUNT(*) FROM notes WHERE id = 'urn:note:abc' AND sku = 'BC-100'`,
+	); n != 1 {
+		t.Errorf("a resume did not run the type pass: sku missing (matching rows = %d)", n)
+	}
+}
+
+// TestReproject_CompleteRunReachesHead pins the number an operator feeds back as
+// --after-position. Pass 2 only advances LastPosition on events it accepts, and
+// this feed ends with a ResourceType.Updated, so without the terminal assignment
+// a fully successful run under-reports.
 func TestReproject_CompleteRunReachesHead(t *testing.T) {
 	env := newReprojectTestEnv(t)
-	env.seedImportedHistory(t)
+	env.seedSchemaChangeHistory(t)
 
 	res, err := Reproject(context.Background(), env.rt, ReprojectOptions{})
 	if err != nil {
@@ -398,23 +473,22 @@ func TestReproject_CompleteRunReachesHead(t *testing.T) {
 	}
 }
 
-// TestReproject_CountsEachEventOnce guards the two-pass split: the passes'
-// accept filters partition the feed, so no event may be double-counted or fall
-// out of both counters.
+// TestReproject_CountsEachEventOnce guards the two-pass split. The feed carries
+// a ResourceType.* event with no synchronous handler, which only pass 1 can
+// account for — drop countSkip there and it falls out of both counters.
 func TestReproject_CountsEachEventOnce(t *testing.T) {
 	env := newReprojectTestEnv(t)
-	env.seedImportedHistory(t)
+	env.seedSchemaChangeHistory(t)
 
 	res, err := Reproject(context.Background(), env.rt, ReprojectOptions{})
 	if err != nil {
 		t.Fatalf("reproject: %v", err)
 	}
-	// seedImportedHistory writes 5 events. Two have no synchronous handler of
-	// their own — Custom.Ignored, and Resource.Created (folded in via the
-	// Published handler's transaction read) — so the split must be 3/2 with
-	// every event accounted for exactly once.
-	if got := res.Dispatched + res.Skipped; got != 5 {
-		t.Errorf("Dispatched+Skipped = %d, want 5 (dispatched=%d skipped=%d)",
+	// 6 events: ResourceType.Created, ResourceType.Unarchived, Resource.Created,
+	// Triple.Created, Resource.Published, ResourceType.Updated. Two lack a
+	// synchronous handler (Unarchived; Created, folded into Published).
+	if got := res.Dispatched + res.Skipped; got != 6 {
+		t.Errorf("Dispatched+Skipped = %d, want 6 (dispatched=%d skipped=%d)",
 			got, res.Dispatched, res.Skipped)
 	}
 	if res.Skipped != 2 {

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/wepala/weos/v3/domain/entities"
 	"github.com/wepala/weos/v3/domain/repositories"
 	"github.com/wepala/weos/v3/pkg/jsonld"
+	"github.com/wepala/weos/v3/pkg/utils"
 
 	"github.com/akeemphilbert/pericarp/pkg/auth"
 	authentities "github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
@@ -345,6 +346,11 @@ func (s *resourceTypeService) InstallPreset(
 // Refused, never rewritten; a type with no delta emits no event, which is what
 // keeps repeated restarts from appending a ResourceTypeUpdated per type per
 // boot.
+//
+// Per-type failures never abort the pass. One unparseable stored schema or one
+// transient write error must not leave every LATER type in the preset
+// unreconciled and silently dropping writes — which is the very defect this
+// exists to end — so failures are collected in Failed and the loop continues.
 func (s *resourceTypeService) ReconcilePresetSchemas(
 	ctx context.Context, presetName string,
 ) (*ReconcilePresetResult, error) {
@@ -354,49 +360,119 @@ func (s *resourceTypeService) ReconcilePresetSchemas(
 	}
 	result := &ReconcilePresetResult{}
 	for _, pt := range preset.Types {
+		// A preset type with no schema projects only base columns, so every data
+		// field is dropped on write. That is almost always a packaging mistake
+		// and never a healthy no-op, so it gets its own category instead of
+		// being folded into Unchanged where nothing would ever report it.
+		if len(pt.Schema) == 0 {
+			result.NoSchema = append(result.NoSchema, pt.Slug)
+			continue
+		}
 		existing, err := s.GetBySlug(ctx, pt.Slug)
 		if err != nil {
-			// Not installed yet: InstallPreset's create path owns that case, and
-			// it has already run by the time startup calls this.
+			// Not installed here: InstallPreset's create path owns that case.
 			if errors.Is(err, repositories.ErrNotFound) {
 				continue
 			}
-			return result, fmt.Errorf("failed to look up resource type %q: %w", pt.Slug, err)
-		}
-		rec, rErr := reconcileAdditiveSchema(existing.Schema(), pt.Schema)
-		if rErr != nil {
-			return result, fmt.Errorf("failed to reconcile schema for %q: %w", pt.Slug, rErr)
-		}
-		if len(rec.Conflicts) > 0 {
-			s.logger.Warn(ctx,
-				"preset schema diverges non-additively; leaving stored resource type unchanged",
-				"preset", presetName, "slug", pt.Slug, "conflictingProperties", rec.Conflicts)
-			if result.Refused == nil {
-				result.Refused = make(map[string][]string)
-			}
-			result.Refused[pt.Slug] = rec.Conflicts
+			s.recordReconcileFailure(ctx, result, presetName, pt.Slug,
+				fmt.Errorf("failed to look up resource type: %w", err))
 			continue
 		}
-		if !rec.Changed {
-			result.Unchanged = append(result.Unchanged, pt.Slug)
-			continue
-		}
-		if _, uErr := s.Update(ctx, UpdateResourceTypeCommand{
-			ID:          existing.GetID(),
-			Name:        existing.Name(),
-			Slug:        existing.Slug(),
-			Description: existing.Description(),
-			Status:      existing.Status(),
-			Context:     existing.Context(),
-			Schema:      rec.Schema,
-		}); uErr != nil {
-			return result, fmt.Errorf("failed to reconcile resource type %q: %w", pt.Slug, uErr)
-		}
-		s.logger.Info(ctx, "reconciled preset schema into existing resource type",
-			"preset", presetName, "slug", pt.Slug, "addedProperties", rec.Added)
-		result.Updated = append(result.Updated, pt.Slug)
+		s.reconcileOneType(ctx, result, presetName, pt, existing)
 	}
 	return result, nil
+}
+
+// reconcileOneType applies the additive merge to a single installed type,
+// recording the outcome on result. It never returns an error: every outcome is
+// a category on the result so one type can't mask another.
+func (s *resourceTypeService) reconcileOneType(
+	ctx context.Context, result *ReconcilePresetResult,
+	presetName string, pt PresetResourceType, existing *entities.ResourceType,
+) {
+	rec, err := reconcileAdditiveSchema(existing.Schema(), pt.Schema)
+	if err != nil {
+		s.recordReconcileFailure(ctx, result, presetName, pt.Slug,
+			fmt.Errorf("failed to reconcile schema: %w", err))
+		return
+	}
+	if len(rec.Conflicts) > 0 {
+		// Refusal is all-or-nothing, so naming only the conflicting properties
+		// hides the real cost: every additive property blocked alongside them is
+		// still having its writes dropped. Report both.
+		s.logger.Warn(ctx,
+			"preset schema diverges non-additively; leaving stored resource type unchanged",
+			"preset", presetName, "slug", pt.Slug,
+			"conflictingProperties", rec.Conflicts, "blockedAdditions", rec.Added)
+		if result.Refused == nil {
+			result.Refused = make(map[string][]string)
+		}
+		result.Refused[pt.Slug] = rec.Conflicts
+		if len(rec.Added) > 0 {
+			if result.BlockedAdditions == nil {
+				result.BlockedAdditions = make(map[string][]string)
+			}
+			result.BlockedAdditions[pt.Slug] = rec.Added
+		}
+		return
+	}
+	if !rec.Changed {
+		result.Unchanged = append(result.Unchanged, pt.Slug)
+		return
+	}
+	if _, err := s.Update(ctx, UpdateResourceTypeCommand{
+		ID:          existing.GetID(),
+		Name:        existing.Name(),
+		Slug:        existing.Slug(),
+		Description: existing.Description(),
+		Status:      existing.Status(),
+		Context:     existing.Context(),
+		Schema:      rec.Schema,
+	}); err != nil {
+		s.recordReconcileFailure(ctx, result, presetName, pt.Slug, err)
+		return
+	}
+	// A successful Update is NOT evidence the column exists. The column is added
+	// by the ResourceType.Updated handler, and SimpleUnitOfWork.Commit discards
+	// dispatch errors as non-fatal (eventual-consistency model), so EnsureTable
+	// can fail while Update still returns nil. Reporting "reconciled" on that
+	// basis would announce success over exactly the silent drop this change
+	// exists to end, so confirm the columns actually landed.
+	if missing := s.missingColumns(pt.Slug, rec.Added); len(missing) > 0 {
+		s.recordReconcileFailure(ctx, result, presetName, pt.Slug,
+			fmt.Errorf("stored schema updated but projection columns are still missing: %v", missing))
+		return
+	}
+	s.logger.Info(ctx, "reconciled preset schema into existing resource type",
+		"preset", presetName, "slug", pt.Slug, "addedProperties", rec.Added)
+	result.Updated = append(result.Updated, pt.Slug)
+}
+
+// missingColumns returns the subset of property names with no matching
+// projection column, using the same camelCase→snake_case mapping the projection
+// writer uses to decide which keys to keep.
+func (s *resourceTypeService) missingColumns(slug string, properties []string) []string {
+	if s.projMgr == nil {
+		return nil
+	}
+	var missing []string
+	for _, prop := range properties {
+		if !s.projMgr.HasColumn(slug, utils.CamelToSnake(prop)) {
+			missing = append(missing, prop)
+		}
+	}
+	return missing
+}
+
+func (s *resourceTypeService) recordReconcileFailure(
+	ctx context.Context, result *ReconcilePresetResult, presetName, slug string, err error,
+) {
+	s.logger.Error(ctx, "failed to reconcile preset schema into resource type",
+		"preset", presetName, "slug", slug, "error", err)
+	if result.Failed == nil {
+		result.Failed = make(map[string]string)
+	}
+	result.Failed[slug] = err.Error()
 }
 
 // seedFixtures creates resources from the preset type's fixture data.

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -101,6 +101,7 @@ type ResourceTypeService interface {
 	Delete(ctx context.Context, cmd DeleteResourceTypeCommand) error
 	ListPresets() []PresetDefinition
 	InstallPreset(ctx context.Context, presetName string, update bool) (*InstallPresetResult, error)
+	ReconcilePresetSchemas(ctx context.Context, presetName string) (*ReconcilePresetResult, error)
 	ListBehaviors(ctx context.Context, typeSlug string) ([]BehaviorInfo, error)
 	SetBehaviors(ctx context.Context, typeSlug string, slugs []string) error
 }
@@ -316,6 +317,84 @@ func (s *resourceTypeService) InstallPreset(
 			result.Warnings = append(result.Warnings,
 				fmt.Sprintf("link reconciliation failed: %s", rErr.Error()))
 		}
+	}
+	return result, nil
+}
+
+// ReconcilePresetSchemas merges additive schema changes from a preset's code
+// definition into the resource types already stored in this database (issue
+// #379).
+//
+// This exists because InstallPreset can't do the job at startup. With
+// update=false it skips an existing type entirely, so a preset that gains a
+// property in a new build never reaches an already-provisioned database — the
+// stored schema stays stale, EnsureTable derives the old column set from it,
+// and every write to the new field is silently dropped by dropMissingColumns.
+// With update=true it overwrites Name, Description, Context and Schema from
+// code on every boot, which would silently discard any operator customization
+// of a built-in type. Neither is acceptable unattended, so startup gets this
+// third, narrower behavior instead.
+//
+// Only the schema is touched, and only additively (see reconcileAdditiveSchema
+// for the merge rules). Name, Description, Context and Status are read back
+// from the stored type and passed through unchanged. The explicit
+// `resource-type preset install --update` path keeps its full-overwrite
+// semantics — there an operator asked for it.
+//
+// A type whose preset schema diverged non-additively is logged and recorded in
+// Refused, never rewritten; a type with no delta emits no event, which is what
+// keeps repeated restarts from appending a ResourceTypeUpdated per type per
+// boot.
+func (s *resourceTypeService) ReconcilePresetSchemas(
+	ctx context.Context, presetName string,
+) (*ReconcilePresetResult, error) {
+	preset, ok := s.registry.Get(presetName)
+	if !ok {
+		return nil, fmt.Errorf("unknown preset %q", presetName)
+	}
+	result := &ReconcilePresetResult{}
+	for _, pt := range preset.Types {
+		existing, err := s.GetBySlug(ctx, pt.Slug)
+		if err != nil {
+			// Not installed yet: InstallPreset's create path owns that case, and
+			// it has already run by the time startup calls this.
+			if errors.Is(err, repositories.ErrNotFound) {
+				continue
+			}
+			return result, fmt.Errorf("failed to look up resource type %q: %w", pt.Slug, err)
+		}
+		rec, rErr := reconcileAdditiveSchema(existing.Schema(), pt.Schema)
+		if rErr != nil {
+			return result, fmt.Errorf("failed to reconcile schema for %q: %w", pt.Slug, rErr)
+		}
+		if len(rec.Conflicts) > 0 {
+			s.logger.Warn(ctx,
+				"preset schema diverges non-additively; leaving stored resource type unchanged",
+				"preset", presetName, "slug", pt.Slug, "conflictingProperties", rec.Conflicts)
+			if result.Refused == nil {
+				result.Refused = make(map[string][]string)
+			}
+			result.Refused[pt.Slug] = rec.Conflicts
+			continue
+		}
+		if !rec.Changed {
+			result.Unchanged = append(result.Unchanged, pt.Slug)
+			continue
+		}
+		if _, uErr := s.Update(ctx, UpdateResourceTypeCommand{
+			ID:          existing.GetID(),
+			Name:        existing.Name(),
+			Slug:        existing.Slug(),
+			Description: existing.Description(),
+			Status:      existing.Status(),
+			Context:     existing.Context(),
+			Schema:      rec.Schema,
+		}); uErr != nil {
+			return result, fmt.Errorf("failed to reconcile resource type %q: %w", pt.Slug, uErr)
+		}
+		s.logger.Info(ctx, "reconciled preset schema into existing resource type",
+			"preset", presetName, "slug", pt.Slug, "addedProperties", rec.Added)
+		result.Updated = append(result.Updated, pt.Slug)
 	}
 	return result, nil
 }

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -397,24 +397,16 @@ func (s *resourceTypeService) reconcileOneType(
 		return
 	}
 	if len(rec.Conflicts) > 0 {
-		// Refusal is all-or-nothing, so naming only the conflicting properties
-		// hides the real cost: every additive property blocked alongside them is
-		// still having its writes dropped. Report both.
+		// Held, not applied — and the rest of the merge still proceeds, so one
+		// changed property definition can't block every additive property beside
+		// it. Report which properties are stuck at their stored definition.
 		s.logger.Warn(ctx,
-			"preset schema diverges non-additively; leaving stored resource type unchanged",
-			"preset", presetName, "slug", pt.Slug,
-			"conflictingProperties", rec.Conflicts, "blockedAdditions", rec.Added)
+			"preset property definitions diverge non-additively; holding them at their stored definition",
+			"preset", presetName, "slug", pt.Slug, "heldProperties", rec.Conflicts)
 		if result.Refused == nil {
 			result.Refused = make(map[string][]string)
 		}
 		result.Refused[pt.Slug] = rec.Conflicts
-		if len(rec.Added) > 0 {
-			if result.BlockedAdditions == nil {
-				result.BlockedAdditions = make(map[string][]string)
-			}
-			result.BlockedAdditions[pt.Slug] = rec.Added
-		}
-		return
 	}
 	if !rec.Changed {
 		result.Unchanged = append(result.Unchanged, pt.Slug)

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -360,22 +360,27 @@ func (s *resourceTypeService) ReconcilePresetSchemas(
 	}
 	result := &ReconcilePresetResult{}
 	for _, pt := range preset.Types {
-		// A preset type with no schema projects only base columns, so every data
-		// field is dropped on write. That is almost always a packaging mistake
-		// and never a healthy no-op, so it gets its own category instead of
-		// being folded into Unchanged where nothing would ever report it.
-		if len(pt.Schema) == 0 {
-			result.NoSchema = append(result.NoSchema, pt.Slug)
-			continue
-		}
 		existing, err := s.GetBySlug(ctx, pt.Slug)
 		if err != nil {
 			// Not installed here: InstallPreset's create path owns that case.
+			// Checked BEFORE the schema check so a preset that isn't installed in
+			// this database stays completely silent — the reconcile now runs for
+			// every registered preset, so warning about types nobody installed
+			// would be noise on every boot.
 			if errors.Is(err, repositories.ErrNotFound) {
 				continue
 			}
 			s.recordReconcileFailure(ctx, result, presetName, pt.Slug,
 				fmt.Errorf("failed to look up resource type: %w", err))
+			continue
+		}
+		// An INSTALLED type whose preset declares no schema projects only base
+		// columns, so every data field is dropped on write. That is almost
+		// always a packaging mistake and never a healthy no-op, so it gets its
+		// own category instead of being folded into Unchanged where nothing
+		// would ever report it.
+		if len(pt.Schema) == 0 {
+			result.NoSchema = append(result.NoSchema, pt.Slug)
 			continue
 		}
 		s.reconcileOneType(ctx, result, presetName, pt, existing)
@@ -440,16 +445,41 @@ func (s *resourceTypeService) reconcileOneType(
 	result.Updated = append(result.Updated, pt.Slug)
 }
 
+// columnlessProperties are schema property names that deliberately yield no
+// projection column of their own, so their absence is correct rather than a
+// failed migration. This mirrors schemaToColumns in the gorm projection
+// manager, which skips the JSON-LD meta-keys outright and skips any property
+// whose snake_case name collides with a standard column. Only `data` is
+// enumerated from that second set: every other standard column IS cached as
+// present by EnsureTable, so a property named `status` or `createdAt` — both of
+// which real presets declare — verifies correctly without special-casing.
+var columnlessProperties = map[string]bool{
+	"@id":      true,
+	"@type":    true,
+	"@context": true,
+	"data":     true, // lives on the canonical resources row, not the projection
+}
+
 // missingColumns returns the subset of property names with no matching
 // projection column, using the same camelCase→snake_case mapping the projection
 // writer uses to decide which keys to keep.
+//
+// Properties that never map to a column are skipped: reporting them would raise
+// a false alarm announcing data loss that isn't happening.
 func (s *resourceTypeService) missingColumns(slug string, properties []string) []string {
 	if s.projMgr == nil {
 		return nil
 	}
 	var missing []string
 	for _, prop := range properties {
-		if !s.projMgr.HasColumn(slug, utils.CamelToSnake(prop)) {
+		if columnlessProperties[prop] {
+			continue
+		}
+		column := utils.CamelToSnake(prop)
+		if columnlessProperties[column] {
+			continue
+		}
+		if !s.projMgr.HasColumn(slug, column) {
 			missing = append(missing, prop)
 		}
 	}

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -17,3 +17,4 @@ Architecture Decision Records (ADRs) capture significant technical decisions mad
 | [Cross-Resource Writes from ResourceBehavior Hooks]({% link decisions/behavior-resource-writer.md %}) | Accepted (Implemented) | 2026-04-07 |
 | [Admin Index Override for Thin-Wrap Binaries]({% link decisions/admin-index-override.md %}) | Proposed | 2026-04-14 |
 | [Cross-Preset Link Definitions]({% link decisions/cross-preset-link-definitions.md %}) | Accepted (Implemented) | 2026-04-19 |
+| [Projection Schema Migration]({% link decisions/projection-schema-migration.md %}) | Accepted (Implemented) | 2026-08-06 |

--- a/docs/decisions/projection-schema-migration.md
+++ b/docs/decisions/projection-schema-migration.md
@@ -69,7 +69,7 @@ The reconcile runs for **every registered preset**, not only the `AutoInstall` o
 | Property in the preset, absent from stored | **Merged in** — this is what yields the missing column |
 | Property in stored, absent from the preset | **Preserved** — never dropped |
 | Property in both, same definition | No-op |
-| Property in both, **different** definition | **Refused** — the whole type is left untouched and logged |
+| Property in both, **different** definition | **Held** at its stored definition and logged — the rest of the merge still proceeds |
 | `required` naming a stored-only property | **Carried over** — the preset has no opinion about a property it doesn't declare |
 | Other top-level keywords (`type`, `additionalProperties`, …) | Follow the preset where it declares them |
 
@@ -138,18 +138,19 @@ The filter case deserves emphasis: dropping a filter does not narrow results, it
 ### Risks
 
 - **`required` tightening breaks existing rows.** A property the preset newly marks required will fail validation for rows that lack it, on their next write. Accepted deliberately; operators changing `required` on a populated type should plan a data pass.
-- **Refusal is all-or-nothing per type.** One conflicting property blocks that type's additive changes too, until an operator resolves it. Chosen over partial application, which would leave a schema in a state neither the preset nor the operator authored. The cost is real, because the conflict test is an exact comparison: a preset that merely adds a `description` or `maxLength` to an existing property refuses the whole type. The refusal warning therefore names the blocked additive properties (`BlockedAdditions`) alongside the conflict, since those are the ones still losing writes.
+- **A held property leaves the stored schema in a state neither side authored.** Refusal is per-property: the conflicting property keeps its stored definition while the preset's additive properties are merged around it, so the result matches the preset in part and the database in part until an operator resolves it. This was chosen over refusing the whole type because the conflict test is an exact comparison — a preset that merely adds a `description` or `maxLength` to an existing property would otherwise block every additive property beside it, and the silent drop this change exists to fix would persist for that type on a routine upgrade. Nothing non-additive is ever applied, and every held property is named in the boot log.
 - **The conflict check does not follow indirection.** Property definitions are compared verbatim, so a schema reaching its types through `$ref`/`$defs`, `definitions`, `allOf`, or `patternProperties` can be retyped without tripping the guard — the change lands in a top-level keyword the preset simply wins. No preset in the tree uses those keywords today; one that starts to would need the check to resolve indirection first.
 - **Concurrent startup against a shared database.** Two replicas booting at once can both append `ResourceType.Updated` at the same sequence, and `addMissingColumns`' `HasColumn` guard is TOCTOU. Before this change a steady-state boot had nothing to ALTER, so the window didn't exist; the upgrade boot opens it. The loser's type lands in `Failed` with the reason logged rather than being silently skipped, and the next boot reconciles it.
 - **Drift is still silent at read time.** Until the follow-up tickets land, a filter on a column that does not exist still widens results rather than erroring.
 
 ## Alternatives Considered
 
-1. **Flip `ensureBuiltInResourceTypes` to `InstallPreset(..., true)`.** The smallest possible diff, and rejected: it makes preset code authoritative for `Name`, `Description`, `Context` and `Schema` on every boot, silently discarding operator customisation. Trading a silent-data-loss bug for a different silent-data-loss bug is not a fix.
-2. **A config flag selecting overwrite / merge / off.** Rejected for v1 as surface area without a decision: the merge behaviour is what a correct default looks like, and the explicit `--update` path already exists for operators who want overwrite.
-3. **GORM `AutoMigrate`.** Rejected — see above.
-4. **Backfill automatically after adding a column.** Rejected: a full replay on boot is expensive and unpredictable. Reproject stays an explicit operator action.
-5. **Add a provenance field to `ResourceType` (preset-owned vs operator-edited).** A cleaner long-term answer to "who owns this property", and out of scope here — the additive merge achieves the same protection without a schema migration on the entity itself.
+1. **Refuse the whole type on any conflict.** Simpler to reason about and never produces a mixed schema, but it made one cosmetic property edit block every additive property in the same type — defeating the ticket's purpose on exactly the kind of upgrade that motivated it. Rejected in favour of per-property holds.
+2. **Flip `ensureBuiltInResourceTypes` to `InstallPreset(..., true)`.** The smallest possible diff, and rejected: it makes preset code authoritative for `Name`, `Description`, `Context` and `Schema` on every boot, silently discarding operator customisation. Trading a silent-data-loss bug for a different silent-data-loss bug is not a fix.
+3. **A config flag selecting overwrite / merge / off.** Rejected for v1 as surface area without a decision: the merge behaviour is what a correct default looks like, and the explicit `--update` path already exists for operators who want overwrite.
+4. **GORM `AutoMigrate`.** Rejected — see above.
+5. **Backfill automatically after adding a column.** Rejected: a full replay on boot is expensive and unpredictable. Reproject stays an explicit operator action.
+6. **Add a provenance field to `ResourceType` (preset-owned vs operator-edited).** A cleaner long-term answer to "who owns this property", and out of scope here — the additive merge achieves the same protection without a schema migration on the entity itself.
 
 ## Further Reading
 

--- a/docs/decisions/projection-schema-migration.md
+++ b/docs/decisions/projection-schema-migration.md
@@ -104,9 +104,15 @@ Note the resume caveat the two-pass split introduces: pass 1 always runs and can
 
 Making that true required a fix. Reproject previously replayed the feed in one strict position order, which meant each type's *original* schema was applied, every resource projected against it, and only then the later `ResourceType.Updated` that added the column — so the column was never backfilled, and re-running didn't help because the ordering was identical every pass. Reproject now replays in **two passes, resource types first**, so every type reaches its final shape before a single resource projects. Pass 1 always starts at the beginning of the feed (re-applying type events is idempotent); pass 2 is the resumable one and alone honours `--after-position`.
 
-### 5. Non-additive changes — detected, deferred
+### 5. Non-additive changes — partially detected, deferred
 
-Renames, type changes, and drops remain out of scope. They are now **detected** rather than ignored: a property whose definition differs between the preset and the stored schema refuses the whole type, logs a warning naming the conflicting properties, and reports them in `ReconcilePresetResult.Refused`. Nothing is rewritten, so an operator decides.
+Renames, type changes, and drops remain out of scope. Only one of the three is actually **detected**, and the distinction matters:
+
+- **Type change / redefinition** — detected. A property present in both schemas whose definition differs is held at its stored definition, logged with the property named, and reported in `ReconcilePresetResult.Refused`. The preset's version is never applied.
+- **Rename** — *not* detected, and not detectable by this comparison. `sku` → `stockKeepingUnit` reads as one property added and one preserved: both columns end up on the table, the old one keeps its data, and the new one is NULL. Nothing is lost, but nothing is migrated either.
+- **Drop** — *not* detected. A property the preset stops declaring is silently preserved, by the same rule that protects operator customization.
+
+Both undetected cases are additively safe — no data is destroyed — which is why they are tolerated rather than blocked. Genuinely migrating them needs intent the schemas alone don't carry, which is what the follow-up ticket is for.
 
 ### 6. Drift detection — the remaining gap
 

--- a/docs/decisions/projection-schema-migration.md
+++ b/docs/decisions/projection-schema-migration.md
@@ -1,0 +1,146 @@
+---
+title: "ADR: Projection Schema Migration"
+parent: Architecture Decision Records
+layout: default
+nav_order: 7
+---
+
+# ADR: Migrating Projection Tables When a Resource Type Gains a Property
+
+**Status:** Accepted — Implemented (additive scope)
+**Date:** 2026-08-06
+**Issue:** [#379 — Spike: migrate projection tables when a resource type gains a column](https://github.com/wepala/weos/issues/379)
+
+## Problem
+
+When a resource type's JSON Schema gained a property in a new build, databases provisioned by an earlier build kept the old projection table. Writes to the new field were then **silently dropped**: `dropMissingColumns` deletes any key with no matching column before the INSERT, so the write succeeded, no error surfaced, and every read, filter, or sort on the new field behaved as if it were empty.
+
+This surfaced in finexity, where a resource type gained bill fields. Databases created before the change lacked the columns, so bill detection persisted candidates whose new fields vanished, the SPA's bill list (filtering on those fields) showed empty results, and confirming a bill returned 422 because the read-back saw an empty value. The data survived in the event store the whole time — only the projection lost it.
+
+The spike asked where migration should live, whether GORM's `AutoMigrate` could do it, how existing rows get backfilled, what to do about non-additive changes, and how to detect drift.
+
+### What already worked
+
+Most of the machinery was already in place and correct:
+
+- `addMissingColumns` (`infrastructure/database/gorm/projection_manager.go`) issues idempotent, `HasColumn`-guarded `ALTER TABLE ... ADD COLUMN` statements.
+- `EnsureTable` calls it for both the base system columns and the schema-derived ones.
+- `EnsureExistingTables` runs `EnsureTable` over every live resource type at **every** startup, via `fx.Invoke(ensureProjectionTables)`.
+- `ResourceType.Updated` → `ensureProjection` → `EnsureTable` applies the same reconciliation the moment a type changes at runtime.
+
+### The actual gap
+
+All of that derives its column set from the schema **stored in the database**, and nothing refreshed that stored schema from the preset's code definition. `ensureBuiltInResourceTypes` called `InstallPreset(ctx, preset.Name, false)`; with `update=false`, an already-installed type is *Skipped*. So the chain was:
+
+1. A preset's schema gains a property in code.
+2. Startup skips the existing type — `resource_types.schema` stays stale.
+3. `EnsureExistingTables` derives the **old** column set from that stale schema.
+4. `addMissingColumns` finds nothing to add.
+5. `dropMissingColumns` silently deletes the field on every write.
+
+The fix belongs at step 2, not in the ALTER machinery.
+
+## Design Goals
+
+1. An additive schema change in code reaches an already-provisioned database on the next restart.
+2. Operator customisation of a built-in resource type is never silently overwritten.
+3. A restart with an unchanged preset is a no-op — no `ResourceTypeUpdated` event per type per boot.
+4. Non-additive changes are detected and reported, never applied.
+5. No change to the ALTER machinery, the write hot path, or the explicit `preset install --update` semantics.
+
+## Decision
+
+### 1. Where migration runs
+
+Additive-column migration stays exactly where it was — `ensureProjectionTables` at startup. What was added is a narrower **schema reconciliation** step ahead of it.
+
+`ResourceTypeService.ReconcilePresetSchemas` merges a preset's code-defined schema into the stored resource types, and `ensureBuiltInResourceTypes` calls it after `InstallPreset`. Because it runs before `fx.Invoke(ensureProjectionTables)` — and because the `ResourceType.Updated` it emits is handled synchronously — the refreshed schema is in place by the time any column set is derived.
+
+`InstallPreset` was deliberately **not** changed. Neither of its modes is safe unattended: `update=false` skips existing types (the bug), and `update=true` overwrites `Name`, `Description`, `Context` *and* `Schema` from code on every boot, which would discard operator customisation. Startup gets a third, narrower behaviour instead; the explicit `resource-type preset install --update` path keeps its full-overwrite semantics, because there an operator asked for it.
+
+### 2. The merge rules
+
+`reconcileAdditiveSchema` compares the preset's schema against the stored one:
+
+| Case | Action |
+|---|---|
+| Property in the preset, absent from stored | **Merged in** — this is what yields the missing column |
+| Property in stored, absent from the preset | **Preserved** — never dropped |
+| Property in both, same definition | No-op |
+| Property in both, **different** definition | **Refused** — the whole type is left untouched and logged |
+| Other top-level keywords (`required`, `type`, …) | Follow the preset where it declares them |
+
+Preserving stored-only properties is what protects operator customisation. WeOS has no provenance field on `ResourceType`, so an operator's addition through the API is indistinguishable from drift — dropping it would trade one silent data loss for another. Preserving it also stops a single customisation from permanently blocking later preset additions.
+
+The merge is idempotent: re-running it against its own output reports no change, which is what keeps repeated restarts quiet.
+
+**`required` is authoritative.** A property the preset newly marks required tightens the stored schema. This is a deliberate choice, and it has a consequence worth stating plainly: existing rows that lack that property will start failing validation on their next write.
+
+### 3. GORM `AutoMigrate` — rejected
+
+`AutoMigrate` reflects over Go structs. Projection tables have none: they are generated from each resource type's JSON Schema at runtime, with column names and SQL types derived by `schemaToColumns`. There is nothing for `AutoMigrate` to reflect over, so using it would mean synthesising throwaway structs per type on every boot.
+
+Rejecting it also avoids its broader behaviour. `AutoMigrate` will attempt type alters and constraint changes, which diverge across SQLite and Postgres — precisely the destructive class this work defers. The hand-rolled `ALTER TABLE ... ADD COLUMN` is additive by construction and behaves identically on both stores.
+
+One nuance the hand-rolled path already encodes (see `baseColumnDefs`): `ADD COLUMN` cannot introduce `NOT NULL` without a default on a populated table, so added columns are deliberately nullable.
+
+### 4. Backfilling existing rows
+
+Adding a column leaves it `NULL` on every pre-existing row. Two paths exist, and they cover different cases:
+
+- `backfillFromCanonical` fills rows missing **entirely** from the projection, via a `NOT EXISTS` anti-join. It never touches rows that already have a projection row, so it does *not* populate a newly added column.
+- `weos worker reproject` replays the event feed through the synchronous projection handlers, rewriting each row from its canonical JSON-LD. **This is the backfill path for a newly added column.**
+
+Reproject stays **operator-invoked**. A full replay is expensive and must not fire on boot; the runbook case (server stopped, column added, operator reprojects) is the right shape.
+
+Making that true required a fix. Reproject previously replayed the feed in one strict position order, which meant each type's *original* schema was applied, every resource projected against it, and only then the later `ResourceType.Updated` that added the column — so the column was never backfilled, and re-running didn't help because the ordering was identical every pass. Reproject now replays in **two passes, resource types first**, so every type reaches its final shape before a single resource projects. Pass 1 always starts at the beginning of the feed (re-applying type events is idempotent); pass 2 is the resumable one and alone honours `--after-position`.
+
+### 5. Non-additive changes — detected, deferred
+
+Renames, type changes, and drops remain out of scope. They are now **detected** rather than ignored: a property whose definition differs between the preset and the stored schema refuses the whole type, logs a warning naming the conflicting properties, and reports them in `ReconcilePresetResult.Refused`. Nothing is rewritten, so an operator decides.
+
+### 6. Drift detection — the remaining gap
+
+Three sites still degrade silently when a schema property has no matching column. They are **not** fixed here and are tracked separately:
+
+| Site | Behaviour | Severity |
+|---|---|---|
+| `resource_repository.go` — `dropMissingColumns` | Silently deletes the key on write | Lossy, silent |
+| `resource_repository.go` — filter loop in `findAllFromProjectionWithFilters` | A filter on a missing column is `continue`d, **widening** the result set | **Most severe** |
+| `resource_repository.go` — sort-column validation | Silently falls back to `id` | Cosmetic but confusing |
+
+The filter case deserves emphasis: dropping a filter does not narrow results, it *widens* them — the query returns rows the caller explicitly asked to exclude. That is a correctness and potential exposure problem in its own right, independent of migration, and it should fail loudly rather than degrade.
+
+## Consequences
+
+### Good
+
+- An additive schema change in code reaches every provisioned database on the next restart, with no operator action.
+- Operator customisation of a built-in type survives restarts by construction.
+- Non-additive divergence is surfaced with the offending property names instead of being applied or ignored.
+- `worker reproject` genuinely backfills added columns now, making it a usable repair tool rather than a no-op for this case.
+- No change to the write hot path, `EnsureTable`, `addMissingColumns`, or `preset install --update`.
+
+### Neutral
+
+- Reconciliation re-marshals the stored schema, so its top-level key order becomes alphabetical. Semantically equivalent; `jsonEquivalent` compares decoded values, so this does not cause spurious updates.
+- Reproject now scans the feed twice. The event store has no server-side type filter, so this trades a second read for correctness in an operator-invoked one-shot.
+
+### Risks
+
+- **`required` tightening breaks existing rows.** A property the preset newly marks required will fail validation for rows that lack it, on their next write. Accepted deliberately; operators changing `required` on a populated type should plan a data pass.
+- **Refusal is all-or-nothing per type.** One conflicting property blocks that type's additive changes too, until an operator resolves it. Chosen over partial application, which would leave a schema in a state neither the preset nor the operator authored.
+- **Drift is still silent at read time.** Until the follow-up tickets land, a filter on a column that does not exist still widens results rather than erroring.
+
+## Alternatives Considered
+
+1. **Flip `ensureBuiltInResourceTypes` to `InstallPreset(..., true)`.** The smallest possible diff, and rejected: it makes preset code authoritative for `Name`, `Description`, `Context` and `Schema` on every boot, silently discarding operator customisation. Trading a silent-data-loss bug for a different silent-data-loss bug is not a fix.
+2. **A config flag selecting overwrite / merge / off.** Rejected for v1 as surface area without a decision: the merge behaviour is what a correct default looks like, and the explicit `--update` path already exists for operators who want overwrite.
+3. **GORM `AutoMigrate`.** Rejected — see above.
+4. **Backfill automatically after adding a column.** Rejected: a full replay on boot is expensive and unpredictable. Reproject stays an explicit operator action.
+5. **Add a provenance field to `ResourceType` (preset-owned vs operator-edited).** A cleaner long-term answer to "who owns this property", and out of scope here — the additive merge achieves the same protection without a schema migration on the entity itself.
+
+## Further Reading
+
+- [Projections]({% link _explanation/projections.md %}) — how projection tables are derived from resource type schemas.
+- [Cross-Preset Link Definitions]({% link decisions/cross-preset-link-definitions.md %}) — the other mechanism that adds columns to a projection table via `addMissingColumns`.

--- a/docs/decisions/projection-schema-migration.md
+++ b/docs/decisions/projection-schema-migration.md
@@ -54,7 +54,9 @@ The fix belongs at step 2, not in the ALTER machinery.
 
 Additive-column migration stays exactly where it was — `ensureProjectionTables` at startup. What was added is a narrower **schema reconciliation** step ahead of it.
 
-`ResourceTypeService.ReconcilePresetSchemas` merges a preset's code-defined schema into the stored resource types, and `ensureBuiltInResourceTypes` calls it after `InstallPreset`. Because it runs before `fx.Invoke(ensureProjectionTables)` — and because the `ResourceType.Updated` it emits is handled synchronously — the refreshed schema is in place by the time any column set is derived.
+`ResourceTypeService.ReconcilePresetSchemas` merges a preset's code-defined schema into the stored resource types, and `ensureBuiltInResourceTypes` calls it at startup. Because it runs before `fx.Invoke(ensureProjectionTables)` — and because the `ResourceType.Updated` it emits is handled synchronously — the refreshed schema is in place by the time any column set is derived.
+
+The reconcile runs for **every registered preset**, not only the `AutoInstall` ones. Only two presets in the tree set `AutoInstall`, so gating it on that flag would leave this bug unfixed for every preset an operator installs on demand — including any shipped by a private registrar. A preset type that isn't installed in the current database is a no-op inside the reconcile, so running it unconditionally is safe.
 
 `InstallPreset` was deliberately **not** changed. Neither of its modes is safe unattended: `update=false` skips existing types (the bug), and `update=true` overwrites `Name`, `Description`, `Context` *and* `Schema` from code on every boot, which would discard operator customisation. Startup gets a third, narrower behaviour instead; the explicit `resource-type preset install --update` path keeps its full-overwrite semantics, because there an operator asked for it.
 
@@ -68,13 +70,18 @@ Additive-column migration stays exactly where it was — `ensureProjectionTables
 | Property in stored, absent from the preset | **Preserved** — never dropped |
 | Property in both, same definition | No-op |
 | Property in both, **different** definition | **Refused** — the whole type is left untouched and logged |
-| Other top-level keywords (`required`, `type`, …) | Follow the preset where it declares them |
+| `required` naming a stored-only property | **Carried over** — the preset has no opinion about a property it doesn't declare |
+| Other top-level keywords (`type`, `additionalProperties`, …) | Follow the preset where it declares them |
 
 Preserving stored-only properties is what protects operator customisation. WeOS has no provenance field on `ResourceType`, so an operator's addition through the API is indistinguishable from drift — dropping it would trade one silent data loss for another. Preserving it also stops a single customisation from permanently blocking later preset additions.
 
 The merge is idempotent: re-running it against its own output reports no change, which is what keeps repeated restarts quiet.
 
-**`required` is authoritative.** A property the preset newly marks required tightens the stored schema. This is a deliberate choice, and it has a consequence worth stating plainly: existing rows that lack that property will start failing validation on their next write.
+**`required` is authoritative — for properties the preset declares.** A property the preset newly marks required tightens the stored schema. This is a deliberate choice, and it has a consequence worth stating plainly: `validateAgainstSchema` runs on **update** as well as create, so existing rows that lack that property become un-editable through every surface — API, admin UI, MCP, and any behavior writing a partial payload — until they are backfilled. Requirements naming *stored-only* properties are carried over instead of dropped, since the preset expresses no opinion about a property it doesn't declare; dropping them would silently weaken a constraint the operator set.
+
+**Reported success means the column exists.** A successful `Update` is not evidence of that: the column is added by the `ResourceType.Updated` handler, and `SimpleUnitOfWork.Commit` discards dispatch errors as non-fatal under its eventual-consistency model, so `EnsureTable` can fail while `Update` still returns nil. The reconcile therefore re-checks `HasColumn` for every added property and demotes the type to `Failed` when they didn't land. Announcing "reconciled" over a still-broken projection would be the same silent success this change exists to eliminate.
+
+**A per-type failure never aborts the pass.** One unparseable stored schema or one transient write error must not leave every later type in the preset unreconciled and silently dropping writes. Failures are collected per type in `Failed`, and a preset type declaring no schema at all is reported under `NoSchema` rather than folded into `Unchanged`, where nothing would ever surface it.
 
 ### 3. GORM `AutoMigrate` — rejected
 
@@ -92,6 +99,8 @@ Adding a column leaves it `NULL` on every pre-existing row. Two paths exist, and
 - `weos worker reproject` replays the event feed through the synchronous projection handlers, rewriting each row from its canonical JSON-LD. **This is the backfill path for a newly added column.**
 
 Reproject stays **operator-invoked**. A full replay is expensive and must not fire on boot; the runbook case (server stopped, column added, operator reprojects) is the right shape.
+
+Note the resume caveat the two-pass split introduces: pass 1 always runs and cannot be skipped with `--after-position`, so a single unconvertible `ResourceType.*` event anywhere in history blocks the whole command. That trade buys correctness — resources must never project against a stale column set — but it means the escape hatch that used to step past a poison event no longer covers type events.
 
 Making that true required a fix. Reproject previously replayed the feed in one strict position order, which meant each type's *original* schema was applied, every resource projected against it, and only then the later `ResourceType.Updated` that added the column — so the column was never backfilled, and re-running didn't help because the ordering was identical every pass. Reproject now replays in **two passes, resource types first**, so every type reaches its final shape before a single resource projects. Pass 1 always starts at the beginning of the feed (re-applying type events is idempotent); pass 2 is the resumable one and alone honours `--after-position`.
 
@@ -129,7 +138,9 @@ The filter case deserves emphasis: dropping a filter does not narrow results, it
 ### Risks
 
 - **`required` tightening breaks existing rows.** A property the preset newly marks required will fail validation for rows that lack it, on their next write. Accepted deliberately; operators changing `required` on a populated type should plan a data pass.
-- **Refusal is all-or-nothing per type.** One conflicting property blocks that type's additive changes too, until an operator resolves it. Chosen over partial application, which would leave a schema in a state neither the preset nor the operator authored.
+- **Refusal is all-or-nothing per type.** One conflicting property blocks that type's additive changes too, until an operator resolves it. Chosen over partial application, which would leave a schema in a state neither the preset nor the operator authored. The cost is real, because the conflict test is an exact comparison: a preset that merely adds a `description` or `maxLength` to an existing property refuses the whole type. The refusal warning therefore names the blocked additive properties (`BlockedAdditions`) alongside the conflict, since those are the ones still losing writes.
+- **The conflict check does not follow indirection.** Property definitions are compared verbatim, so a schema reaching its types through `$ref`/`$defs`, `definitions`, `allOf`, or `patternProperties` can be retyped without tripping the guard — the change lands in a top-level keyword the preset simply wins. No preset in the tree uses those keywords today; one that starts to would need the check to resolve indirection first.
+- **Concurrent startup against a shared database.** Two replicas booting at once can both append `ResourceType.Updated` at the same sequence, and `addMissingColumns`' `HasColumn` guard is TOCTOU. Before this change a steady-state boot had nothing to ALTER, so the window didn't exist; the upgrade boot opens it. The loser's type lands in `Failed` with the reason logged rather than being silently skipped, and the next boot reconciles it.
 - **Drift is still silent at read time.** Until the follow-up tickets land, a filter on a column that does not exist still widens results rather than erroring.
 
 ## Alternatives Considered

--- a/infrastructure/database/gorm/projection_manager_test.go
+++ b/infrastructure/database/gorm/projection_manager_test.go
@@ -1100,7 +1100,7 @@ func TestEnsureTable_BackfillSkipsSoftDeletedRows(t *testing.T) {
 		ID: "rec-gone", TypeSlug: "recipe", Status: "active",
 		CreatedBy: "u1", AccountID: "acct-1", SequenceNo: 2,
 		CreatedAt: time.Now(), DeletedAt: &deleted,
-		Data:      `{"@id":"rec-gone","@type":"Recipe","name":"Gone"}`,
+		Data: `{"@id":"rec-gone","@type":"Recipe","name":"Gone"}`,
 	})
 
 	schema := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`)
@@ -1133,7 +1133,7 @@ func TestEnsureTable_BackfillSkipsPoisonedRowAndContinues(t *testing.T) {
 	}
 
 	// Pre-create the projection table with a CHECK on servings so a legacy row
-	// carrying an out-of-range value fails its insert while its neighbours don't.
+	// carrying an out-of-range value fails its insert while its neighbors don't.
 	// CREATE ... IF NOT EXISTS inside EnsureTable is a no-op against this table,
 	// and addMissingColumns fills in the rest (name) idempotently.
 	if err := db.Exec(`CREATE TABLE recipes (

--- a/internal/mcp/handler_test.go
+++ b/internal/mcp/handler_test.go
@@ -58,6 +58,12 @@ func (s *stubResourceTypeService) InstallPreset(
 	return nil, nil
 }
 
+func (s *stubResourceTypeService) ReconcilePresetSchemas(
+	_ context.Context, _ string,
+) (*application.ReconcilePresetResult, error) {
+	return nil, nil
+}
+
 func (s *stubResourceTypeService) ListBehaviors(
 	_ context.Context, _ string,
 ) ([]application.BehaviorInfo, error) {

--- a/tests/e2e/features/projection_column_migration.feature
+++ b/tests/e2e/features/projection_column_migration.feature
@@ -1,0 +1,67 @@
+@issue-379
+Feature: A built-in preset's schema change reaches an already-provisioned database
+  As an operator upgrading WeOS across an additive resource type schema change
+  I want the projection table of a built-in type to gain the property the new build declares
+  So that writes to the new field are stored and readable instead of silently dropped
+
+  Background:
+    Given a built-in preset "catalog" declaring a "widget" type with the properties:
+      | property | type   |
+      | name     | string |
+    And the "catalog" preset seeds 3 "widget" fixtures
+    And a clean WeOS database provisioned by that build
+
+  Scenario: A property added to a built-in preset becomes a projection column after restart
+    When the "catalog" preset adds a "sku" string property to "widget"
+    And the twin restarts against the same database
+    Then the "widget" projection table has a "sku" column
+
+  Scenario: A field added to a built-in preset round-trips after restart
+    Given the "catalog" preset adds a "sku" string property to "widget"
+    And the twin restarts against the same database
+    When I create a "widget" named "Bolt cutter" with "sku" set to "BC-100"
+    Then reading the "widget" "Bolt cutter" back over the API returns "sku" as "BC-100"
+
+  Scenario: Restarting with an unchanged preset records no resource type update
+    When the twin restarts against the same database
+    Then no resource type update is recorded for "widget"
+    And the "widget" projection table has a "name" column
+
+  Scenario: The schema refresh happens once and then settles
+    Given the "catalog" preset adds a "sku" string property to "widget"
+    When the twin restarts against the same database
+    And the twin restarts against the same database again
+    Then exactly one resource type update is recorded for "widget"
+
+  Scenario: Rows written before the column existed still read back, with the new field empty
+    Given a "widget" named "Hex key" exists
+    When the "catalog" preset adds a "sku" string property to "widget"
+    And the twin restarts against the same database
+    Then reading the "widget" "Hex key" back over the API succeeds
+    And it returns no value for "sku"
+
+  Scenario: Fixture data is not re-seeded when a preset's schema changes
+    When the "catalog" preset adds a "sku" string property to "widget"
+    And the twin restarts against the same database
+    Then there are still exactly 3 "widget" resources
+
+  Scenario: An archived resource type stays archived across the schema refresh
+    Given the "widget" resource type is archived
+    When the "catalog" preset adds a "sku" string property to "widget"
+    And the twin restarts against the same database
+    Then the "widget" resource type is still archived
+    And the "widget" projection table has a "sku" column
+
+  Scenario: A field written while the column was missing survives in the canonical record
+    Given a "widget" named "Bolt cutter" is created with an undeclared "sku" of "BC-100"
+    When the "catalog" preset adds a "sku" string property to "widget"
+    And the twin restarts against the same database
+    Then the JSON-LD representation of the "widget" "Bolt cutter" still carries "sku" as "BC-100"
+
+  Scenario: Reprojecting populates the new column on rows written before it existed
+    Given a "widget" named "Bolt cutter" is created with an undeclared "sku" of "BC-100"
+    And the "catalog" preset adds a "sku" string property to "widget"
+    And the twin restarts against the same database
+    And reading the "widget" "Bolt cutter" back over the API returns no value for "sku"
+    When the operator reprojects the event feed
+    Then reading the "widget" "Bolt cutter" back over the API returns "sku" as "BC-100"

--- a/tests/e2e/projection_column_migration_test.go
+++ b/tests/e2e/projection_column_migration_test.go
@@ -296,7 +296,14 @@ func (w *projectionMigrationWorld) widgetColumns() string {
 	return strings.Join(names, ", ")
 }
 
-func (w *projectionMigrationWorld) createWidget(data map[string]any) error {
+// createWidget creates a widget and records its ID under name. The name is
+// passed explicitly rather than read back out of data: deriving it would fall
+// back to "" whenever the key were missing, silently overwriting a previous
+// entry and breaking every later lookup with a confusing failure.
+func (w *projectionMigrationWorld) createWidget(name string, data map[string]any) error {
+	if name == "" {
+		return fmt.Errorf("a widget must be created with a name")
+	}
 	raw, err := json.Marshal(data)
 	if err != nil {
 		return err
@@ -306,26 +313,25 @@ func (w *projectionMigrationWorld) createWidget(data map[string]any) error {
 		Data:     raw,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create widget: %w", err)
+		return fmt.Errorf("failed to create widget %q: %w", name, err)
 	}
-	name, _ := data["name"].(string)
 	w.createdIDs[name] = res.GetID()
 	return nil
 }
 
 func (w *projectionMigrationWorld) iCreateWidgetWith(name, field, value string) error {
-	return w.createWidget(map[string]any{"name": name, field: value})
+	return w.createWidget(name, map[string]any{"name": name, field: value})
 }
 
 func (w *projectionMigrationWorld) aWidgetExists(name string) error {
-	return w.createWidget(map[string]any{"name": name})
+	return w.createWidget(name, map[string]any{"name": name})
 }
 
 // aWidgetIsCreatedWithUndeclared writes a field the CURRENT schema does not
 // declare — the state the bug leaves behind: the value reaches the canonical
 // resources row but has no projection column to land in.
 func (w *projectionMigrationWorld) aWidgetIsCreatedWithUndeclared(name, field, value string) error {
-	return w.createWidget(map[string]any{"name": name, field: value})
+	return w.createWidget(name, map[string]any{"name": name, field: value})
 }
 
 // flatRead reads a widget back through the projection (GetFlat), which is the

--- a/tests/e2e/projection_column_migration_test.go
+++ b/tests/e2e/projection_column_migration_test.go
@@ -1,0 +1,570 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cucumber/godog"
+	"go.uber.org/fx"
+	"gorm.io/gorm"
+
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/domain/repositories"
+	"github.com/wepala/weos/v3/internal/config"
+)
+
+// TestProjectionColumnMigration is the acceptance suite for issue #379: a
+// built-in preset that gains a property in a new build must reach a database
+// provisioned by an older one, instead of silently dropping every write to the
+// new field.
+//
+// The suite drives real restarts — each "restart" stops the Fx app and starts a
+// fresh one against the SAME SQLite file with a differently-shaped preset
+// registry — because the defect only exists across a boot boundary.
+func TestProjectionColumnMigration(t *testing.T) {
+	tags := "~@wip"
+	if override := os.Getenv("GODOG_TAGS"); override != "" {
+		tags = override
+	}
+	suite := godog.TestSuite{
+		Name:                "projection-column-migration",
+		ScenarioInitializer: initProjectionMigrationScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"features/projection_column_migration.feature"},
+			Tags:     tags,
+			Strict:   true,
+			TestingT: t,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("projection_column_migration acceptance scenarios failed")
+	}
+}
+
+// projectionMigrationWorld holds one scenario's database and the shape the
+// "catalog" preset declares on the next boot. Mutating properties then calling
+// restart is how a scenario expresses "a new build of WeOS".
+type projectionMigrationWorld struct {
+	tmpDir string
+	dsn    string
+
+	app    *fx.App
+	cancel context.CancelFunc
+
+	rts application.ResourceTypeService
+	rs  application.ResourceService
+	db  *gorm.DB
+
+	// properties is the widget type's JSON Schema properties, in declaration
+	// order, as the preset would declare them on the next boot.
+	properties []widgetProperty
+	// fixtureCount is how many widget fixtures the preset seeds on create.
+	fixtureCount int
+
+	// createdIDs maps a widget's name to its resource ID so later steps can
+	// read it back without re-querying by name.
+	createdIDs map[string]string
+	// lastReadRow backs the "it returns no value for X" step, which reads as a
+	// continuation of the preceding read step.
+	lastReadRow map[string]any
+}
+
+type widgetProperty struct {
+	name    string
+	jsonTyp string
+}
+
+func initProjectionMigrationScenario(sc *godog.ScenarioContext) {
+	w := &projectionMigrationWorld{createdIDs: map[string]string{}}
+
+	sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		w.teardown()
+		return ctx, nil
+	})
+
+	sc.Step(`^a built-in preset "catalog" declaring a "widget" type with the properties:$`, w.aPresetDeclaring)
+	sc.Step(`^the "catalog" preset seeds (\d+) "widget" fixtures$`, w.thePresetSeedsFixtures)
+	sc.Step(`^a clean WeOS database provisioned by that build$`, w.aCleanDatabase)
+
+	sc.Step(`^the "catalog" preset adds a "([^"]*)" (\w+) property to "widget"$`, w.thePresetAddsProperty)
+	sc.Step(`^the twin restarts against the same database$`, w.theTwinRestarts)
+	sc.Step(`^the twin restarts against the same database again$`, w.theTwinRestarts)
+
+	sc.Step(`^the "widget" projection table has a "([^"]*)" column$`, w.theProjectionTableHasColumn)
+	sc.Step(`^I create a "widget" named "([^"]*)" with "([^"]*)" set to "([^"]*)"$`, w.iCreateWidgetWith)
+	sc.Step(`^a "widget" named "([^"]*)" exists$`, w.aWidgetExists)
+	sc.Step(`^a "widget" named "([^"]*)" is created with an undeclared "([^"]*)" of "([^"]*)"$`,
+		w.aWidgetIsCreatedWithUndeclared)
+
+	sc.Step(`^reading the "widget" "([^"]*)" back over the API returns "([^"]*)" as "([^"]*)"$`,
+		w.readingReturnsValue)
+	sc.Step(`^reading the "widget" "([^"]*)" back over the API returns no value for "([^"]*)"$`,
+		w.readingReturnsNoValue)
+	sc.Step(`^reading the "widget" "([^"]*)" back over the API succeeds$`, w.readingSucceeds)
+	sc.Step(`^it returns no value for "([^"]*)"$`, w.itReturnsNoValueForLastRead)
+	sc.Step(`^the JSON-LD representation of the "widget" "([^"]*)" still carries "([^"]*)" as "([^"]*)"$`,
+		w.canonicalStillCarries)
+
+	sc.Step(`^no resource type update is recorded for "([^"]*)"$`, w.noUpdateRecorded)
+	sc.Step(`^exactly one resource type update is recorded for "([^"]*)"$`, w.exactlyOneUpdateRecorded)
+	sc.Step(`^there are still exactly (\d+) "widget" resources$`, w.thereAreExactlyNWidgets)
+
+	sc.Step(`^the "widget" resource type is archived$`, w.theTypeIsArchived)
+	sc.Step(`^the "widget" resource type is still archived$`, w.theTypeIsStillArchived)
+
+	sc.Step(`^the operator reprojects the event feed$`, w.theOperatorReprojects)
+}
+
+// --- preset shaping ---
+
+func (w *projectionMigrationWorld) aPresetDeclaring(table *godog.Table) error {
+	w.properties = nil
+	// Row 0 is the header (| property | type |).
+	for _, row := range table.Rows[1:] {
+		if len(row.Cells) != 2 {
+			return fmt.Errorf("expected 2 columns per property row, got %d", len(row.Cells))
+		}
+		w.properties = append(w.properties, widgetProperty{
+			name:    strings.TrimSpace(row.Cells[0].Value),
+			jsonTyp: strings.TrimSpace(row.Cells[1].Value),
+		})
+	}
+	return nil
+}
+
+func (w *projectionMigrationWorld) thePresetSeedsFixtures(count int) error {
+	w.fixtureCount = count
+	return nil
+}
+
+func (w *projectionMigrationWorld) thePresetAddsProperty(name, jsonTyp string) error {
+	for _, p := range w.properties {
+		if p.name == name {
+			return fmt.Errorf("property %q is already declared", name)
+		}
+	}
+	w.properties = append(w.properties, widgetProperty{name: name, jsonTyp: jsonTyp})
+	return nil
+}
+
+// catalogRegistry builds the preset registry for the next boot from the
+// world's current property list. AutoInstall is what routes it through
+// ensureBuiltInResourceTypes — the startup path under test.
+func (w *projectionMigrationWorld) catalogRegistry() *application.PresetRegistry {
+	props := make([]string, 0, len(w.properties))
+	for _, p := range w.properties {
+		props = append(props, fmt.Sprintf("%q:{\"type\":%q}", p.name, p.jsonTyp))
+	}
+	schema := fmt.Sprintf(`{"type":"object","properties":{%s}}`, strings.Join(props, ","))
+
+	fixtures := make([]json.RawMessage, 0, w.fixtureCount)
+	for i := 0; i < w.fixtureCount; i++ {
+		fixtures = append(fixtures, json.RawMessage(fmt.Sprintf(`{"name":"fixture-%d"}`, i)))
+	}
+
+	registry := application.NewPresetRegistry()
+	registry.MustAdd(application.PresetDefinition{
+		Name:        "catalog",
+		Description: "issue #379 acceptance preset",
+		AutoInstall: true,
+		Types: []application.PresetResourceType{{
+			Name:        "Widget",
+			Slug:        "widget",
+			Description: "A widget",
+			Context:     json.RawMessage(`{"@vocab":"https://schema.org/"}`),
+			Schema:      json.RawMessage(schema),
+			Fixtures:    fixtures,
+		}},
+	})
+	return registry
+}
+
+// --- boot / restart ---
+
+func (w *projectionMigrationWorld) aCleanDatabase() error {
+	dir, err := os.MkdirTemp("", "weos-projection-migration-e2e-")
+	if err != nil {
+		return err
+	}
+	w.tmpDir = dir
+	w.dsn = filepath.Join(dir, "test.db")
+	return w.boot()
+}
+
+// boot starts a fresh Fx app against the world's existing database file. It is
+// the "restart" primitive: the process and its preset registry are new, the
+// data is not.
+func (w *projectionMigrationWorld) boot() error {
+	cfg := config.Default()
+	cfg.DatabaseDSN = w.dsn
+	cfg.LogLevel = "error"
+	if lvl := os.Getenv("E2E_LOG_LEVEL"); lvl != "" {
+		cfg.LogLevel = lvl
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	w.cancel = cancel
+
+	var rts application.ResourceTypeService
+	var rs application.ResourceService
+	var db *gorm.DB
+
+	app := fx.New(
+		fx.NopLogger,
+		application.Module(cfg, w.catalogRegistry()),
+		fx.Populate(&rts, &rs, &db),
+	)
+	startCtx, startCancel := context.WithTimeout(ctx, fx.DefaultTimeout)
+	defer startCancel()
+	if err := app.Start(startCtx); err != nil {
+		return fmt.Errorf("failed to start app: %w", err)
+	}
+	w.app, w.rts, w.rs, w.db = app, rts, rs, db
+	return nil
+}
+
+func (w *projectionMigrationWorld) stop() {
+	if w.app != nil {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		_ = w.app.Stop(stopCtx)
+		stopCancel()
+		w.app = nil
+	}
+	if w.cancel != nil {
+		w.cancel()
+		w.cancel = nil
+	}
+}
+
+func (w *projectionMigrationWorld) theTwinRestarts() error {
+	w.stop()
+	return w.boot()
+}
+
+func (w *projectionMigrationWorld) teardown() {
+	w.stop()
+	if w.tmpDir != "" {
+		_ = os.RemoveAll(w.tmpDir)
+		w.tmpDir = ""
+	}
+}
+
+// --- assertions ---
+
+func (w *projectionMigrationWorld) theProjectionTableHasColumn(column string) error {
+	if !w.db.Migrator().HasColumn("widgets", column) {
+		return fmt.Errorf("projection table `widgets` has no %q column (columns: %s)",
+			column, w.widgetColumns())
+	}
+	return nil
+}
+
+// widgetColumns renders the projection table's actual columns for failure
+// messages — the single most useful thing to see when this suite goes red.
+func (w *projectionMigrationWorld) widgetColumns() string {
+	types, err := w.db.Migrator().ColumnTypes("widgets")
+	if err != nil {
+		return fmt.Sprintf("<unreadable: %v>", err)
+	}
+	names := make([]string, 0, len(types))
+	for _, ct := range types {
+		names = append(names, ct.Name())
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+func (w *projectionMigrationWorld) createWidget(data map[string]any) error {
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	res, err := w.rs.Create(context.Background(), application.CreateResourceCommand{
+		TypeSlug: "widget",
+		Data:     raw,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create widget: %w", err)
+	}
+	name, _ := data["name"].(string)
+	w.createdIDs[name] = res.GetID()
+	return nil
+}
+
+func (w *projectionMigrationWorld) iCreateWidgetWith(name, field, value string) error {
+	return w.createWidget(map[string]any{"name": name, field: value})
+}
+
+func (w *projectionMigrationWorld) aWidgetExists(name string) error {
+	return w.createWidget(map[string]any{"name": name})
+}
+
+// aWidgetIsCreatedWithUndeclared writes a field the CURRENT schema does not
+// declare — the state the bug leaves behind: the value reaches the canonical
+// resources row but has no projection column to land in.
+func (w *projectionMigrationWorld) aWidgetIsCreatedWithUndeclared(name, field, value string) error {
+	return w.createWidget(map[string]any{"name": name, field: value})
+}
+
+// flatRead reads a widget back through the projection (GetFlat), which is the
+// surface the silent drop actually shows up on.
+func (w *projectionMigrationWorld) flatRead(name string) (map[string]any, error) {
+	id, ok := w.createdIDs[name]
+	if !ok {
+		return nil, fmt.Errorf("no widget named %q was created in this scenario", name)
+	}
+	row, err := w.rs.GetFlat(context.Background(), "widget", id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read widget %q back: %w", name, err)
+	}
+	return row, nil
+}
+
+func (w *projectionMigrationWorld) readingReturnsValue(name, field, want string) error {
+	row, err := w.flatRead(name)
+	if err != nil {
+		return err
+	}
+	w.lastReadRow = row
+	got, ok := row[field]
+	if !ok {
+		return fmt.Errorf("read of %q carries no %q key (keys: %s)", name, field, mapKeys(row))
+	}
+	if fmt.Sprintf("%v", got) != want {
+		return fmt.Errorf("read of %q returned %s = %v, want %q", name, field, got, want)
+	}
+	return nil
+}
+
+func (w *projectionMigrationWorld) readingReturnsNoValue(name, field string) error {
+	row, err := w.flatRead(name)
+	if err != nil {
+		return err
+	}
+	w.lastReadRow = row
+	return assertEmpty(row, field)
+}
+
+func (w *projectionMigrationWorld) readingSucceeds(name string) error {
+	row, err := w.flatRead(name)
+	if err != nil {
+		return err
+	}
+	w.lastReadRow = row
+	return nil
+}
+
+func (w *projectionMigrationWorld) itReturnsNoValueForLastRead(field string) error {
+	if w.lastReadRow == nil {
+		return fmt.Errorf("no resource has been read yet")
+	}
+	return assertEmpty(w.lastReadRow, field)
+}
+
+// assertEmpty tolerates both an absent key and a present-but-null/empty value:
+// a column added by ALTER TABLE is NULL on every pre-existing row, and the flat
+// projection may or may not carry the key depending on how the row was built.
+func assertEmpty(row map[string]any, field string) error {
+	got, ok := row[field]
+	if !ok || got == nil || got == "" {
+		return nil
+	}
+	return fmt.Errorf("expected no value for %q, got %v", field, got)
+}
+
+func mapKeys(m map[string]any) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ", ")
+}
+
+// canonicalStillCarries reads the canonical JSON-LD blob rather than the
+// projection — proving the event store never lost the field even while the
+// projection column was missing.
+func (w *projectionMigrationWorld) canonicalStillCarries(name, field, want string) error {
+	id, ok := w.createdIDs[name]
+	if !ok {
+		return fmt.Errorf("no widget named %q was created in this scenario", name)
+	}
+	res, err := w.rs.GetByID(context.Background(), id)
+	if err != nil {
+		return fmt.Errorf("failed to read widget %q by id: %w", name, err)
+	}
+	var data map[string]any
+	if err := json.Unmarshal(res.Data(), &data); err != nil {
+		return fmt.Errorf("canonical data for %q is not a JSON object: %w", name, err)
+	}
+	got, ok := jsonLDField(data, field)
+	if !ok {
+		return fmt.Errorf("canonical record for %q lost %q (payload: %s)", name, field, res.Data())
+	}
+	if fmt.Sprintf("%v", got) != want {
+		return fmt.Errorf("canonical record for %q has %s = %v, want %q", name, field, got, want)
+	}
+	return nil
+}
+
+// jsonLDField looks a property up in a stored JSON-LD blob, which may carry it
+// at the top level or inside an @graph node depending on how the document was
+// framed.
+func jsonLDField(data map[string]any, field string) (any, bool) {
+	if v, ok := data[field]; ok {
+		return v, true
+	}
+	graph, ok := data["@graph"]
+	if !ok {
+		return nil, false
+	}
+	switch g := graph.(type) {
+	case map[string]any:
+		v, ok := g[field]
+		return v, ok
+	case []any:
+		for _, node := range g {
+			n, isMap := node.(map[string]any)
+			if !isMap {
+				continue
+			}
+			if v, ok := n[field]; ok {
+				return v, true
+			}
+		}
+	}
+	return nil, false
+}
+
+// countTypeUpdates counts ResourceType.Updated events in the event store for a
+// slug's aggregate. Reading the store (not a live subscription) is deliberate:
+// the count has to survive the restarts these scenarios perform.
+func (w *projectionMigrationWorld) countTypeUpdates(slug string) (int64, error) {
+	var n int64
+	err := w.db.Table("events").
+		Where("aggregate_id = ? AND event_type = ?", "urn:type:"+slug, "ResourceType.Updated").
+		Count(&n).Error
+	if err != nil {
+		return 0, fmt.Errorf("failed to count ResourceType.Updated events: %w", err)
+	}
+	return n, nil
+}
+
+func (w *projectionMigrationWorld) noUpdateRecorded(slug string) error {
+	n, err := w.countTypeUpdates(slug)
+	if err != nil {
+		return err
+	}
+	if n != 0 {
+		return fmt.Errorf("expected no ResourceType.Updated events for %q, got %d", slug, n)
+	}
+	return nil
+}
+
+func (w *projectionMigrationWorld) exactlyOneUpdateRecorded(slug string) error {
+	n, err := w.countTypeUpdates(slug)
+	if err != nil {
+		return err
+	}
+	if n != 1 {
+		return fmt.Errorf("expected exactly 1 ResourceType.Updated event for %q, got %d", slug, n)
+	}
+	return nil
+}
+
+func (w *projectionMigrationWorld) thereAreExactlyNWidgets(want int) error {
+	page, err := w.rs.List(context.Background(), "widget", "", 100, repositories.SortOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list widgets: %w", err)
+	}
+	if got := len(page.Data); got != want {
+		return fmt.Errorf("expected exactly %d widget resources, got %d", want, got)
+	}
+	return nil
+}
+
+func (w *projectionMigrationWorld) theTypeIsArchived() error {
+	existing, err := w.rts.GetBySlug(context.Background(), "widget")
+	if err != nil {
+		return fmt.Errorf("failed to load the widget type: %w", err)
+	}
+	_, err = w.rts.Update(context.Background(), application.UpdateResourceTypeCommand{
+		ID:          existing.GetID(),
+		Name:        existing.Name(),
+		Slug:        existing.Slug(),
+		Description: existing.Description(),
+		Status:      "archived",
+		Context:     existing.Context(),
+		Schema:      existing.Schema(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to archive the widget type: %w", err)
+	}
+	return nil
+}
+
+func (w *projectionMigrationWorld) theTypeIsStillArchived() error {
+	existing, err := w.rts.GetBySlug(context.Background(), "widget")
+	if err != nil {
+		return fmt.Errorf("failed to load the widget type: %w", err)
+	}
+	if existing.Status() != "archived" {
+		return fmt.Errorf("expected the widget type to still be archived, got status %q", existing.Status())
+	}
+	return nil
+}
+
+// theOperatorReprojects runs the same replay rail `weos worker reproject`
+// drives, against the stopped-then-restarted database. The app is stopped for
+// the duration so the replay is the one-shot operator pass it is designed to be
+// rather than racing the live synchronous projections.
+func (w *projectionMigrationWorld) theOperatorReprojects() error {
+	w.stop()
+
+	cfg := config.Default()
+	cfg.DatabaseDSN = w.dsn
+	cfg.LogLevel = "error"
+
+	var rt application.ReprojectRuntime
+	app := fx.New(
+		fx.NopLogger,
+		application.ReprojectModule(cfg),
+		fx.Populate(&rt),
+	)
+	startCtx, startCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+	defer startCancel()
+	if err := app.Start(startCtx); err != nil {
+		return fmt.Errorf("failed to start the reproject runtime: %w", err)
+	}
+	_, err := application.Reproject(context.Background(), rt, application.ReprojectOptions{})
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+	_ = app.Stop(stopCtx)
+	stopCancel()
+	if err != nil {
+		return fmt.Errorf("reproject failed: %w", err)
+	}
+
+	return w.boot()
+}


### PR DESCRIPTION
Closes #379.

## The problem

When a preset's JSON Schema gained a property in a new build, databases provisioned by an earlier build kept the old projection table. Writes to the new field were **silently dropped** — `dropMissingColumns` deletes any key with no matching column before the INSERT, so the write succeeded, no error surfaced, and every read, filter and sort on the new field behaved as if it were empty. The data survived in the event store the whole time; only the projection lost it.

## What the spike found

The additive-column ALTER machinery already existed and was correct: `addMissingColumns` is idempotent and `HasColumn`-guarded, `EnsureTable` calls it, `EnsureExistingTables` runs it over every live type at **every** startup, and `ResourceType.Updated` applies the same reconciliation at runtime.

All of it derives its column set from the schema **stored in the database**, and nothing refreshed that stored schema from the preset's code definition. `ensureBuiltInResourceTypes` called `InstallPreset(..., update=false)`, which *skips* an existing type — so the stored schema stayed stale, the old column set was derived from it, `addMissingColumns` found nothing to add, and the write path silently dropped the field.

The fix belongs there, not in the ALTER machinery.

## The change

**`ResourceTypeService.ReconcilePresetSchemas`** merges a preset's code-defined schema into the stored types at startup, additively:

| Case | Action |
|---|---|
| Property in the preset, absent from stored | Merged in — yields the missing column |
| Property in stored, absent from the preset | Preserved, never dropped |
| Property in both, different definition | **Held** at its stored definition and logged; the rest of the merge proceeds |
| `required` naming a stored-only property | Carried over |
| Other top-level keywords | Follow the preset |

`InstallPreset` is unchanged and `preset install --update` keeps its full-overwrite semantics. Neither of its modes is safe unattended: `update=false` is the bug, and `update=true` would overwrite name/description/context/schema from code on every boot, discarding operator customization. Startup gets this third, narrower behaviour instead — name, description, context and status are read back from the stored type and passed through untouched.

It runs for **every registered preset**, not just the two that set `AutoInstall`.

**`worker reproject` now replays in two passes**, resource types first. A single position-ordered replay applied each type's *historical* schema, projected every resource against it, and only then the `ResourceType.Updated` that added the column — so a column added by a schema change could never be backfilled, and re-running never helped because the ordering was identical every pass.

## Reported success now means the column exists

`SimpleUnitOfWork.Commit` discards dispatch errors as non-fatal under its eventual-consistency model, so `EnsureTable` can fail while `Update` still returns nil. The reconcile re-checks `HasColumn` for every added property and demotes the type to `Failed` when they didn't land — announcing "reconciled" over a still-broken projection would be the same silent success this change exists to eliminate.

Per-type failures never abort the pass, so one unparseable schema can't leave every later type in the preset unreconciled.

## Testing

`tests/e2e/features/projection_column_migration.feature` — 9 scenarios driving **real Fx restarts against the same SQLite file** with a changed preset registry, since the defect only exists across a boot boundary. Covers the column landing, the field round-tripping, no event spam across restarts, pre-existing rows, fixtures not re-seeded, archived status surviving, the canonical record retaining the field, and reproject backfilling.

Unit coverage for the merge rules (retype, removal, nested/`$ref` shapes, both `required` directions, idempotence, malformed schemas), the column-verification failure path, per-type failure isolation, and reproject's resume / head-reporting / counter-accounting semantics.

`make lint` and `make vet` clean; `make test` green except `web/TestStaticFS_DefaultEmbed`, which needs the built frontend and **fails identically on a clean `v3`**.

## Deliberately not fixed here

Filed as follow-ups: #457 (a filter on a missing column silently **widens** the result set — the most severe of the read-side drift sites), #458 (operator-facing surface for reconcile results), #459 (top-level keyword ownership), #460 (concurrent-startup ALTER race), #461 (reproject pass-1 escape hatch), #462 (property key ordering).

Recorded in `docs/decisions/projection-schema-migration.md`, which answers all five of the spike's questions — including why GORM `AutoMigrate` is rejected (projection tables are built from JSON Schema at runtime, so there is no struct to reflect over).

## Risk worth flagging

`required` is authoritative for properties the preset declares, and `validateAgainstSchema` runs on **update** as well as create — so a property a preset newly marks required makes existing rows lacking it un-editable through every surface until backfilled. This was an explicit decision, and it's documented in the ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)