### PR TITLE
Story #136: an instance can enable password sign-in without opening registration

### DIFF
--- a/api/handlers/password_auth_handler.go
+++ b/api/handlers/password_auth_handler.go
@@ -68,6 +68,38 @@ func NewPasswordAuthHandler(cfg PasswordAuthHandlerConfig) *PasswordAuthHandler 
 	return &PasswordAuthHandler{cfg: cfg}
 }
 
+// PasswordAuthRoutes describes which of the two password endpoints an
+// instance offers. They are independent on purpose: an instance can accept
+// sign-ins from accounts it already has (SignIn) without letting anyone who
+// reaches the hostname create another (Registration).
+type PasswordAuthRoutes struct {
+	// SignIn mounts POST /auth/password-login.
+	SignIn bool
+	// Registration mounts POST /auth/register. Ignored unless SignIn is
+	// also set — registering an account that could never sign in is not a
+	// configuration worth honoring.
+	Registration bool
+}
+
+// MountPasswordAuth registers the password endpoints an instance has turned
+// on, and *only* those. An endpoint that is off is never registered, so its
+// path answers exactly like a path the server has never had: 404, no
+// authentication challenge, no Allow header, nothing to probe and no
+// allowlist to keep correct. This is deliberately not a handler that
+// inspects the request and refuses it.
+//
+// serve.go and the acceptance tests both mount through here so there is one
+// copy of this decision rather than two that can drift apart.
+func MountPasswordAuth(g *echo.Group, h *PasswordAuthHandler, routes PasswordAuthRoutes) {
+	if !routes.SignIn {
+		return
+	}
+	if routes.Registration {
+		g.POST("/auth/register", h.Register)
+	}
+	g.POST("/auth/password-login", h.Login)
+}
+
 type registerRequest struct {
 	Email       string `json:"email"`
 	Password    string `json:"password"`

--- a/docs/_reference/environment-variables.md
+++ b/docs/_reference/environment-variables.md
@@ -35,6 +35,21 @@ OAuth is enabled when both `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are set
 | `GOOGLE_CLIENT_SECRET` | string | | Google OAuth 2.0 client secret |
 | `FRONTEND_URL` | string | | Frontend URL for OAuth redirect callbacks |
 
+## Authentication (email + password)
+
+Sign-in and registration are separate settings, so an instance can accept sign-ins from the accounts it already has without letting anyone who reaches the hostname create another.
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `PASSWORD_AUTH_ENABLED` | bool | `false` | Mounts `POST /api/auth/password-login` |
+| `PASSWORD_REGISTRATION_ENABLED` | bool | `false` | Mounts `POST /api/auth/register`. Requires `PASSWORD_AUTH_ENABLED` — on its own it does nothing, since the accounts it created could not sign in |
+
+An endpoint that is off is never mounted, so its path answers `404` exactly like a path the server has never had: no authentication challenge, no `Allow` header, nothing to probe and no allowlist to keep correct.
+
+Set `SESSION_SECRET` to a real value before enabling either one — with the default secret, sessions are forgeable.
+
+> **Upgrading:** `PASSWORD_AUTH_ENABLED` used to mount registration as well. A deployment that sets only that variable keeps working for sign-in, but its register route is now closed. That is the intended change; set `PASSWORD_REGISTRATION_ENABLED=true` to restore the old behaviour on an instance that genuinely wants open self-service signup.
+
 ## MCP Server
 
 | Variable | Type | Default | Description |

--- a/docs/_reference/environment-variables.md
+++ b/docs/_reference/environment-variables.md
@@ -44,7 +44,9 @@ Sign-in and registration are separate settings, so an instance can accept sign-i
 | `PASSWORD_AUTH_ENABLED` | bool | `false` | Mounts `POST /api/auth/password-login` |
 | `PASSWORD_REGISTRATION_ENABLED` | bool | `false` | Mounts `POST /api/auth/register`. Requires `PASSWORD_AUTH_ENABLED` — on its own it does nothing, since the accounts it created could not sign in |
 
-An endpoint that is off is never mounted, so its path answers `404` exactly like a path the server has never had: no authentication challenge, no `Allow` header, nothing to probe and no allowlist to keep correct.
+An endpoint that is off is never mounted, so its path answers exactly what a path the server has never had answers — nothing to probe and no allowlist to keep correct.
+
+What that looks like depends on the deployment rather than on registration: an unmatched `POST` under `/api` gets a bare `404`, while `GET`/`PUT`/`DELETE` are claimed by the generic resource route and get `401`, and on an instance with OAuth configured every unmatched path answers `401` with a `WWW-Authenticate: Bearer` challenge. In each case `/api/auth/register` answers identically to any address the server has never had, which is the property that matters.
 
 Set `SESSION_SECRET` to a real value before enabling either one — with the default secret, sessions are forgeable.
 
@@ -86,4 +88,8 @@ SESSION_SECRET=my-super-secret-key
 # GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
 # GOOGLE_CLIENT_SECRET=your-client-secret
 # FRONTEND_URL=http://localhost:3000
+
+# Email + password sign-in (both default to false)
+# PASSWORD_AUTH_ENABLED=true
+# PASSWORD_REGISTRATION_ENABLED=true
 ```

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -483,6 +483,23 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 	mcpGroup.Use(apimw.AuthorizeResource(authzChecker, accountRepo, logger))
 
+	// Careful: this is the last Use() on an empty-prefix group under /api, and
+	// echo's Group.Use registers the group's not-found catch-all at the group
+	// prefix. So THIS group owns what an unmatched /api/... path answers —
+	// a bare 404 in dev, and 401 with a Bearer challenge once OAuth is
+	// configured, because BearerOrSession sets the challenge before it checks
+	// the session.
+	//
+	// Adding a later empty-prefix group, or reordering these three (protected,
+	// acceptGroup, mcpGroup), silently moves that ownership and changes the
+	// answer for every unmounted path — including /api/auth/register when
+	// PASSWORD_REGISTRATION_ENABLED is off. What must stay true is that the
+	// registration path answers exactly what an invented path answers; the
+	// specific status is allowed to differ per deployment. The acceptance
+	// scenarios in tests/e2e/features/password_registration_flag.feature pin
+	// that parity, and tests/e2e/password_registration_flag_test.go builds its
+	// own echo instance, so it will NOT notice if this ordering changes.
+
 	// The in-app agent is independent of the MCP transport flag: with MCP
 	// disabled it still chats, just tool-less (the orchestrator degrades).
 	agentHandler := handlers.NewAgentHandler(orchestrator, logger)

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -246,9 +246,26 @@ func runServe(cmd *cobra.Command, args []string) error {
 		SecureCookies:  secureCookies,
 		Logger:         logger,
 	})
-	if appCfg.PasswordAuthEnabled {
-		api.POST("/auth/register", passwordAuthHandlers.Register)
-		api.POST("/auth/password-login", passwordAuthHandlers.Login)
+	handlers.MountPasswordAuth(api, passwordAuthHandlers, handlers.PasswordAuthRoutes{
+		SignIn:       appCfg.PasswordAuthEnabled,
+		Registration: appCfg.PasswordRegistrationEnabled,
+	})
+	// Registration used to come along with PASSWORD_AUTH_ENABLED, so an
+	// existing deployment that upgrades loses its register route the moment it
+	// picks up this version. Say so at startup: without a line here the change
+	// is invisible until someone's signup form 404s in production.
+	if appCfg.PasswordAuthEnabled && !appCfg.PasswordRegistrationEnabled {
+		logger.Info(context.Background(),
+			"password sign-in is on and account registration is off; POST /api/auth/register is not mounted",
+			"remedy", "set PASSWORD_REGISTRATION_ENABLED=true to offer open self-service signup")
+	}
+	// Registration without sign-in would mint accounts that could never be
+	// used, so it is ignored rather than honored. Warn, because the operator
+	// asked for something they are not getting.
+	if appCfg.PasswordRegistrationEnabled && !appCfg.PasswordAuthEnabled {
+		logger.Warn(context.Background(),
+			"PASSWORD_REGISTRATION_ENABLED is set but PASSWORD_AUTH_ENABLED is not; registration stays unmounted",
+			"remedy", "set PASSWORD_AUTH_ENABLED=true as well")
 	}
 
 	// Logout must clear BOTH the gorilla session (pericarp Logout) AND the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,12 +131,24 @@ type Config struct {
 	// SessionSecret is the secret key for session cookies.
 	SessionSecret string
 
-	// PasswordAuthEnabled toggles the email + password register/login
-	// endpoints. Off by default — enabling it without a non-default
-	// SessionSecret is a footgun because sessions become forgeable.
-	// Callers should ensure SessionSecret is set to a production-safe
-	// value before enabling password authentication.
+	// PasswordAuthEnabled toggles the email + password login endpoint.
+	// Off by default — enabling it without a non-default SessionSecret is
+	// a footgun because sessions become forgeable. Callers should ensure
+	// SessionSecret is set to a production-safe value before enabling
+	// password authentication.
 	PasswordAuthEnabled bool
+
+	// PasswordRegistrationEnabled toggles the self-service registration
+	// endpoint (POST /api/auth/register). Off by default, and independent
+	// of PasswordAuthEnabled: an instance can offer password sign-in to
+	// accounts it already has without letting anyone who reaches the
+	// hostname create another. When off the route is never mounted, so the
+	// path 404s exactly like one the server has never had — there is no
+	// handler to probe and no allowlist to keep correct.
+	//
+	// Registration still requires PasswordAuthEnabled: opening this alone
+	// would mint accounts that have no way to sign in.
+	PasswordRegistrationEnabled bool
 
 	// LLM holds configuration for LLM integrations.
 	LLM LLMConfig
@@ -451,6 +463,12 @@ func (c *Config) LoadFromEnvironment() {
 	if v := os.Getenv("PASSWORD_AUTH_ENABLED"); v != "" {
 		if enabled, err := strconv.ParseBool(v); err == nil {
 			c.PasswordAuthEnabled = enabled
+		}
+	}
+
+	if v := os.Getenv("PASSWORD_REGISTRATION_ENABLED"); v != "" {
+		if enabled, err := strconv.ParseBool(v); err == nil {
+			c.PasswordRegistrationEnabled = enabled
 		}
 	}
 

--- a/tests/e2e/features/password_registration_flag.feature
+++ b/tests/e2e/features/password_registration_flag.feature
@@ -18,8 +18,19 @@ Feature: Password sign-in without open registration
   path this instance has never had, under every method. A status that singled the
   registration path out — including a "404 Not Found" where neighbouring unknown
   paths answer otherwise — would give it away just as loudly as a refusal would.
-  So the scenarios below fix a status only where an invented path returns that same
-  status, and otherwise compare against an invented path directly.
+  So these scenarios assert by comparison against an invented control path, and
+  "answered identically" means the same status, the same body and the same
+  authentication challenge, because a prober reads all three.
+
+  What an ordinary unknown path returns depends on how the instance is deployed. With
+  no OAuth provider configured, an unmatched path under /api answers "404 Not Found".
+  With one configured it answers "401 Unauthorized" carrying a bearer challenge,
+  because the group that owns unmatched paths then authenticates before it routes.
+  Both are correct, and neither is the point of this story. A scenario that fixes a
+  literal status is therefore only sound for the deployment shape its Given describes,
+  which is why the ones that could run either way compare instead — and why two
+  scenarios below pin the property on an OAuth-configured instance, so that shape
+  stops being invisible.
 
   Scenario: An existing account signs in while registration is closed
     Given a WeOS instance where password sign-in is enabled and account registration is disabled
@@ -28,12 +39,12 @@ Feature: Password sign-in without open registration
     Then the sign-in succeeds
     And "ops@harborlegal.example" holds an authenticated session
 
-  Scenario: A closed registration endpoint is absent rather than refusing
+  Scenario: A closed registration endpoint issues no challenge or method hint of its own
     Given a WeOS instance where password sign-in is enabled and account registration is disabled
     When someone submits a registration for "newcomer@harborlegal.example" with password "correct-horse-battery-staple"
-    Then the registration request is answered "404 Not Found"
-    And the answer offers no authentication challenge
-    And the answer advertises no permitted methods for that path
+    And someone posts the same details to "/api/auth/enroll", an endpoint this instance has never had
+    Then both answers carry the same authentication challenge
+    And neither answer advertises permitted methods for its path
 
   Scenario Outline: Under every method the registration path answers like one that never existed
     Given a WeOS instance where password sign-in is enabled and account registration is disabled
@@ -69,7 +80,8 @@ Feature: Password sign-in without open registration
   Scenario: Enabling password sign-in alone leaves registration closed
     Given a WeOS instance where password sign-in is enabled and account registration is not configured
     When someone submits a registration for "newcomer@harborlegal.example" with password "correct-horse-battery-staple"
-    Then the registration request is answered "404 Not Found"
+    And someone posts the same details to "/api/auth/enroll", an endpoint this instance has never had
+    Then both requests are answered identically, including any authentication challenge
 
   Scenario: Opening both settings lets a new account register and sign straight in
     Given a WeOS instance where password sign-in is enabled and account registration is enabled
@@ -81,13 +93,31 @@ Feature: Password sign-in without open registration
   Scenario: Registration cannot be opened while password sign-in is off
     Given a WeOS instance where password sign-in is disabled and account registration is enabled
     When someone submits a registration for "newcomer@harborlegal.example" with password "correct-horse-battery-staple"
-    Then the registration request is answered "404 Not Found"
+    And someone posts the same details to "/api/auth/enroll", an endpoint this instance has never had
+    Then both requests are answered identically, including any authentication challenge
 
   Scenario: With password sign-in off, neither password endpoint is mounted
     Given a WeOS instance where password sign-in is disabled and account registration is not configured
     When someone submits a registration for "newcomer@harborlegal.example" with password "correct-horse-battery-staple"
     And "ops@harborlegal.example" attempts a password sign-in with password "correct-horse-battery-staple"
-    Then both requests are answered "404 Not Found"
+    And someone posts the same details to "/api/auth/enroll", an endpoint this instance has never had
+    Then all three requests are answered identically, including any authentication challenge
+
+  Scenario: The registration path stays ordinary on an instance that also uses OAuth
+    Given a WeOS instance where password sign-in is enabled and account registration is disabled
+    And an OAuth provider is also configured on that instance
+    When someone submits a registration for "newcomer@harborlegal.example" with password "correct-horse-battery-staple"
+    And someone posts the same details to "/api/auth/enroll", an endpoint this instance has never had
+    Then both requests are answered identically, including any authentication challenge
+    And no account exists for "newcomer@harborlegal.example"
+
+  Scenario: Password sign-in still works on an instance that also uses OAuth
+    Given a WeOS instance where password sign-in is enabled and account registration is disabled
+    And an OAuth provider is also configured on that instance
+    And the instance already has the account "ops@harborlegal.example" with password "correct-horse-battery-staple"
+    When "ops@harborlegal.example" signs in with password "correct-horse-battery-staple"
+    Then the sign-in succeeds
+    And "ops@harborlegal.example" holds an authenticated session
 
   Scenario: Closing registration does not lock out an account that registered earlier
     Given a WeOS instance where password sign-in is enabled and account registration is enabled
@@ -95,4 +125,4 @@ Feature: Password sign-in without open registration
     When the operator restarts the instance with account registration disabled
     And "founder@harborlegal.example" signs in with password "correct-horse-battery-staple"
     Then the sign-in succeeds
-    And a registration for "second-user@harborlegal.example" is answered "404 Not Found"
+    And a registration for "second-user@harborlegal.example" is answered exactly like a post to an endpoint that has never existed

--- a/tests/e2e/features/password_registration_flag.feature
+++ b/tests/e2e/features/password_registration_flag.feature
@@ -1,0 +1,98 @@
+@epic-135 @story-136
+Feature: Password sign-in without open registration
+  As an operator running a WeOS instance
+  I want to turn on password sign-in without also letting anyone who reaches the
+  hostname create an account
+  So that an instance can ship with its own sign-in account and no way to make another
+
+  Registration is governed by its own setting, PASSWORD_REGISTRATION_ENABLED, which
+  defaults to off. When it is off the register endpoint is never mounted: a caller
+  finds nothing there at all, rather than a handler that inspects the request and
+  refuses it. That difference is the point of this story — a route that answers its
+  own distinctive refusal still confirms it exists, still parses what is sent to it,
+  and still has to be kept correct forever. A route that was never mounted does none
+  of those things.
+
+  The test of absence is therefore not any one status code. It is that the path
+  becomes ordinary: whoever probes it learns exactly what they would learn probing a
+  path this instance has never had, under every method. A status that singled the
+  registration path out — including a "404 Not Found" where neighbouring unknown
+  paths answer otherwise — would give it away just as loudly as a refusal would.
+  So the scenarios below fix a status only where an invented path returns that same
+  status, and otherwise compare against an invented path directly.
+
+  Scenario: An existing account signs in while registration is closed
+    Given a WeOS instance where password sign-in is enabled and account registration is disabled
+    And the instance already has the account "ops@harborlegal.example" with password "correct-horse-battery-staple"
+    When "ops@harborlegal.example" signs in with password "correct-horse-battery-staple"
+    Then the sign-in succeeds
+    And "ops@harborlegal.example" holds an authenticated session
+
+  Scenario: A closed registration endpoint is absent rather than refusing
+    Given a WeOS instance where password sign-in is enabled and account registration is disabled
+    When someone submits a registration for "newcomer@harborlegal.example" with password "correct-horse-battery-staple"
+    Then the registration request is answered "404 Not Found"
+    And the answer offers no authentication challenge
+    And the answer advertises no permitted methods for that path
+
+  Scenario Outline: Under every method the registration path answers like one that never existed
+    Given a WeOS instance where password sign-in is enabled and account registration is disabled
+    When someone sends a <method> request to the registration endpoint
+    And someone sends the same <method> request to "/api/auth/enroll", a path this instance has never had
+    Then both requests are answered with the same status and the same body
+
+    Examples:
+      | method |
+      | POST   |
+      | GET    |
+      | PUT    |
+      | DELETE |
+
+  Scenario: A closed registration path answers like a path the instance has never had
+    Given a WeOS instance where password sign-in is enabled and account registration is disabled
+    When someone submits a registration for "newcomer@harborlegal.example" with password "correct-horse-battery-staple"
+    And someone posts the same details to "/api/auth/enroll", an endpoint this instance has never had
+    Then both requests are answered with the same status and the same body
+
+  Scenario: A closed registration endpoint reveals nothing about what it was sent
+    Given a WeOS instance where password sign-in is enabled and account registration is disabled
+    When someone submits a well-formed registration for "newcomer@harborlegal.example" with password "correct-horse-battery-staple"
+    And someone submits a registration request whose body is not valid JSON
+    Then both requests are answered with the same status and the same body
+
+  Scenario: A registration attempt made while registration is closed creates nothing
+    Given a WeOS instance where password sign-in is enabled and account registration is disabled
+    When someone submits a registration for "newcomer@harborlegal.example" with password "correct-horse-battery-staple"
+    Then no account exists for "newcomer@harborlegal.example"
+    And "newcomer@harborlegal.example" cannot sign in with password "correct-horse-battery-staple"
+
+  Scenario: Enabling password sign-in alone leaves registration closed
+    Given a WeOS instance where password sign-in is enabled and account registration is not configured
+    When someone submits a registration for "newcomer@harborlegal.example" with password "correct-horse-battery-staple"
+    Then the registration request is answered "404 Not Found"
+
+  Scenario: Opening both settings lets a new account register and sign straight in
+    Given a WeOS instance where password sign-in is enabled and account registration is enabled
+    When someone registers "newcomer@harborlegal.example" with password "correct-horse-battery-staple"
+    Then the registration succeeds
+    And "newcomer@harborlegal.example" holds an authenticated session
+    And "newcomer@harborlegal.example" can sign in again with password "correct-horse-battery-staple"
+
+  Scenario: Registration cannot be opened while password sign-in is off
+    Given a WeOS instance where password sign-in is disabled and account registration is enabled
+    When someone submits a registration for "newcomer@harborlegal.example" with password "correct-horse-battery-staple"
+    Then the registration request is answered "404 Not Found"
+
+  Scenario: With password sign-in off, neither password endpoint is mounted
+    Given a WeOS instance where password sign-in is disabled and account registration is not configured
+    When someone submits a registration for "newcomer@harborlegal.example" with password "correct-horse-battery-staple"
+    And "ops@harborlegal.example" attempts a password sign-in with password "correct-horse-battery-staple"
+    Then both requests are answered "404 Not Found"
+
+  Scenario: Closing registration does not lock out an account that registered earlier
+    Given a WeOS instance where password sign-in is enabled and account registration is enabled
+    And "founder@harborlegal.example" registered with password "correct-horse-battery-staple"
+    When the operator restarts the instance with account registration disabled
+    And "founder@harborlegal.example" signs in with password "correct-horse-battery-staple"
+    Then the sign-in succeeds
+    And a registration for "second-user@harborlegal.example" is answered "404 Not Found"

--- a/tests/e2e/password_registration_flag_test.go
+++ b/tests/e2e/password_registration_flag_test.go
@@ -41,7 +41,7 @@ import (
 // never had answers. That is deliberately not a fixed status. What an unknown
 // path returns varies by deployment — a bare 404 here, 401 with a Bearer
 // challenge on an instance with OAuth configured — and singling the
-// registration path out with a status its neighbours don't return would give it
+// registration path out with a status its neighbors don't return would give it
 // away just as loudly as refusing would.
 //
 // So these tests drive real HTTP against an echo instance mounted through
@@ -298,7 +298,7 @@ func (w *passwordAuthWorld) boot(signIn bool, registration *bool) error {
 	// Reproducing that by declaring three throwaway groups here would be
 	// copying an accident. Attaching the middleware to the routes themselves
 	// leaves the catch-all as api.Use registered it and reproduces both
-	// observed behaviours exactly, which is what these scenarios rest on.
+	// observed behaviors exactly, which is what these scenarios rest on.
 	var guards []echo.MiddlewareFunc
 	if cfg.AuthEnabled() {
 		guards = []echo.MiddlewareFunc{

--- a/tests/e2e/password_registration_flag_test.go
+++ b/tests/e2e/password_registration_flag_test.go
@@ -1,0 +1,564 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/wepala/weos/v3/api/handlers"
+	apimw "github.com/wepala/weos/v3/api/middleware"
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/application/presets"
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/internal/config"
+
+	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
+	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
+	authcasbin "github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/casbin"
+	authhttp "github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/http"
+	"github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/session"
+	"github.com/cucumber/godog"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo/v4"
+	"go.uber.org/fx"
+)
+
+// TestPasswordRegistrationFlag runs the acceptance scenarios for story #136
+// (epic #135): an instance can offer password sign-in without also opening
+// account registration.
+//
+// The scenarios turn on a distinction that only holds if the route is truly
+// absent — 404 with no authentication challenge and no Allow header, answering
+// exactly like a path the server has never had. So these tests drive real HTTP
+// against an Echo instance mounted through handlers.MountPasswordAuth, the same
+// call serve.go makes. Re-declaring the routes here instead would let the test
+// and production drift apart while both stayed green.
+func TestPasswordRegistrationFlag(t *testing.T) {
+	tags := "~@wip"
+	if override := os.Getenv("GODOG_TAGS"); override != "" {
+		tags = override
+	}
+	suite := godog.TestSuite{
+		Name:                "password-registration-flag",
+		ScenarioInitializer: initPasswordRegistrationScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"features/password_registration_flag.feature"},
+			Tags:     tags,
+			Strict:   true,
+			TestingT: t,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("password registration flag acceptance scenarios failed")
+	}
+}
+
+const registrationPath = "/api/auth/register"
+const signInPath = "/api/auth/password-login"
+
+// capturedResponse is everything a caller can observe about one answer. The
+// scenarios compare whole answers against each other ("the same status and the
+// same body"), so the body is kept verbatim rather than parsed.
+type capturedResponse struct {
+	status     int
+	body       string
+	wwwAuth    string
+	allow      string
+	setCookies []string
+}
+
+// passwordAuthWorld boots the real application against a temp SQLite database
+// and mounts the password routes exactly as serve.go does.
+type passwordAuthWorld struct {
+	app    *fx.App
+	tmpDir string
+	dsn    string
+	server *httptest.Server
+
+	authService authapp.AuthenticationService
+	credRepo    authrepos.CredentialRepository
+	agentRepo   authrepos.AgentRepository
+	accountRepo authrepos.AccountRepository
+	sessionMgr  session.SessionManager
+	sessionsSt  sessions.Store
+	authzCheck  *authcasbin.CasbinAuthorizationChecker
+	resources   application.ResourceService
+	resourceTps application.ResourceTypeService
+	logger      entities.Logger
+
+	// answers accumulates every response the scenario provoked, in order, so
+	// steps phrased as "both requests..." can compare them.
+	answers []*capturedResponse
+}
+
+func initPasswordRegistrationScenario(sc *godog.ScenarioContext) {
+	w := &passwordAuthWorld{}
+
+	sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+		*w = passwordAuthWorld{}
+		return ctx, nil
+	})
+	sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		w.teardown()
+		return ctx, nil
+	})
+
+	sc.Step(`^a WeOS instance where password sign-in is (enabled|disabled) and account registration is (enabled|disabled|not configured)$`,
+		w.anInstanceConfigured)
+	sc.Step(`^the instance already has the account "([^"]*)" with password "([^"]*)"$`, w.instanceHasAccount)
+	sc.Step(`^"([^"]*)" registered with password "([^"]*)"$`, w.someoneRegisters)
+	sc.Step(`^the operator restarts the instance with account registration disabled$`, w.restartWithRegistrationDisabled)
+
+	sc.Step(`^"([^"]*)" signs in with password "([^"]*)"$`, w.signIn)
+	sc.Step(`^"([^"]*)" attempts a password sign-in with password "([^"]*)"$`, w.signIn)
+	sc.Step(`^someone submits a registration for "([^"]*)" with password "([^"]*)"$`, w.submitRegistration)
+	sc.Step(`^someone submits a well-formed registration for "([^"]*)" with password "([^"]*)"$`, w.submitRegistration)
+	sc.Step(`^someone registers "([^"]*)" with password "([^"]*)"$`, w.submitRegistration)
+	sc.Step(`^someone sends a ([A-Z]+) request to the registration endpoint$`, w.sendMethodToRegistration)
+	sc.Step(`^someone posts the same details to "([^"]*)", an endpoint this instance has never had$`, w.postToNeverMountedPath)
+	sc.Step(`^someone sends the same ([A-Z]+) request to "([^"]*)", a path this instance has never had$`, w.sendMethodToNeverMountedPath)
+	sc.Step(`^someone submits a registration request whose body is not valid JSON$`, w.submitMalformedRegistration)
+
+	sc.Step(`^the sign-in succeeds$`, w.lastSucceeded)
+	sc.Step(`^the registration succeeds$`, w.lastSucceeded)
+	sc.Step(`^"([^"]*)" holds an authenticated session$`, w.holdsAuthenticatedSession)
+	sc.Step(`^the registration request is answered "([^"]*)"$`, w.lastAnsweredWith)
+	sc.Step(`^the request is answered "([^"]*)"$`, w.lastAnsweredWith)
+	sc.Step(`^a registration for "([^"]*)" is answered "([^"]*)"$`, w.registrationForIsAnswered)
+	sc.Step(`^the answer offers no authentication challenge$`, w.noAuthChallenge)
+	sc.Step(`^the answer advertises no permitted methods for that path$`, w.noAllowHeader)
+	sc.Step(`^both requests are answered with the same status and the same body$`, w.lastTwoAnswersIdentical)
+	sc.Step(`^both requests are answered "([^"]*)"$`, w.lastTwoAnsweredWith)
+	sc.Step(`^no account exists for "([^"]*)"$`, w.noAccountExistsFor)
+	sc.Step(`^"([^"]*)" cannot sign in with password "([^"]*)"$`, w.cannotSignIn)
+	sc.Step(`^"([^"]*)" can sign in again with password "([^"]*)"$`, w.canSignInAgain)
+}
+
+// --- Boot ---
+
+// anInstanceConfigured boots an instance with the two settings in the stated
+// positions. The settings are delivered as environment variables and read back
+// through config.LoadFromEnvironment so the scenarios cover the real parsing
+// path — including "not configured", which is the default that decides whether
+// an existing deployment's register route stays open after an upgrade.
+func (w *passwordAuthWorld) anInstanceConfigured(signIn, registration string) error {
+	dir, err := os.MkdirTemp("", "weos-password-registration-e2e-")
+	if err != nil {
+		return err
+	}
+	w.tmpDir = dir
+	w.dsn = filepath.Join(dir, "test.db")
+	return w.boot(signIn == "enabled", registrationSetting(registration))
+}
+
+// registrationSetting maps the Gherkin wording to the environment variable's
+// value: "not configured" means the variable is absent entirely, which is a
+// different input from an explicit "false" even though both must end up off.
+func registrationSetting(registration string) *bool {
+	switch registration {
+	case "enabled":
+		v := true
+		return &v
+	case "disabled":
+		v := false
+		return &v
+	default: // "not configured"
+		return nil
+	}
+}
+
+func (w *passwordAuthWorld) boot(signIn bool, registration *bool) error {
+	os.Setenv("PASSWORD_AUTH_ENABLED", strconv.FormatBool(signIn))
+	if registration == nil {
+		os.Unsetenv("PASSWORD_REGISTRATION_ENABLED")
+	} else {
+		os.Setenv("PASSWORD_REGISTRATION_ENABLED", strconv.FormatBool(*registration))
+	}
+
+	cfg := config.Default()
+	cfg.LoadFromEnvironment()
+	// Pin the storage and noise level after reading the environment so an
+	// ambient DATABASE_DSN can't pull the scenario onto a real database.
+	cfg.DatabaseDSN = w.dsn
+	cfg.LogLevel = "error"
+
+	app := fx.New(
+		fx.NopLogger,
+		application.Module(cfg, presets.NewDefaultRegistry()),
+		fx.Populate(&w.authService, &w.credRepo, &w.agentRepo, &w.accountRepo),
+		fx.Populate(&w.sessionMgr, &w.sessionsSt, &w.authzCheck, &w.logger),
+		fx.Populate(&w.resources, &w.resourceTps),
+	)
+	startCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+	defer cancel()
+	if err := app.Start(startCtx); err != nil {
+		return fmt.Errorf("failed to start app: %w", err)
+	}
+	w.app = app
+
+	// The same public route layout serve.go builds, mounted through the same
+	// call — so whichever endpoints production would expose for this config
+	// are exactly the ones under test.
+	e := echo.New()
+	e.HideBanner = true
+	api := e.Group("/api")
+	api.Use(apimw.Messages())
+	passwordAuthHandlers := handlers.NewPasswordAuthHandler(handlers.PasswordAuthHandlerConfig{
+		AuthService:    w.authService,
+		SessionManager: w.sessionMgr,
+		SecureCookies:  false,
+		Logger:         w.logger,
+	})
+	handlers.MountPasswordAuth(api, passwordAuthHandlers, handlers.PasswordAuthRoutes{
+		SignIn:       cfg.PasswordAuthEnabled,
+		Registration: cfg.PasswordRegistrationEnabled,
+	})
+
+	// The generic resource catch-all, mounted the way serve.go mounts it.
+	//
+	// This is not incidental scenery. /api/auth/register is two path segments,
+	// so GET, PUT and DELETE on it match `/:typeSlug/:id` and are answered by
+	// the catch-all rather than by anything to do with registration. Leaving
+	// these routes out would let a scenario "prove" that a closed register
+	// endpoint is indistinguishable from a path that never existed while
+	// comparing two paths that were both simply absent from a much smaller
+	// routing table than production's. The comparison only means something
+	// against the real one.
+	// The auth middleware is attached per route rather than through
+	// api.Group("").Use(...), which is how serve.go spells it. That is not a
+	// cosmetic difference and it is worth knowing why.
+	//
+	// echo's Group.Use registers a catch-all not-found route for the group's
+	// prefix, wrapped in that group's middleware. serve.go builds *three*
+	// groups on the same empty prefix (the protected group, the invite-accept
+	// group, and the MCP group), so the /api/* catch-all ends up owned by
+	// whichever of them called Use last — the invite/MCP groups, whose
+	// middleware does not reject anonymous callers. That accident is why an
+	// unmatched POST under /api answers a plain 404 while an unmatched GET
+	// answers 401: the GET matches the real /:typeSlug/:id route and meets
+	// RequireAuth, the POST matches nothing and falls to the catch-all.
+	//
+	// Reproducing that by declaring three throwaway groups here would be
+	// copying an accident. Attaching the middleware to the routes themselves
+	// leaves the catch-all as api.Use registered it and reproduces both
+	// observed behaviours exactly, which is what these scenarios rest on.
+	var guards []echo.MiddlewareFunc
+	if cfg.AuthEnabled() {
+		guards = []echo.MiddlewareFunc{
+			echo.WrapMiddleware(authhttp.RequireAuth(w.sessionMgr, w.authService)),
+			apimw.Impersonation(w.sessionsSt, w.accountRepo, w.logger),
+			apimw.AuthorizeResource(w.authzCheck, w.accountRepo, w.logger),
+		}
+	} else {
+		guards = []echo.MiddlewareFunc{apimw.SoftAuth(w.credRepo, w.agentRepo, w.accountRepo, w.logger)}
+	}
+	resourceHandler := handlers.NewResourceHandler(w.resources, w.resourceTps, w.logger)
+	api.POST("/:typeSlug", resourceHandler.Create, guards...)
+	api.GET("/:typeSlug", resourceHandler.List, guards...)
+	api.GET("/:typeSlug/:id", resourceHandler.Get, guards...)
+	api.PUT("/:typeSlug/:id", resourceHandler.Update, guards...)
+	api.DELETE("/:typeSlug/:id", resourceHandler.Delete, guards...)
+
+	w.server = httptest.NewServer(e)
+	return nil
+}
+
+// restartWithRegistrationDisabled stops the instance and brings it back up
+// against the same database with registration off — the upgrade an operator
+// performs, and the moment an already-registered account must not lose access.
+func (w *passwordAuthWorld) restartWithRegistrationDisabled() error {
+	w.stopServer()
+	off := false
+	return w.boot(true, &off)
+}
+
+func (w *passwordAuthWorld) stopServer() {
+	if w.server != nil {
+		w.server.Close()
+		w.server = nil
+	}
+	if w.app != nil {
+		stopCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		defer cancel()
+		_ = w.app.Stop(stopCtx)
+		w.app = nil
+	}
+}
+
+func (w *passwordAuthWorld) teardown() {
+	w.stopServer()
+	os.Unsetenv("PASSWORD_AUTH_ENABLED")
+	os.Unsetenv("PASSWORD_REGISTRATION_ENABLED")
+	if w.tmpDir != "" {
+		_ = os.RemoveAll(w.tmpDir)
+		w.tmpDir = ""
+	}
+}
+
+// --- Seeding ---
+
+// instanceHasAccount creates an account the way an operator would out of band
+// (the CLI path of story #137) rather than through the HTTP route under test,
+// so the scenario holds even on an instance where registration is closed.
+func (w *passwordAuthWorld) instanceHasAccount(email, password string) error {
+	local, _, _ := strings.Cut(email, "@")
+	_, _, _, err := w.authService.RegisterPassword(context.Background(), email, local, password)
+	if err != nil {
+		return fmt.Errorf("seed account %q: %w", email, err)
+	}
+	return nil
+}
+
+// someoneRegisters registers through the HTTP route and requires it to work —
+// used as a Given on instances where registration is open.
+func (w *passwordAuthWorld) someoneRegisters(email, password string) error {
+	if err := w.submitRegistration(email, password); err != nil {
+		return err
+	}
+	return w.lastSucceeded()
+}
+
+// --- Requests ---
+
+func (w *passwordAuthWorld) do(method, path, body string) error {
+	var reader io.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, w.server.URL+path, reader)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	w.answers = append(w.answers, &capturedResponse{
+		status:     resp.StatusCode,
+		body:       strings.TrimSpace(string(raw)),
+		wwwAuth:    resp.Header.Get("WWW-Authenticate"),
+		allow:      resp.Header.Get("Allow"),
+		setCookies: resp.Header.Values("Set-Cookie"),
+	})
+	return nil
+}
+
+func credentialsJSON(email, password string) string {
+	body, _ := json.Marshal(map[string]string{"email": email, "password": password})
+	return string(body)
+}
+
+func (w *passwordAuthWorld) submitRegistration(email, password string) error {
+	return w.do(http.MethodPost, registrationPath, credentialsJSON(email, password))
+}
+
+func (w *passwordAuthWorld) submitMalformedRegistration() error {
+	return w.do(http.MethodPost, registrationPath, `{"email": "newcomer@harborlegal.example", "password":`)
+}
+
+func (w *passwordAuthWorld) sendMethodToRegistration(method string) error {
+	return w.do(method, registrationPath, "")
+}
+
+func (w *passwordAuthWorld) postToNeverMountedPath(path string) error {
+	return w.do(http.MethodPost, path,
+		credentialsJSON("newcomer@harborlegal.example", "correct-horse-battery-staple"))
+}
+
+// sendMethodToNeverMountedPath issues the same method against a path this
+// instance has never had, so the previous answer can be compared with it. The
+// control is what makes "absent" measurable: the registration path has to be
+// as ordinary as any invented one, whatever that happens to look like.
+func (w *passwordAuthWorld) sendMethodToNeverMountedPath(method, path string) error {
+	return w.do(method, path, "")
+}
+
+func (w *passwordAuthWorld) signIn(email, password string) error {
+	return w.do(http.MethodPost, signInPath, credentialsJSON(email, password))
+}
+
+// --- Assertions ---
+
+func (w *passwordAuthWorld) last() (*capturedResponse, error) {
+	if len(w.answers) == 0 {
+		return nil, fmt.Errorf("no request has been made yet")
+	}
+	return w.answers[len(w.answers)-1], nil
+}
+
+// parseStatus turns the Gherkin wording ("404 Not Found") into a code, so the
+// scenarios stay readable while the assertion stays exact.
+func parseStatus(want string) (int, error) {
+	code, _, _ := strings.Cut(want, " ")
+	n, err := strconv.Atoi(code)
+	if err != nil {
+		return 0, fmt.Errorf("could not read a status code from %q", want)
+	}
+	return n, nil
+}
+
+func (w *passwordAuthWorld) lastSucceeded() error {
+	got, err := w.last()
+	if err != nil {
+		return err
+	}
+	if got.status != http.StatusOK && got.status != http.StatusCreated {
+		return fmt.Errorf("expected success, got %d: %s", got.status, got.body)
+	}
+	return nil
+}
+
+func (w *passwordAuthWorld) lastAnsweredWith(want string) error {
+	code, err := parseStatus(want)
+	if err != nil {
+		return err
+	}
+	got, err := w.last()
+	if err != nil {
+		return err
+	}
+	if got.status != code {
+		return fmt.Errorf("expected %d, got %d: %s", code, got.status, got.body)
+	}
+	return nil
+}
+
+func (w *passwordAuthWorld) registrationForIsAnswered(email, want string) error {
+	if err := w.submitRegistration(email, "correct-horse-battery-staple"); err != nil {
+		return err
+	}
+	return w.lastAnsweredWith(want)
+}
+
+func (w *passwordAuthWorld) lastTwoAnsweredWith(want string) error {
+	code, err := parseStatus(want)
+	if err != nil {
+		return err
+	}
+	if len(w.answers) < 2 {
+		return fmt.Errorf("expected two requests, saw %d", len(w.answers))
+	}
+	for _, got := range w.answers[len(w.answers)-2:] {
+		if got.status != code {
+			return fmt.Errorf("expected both answers to be %d, got %d: %s", code, got.status, got.body)
+		}
+	}
+	return nil
+}
+
+// lastTwoAnswersIdentical is the anti-probe assertion: a closed registration
+// endpoint must be indistinguishable from a path that never existed, and must
+// not betray whether it understood what it was sent.
+func (w *passwordAuthWorld) lastTwoAnswersIdentical() error {
+	if len(w.answers) < 2 {
+		return fmt.Errorf("expected two requests, saw %d", len(w.answers))
+	}
+	a, b := w.answers[len(w.answers)-2], w.answers[len(w.answers)-1]
+	if a.status != b.status {
+		return fmt.Errorf("answers differ in status: %d vs %d", a.status, b.status)
+	}
+	if a.body != b.body {
+		return fmt.Errorf("answers differ in body: %q vs %q", a.body, b.body)
+	}
+	return nil
+}
+
+func (w *passwordAuthWorld) noAuthChallenge() error {
+	got, err := w.last()
+	if err != nil {
+		return err
+	}
+	if got.wwwAuth != "" {
+		return fmt.Errorf("expected no authentication challenge, got WWW-Authenticate: %q", got.wwwAuth)
+	}
+	return nil
+}
+
+func (w *passwordAuthWorld) noAllowHeader() error {
+	got, err := w.last()
+	if err != nil {
+		return err
+	}
+	if got.allow != "" {
+		return fmt.Errorf("expected no permitted methods to be advertised, got Allow: %q", got.allow)
+	}
+	return nil
+}
+
+func (w *passwordAuthWorld) holdsAuthenticatedSession(email string) error {
+	got, err := w.last()
+	if err != nil {
+		return err
+	}
+	if got.status != http.StatusOK && got.status != http.StatusCreated {
+		return fmt.Errorf("expected an authenticated answer, got %d: %s", got.status, got.body)
+	}
+	if len(got.setCookies) == 0 {
+		return fmt.Errorf("expected a session cookie to be issued for %q, none was", email)
+	}
+	// Successful answers ride in the standard {"data": …} envelope.
+	var payload struct {
+		Data struct {
+			Agent struct {
+				Email string `json:"email"`
+			} `json:"agent"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(got.body), &payload); err != nil {
+		return fmt.Errorf("could not read the authentication answer: %w (body: %s)", err, got.body)
+	}
+	if !strings.EqualFold(payload.Data.Agent.Email, email) {
+		return fmt.Errorf("expected the session to belong to %q, got %q", email, payload.Data.Agent.Email)
+	}
+	return nil
+}
+
+func (w *passwordAuthWorld) noAccountExistsFor(email string) error {
+	// An unknown email is an empty result, not an error, so a real error means
+	// the lookup never happened — report it rather than reading it as absence,
+	// which would let a broken database pass this scenario.
+	creds, err := w.credRepo.FindByEmail(context.Background(), email)
+	if err != nil {
+		return fmt.Errorf("could not check whether an account exists for %q: %w", email, err)
+	}
+	if len(creds) > 0 {
+		return fmt.Errorf("expected no account for %q, found %d credential(s)", email, len(creds))
+	}
+	return nil
+}
+
+func (w *passwordAuthWorld) cannotSignIn(email, password string) error {
+	if err := w.signIn(email, password); err != nil {
+		return err
+	}
+	got, err := w.last()
+	if err != nil {
+		return err
+	}
+	if got.status == http.StatusOK || got.status == http.StatusCreated {
+		return fmt.Errorf("expected %q not to be able to sign in, but the sign-in succeeded", email)
+	}
+	return nil
+}
+
+func (w *passwordAuthWorld) canSignInAgain(email, password string) error {
+	if err := w.signIn(email, password); err != nil {
+		return err
+	}
+	return w.holdsAuthenticatedSession(email)
+}

--- a/tests/e2e/password_registration_flag_test.go
+++ b/tests/e2e/password_registration_flag_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/wepala/weos/v3/application/presets"
 	"github.com/wepala/weos/v3/domain/entities"
 	"github.com/wepala/weos/v3/internal/config"
+	weosoauth "github.com/wepala/weos/v3/internal/oauth"
 
 	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
 	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
@@ -36,11 +37,18 @@ import (
 // account registration.
 //
 // The scenarios turn on a distinction that only holds if the route is truly
-// absent — 404 with no authentication challenge and no Allow header, answering
-// exactly like a path the server has never had. So these tests drive real HTTP
-// against an Echo instance mounted through handlers.MountPasswordAuth, the same
-// call serve.go makes. Re-declaring the routes here instead would let the test
-// and production drift apart while both stayed green.
+// absent: the registration path has to answer whatever a path the server has
+// never had answers. That is deliberately not a fixed status. What an unknown
+// path returns varies by deployment — a bare 404 here, 401 with a Bearer
+// challenge on an instance with OAuth configured — and singling the
+// registration path out with a status its neighbours don't return would give it
+// away just as loudly as refusing would.
+//
+// So these tests drive real HTTP against an echo instance mounted through
+// handlers.MountPasswordAuth, the same call serve.go makes, and compare the
+// registration path against an invented control path. Re-declaring the routes
+// here instead would let the test and production drift apart while both
+// stayed green.
 func TestPasswordRegistrationFlag(t *testing.T) {
 	tags := "~@wip"
 	if override := os.Getenv("GODOG_TAGS"); override != "" {
@@ -65,6 +73,10 @@ func TestPasswordRegistrationFlag(t *testing.T) {
 const registrationPath = "/api/auth/register"
 const signInPath = "/api/auth/password-login"
 
+// aPassword is used only by steps whose Gherkin doesn't name one, because the
+// scenario is about the answer rather than the credential.
+const aPassword = "correct-horse-battery-staple"
+
 // capturedResponse is everything a caller can observe about one answer. The
 // scenarios compare whole answers against each other ("the same status and the
 // same body"), so the body is kept verbatim rather than parsed.
@@ -84,29 +96,47 @@ type passwordAuthWorld struct {
 	dsn    string
 	server *httptest.Server
 
-	authService authapp.AuthenticationService
-	credRepo    authrepos.CredentialRepository
-	agentRepo   authrepos.AgentRepository
-	accountRepo authrepos.AccountRepository
-	sessionMgr  session.SessionManager
-	sessionsSt  sessions.Store
-	authzCheck  *authcasbin.CasbinAuthorizationChecker
-	resources   application.ResourceService
-	resourceTps application.ResourceTypeService
-	logger      entities.Logger
+	authService         authapp.AuthenticationService
+	credRepo            authrepos.CredentialRepository
+	agentRepo           authrepos.AgentRepository
+	accountRepo         authrepos.AccountRepository
+	sessionManager      session.SessionManager
+	sessionStore        sessions.Store
+	authzChecker        *authcasbin.CasbinAuthorizationChecker
+	resourceService     application.ResourceService
+	resourceTypeService application.ResourceTypeService
+	jwtService          authapp.JWTService
+	logger              entities.Logger
+
+	// signIn / registration / oauth are the shape the instance was last booted
+	// with, so a Given that adds a provider can rebuild it without the scenario
+	// having to restate the settings it already gave.
+	signInEnabled       bool
+	registrationEnabled *bool
+	oauthConfigured     bool
 
 	// answers accumulates every response the scenario provoked, in order, so
 	// steps phrased as "both requests..." can compare them.
 	answers []*capturedResponse
+
+	// lastCredentials is the body the previous request actually carried, so a
+	// step saying "the same details" sends the same details rather than a
+	// second copy of them written out again down here.
+	lastCredentials string
+
+	// envBefore is the environment as this scenario found it, restored on
+	// teardown so the suite doesn't leave its settings behind for whatever
+	// runs next in the process.
+	envBefore map[string]*string
 }
 
+// initPasswordRegistrationScenario runs once per scenario, so the world below
+// starts fresh each time and needs no reset hook. The suite relies on staying
+// serial (godog Concurrency is unset and nothing here calls t.Parallel) because
+// the scenarios set process environment to exercise the real config parsing.
 func initPasswordRegistrationScenario(sc *godog.ScenarioContext) {
 	w := &passwordAuthWorld{}
 
-	sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
-		*w = passwordAuthWorld{}
-		return ctx, nil
-	})
 	sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
 		w.teardown()
 		return ctx, nil
@@ -128,16 +158,20 @@ func initPasswordRegistrationScenario(sc *godog.ScenarioContext) {
 	sc.Step(`^someone sends the same ([A-Z]+) request to "([^"]*)", a path this instance has never had$`, w.sendMethodToNeverMountedPath)
 	sc.Step(`^someone submits a registration request whose body is not valid JSON$`, w.submitMalformedRegistration)
 
+	sc.Step(`^an OAuth provider is also configured on that instance$`, w.andAnOAuthProviderConfigured)
+
 	sc.Step(`^the sign-in succeeds$`, w.lastSucceeded)
 	sc.Step(`^the registration succeeds$`, w.lastSucceeded)
 	sc.Step(`^"([^"]*)" holds an authenticated session$`, w.holdsAuthenticatedSession)
-	sc.Step(`^the registration request is answered "([^"]*)"$`, w.lastAnsweredWith)
-	sc.Step(`^the request is answered "([^"]*)"$`, w.lastAnsweredWith)
-	sc.Step(`^a registration for "([^"]*)" is answered "([^"]*)"$`, w.registrationForIsAnswered)
-	sc.Step(`^the answer offers no authentication challenge$`, w.noAuthChallenge)
-	sc.Step(`^the answer advertises no permitted methods for that path$`, w.noAllowHeader)
 	sc.Step(`^both requests are answered with the same status and the same body$`, w.lastTwoAnswersIdentical)
-	sc.Step(`^both requests are answered "([^"]*)"$`, w.lastTwoAnsweredWith)
+	sc.Step(`^both answers carry the same authentication challenge$`, w.lastTwoSameChallenge)
+	sc.Step(`^neither answer advertises permitted methods for its path$`, w.lastTwoAdvertiseNoMethods)
+	sc.Step(`^both requests are answered identically, including any authentication challenge$`,
+		func() error { return w.lastNAnswersIdentical(2) })
+	sc.Step(`^all three requests are answered identically, including any authentication challenge$`,
+		func() error { return w.lastNAnswersIdentical(3) })
+	sc.Step(`^a registration for "([^"]*)" is answered exactly like a post to an endpoint that has never existed$`,
+		w.registrationAnsweredLikeNeverExisted)
 	sc.Step(`^no account exists for "([^"]*)"$`, w.noAccountExistsFor)
 	sc.Step(`^"([^"]*)" cannot sign in with password "([^"]*)"$`, w.cannotSignIn)
 	sc.Step(`^"([^"]*)" can sign in again with password "([^"]*)"$`, w.canSignInAgain)
@@ -177,11 +211,22 @@ func registrationSetting(registration string) *bool {
 }
 
 func (w *passwordAuthWorld) boot(signIn bool, registration *bool) error {
-	os.Setenv("PASSWORD_AUTH_ENABLED", strconv.FormatBool(signIn))
+	w.signInEnabled, w.registrationEnabled = signIn, registration
+	w.setEnv("PASSWORD_AUTH_ENABLED", ptr(strconv.FormatBool(signIn)))
 	if registration == nil {
-		os.Unsetenv("PASSWORD_REGISTRATION_ENABLED")
+		w.setEnv("PASSWORD_REGISTRATION_ENABLED", nil)
 	} else {
-		os.Setenv("PASSWORD_REGISTRATION_ENABLED", strconv.FormatBool(*registration))
+		w.setEnv("PASSWORD_REGISTRATION_ENABLED", ptr(strconv.FormatBool(*registration)))
+	}
+	// Credentials are never contacted — OAuthEnabled() only asks whether a
+	// provider is configured, and that is what changes who answers an
+	// unmatched path.
+	if w.oauthConfigured {
+		w.setEnv("GOOGLE_CLIENT_ID", ptr("acceptance-client-id.apps.googleusercontent.com"))
+		w.setEnv("GOOGLE_CLIENT_SECRET", ptr("acceptance-client-secret"))
+	} else {
+		w.setEnv("GOOGLE_CLIENT_ID", nil)
+		w.setEnv("GOOGLE_CLIENT_SECRET", nil)
 	}
 
 	cfg := config.Default()
@@ -194,9 +239,12 @@ func (w *passwordAuthWorld) boot(signIn bool, registration *bool) error {
 	app := fx.New(
 		fx.NopLogger,
 		application.Module(cfg, presets.NewDefaultRegistry()),
+		// serve.go provides this alongside the module rather than from it, and
+		// the bearer middleware that owns the catch-all needs it.
+		fx.Provide(weosoauth.ProvideJWTService),
 		fx.Populate(&w.authService, &w.credRepo, &w.agentRepo, &w.accountRepo),
-		fx.Populate(&w.sessionMgr, &w.sessionsSt, &w.authzCheck, &w.logger),
-		fx.Populate(&w.resources, &w.resourceTps),
+		fx.Populate(&w.sessionManager, &w.sessionStore, &w.authzChecker, &w.logger),
+		fx.Populate(&w.resourceService, &w.resourceTypeService, &w.jwtService),
 	)
 	startCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
 	defer cancel()
@@ -214,7 +262,7 @@ func (w *passwordAuthWorld) boot(signIn bool, registration *bool) error {
 	api.Use(apimw.Messages())
 	passwordAuthHandlers := handlers.NewPasswordAuthHandler(handlers.PasswordAuthHandlerConfig{
 		AuthService:    w.authService,
-		SessionManager: w.sessionMgr,
+		SessionManager: w.sessionManager,
 		SecureCookies:  false,
 		Logger:         w.logger,
 	})
@@ -254,22 +302,58 @@ func (w *passwordAuthWorld) boot(signIn bool, registration *bool) error {
 	var guards []echo.MiddlewareFunc
 	if cfg.AuthEnabled() {
 		guards = []echo.MiddlewareFunc{
-			echo.WrapMiddleware(authhttp.RequireAuth(w.sessionMgr, w.authService)),
-			apimw.Impersonation(w.sessionsSt, w.accountRepo, w.logger),
-			apimw.AuthorizeResource(w.authzCheck, w.accountRepo, w.logger),
+			echo.WrapMiddleware(authhttp.RequireAuth(w.sessionManager, w.authService)),
+			apimw.Impersonation(w.sessionStore, w.accountRepo, w.logger),
+			apimw.AuthorizeResource(w.authzChecker, w.accountRepo, w.logger),
 		}
 	} else {
 		guards = []echo.MiddlewareFunc{apimw.SoftAuth(w.credRepo, w.agentRepo, w.accountRepo, w.logger)}
 	}
-	resourceHandler := handlers.NewResourceHandler(w.resources, w.resourceTps, w.logger)
+	resourceHandler := handlers.NewResourceHandler(w.resourceService, w.resourceTypeService, w.logger)
 	api.POST("/:typeSlug", resourceHandler.Create, guards...)
 	api.GET("/:typeSlug", resourceHandler.List, guards...)
 	api.GET("/:typeSlug/:id", resourceHandler.Get, guards...)
 	api.PUT("/:typeSlug/:id", resourceHandler.Update, guards...)
 	api.DELETE("/:typeSlug/:id", resourceHandler.Delete, guards...)
 
+	// And now the part that decides what an *unmatched* path answers.
+	//
+	// echo's Group.Use registers the group's not-found catch-all at the group
+	// prefix, so whichever empty-prefix group calls Use last owns every
+	// unmatched /api path. In serve.go that is the MCP group, and its
+	// middleware changes with the deployment: SoftAuth on its own, or
+	// BearerOrSession once an OAuth provider is configured — which sets a
+	// WWW-Authenticate challenge before it ever checks the session. That is why
+	// an unmatched POST answers a bare 404 on one instance and 401 with a
+	// bearer challenge on another.
+	//
+	// Mirroring that group is copying an accident of serve.go's structure, and
+	// I would rather not — but it is the accident that decides the observable
+	// these scenarios are about, so a harness without it would let the
+	// OAuth-shaped scenarios pass while never producing an OAuth-shaped answer.
+	// weos#467 tracks extracting the real route table so this can go away.
+	catchAllOwner := api.Group("")
+	if cfg.OAuthEnabled() {
+		sessionAuth := authhttp.RequireAuth(w.sessionManager, w.authService)
+		catchAllOwner.Use(apimw.BearerOrSession(w.jwtService, sessionAuth, "http://acceptance.invalid"))
+		catchAllOwner.Use(apimw.Impersonation(w.sessionStore, w.accountRepo, w.logger))
+	} else {
+		catchAllOwner.Use(apimw.SoftAuth(w.credRepo, w.agentRepo, w.accountRepo, w.logger))
+	}
+	catchAllOwner.Use(apimw.AuthorizeResource(w.authzChecker, w.accountRepo, w.logger))
+
 	w.server = httptest.NewServer(e)
 	return nil
+}
+
+// andAnOAuthProviderConfigured rebuilds the instance it was given with a
+// provider configured, keeping the password settings and the database. It is a
+// second Given rather than another axis on the first so the scenarios that do
+// not care about OAuth stay readable.
+func (w *passwordAuthWorld) andAnOAuthProviderConfigured() error {
+	w.stopServer()
+	w.oauthConfigured = true
+	return w.boot(w.signInEnabled, w.registrationEnabled)
 }
 
 // restartWithRegistrationDisabled stops the instance and brings it back up
@@ -294,10 +378,43 @@ func (w *passwordAuthWorld) stopServer() {
 	}
 }
 
+func ptr[T any](v T) *T { return &v }
+
+// setEnv sets (or clears) a variable, remembering what was there the first time
+// this scenario touched it. A nil value means "absent", which is a different
+// input from an explicit "false" for the setting under test.
+func (w *passwordAuthWorld) setEnv(key string, value *string) {
+	if w.envBefore == nil {
+		w.envBefore = map[string]*string{}
+	}
+	if _, remembered := w.envBefore[key]; !remembered {
+		if prior, ok := os.LookupEnv(key); ok {
+			w.envBefore[key] = &prior
+		} else {
+			w.envBefore[key] = nil
+		}
+	}
+	if value == nil {
+		os.Unsetenv(key)
+		return
+	}
+	os.Setenv(key, *value)
+}
+
+func (w *passwordAuthWorld) restoreEnv() {
+	for key, prior := range w.envBefore {
+		if prior == nil {
+			os.Unsetenv(key)
+			continue
+		}
+		os.Setenv(key, *prior)
+	}
+	w.envBefore = nil
+}
+
 func (w *passwordAuthWorld) teardown() {
 	w.stopServer()
-	os.Unsetenv("PASSWORD_AUTH_ENABLED")
-	os.Unsetenv("PASSWORD_REGISTRATION_ENABLED")
+	w.restoreEnv()
 	if w.tmpDir != "" {
 		_ = os.RemoveAll(w.tmpDir)
 		w.tmpDir = ""
@@ -364,20 +481,32 @@ func credentialsJSON(email, password string) string {
 }
 
 func (w *passwordAuthWorld) submitRegistration(email, password string) error {
-	return w.do(http.MethodPost, registrationPath, credentialsJSON(email, password))
+	w.lastCredentials = credentialsJSON(email, password)
+	return w.do(http.MethodPost, registrationPath, w.lastCredentials)
 }
 
+// submitMalformedRegistration truncates whatever the scenario last sent, so the
+// malformed body stays the well-formed one's twin however the feature's data
+// changes. The pair is only comparable if the only difference is the damage.
 func (w *passwordAuthWorld) submitMalformedRegistration() error {
-	return w.do(http.MethodPost, registrationPath, `{"email": "newcomer@harborlegal.example", "password":`)
+	wellFormed := w.lastCredentials
+	if wellFormed == "" {
+		wellFormed = credentialsJSON("newcomer@harborlegal.example", aPassword)
+	}
+	return w.do(http.MethodPost, registrationPath, strings.TrimSuffix(wellFormed, `"}`))
 }
 
 func (w *passwordAuthWorld) sendMethodToRegistration(method string) error {
 	return w.do(method, registrationPath, "")
 }
 
+// postToNeverMountedPath replays the details the scenario just submitted, so
+// "the same details" stays literally true if the feature's data ever changes.
 func (w *passwordAuthWorld) postToNeverMountedPath(path string) error {
-	return w.do(http.MethodPost, path,
-		credentialsJSON("newcomer@harborlegal.example", "correct-horse-battery-staple"))
+	if w.lastCredentials == "" {
+		return fmt.Errorf("no registration has been submitted yet, so there are no same details to send")
+	}
+	return w.do(http.MethodPost, path, w.lastCredentials)
 }
 
 // sendMethodToNeverMountedPath issues the same method against a path this
@@ -401,17 +530,6 @@ func (w *passwordAuthWorld) last() (*capturedResponse, error) {
 	return w.answers[len(w.answers)-1], nil
 }
 
-// parseStatus turns the Gherkin wording ("404 Not Found") into a code, so the
-// scenarios stay readable while the assertion stays exact.
-func parseStatus(want string) (int, error) {
-	code, _, _ := strings.Cut(want, " ")
-	n, err := strconv.Atoi(code)
-	if err != nil {
-		return 0, fmt.Errorf("could not read a status code from %q", want)
-	}
-	return n, nil
-}
-
 func (w *passwordAuthWorld) lastSucceeded() error {
 	got, err := w.last()
 	if err != nil {
@@ -419,44 +537,6 @@ func (w *passwordAuthWorld) lastSucceeded() error {
 	}
 	if got.status != http.StatusOK && got.status != http.StatusCreated {
 		return fmt.Errorf("expected success, got %d: %s", got.status, got.body)
-	}
-	return nil
-}
-
-func (w *passwordAuthWorld) lastAnsweredWith(want string) error {
-	code, err := parseStatus(want)
-	if err != nil {
-		return err
-	}
-	got, err := w.last()
-	if err != nil {
-		return err
-	}
-	if got.status != code {
-		return fmt.Errorf("expected %d, got %d: %s", code, got.status, got.body)
-	}
-	return nil
-}
-
-func (w *passwordAuthWorld) registrationForIsAnswered(email, want string) error {
-	if err := w.submitRegistration(email, "correct-horse-battery-staple"); err != nil {
-		return err
-	}
-	return w.lastAnsweredWith(want)
-}
-
-func (w *passwordAuthWorld) lastTwoAnsweredWith(want string) error {
-	code, err := parseStatus(want)
-	if err != nil {
-		return err
-	}
-	if len(w.answers) < 2 {
-		return fmt.Errorf("expected two requests, saw %d", len(w.answers))
-	}
-	for _, got := range w.answers[len(w.answers)-2:] {
-		if got.status != code {
-			return fmt.Errorf("expected both answers to be %d, got %d: %s", code, got.status, got.body)
-		}
 	}
 	return nil
 }
@@ -478,26 +558,75 @@ func (w *passwordAuthWorld) lastTwoAnswersIdentical() error {
 	return nil
 }
 
-func (w *passwordAuthWorld) noAuthChallenge() error {
-	got, err := w.last()
+// lastN returns the last n answers, so the "identically" steps can compare a
+// pair or a trio without each writing out the same bounds check.
+func (w *passwordAuthWorld) lastN(n int) ([]*capturedResponse, error) {
+	if len(w.answers) < n {
+		return nil, fmt.Errorf("expected %d requests, saw %d", n, len(w.answers))
+	}
+	return w.answers[len(w.answers)-n:], nil
+}
+
+// lastNAnswersIdentical is the anti-probe assertion in its fullest form. A
+// prober reads the status, the body and the challenge, so all three have to
+// match — the registration path must be as ordinary as an address the instance
+// has never had, whatever ordinary happens to mean on this deployment.
+func (w *passwordAuthWorld) lastNAnswersIdentical(n int) error {
+	answers, err := w.lastN(n)
 	if err != nil {
 		return err
 	}
-	if got.wwwAuth != "" {
-		return fmt.Errorf("expected no authentication challenge, got WWW-Authenticate: %q", got.wwwAuth)
+	first := answers[0]
+	for _, other := range answers[1:] {
+		if first.status != other.status {
+			return fmt.Errorf("answers differ in status: %d vs %d", first.status, other.status)
+		}
+		if first.body != other.body {
+			return fmt.Errorf("answers differ in body: %q vs %q", first.body, other.body)
+		}
+		if first.wwwAuth != other.wwwAuth {
+			return fmt.Errorf("answers differ in authentication challenge: %q vs %q", first.wwwAuth, other.wwwAuth)
+		}
 	}
 	return nil
 }
 
-func (w *passwordAuthWorld) noAllowHeader() error {
-	got, err := w.last()
+func (w *passwordAuthWorld) lastTwoSameChallenge() error {
+	answers, err := w.lastN(2)
 	if err != nil {
 		return err
 	}
-	if got.allow != "" {
-		return fmt.Errorf("expected no permitted methods to be advertised, got Allow: %q", got.allow)
+	if answers[0].wwwAuth != answers[1].wwwAuth {
+		return fmt.Errorf("answers differ in authentication challenge: %q vs %q",
+			answers[0].wwwAuth, answers[1].wwwAuth)
 	}
 	return nil
+}
+
+func (w *passwordAuthWorld) lastTwoAdvertiseNoMethods() error {
+	answers, err := w.lastN(2)
+	if err != nil {
+		return err
+	}
+	for _, answer := range answers {
+		if answer.allow != "" {
+			return fmt.Errorf("expected no permitted methods to be advertised, got Allow: %q", answer.allow)
+		}
+	}
+	return nil
+}
+
+// registrationAnsweredLikeNeverExisted submits a registration and the same
+// details to an address the instance has never had, and requires the two to be
+// indistinguishable.
+func (w *passwordAuthWorld) registrationAnsweredLikeNeverExisted(email string) error {
+	if err := w.submitRegistration(email, aPassword); err != nil {
+		return err
+	}
+	if err := w.postToNeverMountedPath("/api/auth/enroll"); err != nil {
+		return err
+	}
+	return w.lastNAnswersIdentical(2)
 }
 
 func (w *passwordAuthWorld) holdsAuthenticatedSession(email string) error {


### PR DESCRIPTION
Implements **wepala/mini-me-weos#136**, part of epic **wepala/mini-me-weos#135** ("An instance can ship with its own sign-in account, and no way to make another").

Cross-repo: the ticket lives in `wepala/mini-me-weos`; this change lands here per that repo's CLAUDE.md routing table (framework-shaped auth belongs in core). GitHub will not auto-close across repos — close #136 by hand on merge.

## What changed

`PASSWORD_AUTH_ENABLED` mounted **both** `/api/auth/register` and `/api/auth/password-login`, so any instance wanting password sign-in also got open self-service signup on whatever hostname it answered. Registration now has its own setting, `PASSWORD_REGISTRATION_ENABLED`, defaulting to **false**.

- `internal/config/config.go` — new `PasswordRegistrationEnabled` field + env parsing.
- `api/handlers/password_auth_handler.go` — new `MountPasswordAuth` / `PasswordAuthRoutes`. Registration is ignored unless sign-in is also on, since accounts that could never sign in are not a configuration worth honouring.
- `internal/cli/serve.go` — mounts through that helper, and logs at startup which password endpoints are mounted.
- `docs/_reference/environment-variables.md` — documents both flags (password auth was previously undocumented) plus an upgrade note.
- `tests/e2e/` — godog feature + step definitions.

## The behaviour, measured

An unmounted route had to be indistinguishable from one that never existed, not a handler that refuses. Measured against the real `weos serve` binary with `PASSWORD_AUTH_ENABLED=true` and registration off:

| method | `/api/auth/register` | `/api/auth/enroll` | `/api/madeup/thing` |
|---|---|---|---|
| POST | `404 {"message":"Not Found"}` | identical | identical |
| GET / PUT / DELETE | `401 {"error":"not authenticated"}` | identical | identical |

With both flags on: register `200`, login `200`, duplicate register `409` — byte-identical to today.

Note the answer is **not** uniformly 404. `/api/auth/register` is two path segments, so GET/PUT/DELETE are matched by the generic `/:typeSlug/:id` resource route and meet `RequireAuth` before anything registration-related happens. Forcing 404 there was deliberately rejected: it would make the registration path *uniquely identifiable* — a 404 where every neighbouring unknown path answers 401 — which is the leak this story exists to close. The acceptance scenarios therefore assert equality against a never-existent control path rather than hardcoding a status.

## Test fidelity

The acceptance harness mounts through the same `MountPasswordAuth` call `serve.go` uses, **and** mounts the generic resource catch-all. An earlier revision omitted the catch-all and the method scenarios passed vacuously against a routing table far smaller than production's. Auth middleware is attached per route rather than via `api.Group("").Use(...)`; the reason is commented in the test — echo's `Group.Use` registers a not-found catch-all wrapped in that group's middleware, and `serve.go` builds three groups on the same empty prefix (lines 325, 423, 459), so `/api/*` is owned by whichever called `Use` last.

Green: 13 acceptance scenarios, plus `./api/...`, `./internal/config/...`, `./internal/cli/...`, `./tests/e2e/...`.

## ⚠️ Downstream coordination required before this reaches consumers

The default flip is a live behaviour change for anyone who sets only `PASSWORD_AUTH_ENABLED`. A premortem review verified these against the actual consumer code — **these are not fixed by this PR**:

1. **Desktop shells break on fresh installs.** Both `mini-me-weos` and `finexity` run their sidecar with only `PASSWORD_AUTH_ENABLED=true` (`desktop/src-tauri/src/main.rs:522`) and self-register on first launch (`:105`). Fresh installs and the wiped-DB self-heal path both fail; *upgrades of existing installs keep working*, so upgrade testing will not catch it. Fix: add `PASSWORD_REGISTRATION_ENABLED=true` beside line 522 in both shells, shipped in the same bump commit. Loopback-only, so open registration there is fine.
2. **New cloud instances cannot claim their first account.** `terraform/mini-me/module/main.tf:69` sets only `PASSWORD_AUTH_ENABLED`; the provisioning runbook and `mini-me-chrome`'s first-run flow both register over HTTP. The replacement is epic #135's story #137 (out-of-band account creation) — sequence that into the same release train, or bricked provisioning.
3. **Downstream e2e harnesses go red at bump time.** crossdeck's playwright harness and apollo's e2e seed both register over HTTP. They need `PASSWORD_REGISTRATION_ENABLED: 'true'` in their env maps.

Refs wepala/mini-me-weos#136