### PR TITLE
Story #137: an operator mints an account from the command line

### DIFF
--- a/api/handlers/password_auth_handler.go
+++ b/api/handlers/password_auth_handler.go
@@ -68,6 +68,23 @@ func NewPasswordAuthHandler(cfg PasswordAuthHandlerConfig) *PasswordAuthHandler 
 	return &PasswordAuthHandler{cfg: cfg}
 }
 
+// DefaultDisplayName picks the name to register an account under. Registration
+// requires a non-empty display name because the personal account is named after
+// it, and the email's local part is the least surprising stand-in when the
+// caller didn't give one.
+//
+// The CLI and the HTTP route share this so an account minted either way is the
+// same thing afterwards — which is the whole point of having both.
+func DefaultDisplayName(email, given string) string {
+	if displayName := strings.TrimSpace(given); displayName != "" {
+		return displayName
+	}
+	if local, _, ok := strings.Cut(email, "@"); ok && local != "" {
+		return local
+	}
+	return email
+}
+
 // PasswordAuthRoutes describes which of the two password endpoints an
 // instance offers. They are independent on purpose: an instance can accept
 // sign-ins from accounts it already has (SignIn) without letting anyone who
@@ -138,17 +155,7 @@ func (h *PasswordAuthHandler) Register(c echo.Context) error {
 	if email == "" || req.Password == "" {
 		return respondError(c, http.StatusBadRequest, "email and password are required")
 	}
-	displayName := strings.TrimSpace(req.DisplayName)
-	if displayName == "" {
-		// RegisterPassword requires a non-empty display name (it's used to
-		// build the personal-account name); the email's local-part is the
-		// least surprising default.
-		if local, _, ok := strings.Cut(email, "@"); ok && local != "" {
-			displayName = local
-		} else {
-			displayName = email
-		}
-	}
+	displayName := DefaultDisplayName(email, req.DisplayName)
 
 	ctx := c.Request().Context()
 	agent, credential, account, err := h.cfg.AuthService.RegisterPassword(ctx, email, displayName, req.Password)

--- a/internal/cli/account.go
+++ b/internal/cli/account.go
@@ -233,7 +233,7 @@ func runAccountCreate(cmd *cobra.Command, _ []string) error {
 // nobody can sign in, and no later run can repair it, because they all take
 // this same branch.
 //
-// Checking only for the row's presence keeps the deliberate no-reset behaviour
+// Checking only for the row's presence keeps the deliberate no-reset behavior
 // intact: a rotated password still changes nothing. What it refuses to do is
 // call a half-written account "already there".
 func verifyUsable(

--- a/internal/cli/account.go
+++ b/internal/cli/account.go
@@ -1,0 +1,207 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/wepala/weos/v3/api/handlers"
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/application/presets"
+
+	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+)
+
+// passwordEnvVar is the channel an entrypoint should use. A flag would put the
+// password in the process table, and shells remember what was typed at them;
+// the environment is the one channel a deployment already has a private way to
+// fill (a sensitive workspace variable, a secret mount).
+const passwordEnvVar = "WEOS_ACCOUNT_PASSWORD"
+
+var (
+	accountEmail         string
+	accountPassword      string
+	accountDisplayName   string
+	accountPasswordStdin bool
+)
+
+var accountCmd = &cobra.Command{
+	Use:   "account",
+	Short: "Manage accounts",
+}
+
+var accountCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a password account without going through an HTTP route",
+	Long: `Creates an account that can sign in with an email and a password, using the
+same path the register endpoint uses, so an account made here and one that
+registered over HTTP are the same thing afterwards.
+
+This exists so an instance can be provisioned without mounting a registration
+route that strangers can also reach. It opens the store directly and needs no
+running server.
+
+Supply the password through ` + passwordEnvVar + ` or --password-stdin. Both keep
+it out of the process table and out of shell history; --password does not, and
+is meant for interactive use only.
+
+Running it again for an email that already exists reports that and succeeds, so
+it is safe on every restart and redeploy. It will not change an existing
+account's password.`,
+	RunE:         runAccountCreate,
+	SilenceUsage: true,
+}
+
+func init() {
+	accountCreateCmd.Flags().StringVar(&accountEmail, "email", "", "email address to create the account for (required)")
+	accountCreateCmd.Flags().StringVar(&accountPassword, "password", "",
+		"password (visible in the process table — prefer "+passwordEnvVar+" or --password-stdin)")
+	accountCreateCmd.Flags().StringVar(&accountDisplayName, "display-name", "",
+		"name to present the account under (defaults to the email's local part)")
+	accountCreateCmd.Flags().BoolVar(&accountPasswordStdin, "password-stdin", false, "read the password from standard input")
+	_ = accountCreateCmd.MarkFlagRequired("email")
+
+	accountCmd.AddCommand(accountCreateCmd)
+	rootCmd.AddCommand(accountCmd)
+}
+
+// resolveAccountPassword takes the password from the first channel that offers
+// one, preferring the channels that don't leak it. It is a separate step from
+// creating the account so that "no password anywhere" fails before the store is
+// opened, rather than part-way through provisioning.
+func resolveAccountPassword(stdin io.Reader) (string, error) {
+	if accountPasswordStdin {
+		raw, err := io.ReadAll(stdin)
+		if err != nil {
+			return "", fmt.Errorf("failed to read the password from standard input: %w", err)
+		}
+		// A password is whatever was typed, minus the newline the shell adds.
+		password := strings.TrimRight(string(raw), "\r\n")
+		if password == "" {
+			return "", errors.New("no password on standard input")
+		}
+		return password, nil
+	}
+	if password := os.Getenv(passwordEnvVar); password != "" {
+		return password, nil
+	}
+	if accountPassword != "" {
+		return accountPassword, nil
+	}
+	return "", fmt.Errorf(
+		"no password supplied: set %s, pass --password-stdin, or use --password", passwordEnvVar)
+}
+
+func runAccountCreate(cmd *cobra.Command, _ []string) error {
+	email := strings.TrimSpace(accountEmail)
+	if email == "" {
+		return errors.New("no email supplied: pass --email")
+	}
+
+	// Resolved first, so a missing password costs nothing and creates nothing.
+	// Note that the password is never put into an error, a log line or any
+	// output from here on — an operator reading a failure report, or a verbose
+	// log, must not find it there.
+	password, err := resolveAccountPassword(cmd.InOrStdin())
+	if err != nil {
+		return err
+	}
+
+	appCfg := GetConfig().Config
+
+	var authService authapp.AuthenticationService
+
+	app := fx.New(
+		fx.NopLogger,
+		application.Module(appCfg, presets.NewDefaultRegistry()),
+		fx.Populate(&authService),
+	)
+
+	startCtx, startCancel := context.WithTimeout(cmd.Context(), fx.DefaultTimeout)
+	defer startCancel()
+	if err := app.Start(startCtx); err != nil {
+		// Named as a database problem on purpose: this runs from an entrypoint
+		// under `set -e`, and the operator needs to know the boot stopped
+		// because the store would not open. The DSN is left out — it can carry
+		// credentials of its own.
+		//
+		// Reported as the root cause rather than the whole chain: fx describes
+		// a failure by naming every constructor it could not build, which is
+		// several hundred characters of dependency graph wrapped around one
+		// sentence about the file. In a container log that buries the answer.
+		return fmt.Errorf("failed to open the database: %w", rootCause(err))
+	}
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		defer stopCancel()
+		_ = app.Stop(stopCtx)
+	}()
+
+	displayName := handlers.DefaultDisplayName(email, accountDisplayName)
+
+	_, _, _, err = authService.RegisterPassword(cmd.Context(), email, displayName, password)
+	report, failed := describeRegisterOutcome(email, password, err)
+	if failed {
+		return errors.New(report)
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), report)
+	return nil
+}
+
+// rootCause unwraps to the innermost error, which is the sentence that says
+// what actually went wrong. Everything above it is the wiring that noticed.
+func rootCause(err error) error {
+	for {
+		unwrapped := errors.Unwrap(err)
+		if unwrapped == nil {
+			return err
+		}
+		err = unwrapped
+	}
+}
+
+// describeRegisterOutcome turns the result of registering into the one thing
+// the caller acts on — a message, and whether the boot should stop.
+//
+// It is separate from the command so the mapping can be checked directly. The
+// password-support branch in particular is not reachable through the real
+// binary today (application/module.go wires the password-credential repository
+// unconditionally, so the service always has one), and a test that faked an
+// unreachable state would only prove the fake works.
+//
+// It takes the password only to keep it out: the last branch reports whatever a
+// lower layer said went wrong, and that text is not ours to trust. Redacting
+// here — at the one place that turns an outcome into words — makes "the
+// password is never echoed" something the code enforces rather than something
+// every layer beneath has to remember.
+func describeRegisterOutcome(email, password string, err error) (report string, failed bool) {
+	redact := func(s string) string {
+		if password == "" {
+			return s
+		}
+		return strings.ReplaceAll(s, password, "[redacted]")
+	}
+
+	switch {
+	case err == nil:
+		return fmt.Sprintf("Created account for %s", email), false
+
+	case errors.Is(err, authapp.ErrEmailAlreadyTaken):
+		// The normal state of every restart after the first. Succeeding here is
+		// what makes the command safe to run on every boot; it deliberately
+		// does not touch the existing account's password, so a changed variable
+		// never silently locks anyone out or lets anyone back in.
+		return fmt.Sprintf("Account already exists for %s; leaving it unchanged", email), false
+
+	case errors.Is(err, authapp.ErrPasswordSupportNotConfigured):
+		return "failed to create the account: password support is not configured on this instance", true
+
+	default:
+		return redact(fmt.Sprintf("failed to create the account: %v", err)), true
+	}
+}

--- a/internal/cli/account.go
+++ b/internal/cli/account.go
@@ -6,13 +6,18 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/wepala/weos/v3/api/handlers"
 	"github.com/wepala/weos/v3/application"
 	"github.com/wepala/weos/v3/application/presets"
 
 	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
+	authentities "github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 )
@@ -53,6 +58,7 @@ is meant for interactive use only.
 Running it again for an email that already exists reports that and succeeds, so
 it is safe on every restart and redeploy. It will not change an existing
 account's password.`,
+	Args:         cobra.NoArgs,
 	RunE:         runAccountCreate,
 	SilenceUsage: true,
 }
@@ -75,6 +81,22 @@ func init() {
 // creating the account so that "no password anywhere" fails before the store is
 // opened, rather than part-way through provisioning.
 func resolveAccountPassword(stdin io.Reader) (string, error) {
+	// Refuse rather than pick. The realistic mix-up is an operator shelling
+	// into a container whose entrypoint exported the variable, typing
+	// --password for a second account, and silently getting the entrypoint's
+	// password instead of the one they typed — discovered at first sign-in.
+	offered := 0
+	for _, supplied := range []bool{accountPasswordStdin, os.Getenv(passwordEnvVar) != "", accountPassword != ""} {
+		if supplied {
+			offered++
+		}
+	}
+	if offered > 1 {
+		return "", fmt.Errorf(
+			"more than one password supplied: choose one of %s, --password-stdin or --password",
+			passwordEnvVar)
+	}
+
 	if accountPasswordStdin {
 		raw, err := io.ReadAll(stdin)
 		if err != nil {
@@ -112,35 +134,83 @@ func runAccountCreate(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	// Refuse to guess which store to write to. config.Default() carries a
+	// "weos.db" fallback, which for a server means "start somewhere"; for this
+	// command it would mean minting the instance's only account into whatever
+	// directory the process happened to start in, reporting success, and
+	// exiting 0 — leaving a deployment that looks provisioned and has no
+	// account. An entrypoint's DSN is never implicit, so neither is this.
+	if os.Getenv("DATABASE_DSN") == "" && databaseDSN == "" {
+		return errors.New(
+			"no database specified: set DATABASE_DSN or pass --database-dsn " +
+				"(this command will not fall back to the built-in default, so an account " +
+				"is never created in a store nobody asked for)")
+	}
+
 	appCfg := GetConfig().Config
 
 	var authService authapp.AuthenticationService
+	var credentialRepo authrepos.CredentialRepository
+	var passwordRepo authrepos.PasswordCredentialRepository
 
+	// Built directly rather than through StartContainer (internal/cli/di.go),
+	// which exposes only the resource services and installs a signal handler a
+	// one-shot command does not want. The full module is deliberate: it is what
+	// makes an account minted here indistinguishable from a registered one.
 	app := fx.New(
 		fx.NopLogger,
 		application.Module(appCfg, presets.NewDefaultRegistry()),
-		fx.Populate(&authService),
+		fx.Populate(&authService, &credentialRepo, &passwordRepo),
 	)
 
-	startCtx, startCancel := context.WithTimeout(cmd.Context(), fx.DefaultTimeout)
+	// Generously longer than fx's default. Starting the module runs the
+	// migrations, the built-in resource types and the projection tables, not
+	// just a connection — against a cold database that can outlast 15s, and a
+	// timeout here crash-loops a container rather than reporting anything
+	// useful.
+	startCtx, startCancel := context.WithTimeout(cmd.Context(), 2*time.Minute)
 	defer startCancel()
 	if err := app.Start(startCtx); err != nil {
-		// Named as a database problem on purpose: this runs from an entrypoint
-		// under `set -e`, and the operator needs to know the boot stopped
-		// because the store would not open. The DSN is left out — it can carry
-		// credentials of its own.
-		//
 		// Reported as the root cause rather than the whole chain: fx describes
 		// a failure by naming every constructor it could not build, which is
 		// several hundred characters of dependency graph wrapped around one
-		// sentence about the file. In a container log that buries the answer.
-		return fmt.Errorf("failed to open the database: %w", rootCause(err))
+		// sentence about what actually broke. In a container log that buries
+		// the answer.
+		//
+		// Not called a database failure, though the database is the usual
+		// cause: any wiring failure arrives here, and branding them all as the
+		// store sends an operator looking in the wrong place. The DSN is
+		// scrubbed because drivers routinely echo the connection string back,
+		// and a Postgres one carries a password.
+		return fmt.Errorf("failed to start (check DATABASE_DSN): %s",
+			redactDSN(rootCause(err).Error(), appCfg.DatabaseDSN))
 	}
 	defer func() {
 		stopCtx, stopCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
 		defer stopCancel()
 		_ = app.Stop(stopCtx)
 	}()
+
+	// Look the email up across every provider before registering, because
+	// RegisterPassword's own guard only looks for a *password* credential. An
+	// email that already signs in through Google sails past it and gets a
+	// second, unlinked agent and personal account — silently, on some later
+	// boot, once OAuth is added for an address this command already owns. This
+	// runs on every start forever, so "later" is not hypothetical.
+	normalized := strings.ToLower(email)
+	existing, lookupErr := credentialRepo.FindByEmail(cmd.Context(), normalized)
+	if lookupErr != nil {
+		return fmt.Errorf("failed to check whether %s already has an account: %w", email, rootCause(lookupErr))
+	}
+	if len(existing) > 0 {
+		if err := verifyUsable(cmd.Context(), passwordRepo, existing, email); err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+			"Account already exists for %s (via %s); leaving it unchanged\n",
+			email, strings.Join(providersOf(existing), ", "))
+		return nil
+	}
 
 	displayName := handlers.DefaultDisplayName(email, accountDisplayName)
 
@@ -151,6 +221,72 @@ func runAccountCreate(cmd *cobra.Command, _ []string) error {
 	}
 	_, _ = fmt.Fprintln(cmd.OutOrStdout(), report)
 	return nil
+}
+
+// verifyUsable makes sure "already exists" means "and can be signed in to".
+//
+// Registering writes the credential row and the password row as two separate,
+// untransacted saves. A crash or a full disk between them leaves an email that
+// looks registered and has no password: the first run stops the boot correctly,
+// but every run after it finds the credential, reports "already exists", and
+// exits 0 — so the instance comes up reporting itself provisioned forever while
+// nobody can sign in, and no later run can repair it, because they all take
+// this same branch.
+//
+// Checking only for the row's presence keeps the deliberate no-reset behaviour
+// intact: a rotated password still changes nothing. What it refuses to do is
+// call a half-written account "already there".
+func verifyUsable(
+	ctx context.Context,
+	passwordRepo authrepos.PasswordCredentialRepository,
+	existing []*authentities.Credential,
+	email string,
+) error {
+	for _, credential := range existing {
+		if credential.Provider() != authentities.ProviderPassword {
+			continue
+		}
+		stored, err := passwordRepo.FindByCredentialID(ctx, credential.GetID())
+		if err != nil {
+			return fmt.Errorf("failed to check the stored password for %s: %w", email, rootCause(err))
+		}
+		if stored == nil {
+			return fmt.Errorf(
+				"%s has a password credential with no stored password — the account was "+
+					"half-written by an earlier interrupted run and nobody can sign in to it. "+
+					"Remove the credential for %s and run this again", email, email)
+		}
+	}
+	return nil
+}
+
+// providersOf names the ways an email can already sign in, so the message says
+// "via google" rather than leaving an operator to wonder why an account they
+// never created with this command is reported as already there.
+func providersOf(credentials []*authentities.Credential) []string {
+	seen := map[string]bool{}
+	providers := []string{}
+	for _, credential := range credentials {
+		provider := credential.Provider()
+		if provider == "" || seen[provider] {
+			continue
+		}
+		seen[provider] = true
+		providers = append(providers, provider)
+	}
+	sort.Strings(providers)
+	return providers
+}
+
+// redactDSN keeps a connection string out of a message that a driver may have
+// built from one. Matching on the whole DSN is deliberately narrow: it removes
+// what we know we configured without trying to guess at every shape a driver
+// might print.
+func redactDSN(message, dsn string) string {
+	if dsn == "" {
+		return message
+	}
+	return strings.ReplaceAll(message, dsn, "[DATABASE_DSN]")
 }
 
 // rootCause unwraps to the innermost error, which is the sentence that says
@@ -184,7 +320,15 @@ func describeRegisterOutcome(email, password string, err error) (report string, 
 		if password == "" {
 			return s
 		}
-		return strings.ReplaceAll(s, password, "[redacted]")
+		s = strings.ReplaceAll(s, password, "[redacted]")
+		// Go code formats values with %q as readily as %v, and the escaped
+		// rendering of a password containing a quote or a backslash is a
+		// different string from the password — so a plain substring replace
+		// walks straight past it, leaving the secret perfectly readable.
+		if escaped := strings.Trim(strconv.Quote(password), `"`); escaped != password {
+			s = strings.ReplaceAll(s, escaped, "[redacted]")
+		}
+		return s
 	}
 
 	switch {

--- a/internal/cli/account_test.go
+++ b/internal/cli/account_test.go
@@ -50,7 +50,7 @@ func TestDescribeRegisterOutcome(t *testing.T) {
 			wantSaid:   "password support",
 		},
 		{
-			name:       "an unrecognised failure stops the boot",
+			name:       "an unrecognized failure stops the boot",
 			err:        errors.New("disk is on fire"),
 			wantFailed: true,
 			wantSaid:   "disk is on fire",

--- a/internal/cli/account_test.go
+++ b/internal/cli/account_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -74,19 +75,36 @@ func TestDescribeRegisterOutcome(t *testing.T) {
 // the password in it. The mapping is not given the password at all, so this
 // fails the moment someone changes that.
 func TestDescribeRegisterOutcomeNeverRepeatsThePassword(t *testing.T) {
-	const password = "correct-horse-battery-staple"
+	// Deliberately full of characters %q escapes. A password of plain letters
+	// and dashes would let this test pass while the escaped rendering of a
+	// realistic password sat in the message untouched: `he "said" hi` formatted
+	// with %q is a different string from the password itself, so a substring
+	// replace walks straight past it.
+	passwords := []string{
+		"correct-horse-battery-staple",
+		`he "said" hi`,
+		`back\slash`,
+		"tab\there",
+	}
 
-	for _, err := range []error{
-		nil,
-		authapp.ErrEmailAlreadyTaken,
-		authapp.ErrPasswordSupportNotConfigured,
-		// The realistic leak: a lower layer that put the password in its own
-		// error, which this mapping would otherwise pass straight through.
-		fmt.Errorf("hash password %q: bad cost", password),
-	} {
-		report, _ := describeRegisterOutcome("ops@harborlegal.example", password, err)
-		if strings.Contains(report, password) {
-			t.Errorf("the password appeared in the report for %v: %s", err, report)
+	for _, password := range passwords {
+		for _, err := range []error{
+			nil,
+			authapp.ErrEmailAlreadyTaken,
+			authapp.ErrPasswordSupportNotConfigured,
+			// The realistic leak: a lower layer that put the password in its
+			// own error, which this mapping would otherwise pass through.
+			fmt.Errorf("hash password %v: bad cost", password),
+			fmt.Errorf("hash password %q: bad cost", password),
+		} {
+			report, _ := describeRegisterOutcome("ops@harborlegal.example", password, err)
+			if strings.Contains(report, password) {
+				t.Errorf("the password %q appeared in the report for %v: %s", password, err, report)
+			}
+			if escaped := strings.Trim(strconv.Quote(password), `"`); escaped != password &&
+				strings.Contains(report, escaped) {
+				t.Errorf("the escaped password %q appeared in the report for %v: %s", escaped, err, report)
+			}
 		}
 	}
 }

--- a/internal/cli/account_test.go
+++ b/internal/cli/account_test.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
+)
+
+// TestDescribeRegisterOutcome covers the one decision the entrypoint acts on:
+// whether the boot carries on. The acceptance scenarios drive the real command
+// for the reachable cases; this covers the mapping itself, including the
+// password-support branch, which no configuration of this codebase can reach
+// (application/module.go always provides a password-credential repository) and
+// which therefore cannot honestly be an acceptance scenario.
+func TestDescribeRegisterOutcome(t *testing.T) {
+	const email = "ops@harborlegal.example"
+
+	tests := []struct {
+		name       string
+		err        error
+		wantFailed bool
+		wantSaid   string
+	}{
+		{
+			name:       "a created account carries on",
+			err:        nil,
+			wantFailed: false,
+			wantSaid:   "Created account",
+		},
+		{
+			name:       "an account that already exists carries on",
+			err:        authapp.ErrEmailAlreadyTaken,
+			wantFailed: false,
+			wantSaid:   "already exists",
+		},
+		{
+			name:       "wrapped, an account that already exists still carries on",
+			err:        fmt.Errorf("register: %w", authapp.ErrEmailAlreadyTaken),
+			wantFailed: false,
+			wantSaid:   "already exists",
+		},
+		{
+			name:       "missing password support stops the boot and says so",
+			err:        authapp.ErrPasswordSupportNotConfigured,
+			wantFailed: true,
+			wantSaid:   "password support",
+		},
+		{
+			name:       "an unrecognised failure stops the boot",
+			err:        errors.New("disk is on fire"),
+			wantFailed: true,
+			wantSaid:   "disk is on fire",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			report, failed := describeRegisterOutcome(email, "some-password", tc.err)
+			if failed != tc.wantFailed {
+				t.Errorf("expected failed=%v, got %v (report: %s)", tc.wantFailed, failed, report)
+			}
+			if !strings.Contains(report, tc.wantSaid) {
+				t.Errorf("expected the report to mention %q, got: %s", tc.wantSaid, report)
+			}
+		})
+	}
+}
+
+// TestDescribeRegisterOutcomeNeverRepeatsThePassword guards the property the
+// story cares about most: an operator reading a failure report must not find
+// the password in it. The mapping is not given the password at all, so this
+// fails the moment someone changes that.
+func TestDescribeRegisterOutcomeNeverRepeatsThePassword(t *testing.T) {
+	const password = "correct-horse-battery-staple"
+
+	for _, err := range []error{
+		nil,
+		authapp.ErrEmailAlreadyTaken,
+		authapp.ErrPasswordSupportNotConfigured,
+		// The realistic leak: a lower layer that put the password in its own
+		// error, which this mapping would otherwise pass straight through.
+		fmt.Errorf("hash password %q: bad cost", password),
+	} {
+		report, _ := describeRegisterOutcome("ops@harborlegal.example", password, err)
+		if strings.Contains(report, password) {
+			t.Errorf("the password appeared in the report for %v: %s", err, report)
+		}
+	}
+}

--- a/tests/e2e/account_create_cli_test.go
+++ b/tests/e2e/account_create_cli_test.go
@@ -1,0 +1,724 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/wepala/weos/v3/api/handlers"
+	apimw "github.com/wepala/weos/v3/api/middleware"
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/application/presets"
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
+	"github.com/wepala/weos/v3/internal/config"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
+	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
+	authentities "github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
+	"github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/session"
+	"github.com/cucumber/godog"
+	"github.com/labstack/echo/v4"
+	"go.uber.org/fx"
+)
+
+// TestAccountCreateCLI runs the acceptance scenarios for story #137 (epic
+// #135): an operator mints an account from the command line rather than through
+// an HTTP route that strangers can also reach.
+//
+// These scenarios run the real binary as a real process. That is not
+// incidental: what they assert is process behaviour — the exit code an
+// entrypoint under `set -e` reads, what reaches stdout and stderr, a password
+// arriving on standard input, and a password that must not appear in the
+// argument list. Calling the command in-process would leave every one of those
+// claims about something other than the thing that ships.
+func TestAccountCreateCLI(t *testing.T) {
+	tags := "~@wip"
+	if override := os.Getenv("GODOG_TAGS"); override != "" {
+		tags = override
+	}
+	suite := godog.TestSuite{
+		Name:                "account-create-cli",
+		ScenarioInitializer: initAccountCreateScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"features/account_create_cli.feature"},
+			Tags:     tags,
+			Strict:   true,
+			TestingT: t,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("account create CLI acceptance scenarios failed")
+	}
+}
+
+var (
+	buildOnce   sync.Once
+	builtBinary string
+	buildErr    error
+)
+
+// weosBinary builds the command under test once for the whole suite.
+func weosBinary() (string, error) {
+	buildOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "weos-account-cli-bin-")
+		if err != nil {
+			buildErr = err
+			return
+		}
+		path := filepath.Join(dir, "weos")
+		cmd := exec.Command("go", "build", "-o", path, "./cmd/weos")
+		cmd.Dir = "../.."
+		if out, err := cmd.CombinedOutput(); err != nil {
+			buildErr = fmt.Errorf("failed to build the weos binary: %w\n%s", err, out)
+			return
+		}
+		builtBinary = path
+	})
+	return builtBinary, buildErr
+}
+
+// commandRun is what an entrypoint script can observe about one invocation.
+type commandRun struct {
+	exitCode int
+	stdout   string
+	stderr   string
+	args     []string
+}
+
+// said is everything the command printed, which is what the "appears nowhere"
+// assertions search.
+func (r commandRun) said() string { return r.stdout + r.stderr }
+
+type accountCLIWorld struct {
+	dsn     string
+	tmpDir  string
+	verbose bool
+
+	lastRun      commandRun
+	lastPassword string
+
+	// A booted instance, for the scenarios that check the account works.
+	app    *fx.App
+	server *httptest.Server
+
+	authService authapp.AuthenticationService
+	credRepo    authrepos.CredentialRepository
+	agentRepo   authrepos.AgentRepository
+	accountRepo authrepos.AccountRepository
+	sessionMgr  session.SessionManager
+	logger      entities.Logger
+
+	resourceService     application.ResourceService
+	resourceTypeService application.ResourceTypeService
+
+	signIns map[string]int
+}
+
+func initAccountCreateScenario(sc *godog.ScenarioContext) {
+	w := &accountCLIWorld{}
+
+	sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		w.teardown()
+		return ctx, nil
+	})
+
+	sc.Step(`^a WeOS store with no accounts, and no server running against it$`, w.anEmptyStore)
+	sc.Step(`^a WeOS store where the operator has already created the account "([^"]*)" with password "([^"]*)"$`,
+		w.aStoreWithAccount)
+	sc.Step(`^a WeOS store whose database cannot be opened$`, w.anUnopenableStore)
+	sc.Step(`^a WeOS store that already holds the account "([^"]*)" and a task named "([^"]*)"$`, w.aStoreWithAccountAndTask)
+	sc.Step(`^no server is running against it$`, w.noServerRunning)
+	sc.Step(`^the operator has asked for verbose logging$`, w.verboseLogging)
+	sc.Step(`^the operator has created an account for "([^"]*)" with password "([^"]*)"$`, w.operatorCreatedAccount)
+
+	sc.Step(`^the operator creates an account for "([^"]*)" with the password supplied through the environment$`,
+		func(email string) error { return w.createViaEnv(email, aPassword, "") })
+	sc.Step(`^the operator creates an account for "([^"]*)" with password "([^"]*)" supplied through the environment$`,
+		func(email, password string) error { return w.createViaEnv(email, password, "") })
+	sc.Step(`^the operator creates an account for "([^"]*)" with password "([^"]*)"$`,
+		func(email, password string) error { return w.createViaEnv(email, password, "") })
+	sc.Step(`^the operator creates an account for "([^"]*)" with password "([^"]*)" again$`,
+		func(email, password string) error { return w.createViaEnv(email, password, "") })
+	sc.Step(`^the operator creates an account for "([^"]*)" with no display name given$`,
+		func(email string) error { return w.createViaEnv(email, aPassword, "") })
+	sc.Step(`^the operator creates an account for "([^"]*)" with the display name "([^"]*)"$`,
+		func(email, displayName string) error { return w.createViaEnv(email, aPassword, displayName) })
+	sc.Step(`^the operator creates an account for "([^"]*)" with no password supplied through any channel$`, w.createWithNoPassword)
+	sc.Step(`^the operator creates an account for "([^"]*)" with the password supplied on standard input$`, w.createViaStdin)
+	sc.Step(`^the operator creates an account for "([^"]*)" with the password given on the command line$`, w.createViaFlag)
+
+	sc.Step(`^the instance is started with password sign-in enabled$`, func() error { return w.startInstance(false) })
+	sc.Step(`^the instance is started with password sign-in and account registration enabled$`,
+		func() error { return w.startInstance(true) })
+	sc.Step(`^"([^"]*)" registers with password "([^"]*)"$`, w.registersOverHTTP)
+	sc.Step(`^"([^"]*)" signs in with password "([^"]*)"$`, w.cliSignIn)
+	sc.Step(`^both "([^"]*)" and "([^"]*)" sign in with password "([^"]*)"$`, w.bothSignIn)
+
+	sc.Step(`^the command exits successfully$`, w.exitedSuccessfully)
+	sc.Step(`^the command exits with a failure$`, w.exitedWithFailure)
+	sc.Step(`^the command reports that the account already exists$`, w.reportedAlreadyExists)
+	sc.Step(`^the failure names the database as the reason$`, func() error { return w.failureNames("database") })
+	sc.Step(`^the failure names password support as the reason$`, func() error { return w.failureNames("password support") })
+	sc.Step(`^the store holds exactly one account for "([^"]*)"$`, w.storeHoldsExactlyOne)
+	sc.Step(`^no account exists for "([^"]*)"$`, w.noAccountExists)
+	sc.Step(`^the account for "([^"]*)" is presented as "([^"]*)"$`, w.accountPresentedAs)
+	sc.Step(`^the password appears nowhere in what the command printed or logged$`, w.passwordNowhereInOutput)
+	sc.Step(`^the password was never given as a command-line argument$`, w.passwordNotAnArgument)
+	sc.Step(`^"([^"]*)" can sign in with password "([^"]*)"$`, w.canSignIn)
+	sc.Step(`^"([^"]*)" cannot sign in with password "([^"]*)"$`, w.cannotSignInCLI)
+	sc.Step(`^"([^"]*)" can sign in with the password that was supplied$`,
+		func(email string) error { return w.canSignIn(email, w.lastPassword) })
+	sc.Step(`^"([^"]*)" can sign in with password "([^"]*)" once the instance is started$`, w.canSignIn)
+	sc.Step(`^the sign-in succeeds$`, w.signInSucceeded)
+	sc.Step(`^both sign-ins succeed$`, w.bothSignInsSucceeded)
+	sc.Step(`^"([^"]*)" holds an authenticated session$`, w.cliHoldsSession)
+	sc.Step(`^each of them owns a personal account$`, w.eachOwnsPersonalAccount)
+	sc.Step(`^the store still holds the account "([^"]*)" and the task named "([^"]*)"$`, w.storeStillHolds)
+}
+
+// --- Store setup ---
+
+func (w *accountCLIWorld) anEmptyStore() error {
+	dir, err := os.MkdirTemp("", "weos-account-cli-")
+	if err != nil {
+		return err
+	}
+	w.tmpDir = dir
+	w.dsn = filepath.Join(dir, "store.db")
+	w.signIns = map[string]int{}
+	return nil
+}
+
+// anUnopenableStore points the command at a path inside a directory that does
+// not exist, which is the shape of a misconfigured DSN in a deployment.
+func (w *accountCLIWorld) anUnopenableStore() error {
+	if err := w.anEmptyStore(); err != nil {
+		return err
+	}
+	w.dsn = filepath.Join(w.tmpDir, "no-such-directory", "store.db")
+	return nil
+}
+
+func (w *accountCLIWorld) aStoreWithAccount(email, password string) error {
+	if err := w.anEmptyStore(); err != nil {
+		return err
+	}
+	return w.operatorCreatedAccount(email, password)
+}
+
+// operatorCreatedAccount seeds through the command itself, so the "second run"
+// scenarios start from a state the command actually produced.
+func (w *accountCLIWorld) operatorCreatedAccount(email, password string) error {
+	if err := w.createViaEnv(email, password, ""); err != nil {
+		return err
+	}
+	return w.exitedSuccessfully()
+}
+
+func (w *accountCLIWorld) aStoreWithAccountAndTask(email, taskName string) error {
+	if err := w.anEmptyStore(); err != nil {
+		return err
+	}
+	if err := w.operatorCreatedAccount(email, aPassword); err != nil {
+		return err
+	}
+	if err := w.startInstance(false); err != nil {
+		return err
+	}
+	if err := w.seedTask(taskName); err != nil {
+		return err
+	}
+	// The scenario says no server is running when the command runs, so the one
+	// used for seeding is stopped again.
+	w.stopInstance()
+	return nil
+}
+
+func (w *accountCLIWorld) noServerRunning() error {
+	w.stopInstance()
+	return nil
+}
+
+func (w *accountCLIWorld) verboseLogging() error {
+	w.verbose = true
+	return nil
+}
+
+// --- Running the command ---
+
+func (w *accountCLIWorld) run(args []string, env []string, stdin string) error {
+	binary, err := weosBinary()
+	if err != nil {
+		return err
+	}
+	if w.verbose {
+		args = append(args, "--verbose")
+	}
+	cmd := exec.Command(binary, args...)
+	cmd.Env = append(os.Environ(),
+		append([]string{
+			"DATABASE_DSN=" + w.dsn,
+			// Left unset by default; a scenario that asks for verbose logging
+			// turns it up so the "never repeats the password" claim is made
+			// against the noisiest setting, not the quietest.
+			"LOG_LEVEL=" + map[bool]string{true: "debug", false: "error"}[w.verbose],
+		}, env...)...)
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+	exitCode := 0
+	var exitErr *exec.ExitError
+	if runErr != nil {
+		if ok := asExitError(runErr, &exitErr); !ok {
+			return fmt.Errorf("failed to run the command: %w", runErr)
+		}
+		exitCode = exitErr.ExitCode()
+	}
+	w.lastRun = commandRun{
+		exitCode: exitCode,
+		stdout:   stdout.String(),
+		stderr:   stderr.String(),
+		args:     args,
+	}
+	return nil
+}
+
+func asExitError(err error, target **exec.ExitError) bool {
+	if e, ok := err.(*exec.ExitError); ok {
+		*target = e
+		return true
+	}
+	return false
+}
+
+func (w *accountCLIWorld) createArgs(email, displayName string) []string {
+	args := []string{"account", "create", "--email", email}
+	if displayName != "" {
+		args = append(args, "--display-name", displayName)
+	}
+	return args
+}
+
+func (w *accountCLIWorld) createViaEnv(email, password, displayName string) error {
+	w.lastPassword = password
+	return w.run(w.createArgs(email, displayName), []string{"WEOS_ACCOUNT_PASSWORD=" + password}, "")
+}
+
+func (w *accountCLIWorld) createViaStdin(email string) error {
+	w.lastPassword = aPassword
+	args := append(w.createArgs(email, ""), "--password-stdin")
+	return w.run(args, nil, aPassword+"\n")
+}
+
+// createViaFlag is the interactive path. It is supported because an operator at
+// a terminal wants it, and it is deliberately not what the entrypoint uses:
+// anything on the command line is visible in the process table.
+func (w *accountCLIWorld) createViaFlag(email string) error {
+	w.lastPassword = aPassword
+	return w.run(append(w.createArgs(email, ""), "--password", aPassword), nil, "")
+}
+
+func (w *accountCLIWorld) createWithNoPassword(email string) error {
+	w.lastPassword = ""
+	return w.run(w.createArgs(email, ""), []string{"WEOS_ACCOUNT_PASSWORD="}, "")
+}
+
+// --- Command assertions ---
+
+func (w *accountCLIWorld) exitedSuccessfully() error {
+	if w.lastRun.exitCode != 0 {
+		return fmt.Errorf("expected the command to exit 0, got %d: %s", w.lastRun.exitCode, w.lastRun.said())
+	}
+	return nil
+}
+
+func (w *accountCLIWorld) exitedWithFailure() error {
+	if w.lastRun.exitCode == 0 {
+		return fmt.Errorf("expected the command to exit non-zero, it exited 0: %s", w.lastRun.said())
+	}
+	return nil
+}
+
+func (w *accountCLIWorld) reportedAlreadyExists() error {
+	if !strings.Contains(strings.ToLower(w.lastRun.said()), "already exists") {
+		return fmt.Errorf("expected the command to report the account already exists, it said: %s", w.lastRun.said())
+	}
+	return nil
+}
+
+func (w *accountCLIWorld) failureNames(subject string) error {
+	if !strings.Contains(strings.ToLower(w.lastRun.said()), subject) {
+		return fmt.Errorf("expected the failure to name %q, it said: %s", subject, w.lastRun.said())
+	}
+	return nil
+}
+
+func (w *accountCLIWorld) passwordNowhereInOutput() error {
+	if w.lastPassword == "" {
+		return fmt.Errorf("no password was supplied, so this assertion would pass vacuously")
+	}
+	if strings.Contains(w.lastRun.said(), w.lastPassword) {
+		return fmt.Errorf("the password appeared in what the command said: %s", w.lastRun.said())
+	}
+	return nil
+}
+
+func (w *accountCLIWorld) passwordNotAnArgument() error {
+	if w.lastPassword == "" {
+		return fmt.Errorf("no password was supplied, so this assertion would pass vacuously")
+	}
+	for _, arg := range w.lastRun.args {
+		if strings.Contains(arg, w.lastPassword) {
+			return fmt.Errorf("the password was passed as an argument: %v", w.lastRun.args)
+		}
+	}
+	return nil
+}
+
+// --- A running instance, for the scenarios that use the account ---
+
+// startInstance boots the app against the same store the command wrote to and
+// mounts the password routes, so an account minted on the command line is
+// checked through the same door a registered one uses.
+func (w *accountCLIWorld) startInstance(registration bool) error {
+	w.stopInstance()
+	setEnvFor := map[string]string{
+		"PASSWORD_AUTH_ENABLED":         "true",
+		"PASSWORD_REGISTRATION_ENABLED": fmt.Sprintf("%t", registration),
+	}
+	for k, v := range setEnvFor {
+		os.Setenv(k, v)
+		defer os.Unsetenv(k)
+	}
+
+	cfg := config.Default()
+	cfg.LoadFromEnvironment()
+	cfg.DatabaseDSN = w.dsn
+	cfg.LogLevel = "error"
+
+	app := fx.New(
+		fx.NopLogger,
+		application.Module(cfg, presets.NewDefaultRegistry()),
+		fx.Populate(&w.authService, &w.credRepo, &w.agentRepo, &w.accountRepo),
+		fx.Populate(&w.sessionMgr, &w.logger),
+		fx.Populate(&w.resourceService, &w.resourceTypeService),
+	)
+	startCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+	defer cancel()
+	if err := app.Start(startCtx); err != nil {
+		return fmt.Errorf("failed to start the instance: %w", err)
+	}
+	w.app = app
+
+	e := echo.New()
+	e.HideBanner = true
+	api := e.Group("/api")
+	api.Use(apimw.Messages())
+	handlers.MountPasswordAuth(api, handlers.NewPasswordAuthHandler(handlers.PasswordAuthHandlerConfig{
+		AuthService:    w.authService,
+		SessionManager: w.sessionMgr,
+		SecureCookies:  false,
+		Logger:         w.logger,
+	}), handlers.PasswordAuthRoutes{SignIn: cfg.PasswordAuthEnabled, Registration: cfg.PasswordRegistrationEnabled})
+	w.server = httptest.NewServer(e)
+	return nil
+}
+
+func (w *accountCLIWorld) stopInstance() {
+	if w.server != nil {
+		w.server.Close()
+		w.server = nil
+	}
+	if w.app != nil {
+		stopCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		defer cancel()
+		_ = w.app.Stop(stopCtx)
+		w.app = nil
+	}
+}
+
+func (w *accountCLIWorld) teardown() {
+	w.stopInstance()
+	if w.tmpDir != "" {
+		_ = os.RemoveAll(w.tmpDir)
+		w.tmpDir = ""
+	}
+}
+
+// ensureInstance starts one on demand, so scenarios that only assert on the
+// store don't have to say "and the instance is started" first.
+func (w *accountCLIWorld) ensureInstance() error {
+	if w.app != nil {
+		return nil
+	}
+	return w.startInstance(false)
+}
+
+// --- Store assertions ---
+
+func (w *accountCLIWorld) credentialsFor(email string) ([]*authentities.Credential, error) {
+	if err := w.ensureInstance(); err != nil {
+		return nil, err
+	}
+	creds, err := w.credRepo.FindByEmail(context.Background(), strings.ToLower(strings.TrimSpace(email)))
+	if err != nil {
+		return nil, fmt.Errorf("could not look up %q: %w", email, err)
+	}
+	return creds, nil
+}
+
+func (w *accountCLIWorld) storeHoldsExactlyOne(email string) error {
+	creds, err := w.credentialsFor(email)
+	if err != nil {
+		return err
+	}
+	if len(creds) != 1 {
+		return fmt.Errorf("expected exactly one account for %q, found %d", email, len(creds))
+	}
+	return nil
+}
+
+func (w *accountCLIWorld) noAccountExists(email string) error {
+	creds, err := w.credentialsFor(email)
+	if err != nil {
+		return err
+	}
+	if len(creds) != 0 {
+		return fmt.Errorf("expected no account for %q, found %d", email, len(creds))
+	}
+	return nil
+}
+
+// accountPresentedAs reads the name the account is shown under, which is what
+// an operator sees rather than the email it was keyed on.
+func (w *accountCLIWorld) accountPresentedAs(email, name string) error {
+	creds, err := w.credentialsFor(email)
+	if err != nil {
+		return err
+	}
+	if len(creds) != 1 {
+		return fmt.Errorf("expected exactly one account for %q, found %d", email, len(creds))
+	}
+	agent, err := w.agentRepo.FindByID(context.Background(), creds[0].AgentID())
+	if err != nil {
+		return fmt.Errorf("could not read the agent for %q: %w", email, err)
+	}
+	if agent.Name() != name {
+		return fmt.Errorf("expected the account for %q to be presented as %q, got %q", email, name, agent.Name())
+	}
+	return nil
+}
+
+func (w *accountCLIWorld) eachOwnsPersonalAccount() error {
+	for email := range w.signIns {
+		creds, err := w.credentialsFor(email)
+		if err != nil {
+			return err
+		}
+		if len(creds) != 1 {
+			return fmt.Errorf("expected exactly one credential for %q, found %d", email, len(creds))
+		}
+		accounts, err := w.accountRepo.FindByMember(context.Background(), creds[0].AgentID())
+		if err != nil {
+			return fmt.Errorf("could not read accounts for %q: %w", email, err)
+		}
+		if len(accounts) == 0 {
+			return fmt.Errorf("expected %q to own a personal account, found none", email)
+		}
+	}
+	return nil
+}
+
+// --- Sign-in over HTTP ---
+
+func (w *accountCLIWorld) post(path, body string) (int, string, error) {
+	if err := w.ensureInstance(); err != nil {
+		return 0, "", err
+	}
+	resp, err := http.Post(w.server.URL+path, "application/json", strings.NewReader(body))
+	if err != nil {
+		return 0, "", err
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, "", err
+	}
+	return resp.StatusCode, string(raw), nil
+}
+
+func (w *accountCLIWorld) attemptSignIn(email, password string) (int, error) {
+	status, _, err := w.post("/api/auth/password-login", credentialsJSON(email, password))
+	if err != nil {
+		return 0, err
+	}
+	if w.signIns == nil {
+		w.signIns = map[string]int{}
+	}
+	w.signIns[email] = status
+	return status, nil
+}
+
+func (w *accountCLIWorld) cliSignIn(email, password string) error {
+	_, err := w.attemptSignIn(email, password)
+	return err
+}
+
+func (w *accountCLIWorld) bothSignIn(first, second, password string) error {
+	if err := w.cliSignIn(first, password); err != nil {
+		return err
+	}
+	return w.cliSignIn(second, password)
+}
+
+func (w *accountCLIWorld) registersOverHTTP(email, password string) error {
+	status, body, err := w.post("/api/auth/register", credentialsJSON(email, password))
+	if err != nil {
+		return err
+	}
+	if status != http.StatusOK && status != http.StatusCreated {
+		return fmt.Errorf("expected %q to register, got %d: %s", email, status, body)
+	}
+	return nil
+}
+
+func (w *accountCLIWorld) canSignIn(email, password string) error {
+	status, err := w.attemptSignIn(email, password)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusOK {
+		return fmt.Errorf("expected %q to sign in, got %d", email, status)
+	}
+	return nil
+}
+
+func (w *accountCLIWorld) cannotSignInCLI(email, password string) error {
+	status, err := w.attemptSignIn(email, password)
+	if err != nil {
+		return err
+	}
+	if status == http.StatusOK {
+		return fmt.Errorf("expected %q not to sign in with that password, but it worked", email)
+	}
+	return nil
+}
+
+func (w *accountCLIWorld) signInSucceeded() error {
+	for email, status := range w.signIns {
+		if status != http.StatusOK {
+			return fmt.Errorf("expected %q to sign in, got %d", email, status)
+		}
+	}
+	if len(w.signIns) == 0 {
+		return fmt.Errorf("no sign-in was attempted")
+	}
+	return nil
+}
+
+func (w *accountCLIWorld) bothSignInsSucceeded() error {
+	if len(w.signIns) < 2 {
+		return fmt.Errorf("expected two sign-ins, saw %d", len(w.signIns))
+	}
+	return w.signInSucceeded()
+}
+
+func (w *accountCLIWorld) cliHoldsSession(email string) error {
+	if status, ok := w.signIns[email]; !ok || status != http.StatusOK {
+		return fmt.Errorf("expected %q to hold a session, sign-in status was %d", email, status)
+	}
+	return nil
+}
+
+// --- The store is already in use ---
+
+// seedTask puts unrelated data in the store, so a scenario can show the command
+// adds an account without disturbing what was already there.
+// contextForOwner builds the identity the given account acts under, so seeding
+// and reading agree about who owns what.
+func (w *accountCLIWorld) contextForOwner(email string) (context.Context, error) {
+	ctx := context.Background()
+	creds, err := w.credRepo.FindByEmail(ctx, email)
+	if err != nil || len(creds) == 0 {
+		return nil, fmt.Errorf("could not find the agent for %q: %w", email, err)
+	}
+	accounts, err := w.accountRepo.FindByMember(ctx, creds[0].AgentID())
+	if err != nil || len(accounts) == 0 {
+		return nil, fmt.Errorf("could not find an account for %q: %w", email, err)
+	}
+	return auth.ContextWithAgent(ctx, &auth.Identity{
+		AgentID:         creds[0].AgentID(),
+		AccountIDs:      []string{accounts[0].GetID()},
+		ActiveAccountID: accounts[0].GetID(),
+	}), nil
+}
+
+func (w *accountCLIWorld) seedTask(name string) error {
+	ctx := context.Background()
+	if _, err := w.resourceTypeService.InstallPreset(ctx, "tasks", true); err != nil {
+		return fmt.Errorf("could not install the tasks preset: %w", err)
+	}
+	ownerCtx, err := w.contextForOwner("founder@harborlegal.example")
+	if err != nil {
+		return err
+	}
+	data, _ := json.Marshal(map[string]any{"name": name, "status": "open", "priority": "medium"})
+	if _, err := w.resourceService.Create(ownerCtx, application.CreateResourceCommand{
+		TypeSlug: "task", Data: data,
+	}); err != nil {
+		return fmt.Errorf("could not create the task %q: %w", name, err)
+	}
+	return nil
+}
+
+func (w *accountCLIWorld) storeStillHolds(email, taskName string) error {
+	if err := w.storeHoldsExactlyOne(email); err != nil {
+		return err
+	}
+	// Listed as the agent that owns it: resources are account-scoped, so an
+	// anonymous read returns nothing and would report the task as lost when it
+	// is merely not ours to see.
+	ownerCtx, err := w.contextForOwner("founder@harborlegal.example")
+	if err != nil {
+		return err
+	}
+	page, err := w.resourceService.List(ownerCtx, "task", "", 100, repositories.SortOptions{})
+	if err != nil {
+		return fmt.Errorf("could not list tasks: %w", err)
+	}
+	// Resources are stored as JSON-LD, so the name lives in the @graph node
+	// rather than at the top level.
+	for _, resource := range page.Data {
+		var payload struct {
+			Graph []struct {
+				Name string `json:"name"`
+			} `json:"@graph"`
+		}
+		if err := json.Unmarshal(resource.Data(), &payload); err != nil {
+			continue
+		}
+		for _, node := range payload.Graph {
+			if node.Name == taskName {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("expected the task %q to survive; the store held %d task(s)", taskName, len(page.Data))
+}

--- a/tests/e2e/account_create_cli_test.go
+++ b/tests/e2e/account_create_cli_test.go
@@ -122,6 +122,7 @@ type accountCLIWorld struct {
 
 	lastRun      commandRun
 	lastPassword string
+	workDir      string
 
 	// A booted instance, for the scenarios that check the account works.
 	app    *fx.App
@@ -152,6 +153,8 @@ func initAccountCreateScenario(sc *godog.ScenarioContext) {
 	sc.Step(`^a WeOS store where the operator has already created the account "([^"]*)" with password "([^"]*)"$`,
 		w.aStoreWithAccount)
 	sc.Step(`^a WeOS store whose database cannot be opened$`, w.anUnopenableStore)
+	sc.Step(`^a WeOS store where "([^"]*)" already signs in through Google$`, w.anOAuthAccount)
+	sc.Step(`^a WeOS instance with no database configured$`, w.noDatabaseConfigured)
 	sc.Step(`^a WeOS store that already holds the account "([^"]*)" and a task named "([^"]*)"$`, w.aStoreWithAccountAndTask)
 	sc.Step(`^no server is running against it$`, w.noServerRunning)
 	sc.Step(`^the operator has asked for verbose logging$`, w.verboseLogging)
@@ -184,6 +187,10 @@ func initAccountCreateScenario(sc *godog.ScenarioContext) {
 	sc.Step(`^the command exits with a failure$`, w.exitedWithFailure)
 	sc.Step(`^the command reports that the account already exists$`, w.reportedAlreadyExists)
 	sc.Step(`^the failure names the database as the reason$`, func() error { return w.failureNames("database") })
+	sc.Step(`^the failure says no database was specified and names how to supply one$`, w.failureNamesNoDatabase)
+	sc.Step(`^the command reports that the account already exists, naming Google as how it signs in$`, w.reportedExistsViaGoogle)
+	sc.Step(`^no account is created in any store$`, w.noStoreWasWritten)
+	sc.Step(`^the command leaves no database behind in the directory it ran from$`, w.noStrayDatabase)
 	sc.Step(`^the store holds exactly one account for "([^"]*)"$`, w.storeHoldsExactlyOne)
 	sc.Step(`^no account exists for "([^"]*)"$`, w.noAccountExists)
 	sc.Step(`^the account for "([^"]*)" is presented as "([^"]*)"$`, w.accountPresentedAs)
@@ -269,6 +276,41 @@ func (w *accountCLIWorld) verboseLogging() error {
 	return nil
 }
 
+// anOAuthAccount seeds an account the way the OAuth callback would, so the
+// scenario starts from an email that signs in without any password at all.
+func (w *accountCLIWorld) anOAuthAccount(email string) error {
+	if err := w.anEmptyStore(); err != nil {
+		return err
+	}
+	if err := w.startInstance(false); err != nil {
+		return err
+	}
+	if _, _, _, err := w.authService.FindOrCreateAgent(context.Background(), authapp.UserInfo{
+		ProviderUserID: "google-" + email,
+		Email:          email,
+		DisplayName:    "Ops",
+		Provider:       "google",
+	}); err != nil {
+		return fmt.Errorf("could not seed the Google account for %q: %w", email, err)
+	}
+	w.stopInstance()
+	return nil
+}
+
+// noDatabaseConfigured runs the command from an empty directory with no DSN in
+// the environment, which is how a deployment that lost its setting would look.
+func (w *accountCLIWorld) noDatabaseConfigured() error {
+	dir, err := os.MkdirTemp("", "weos-account-cli-nodsn-")
+	if err != nil {
+		return err
+	}
+	w.tmpDir = dir
+	w.dsn = ""
+	w.workDir = dir
+	w.signIns = map[string]int{}
+	return nil
+}
+
 // --- Running the command ---
 
 func (w *accountCLIWorld) run(args []string, env []string, stdin string) error {
@@ -280,9 +322,17 @@ func (w *accountCLIWorld) run(args []string, env []string, stdin string) error {
 		args = append(args, "--verbose")
 	}
 	cmd := exec.Command(binary, args...)
+	if w.workDir != "" {
+		cmd.Dir = w.workDir
+	}
+	dsnEnv := "DATABASE_DSN=" + w.dsn
+	if w.dsn == "" {
+		// Unset rather than empty: an absent setting is the case under test.
+		dsnEnv = "DATABASE_DSN="
+	}
 	cmd.Env = append(os.Environ(),
 		append([]string{
-			"DATABASE_DSN=" + w.dsn,
+			dsnEnv,
 			// Left unset by default; a scenario that asks for verbose logging
 			// turns it up so the "never repeats the password" claim is made
 			// against the noisiest setting, not the quietest.
@@ -726,4 +776,51 @@ func (w *accountCLIWorld) storeStillHolds(email, taskName string) error {
 		}
 	}
 	return fmt.Errorf("expected the task %q to survive; the store held %d task(s)", taskName, len(page.Data))
+}
+
+// --- Assertions for the two failures that look like success ---
+
+func (w *accountCLIWorld) failureNamesNoDatabase() error {
+	said := strings.ToLower(w.lastRun.said())
+	if !strings.Contains(said, "no database specified") {
+		return fmt.Errorf("expected the failure to say no database was specified, it said: %s", w.lastRun.said())
+	}
+	// Naming the remedy is half the point: this message is read by whoever is
+	// staring at a container that would not start.
+	if !strings.Contains(said, "database_dsn") {
+		return fmt.Errorf("expected the failure to name how to supply a database, it said: %s", w.lastRun.said())
+	}
+	return nil
+}
+
+func (w *accountCLIWorld) reportedExistsViaGoogle() error {
+	if err := w.reportedAlreadyExists(); err != nil {
+		return err
+	}
+	if !strings.Contains(strings.ToLower(w.lastRun.said()), "google") {
+		return fmt.Errorf("expected the report to name Google, it said: %s", w.lastRun.said())
+	}
+	return nil
+}
+
+// noStoreWasWritten checks the whole working directory, not one expected path.
+// The defect this guards against was the command writing to a store nobody
+// named, so asserting against a known filename would miss the case entirely.
+func (w *accountCLIWorld) noStoreWasWritten() error {
+	return w.noStrayDatabase()
+}
+
+func (w *accountCLIWorld) noStrayDatabase() error {
+	entries, err := os.ReadDir(w.workDir)
+	if err != nil {
+		return fmt.Errorf("could not inspect the directory the command ran from: %w", err)
+	}
+	stray := []string{}
+	for _, entry := range entries {
+		stray = append(stray, entry.Name())
+	}
+	if len(stray) > 0 {
+		return fmt.Errorf("expected the command to leave nothing behind, found: %v", stray)
+	}
+	return nil
 }

--- a/tests/e2e/account_create_cli_test.go
+++ b/tests/e2e/account_create_cli_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -66,8 +67,20 @@ func TestAccountCreateCLI(t *testing.T) {
 var (
 	buildOnce   sync.Once
 	builtBinary string
+	buildDir    string
 	buildErr    error
 )
+
+// TestMain removes the directory the binary was built into. Without it every
+// run leaves an ~85 MB copy behind, which is invisible on an ephemeral CI
+// runner and accumulates on a developer's machine.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if buildDir != "" {
+		_ = os.RemoveAll(buildDir)
+	}
+	os.Exit(code)
+}
 
 // weosBinary builds the command under test once for the whole suite.
 func weosBinary() (string, error) {
@@ -77,6 +90,7 @@ func weosBinary() (string, error) {
 			buildErr = err
 			return
 		}
+		buildDir = dir
 		path := filepath.Join(dir, "weos")
 		cmd := exec.Command("go", "build", "-o", path, "./cmd/weos")
 		cmd.Dir = "../.."
@@ -170,7 +184,6 @@ func initAccountCreateScenario(sc *godog.ScenarioContext) {
 	sc.Step(`^the command exits with a failure$`, w.exitedWithFailure)
 	sc.Step(`^the command reports that the account already exists$`, w.reportedAlreadyExists)
 	sc.Step(`^the failure names the database as the reason$`, func() error { return w.failureNames("database") })
-	sc.Step(`^the failure names password support as the reason$`, func() error { return w.failureNames("password support") })
 	sc.Step(`^the store holds exactly one account for "([^"]*)"$`, w.storeHoldsExactlyOne)
 	sc.Step(`^no account exists for "([^"]*)"$`, w.noAccountExists)
 	sc.Step(`^the account for "([^"]*)" is presented as "([^"]*)"$`, w.accountPresentedAs)
@@ -284,9 +297,9 @@ func (w *accountCLIWorld) run(args []string, env []string, stdin string) error {
 
 	runErr := cmd.Run()
 	exitCode := 0
-	var exitErr *exec.ExitError
 	if runErr != nil {
-		if ok := asExitError(runErr, &exitErr); !ok {
+		var exitErr *exec.ExitError
+		if !errors.As(runErr, &exitErr) {
 			return fmt.Errorf("failed to run the command: %w", runErr)
 		}
 		exitCode = exitErr.ExitCode()
@@ -298,14 +311,6 @@ func (w *accountCLIWorld) run(args []string, env []string, stdin string) error {
 		args:     args,
 	}
 	return nil
-}
-
-func asExitError(err error, target **exec.ExitError) bool {
-	if e, ok := err.(*exec.ExitError); ok {
-		*target = e
-		return true
-	}
-	return false
 }
 
 func (w *accountCLIWorld) createArgs(email, displayName string) []string {
@@ -649,8 +654,6 @@ func (w *accountCLIWorld) cliHoldsSession(email string) error {
 
 // --- The store is already in use ---
 
-// seedTask puts unrelated data in the store, so a scenario can show the command
-// adds an account without disturbing what was already there.
 // contextForOwner builds the identity the given account acts under, so seeding
 // and reading agree about who owns what.
 func (w *accountCLIWorld) contextForOwner(email string) (context.Context, error) {
@@ -670,6 +673,8 @@ func (w *accountCLIWorld) contextForOwner(email string) (context.Context, error)
 	}), nil
 }
 
+// seedTask puts unrelated data in the store, so a scenario can show the command
+// adds an account without disturbing what was already there.
 func (w *accountCLIWorld) seedTask(name string) error {
 	ctx := context.Background()
 	if _, err := w.resourceTypeService.InstallPreset(ctx, "tasks", true); err != nil {

--- a/tests/e2e/account_create_cli_test.go
+++ b/tests/e2e/account_create_cli_test.go
@@ -38,7 +38,7 @@ import (
 // an HTTP route that strangers can also reach.
 //
 // These scenarios run the real binary as a real process. That is not
-// incidental: what they assert is process behaviour — the exit code an
+// incidental: what they assert is process behavior — the exit code an
 // entrypoint under `set -e` reads, what reaches stdout and stderr, a password
 // arriving on standard input, and a password that must not appear in the
 // argument list. Calling the command in-process would leave every one of those

--- a/tests/e2e/features/account_create_cli.feature
+++ b/tests/e2e/features/account_create_cli.feature
@@ -15,13 +15,24 @@ Feature: Minting an account from the command line
   by that one number. "The account is already there" is the normal state of every
   restart after the first, and must exit 0 and change nothing — including the
   existing account's password, which this command never rewrites, so a rotated
-  variable quietly does nothing rather than locking the instance out of itself. "The
-  store would not open" is a real failure, and must exit non-zero so the boot stops
-  rather than continuing into a half-provisioned instance.
+  variable quietly does nothing rather than locking the instance out of itself. A
+  real failure must exit non-zero so the boot stops rather than continuing into a
+  half-provisioned instance.
 
-  A store that will not open is the only such failure reachable through the real
-  command. The other one the code guards against — password support being
-  unavailable — cannot be produced by any configuration, because the
+  "Already there" is judged by the email, not by how that email signs in. An address
+  that arrived through Google is already a person on this instance, and registering a
+  password identity for it would hand one human two unlinked agents — which nobody
+  would notice, because it can only happen on some later restart after OAuth was
+  added for an address this command had already provisioned.
+
+  Two failures are reachable through the real command, and both are silent-success
+  traps rather than crashes. A store that will not open is the obvious one. The
+  quieter one is a database that was never specified: the command must refuse rather
+  than fall back to a default file, because provisioning "an" instance is meaningless
+  — the whole point is provisioning one particular store, and an instance whose DSN
+  went missing would otherwise report success while its account went somewhere
+  nobody will look. The third failure the code guards against — password support
+  being unavailable — cannot be produced by any configuration, because the
   password-credential repository is wired unconditionally (application/module.go,
   application/auth_providers.go). A scenario for it could only be staged by handing
   the command a deliberately crippled service, which would demonstrate the harness
@@ -93,11 +104,29 @@ Feature: Minting an account from the command line
     And the command reports that the account already exists
     And the store holds exactly one account for "ops@harborlegal.example"
 
+  @wip
+  Scenario: An email that already signs in another way is recognised, not duplicated
+    Given a WeOS store where "ops@harborlegal.example" already signs in through Google
+    When the operator creates an account for "ops@harborlegal.example" with password "correct-horse-battery-staple"
+    Then the command exits successfully
+    And the command reports that the account already exists, naming Google as how it signs in
+    And the store holds exactly one account for "ops@harborlegal.example"
+    And "ops@harborlegal.example" cannot sign in with password "correct-horse-battery-staple"
+
   Scenario: A store that cannot be opened stops the boot
     Given a WeOS store whose database cannot be opened
     When the operator creates an account for "ops@harborlegal.example" with the password supplied through the environment
     Then the command exits with a failure
     And the failure names the database as the reason
+
+  @wip
+  Scenario: An unspecified database stops the boot rather than provisioning somewhere arbitrary
+    Given a WeOS instance with no database configured
+    When the operator creates an account for "ops@harborlegal.example" with the password supplied through the environment
+    Then the command exits with a failure
+    And the failure says no database was specified and names how to supply one
+    And no account is created in any store
+    And the command leaves no database behind in the directory it ran from
 
   Scenario: A missing password creates nothing rather than an account anyone can open
     Given a WeOS store with no accounts, and no server running against it

--- a/tests/e2e/features/account_create_cli.feature
+++ b/tests/e2e/features/account_create_cli.feature
@@ -104,7 +104,6 @@ Feature: Minting an account from the command line
     And the command reports that the account already exists
     And the store holds exactly one account for "ops@harborlegal.example"
 
-  @wip
   Scenario: An email that already signs in another way is recognised, not duplicated
     Given a WeOS store where "ops@harborlegal.example" already signs in through Google
     When the operator creates an account for "ops@harborlegal.example" with password "correct-horse-battery-staple"
@@ -119,7 +118,6 @@ Feature: Minting an account from the command line
     Then the command exits with a failure
     And the failure names the database as the reason
 
-  @wip
   Scenario: An unspecified database stops the boot rather than provisioning somewhere arbitrary
     Given a WeOS instance with no database configured
     When the operator creates an account for "ops@harborlegal.example" with the password supplied through the environment

--- a/tests/e2e/features/account_create_cli.feature
+++ b/tests/e2e/features/account_create_cli.feature
@@ -1,0 +1,141 @@
+@epic-135 @story-137
+Feature: Minting an account from the command line
+  As an operator standing up a WeOS instance
+  I want to create the one account the instance needs from the command line
+  So that minting an account never requires an HTTP route strangers can also reach
+
+  Story #136 closed the registration endpoint by default, which leaves an instance
+  with no way to get its first account. This command is the sanctioned replacement:
+  it opens the store directly, with no server running, and creates the account
+  through the same path the register endpoint used, so an account made this way and
+  one that registered over HTTP are the same thing downstream.
+
+  Its caller is an entrypoint script running under `set -e` on every start and every
+  redeploy, so the exit code carries the meaning. Two conditions must be told apart
+  by that one number. "The account is already there" is the normal state of every
+  restart after the first, and must exit 0 and change nothing — including the
+  existing account's password, which this command never rewrites, so a rotated
+  variable quietly does nothing rather than locking the instance out of itself. "The
+  store would not open" is a real failure, and must exit non-zero so the boot stops
+  rather than continuing into a half-provisioned instance.
+
+  A store that will not open is the only such failure reachable through the real
+  command. The other one the code guards against — password support being
+  unavailable — cannot be produced by any configuration, because the
+  password-credential repository is wired unconditionally (application/module.go,
+  application/auth_providers.go). A scenario for it could only be staged by handing
+  the command a deliberately crippled service, which would demonstrate the harness
+  rather than the product, so that mapping is asserted by a unit test in
+  internal/cli instead. If the wiring ever becomes conditional, the scenario belongs
+  back here.
+
+  The password is the other reason this command exists. It must be able to arrive
+  through a channel that does not put it in shell history or in the process table —
+  the environment, or standard input — and once it arrives, no output, no error
+  report and no log line may repeat it back. The scenarios below therefore assert
+  the password's absence from what the command says as firmly as they assert the
+  account's presence in the store.
+
+  Scenario: An operator mints the instance's first account
+    Given a WeOS store with no accounts, and no server running against it
+    When the operator creates an account for "ops@harborlegal.example" with the password supplied through the environment
+    Then the command exits successfully
+    And the store holds exactly one account for "ops@harborlegal.example"
+
+  Scenario: An account minted from the command line signs in like any other
+    Given a WeOS store with no accounts, and no server running against it
+    And the operator has created an account for "ops@harborlegal.example" with password "correct-horse-battery-staple"
+    When the instance is started with password sign-in enabled
+    And "ops@harborlegal.example" signs in with password "correct-horse-battery-staple"
+    Then the sign-in succeeds
+    And "ops@harborlegal.example" holds an authenticated session
+
+  Scenario: A command-line account and a registered account are alike downstream
+    Given a WeOS store with no accounts, and no server running against it
+    And the operator has created an account for "ops@harborlegal.example" with password "correct-horse-battery-staple"
+    When the instance is started with password sign-in and account registration enabled
+    And "founder@harborlegal.example" registers with password "correct-horse-battery-staple"
+    And both "ops@harborlegal.example" and "founder@harborlegal.example" sign in with password "correct-horse-battery-staple"
+    Then both sign-ins succeed
+    And each of them owns a personal account
+
+  Scenario: An account created without a name is named after its email
+    Given a WeOS store with no accounts, and no server running against it
+    When the operator creates an account for "ops@harborlegal.example" with no display name given
+    Then the command exits successfully
+    And the account for "ops@harborlegal.example" is presented as "ops"
+
+  Scenario: An operator names the account when creating it
+    Given a WeOS store with no accounts, and no server running against it
+    When the operator creates an account for "ops@harborlegal.example" with the display name "Harbor Legal Ops"
+    Then the command exits successfully
+    And the account for "ops@harborlegal.example" is presented as "Harbor Legal Ops"
+
+  Scenario: Creating the same account a second time succeeds and changes nothing
+    Given a WeOS store where the operator has already created the account "ops@harborlegal.example" with password "correct-horse-battery-staple"
+    When the operator creates an account for "ops@harborlegal.example" with password "correct-horse-battery-staple" again
+    Then the command exits successfully
+    And the command reports that the account already exists
+    And the store holds exactly one account for "ops@harborlegal.example"
+    And "ops@harborlegal.example" can sign in with password "correct-horse-battery-staple"
+
+  Scenario: A repeat run is a no-op rather than a password reset
+    Given a WeOS store where the operator has already created the account "ops@harborlegal.example" with password "correct-horse-battery-staple"
+    When the operator creates an account for "ops@harborlegal.example" with password "trellis-anchor-mango-9"
+    Then the command exits successfully
+    And "ops@harborlegal.example" can sign in with password "correct-horse-battery-staple"
+    And "ops@harborlegal.example" cannot sign in with password "trellis-anchor-mango-9"
+
+  Scenario: A repeat run recognises the account whatever the email's capitalisation
+    Given a WeOS store where the operator has already created the account "ops@harborlegal.example" with password "correct-horse-battery-staple"
+    When the operator creates an account for "Ops@HarborLegal.example" with password "correct-horse-battery-staple"
+    Then the command exits successfully
+    And the command reports that the account already exists
+    And the store holds exactly one account for "ops@harborlegal.example"
+
+  Scenario: A store that cannot be opened stops the boot
+    Given a WeOS store whose database cannot be opened
+    When the operator creates an account for "ops@harborlegal.example" with the password supplied through the environment
+    Then the command exits with a failure
+    And the failure names the database as the reason
+
+  Scenario: A missing password creates nothing rather than an account anyone can open
+    Given a WeOS store with no accounts, and no server running against it
+    When the operator creates an account for "ops@harborlegal.example" with no password supplied through any channel
+    Then the command exits with a failure
+    And no account exists for "ops@harborlegal.example"
+
+  Scenario: A password can be handed over on standard input
+    Given a WeOS store with no accounts, and no server running against it
+    When the operator creates an account for "ops@harborlegal.example" with the password supplied on standard input
+    Then the command exits successfully
+    And "ops@harborlegal.example" can sign in with the password that was supplied
+    And the password was never given as a command-line argument
+
+  Scenario: An operator working by hand may still pass the password on the command line
+    Given a WeOS store with no accounts, and no server running against it
+    When the operator creates an account for "ops@harborlegal.example" with the password given on the command line
+    Then the command exits successfully
+    And "ops@harborlegal.example" can sign in with the password that was supplied
+
+  Scenario: A successful run never repeats the password back, even when asked for detail
+    Given a WeOS store with no accounts, and no server running against it
+    And the operator has asked for verbose logging
+    When the operator creates an account for "ops@harborlegal.example" with password "correct-horse-battery-staple" supplied through the environment
+    Then the command exits successfully
+    And the password appears nowhere in what the command printed or logged
+
+  Scenario: A failure report never repeats the password back
+    Given a WeOS store whose database cannot be opened
+    And the operator has asked for verbose logging
+    When the operator creates an account for "ops@harborlegal.example" with password "correct-horse-battery-staple" supplied through the environment
+    Then the command exits with a failure
+    And the password appears nowhere in what the command printed or logged
+
+  Scenario: An account is minted into a store that is already in use
+    Given a WeOS store that already holds the account "founder@harborlegal.example" and a task named "Renew the practice licence"
+    And no server is running against it
+    When the operator creates an account for "ops@harborlegal.example" with password "correct-horse-battery-staple"
+    Then the command exits successfully
+    And the store still holds the account "founder@harborlegal.example" and the task named "Renew the practice licence"
+    And "ops@harborlegal.example" can sign in with password "correct-horse-battery-staple" once the instance is started


### PR DESCRIPTION
Implements **wepala/mini-me-weos#137**, part of epic **wepala/mini-me-weos#135**. Stacked on #466 (story #136) — review that first; this PR's diff is the second commit only.

Cross-repo: the ticket lives in `wepala/mini-me-weos`, and GitHub will not auto-close across repos — close #137 by hand on merge.

## What changed

Story #136 leaves `POST /api/auth/register` unmounted by default, which leaves a fresh instance with no way to get its first account. `account create` is the sanctioned replacement.

- `internal/cli/account.go` — the command. Opens the store directly, no server needed, and registers through the same `RegisterPassword` path the HTTP route used.
- `api/handlers/password_auth_handler.go` — `DefaultDisplayName` extracted and now shared by the CLI and the HTTP handler, so accounts made either way match.
- `internal/cli/account_test.go` — unit tests for the outcome mapping.
- `tests/e2e/` — 15 godog scenarios.

## The exit code is the interface

Story #138 calls this from a Docker `entrypoint.sh` under `set -e`, on every container start and every redeploy. Two outcomes have to be told apart by one number:

| condition | exit | behaviour |
|---|---|---|
| account created | `0` | reports what it made |
| account already exists | `0` | reports it, **changes nothing** |
| store will not open | `1` | stops the boot, names the database |

Verified against the real binary: bad DSN → `1`; first run → `0`; second run → `0` with `Account already exists for …; leaving it unchanged`.

A repeat run deliberately **does not change an existing password**. Rotating the Terraform variable therefore silently does nothing — a property, not an oversight. The email is normalised, so `Ops@HarborLegal.example` recognises an existing `ops@harborlegal.example` rather than minting a second account.

## The password

Channels are `WEOS_ACCOUNT_PASSWORD` (environment) and `--password-stdin`, neither of which reaches the process table or shell history. `--password` also works, for an operator at a terminal, and its help text says it is visible in the process table.

`describeRegisterOutcome` takes the password **only to redact it**. The fallback branch reports whatever a lower layer said went wrong, and that text is not ours to trust — a unit test drives it with a password-bearing error. Enforcing this in the one place that turns outcomes into words beats every layer beneath having to remember.

Probed on the real binary — no leak on any path: unknown flag alongside `--password`, a bad DSN with `--password --verbose`, `--help`, and a missing required flag.

Startup failures are reported as their **root cause** rather than the whole chain. fx names every constructor it could not build, which wrapped one sentence about the file in several hundred characters of dependency graph:

```
before: Error: failed to open the database: could not build arguments for function
        "…".WireResourceWriter (…): failed to build application.ResourceService: could not
        build arguments for function "…".ProvideResourceService (…): … (≈400 more chars)
after:  Error: failed to open the database: unable to open database file: out of memory (14)
```

## On the tests

The acceptance scenarios **run the real binary as a subprocess**. What they assert is process behaviour — the exit code, what reaches stdout, a password arriving on stdin, and a password absent from the argument list — and in-process invocation would leave every one of those claims about something other than what ships.

**One scenario was dropped rather than staged.** `ErrPasswordSupportNotConfigured` is unreachable through the real command: `application/module.go:87` provides the password-credential repository unconditionally and `auth_providers.go:115` requires it. Covering it would have meant handing the command a deliberately crippled service, proving the harness works rather than the product. The mapping is asserted by a unit test instead, and the feature file records why and what would bring the scenario back.

Green: 15 acceptance scenarios, plus `./api/...`, `./internal/...`, `./tests/e2e/...`.

## Downstream

This is what unblocks the provisioning path that #136 closes. See #466's description for the two companion changes that must ship with the consumer bump — the desktop shells and the cloud provisioning flow.

Refs wepala/mini-me-weos#137