### PR TITLE
Story #140: authorize an MCP connector against the instance's own sign-in

### DIFF
--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -291,7 +291,15 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// OAuth 2.1 endpoints for MCP remote auth (unprotected — they handle their own auth).
 	// Registered via e.Pre() so they run before the SPA static middleware,
 	// which would otherwise intercept /.well-known/* and /oauth/* paths.
-	if appCfg.OAuthEnabled() {
+	//
+	// Gated on AuthEnabled rather than OAuthEnabled: this server is the
+	// authorization server, and it can act as one whenever it can authenticate
+	// a resource owner at all — which now includes an instance offering only
+	// password sign-in. Keyed to OAuthEnabled, such an instance mounted none of
+	// these routes, so a connector asking how to authorize against it got the
+	// SPA's static handler instead of the metadata, and could not discover it,
+	// register with it, or authorize at all.
+	if appCfg.AuthEnabled() {
 		clientRepo := weosoauth.NewClientRepository(db)
 		codeRepo := weosoauth.NewAuthCodeRepository(db)
 		refreshRepo := weosoauth.NewRefreshTokenRepository(db)
@@ -306,7 +314,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 		prHandler := weosoauth.ProtectedResourceMetadata(baseURL, defaultResource, knownResources)
 		asHandler := weosoauth.AuthorizationServerMetadata(baseURL, appCfg.OAuth.DynamicRegistration)
 		regHandler := weosoauth.RegisterClient(clientRepo, appCfg.OAuth.DynamicRegistration)
-		authzHandler := weosoauth.Authorize(authService, sessionStore, clientRepo, codeRepo, logger, baseURL)
+		authzHandler := weosoauth.Authorize(authService, sessionManager, sessionStore,
+			clientRepo, codeRepo, accountRepo, logger, baseURL, appCfg.OAuthEnabled())
 		cbHandler := weosoauth.Callback(authService, sessionStore, codeRepo, accountRepo, logger, baseURL, appCfg.OAuth.AllowedEmails)
 		tokHandler := weosoauth.Token(jwtService, codeRepo, refreshRepo, agentRepo, accountRepo, logger)
 

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -315,7 +315,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 		asHandler := weosoauth.AuthorizationServerMetadata(baseURL, appCfg.OAuth.DynamicRegistration)
 		regHandler := weosoauth.RegisterClient(clientRepo, appCfg.OAuth.DynamicRegistration)
 		authzHandler := weosoauth.Authorize(authService, sessionManager, sessionStore,
-			clientRepo, codeRepo, accountRepo, logger, baseURL, appCfg.OAuthEnabled())
+			clientRepo, codeRepo, accountRepo, credentialRepo, logger, baseURL,
+			appCfg.OAuthEnabled(), appCfg.OAuth.AllowedEmails)
 		cbHandler := weosoauth.Callback(authService, sessionStore, codeRepo, accountRepo, logger, baseURL, appCfg.OAuth.AllowedEmails)
 		tokHandler := weosoauth.Token(jwtService, codeRepo, refreshRepo, agentRepo, accountRepo, logger)
 

--- a/internal/oauth/authorize.go
+++ b/internal/oauth/authorize.go
@@ -121,9 +121,11 @@ func Authorize(
 	clientRepo ClientRepository,
 	codeRepo AuthCodeRepository,
 	accountRepo authrepos.AccountRepository,
+	credentialRepo authrepos.CredentialRepository,
 	logger entities.Logger,
 	baseURL string,
 	oauthProviderConfigured bool,
+	allowedEmails []string,
 ) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		clientID := c.QueryParam("client_id")
@@ -192,6 +194,15 @@ func Authorize(
 
 		// Already authenticated? Then there is nobody left to authenticate.
 		if identity := resolveSession(c, sessionManager, authService, accountRepo, logger); identity != nil {
+			// The allowlist decides who may reach this instance, not which door
+			// they came through. It is enforced on the Google path in the
+			// callback, so without this an instance that also offers password
+			// sign-in would hand a code to someone the allowlist excludes —
+			// a way around the gate rather than a second gate.
+			if !sessionAllowed(c, credentialRepo, identity, allowedEmails, logger) {
+				return redirectAuthError(c, redirectURI,
+					"access_denied", "this account is not permitted on this instance", state)
+			}
 			return issueCodeForSession(c, codeRepo, logger, identity, authorizationRequest{
 				clientID:            clientID,
 				redirectURI:         redirectURI,
@@ -385,6 +396,16 @@ func issueCodeForSession(
 		return redirectAuthError(c, req.redirectURI, "server_error", "", req.state)
 	}
 
+	// Bind the identity through the same call the callback uses, which is also
+	// what moves the row from pending to issued. The token endpoint only
+	// accepts issued codes, so a row left pending would be minted, handed over,
+	// and then refused at exchange.
+	if err := codeRepo.UpdateIdentity(ctx, authCode.Code, identity.agentID, identity.accountID); err != nil {
+		logger.Error(ctx, "oauth authorize: identity binding failed",
+			"code_hash", MaskCode(authCode.Code), "error", err)
+		return redirectAuthError(c, req.redirectURI, "server_error", "", req.state)
+	}
+
 	logger.Info(ctx, "oauth authorization code issued from session",
 		"agent", identity.agentID, "client", req.clientID)
 
@@ -400,6 +421,38 @@ func issueCodeForSession(
 	redirectURL.RawQuery = q.Encode()
 
 	return c.Redirect(http.StatusFound, redirectURL.String())
+}
+
+// sessionAllowed applies the instance's identity allowlist to a session-based
+// authorization. An empty allowlist admits everyone, exactly as it does on the
+// Google path.
+func sessionAllowed(
+	c echo.Context,
+	credentialRepo authrepos.CredentialRepository,
+	identity *sessionIdentity,
+	allowedEmails []string,
+	logger entities.Logger,
+) bool {
+	if len(allowedEmails) == 0 {
+		return true
+	}
+	ctx := c.Request().Context()
+	credentials, err := credentialRepo.FindByAgent(ctx, identity.agentID)
+	if err != nil {
+		// Refuse rather than guess: an allowlist that cannot be checked is not
+		// an allowlist that passes.
+		logger.Error(ctx, "oauth authorize: could not read credentials for allowlist check",
+			"agent", identity.agentID, "error", err)
+		return false
+	}
+	for _, credential := range credentials {
+		if emailAllowed(strings.ToLower(credential.Email()), allowedEmails) {
+			return true
+		}
+	}
+	logger.Warn(ctx, "oauth authorize: session refused by the identity allowlist",
+		"agent", identity.agentID)
+	return false
 }
 
 // signInURL points at this instance's own sign-in, carrying the authorization

--- a/internal/oauth/authorize.go
+++ b/internal/oauth/authorize.go
@@ -26,6 +26,8 @@ import (
 	"github.com/wepala/weos/v3/domain/entities"
 
 	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
+	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
+	"github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/session"
 	"github.com/gorilla/sessions"
 	"github.com/labstack/echo/v4"
 )
@@ -86,20 +88,42 @@ func redirectAuthError(c echo.Context, redirectURI, errCode, errDesc, state stri
 	return c.Redirect(http.StatusFound, u.String())
 }
 
+// signInPath is where a person is sent when this instance has to authenticate
+// them itself. It is the SPA's root, which shows whichever sign-in the instance
+// offers — password, OAuth buttons, or both — so this handler never has to know
+// which. returnToParam carries the authorization the sign-in interrupted.
+const signInPath = "/"
+const returnToParam = "return_to"
+
 // Authorize returns a handler for the OAuth authorization endpoint.
 // GET /oauth/authorize
 //
-// This endpoint validates the MCP client's OAuth parameters, creates a pending
-// authorization code, and redirects the user to Google OAuth for authentication.
-// After Google auth completes, the callback handler resolves the identity and
-// redirects back to the MCP client's redirect_uri with an authorization code.
+// It validates the MCP client's OAuth parameters and then establishes who the
+// resource owner is, by whichever means this instance has:
+//
+//   - A request that already carries a valid session needs no further
+//     authentication. The code is issued against that session's identity and
+//     the person goes straight back to the client.
+//   - Otherwise, an instance with an OAuth provider hands off to it, exactly as
+//     before, and the callback finishes the job.
+//   - An instance with no provider sends the person to its own sign-in with a
+//     way back, rather than to a provider it does not have. Without this such an
+//     instance could never complete an authorization at all, however well the
+//     person was signed in to it.
+//
+// What the protocol requires is unchanged on every one of those paths: this
+// decides *who* authenticates the resource owner, not what the client must
+// prove.
 func Authorize(
 	authService authapp.AuthenticationService,
+	sessionManager session.SessionManager,
 	sessionStore sessions.Store,
 	clientRepo ClientRepository,
 	codeRepo AuthCodeRepository,
+	accountRepo authrepos.AccountRepository,
 	logger entities.Logger,
 	baseURL string,
+	oauthProviderConfigured bool,
 ) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		clientID := c.QueryParam("client_id")
@@ -160,6 +184,29 @@ func Authorize(
 		if err := validateScope(scope); err != nil {
 			return redirectAuthError(c, redirectURI,
 				"invalid_scope", err.Error(), state)
+		}
+
+		// Step 3: establish who the resource owner is. Everything the protocol
+		// requires has already been checked above, and stays checked on every
+		// branch below — a session is not a reason to skip the proof key.
+
+		// Already authenticated? Then there is nobody left to authenticate.
+		if identity := resolveSession(c, sessionManager, authService, accountRepo, logger); identity != nil {
+			return issueCodeForSession(c, codeRepo, logger, identity, authorizationRequest{
+				clientID:            clientID,
+				redirectURI:         redirectURI,
+				codeChallenge:       codeChallenge,
+				codeChallengeMethod: codeChallengeMethod,
+				scope:               scope,
+				state:               state,
+			})
+		}
+
+		// No session, and no provider to hand off to: this instance has to
+		// authenticate the person itself. Send them to its own sign-in with a
+		// way back to the authorization they interrupted.
+		if !oauthProviderConfigured {
+			return c.Redirect(http.StatusFound, signInURL(c.Request().URL))
 		}
 
 		// Initiate Google OAuth via pericarp's auth flow.
@@ -230,4 +277,138 @@ func isRedirectURIAllowed(registeredJSON, uri string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// authorizationRequest is the validated request, carried into code issuance so
+// the session path stores exactly what the callback path stores.
+type authorizationRequest struct {
+	clientID            string
+	redirectURI         string
+	codeChallenge       string
+	codeChallengeMethod string
+	scope               string
+	state               string
+}
+
+// sessionIdentity is a resource owner this instance has already authenticated.
+type sessionIdentity struct {
+	agentID   string
+	accountID string
+}
+
+// resolveSession reports who the request is, or nil if it is nobody.
+//
+// The cookie alone is not the answer. GetHTTPSession decodes it and returns
+// whatever it holds — including ExpiresAt, which it does not check — so a
+// session that expired hours ago decodes perfectly well. ValidateSession is
+// what asks the store whether the session is still live, and it is the same
+// pair RequireAuth uses everywhere else in the service. Issuing an
+// authorization code on the strength of the cookie alone would make signing
+// out meaningless for exactly the rail where it matters most.
+//
+// Every failure is "not signed in", deliberately: an unreadable cookie, an
+// expired session and a revoked one are all reasons to authenticate the person
+// again, not reasons to hand the client a server error. Someone whose only
+// mistake was leaving a tab open overnight gets a sign-in page.
+func resolveSession(
+	c echo.Context,
+	sessionManager session.SessionManager,
+	authService authapp.AuthenticationService,
+	accountRepo authrepos.AccountRepository,
+	logger entities.Logger,
+) *sessionIdentity {
+	if sessionManager == nil {
+		return nil
+	}
+	ctx := c.Request().Context()
+	data, err := sessionManager.GetHTTPSession(c.Request())
+	if err != nil || data == nil || data.SessionID == "" {
+		return nil
+	}
+	info, err := authService.ValidateSession(ctx, data.SessionID)
+	if err != nil || info == nil || info.AgentID == "" {
+		return nil
+	}
+
+	accountID := info.AccountID
+	if accountID == "" {
+		accounts, lookupErr := accountRepo.FindByMember(ctx, info.AgentID)
+		if lookupErr != nil {
+			// The session is good; only the account is unknown. Fall through
+			// with none rather than refusing — the callback path tolerates the
+			// same shape.
+			logger.Warn(ctx, "oauth authorize: account lookup failed for session",
+				"agent", info.AgentID, "error", lookupErr)
+		} else if len(accounts) > 0 {
+			accountID = accounts[0].GetID()
+		}
+	}
+	return &sessionIdentity{agentID: info.AgentID, accountID: accountID}
+}
+
+// issueCodeForSession mints an authorization code already bound to an identity
+// and sends the person back to the client with it.
+//
+// This is the callback's tail without the round trip: the same row, in the same
+// issued state, carrying the same proof key and scope. Nothing is written to
+// the OAuth flow session, because there is no flow to resume — the code is
+// complete when it is created.
+func issueCodeForSession(
+	c echo.Context,
+	codeRepo AuthCodeRepository,
+	logger entities.Logger,
+	identity *sessionIdentity,
+	req authorizationRequest,
+) error {
+	ctx := c.Request().Context()
+
+	codeValue, err := generateRandomCode()
+	if err != nil {
+		logger.Error(ctx, "oauth authorize: code generation failed", "error", err)
+		return redirectAuthError(c, req.redirectURI, "server_error", "", req.state)
+	}
+
+	authCode := &OAuthAuthorizationCode{
+		Code:                codeValue,
+		ClientID:            req.clientID,
+		RedirectURI:         req.redirectURI,
+		CodeChallenge:       req.codeChallenge,
+		CodeChallengeMethod: req.codeChallengeMethod,
+		Scope:               req.scope,
+		State:               req.state,
+		AgentID:             identity.agentID,
+		AccountID:           identity.accountID,
+		Status:              StatusPending,
+	}
+	if err := codeRepo.Create(ctx, authCode); err != nil {
+		logger.Error(ctx, "oauth authorize: code persistence failed", "error", err)
+		return redirectAuthError(c, req.redirectURI, "server_error", "", req.state)
+	}
+
+	logger.Info(ctx, "oauth authorization code issued from session",
+		"agent", identity.agentID, "client", req.clientID)
+
+	redirectURL, err := url.Parse(req.redirectURI)
+	if err != nil {
+		return redirectAuthError(c, req.redirectURI, "server_error", "", req.state)
+	}
+	q := redirectURL.Query()
+	q.Set("code", authCode.Code)
+	if req.state != "" {
+		q.Set("state", req.state)
+	}
+	redirectURL.RawQuery = q.Encode()
+
+	return c.Redirect(http.StatusFound, redirectURL.String())
+}
+
+// signInURL points at this instance's own sign-in, carrying the authorization
+// it interrupted so the person can be returned to it once they are known.
+//
+// Relative on purpose: it is the same origin the person is already on, and
+// building it from a configured base URL would send them somewhere else the
+// moment that base URL is wrong.
+func signInURL(authorizeURL *url.URL) string {
+	returnTo := authorizeURL.RequestURI()
+	return signInPath + "?" + returnToParam + "=" + url.QueryEscape(returnTo)
 }

--- a/tests/e2e/features/oauth_authorize_session.feature
+++ b/tests/e2e/features/oauth_authorize_session.feature
@@ -1,0 +1,300 @@
+@epic-135 @story-140
+Feature: Authorizing an MCP connector against the instance's own sign-in
+  As someone looking at a demo WeOS instance
+  I want to add it to my own Claude as an MCP connector
+  So that I can use the instance from my assistant without a Google account and
+  without being on anybody's allowlist
+
+  Today the authorization endpoint has exactly one idea of who the resource
+  owner is: it validates the connector's OAuth parameters and then, always,
+  hands the person to Google. An instance that offers password sign-in and no
+  Google provider therefore cannot complete an authorization at all, however
+  well the person is signed in to it.
+
+  This story changes *who* authenticates the resource owner, and nothing else.
+  A request that already carries a valid session is one whose resource owner has
+  already been authenticated, so the code is minted there and then and the
+  person goes straight back to the connector. A request that carries no session
+  is sent to whatever sign-in this instance has configured, with a way back to
+  the authorization it interrupted — rather than to Google by name.
+
+  Everything the protocol does stays where it is. The connector and its redirect
+  URI are validated first and answered in place, because an unverified redirect
+  URI must not be redirected to; every later error still goes back to the
+  connector as an OAuth error; the proof key must be present and S256; the scope
+  must be one this instance issues; the state comes back untouched. A session
+  changes none of that, which is why several scenarios below pin the protocol
+  *on the session path* specifically. They exist so that a later simplification
+  of the new branch — skipping the proof key because "the person is already
+  signed in" — fails here rather than in the field.
+
+  "A valid session" means one this instance would accept anywhere else: the
+  cookie decodes, and the session it names is live. Three ways it can fail to be
+  valid are staged below — expired, revoked by signing out, and undecodable —
+  because the two wrong answers are both plausible and both bad. Minting a code
+  for a session that has expired would make sign-out meaningless for the rail
+  that matters most; answering with an internal error would strand a person
+  whose only mistake was leaving a tab open overnight. Both must instead be
+  treated as "not signed in".
+
+  The instance that must not regress is the one already in production on the
+  Google path with OAUTH_ALLOWED_EMAILS set. Its authorization still has to
+  reach Google, and its allowlist still has to decide who gets in. Two limits are
+  worth stating. The allowlist gate itself sits in the Google callback, which
+  cannot be driven from here without a real Google — the provider's endpoints
+  are compiled in, not configured — so that gate stays pinned by the unit tests
+  in internal/oauth/callback_test.go, and what these scenarios add is the part
+  that is reachable: an allowlisted instance must not let the *new* path around
+  the allowlist. And the final acceptance criterion, adding the instance in
+  Claude's own connector UI, is manual by nature. What is automated here is
+  everything that UI does over the wire — discovery, dynamic registration,
+  authorization, token exchange, and then listing and calling tools with the
+  token that came out — so a manual pass confirms the UI, not the protocol.
+
+  The instance is a demo: every viewer's Claude connects as the same bootstrap
+  account and they see each other's writes. That is the decided expectation, not
+  an oversight, and the last scenario says so out loud.
+
+  # --- The instance is an authorization server at all ---
+
+  @wip
+  Scenario: A password-only instance tells a connector how to authorize
+    Given a demo instance where password sign-in is enabled, no Google provider is configured, and dynamic client registration is on
+    When a connector asks the instance how to authorize against it
+    Then the instance names itself as the authorization server
+    And it offers to register connectors on the spot
+    And it requires the S256 proof-key method
+
+  @wip
+  Scenario: A connector registers itself on a password-only instance
+    Given a demo instance where password sign-in is enabled, no Google provider is configured, and dynamic client registration is on
+    When Claude registers itself as a connector with the redirect URI "https://claude.ai/api/mcp/auth_callback"
+    Then the registration succeeds
+    And the connector is issued its own client identifier
+    And the redirect URI it registered is the one the instance will send people back to
+
+  @wip
+  Scenario: With dynamic registration off, a connector has no way to register itself
+    Given a demo instance where password sign-in is enabled, no Google provider is configured, and dynamic client registration is off
+    When a connector asks the instance how to authorize against it
+    Then the instance offers no way to register connectors on the spot
+    When Claude registers itself as a connector with the redirect URI "https://claude.ai/api/mcp/auth_callback"
+    Then the registration is refused
+
+  # --- A request that already carries a session ---
+
+  @wip
+  Scenario: A signed-in person's authorization comes straight back to the connector
+    Given a demo instance where password sign-in is enabled and no Google provider is configured
+    And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
+    And Claude is registered as a connector on that instance
+    And the person adding the connector is signed in as "demo@harborlegal.example"
+    When Claude asks the instance to authorize the connector
+    Then the person is sent back to Claude with an authorization code
+    And the state Claude sent is returned with it
+    And the person is never sent to Google
+
+  @wip
+  Scenario: The code from a signed-in authorization exchanges for a working access token
+    Given a demo instance where password sign-in is enabled and no Google provider is configured
+    And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
+    And Claude is registered as a connector on that instance
+    And the person adding the connector is signed in as "demo@harborlegal.example"
+    When Claude asks the instance to authorize the connector
+    And Claude exchanges the authorization code it received, presenting the proof key it started with
+    Then Claude receives an access token
+    And the token is issued for the scope Claude asked for
+
+  @wip
+  Scenario: The access token acts as the account that was signed in
+    Given a demo instance where password sign-in is enabled and no Google provider is configured
+    And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
+    And a second account "counsel@harborlegal.example" with password "trellis-anchor-mango-9"
+    And Claude is registered as a connector on that instance
+    And the person adding the connector is signed in as "counsel@harborlegal.example"
+    When Claude asks the instance to authorize the connector
+    And Claude exchanges the authorization code it received, presenting the proof key it started with
+    Then the access token acts as "counsel@harborlegal.example"
+
+  @wip
+  Scenario: A code minted from a session can only be exchanged once
+    Given a demo instance where password sign-in is enabled and no Google provider is configured
+    And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
+    And Claude is registered as a connector on that instance
+    And the person adding the connector is signed in as "demo@harborlegal.example"
+    When Claude asks the instance to authorize the connector
+    And Claude exchanges the authorization code it received, presenting the proof key it started with
+    And Claude exchanges the same authorization code a second time
+    Then the second exchange is refused
+    And no second access token is issued
+
+  @wip
+  Scenario: A code minted from a session still requires the proof key it was minted with
+    Given a demo instance where password sign-in is enabled and no Google provider is configured
+    And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
+    And Claude is registered as a connector on that instance
+    And the person adding the connector is signed in as "demo@harborlegal.example"
+    When Claude asks the instance to authorize the connector
+    And someone else exchanges the authorization code presenting a proof key of their own
+    Then the exchange is refused
+    And no access token is issued
+
+  @wip
+  Scenario Outline: A signed-in person gets no code for an authorization the protocol rejects
+    Given a demo instance where password sign-in is enabled and no Google provider is configured
+    And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
+    And Claude is registered as a connector on that instance
+    And the person adding the connector is signed in as "demo@harborlegal.example"
+    When Claude asks the instance to authorize the connector <flaw>
+    Then Claude is sent the error "<error>" instead of an authorization code
+    And the state Claude sent is returned with the error
+
+    Examples:
+      | flaw                                          | error                     |
+      | asking for a token rather than a code         | unsupported_response_type |
+      | with no proof key at all                      | invalid_request           |
+      | with an unhashed proof key                    | invalid_request           |
+      | asking for a scope this instance never issues | invalid_scope             |
+
+  @wip
+  Scenario: An unknown connector is refused in place even for a signed-in person
+    Given a demo instance where password sign-in is enabled and no Google provider is configured
+    And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
+    And the person adding the connector is signed in as "demo@harborlegal.example"
+    When a connector the instance has never registered asks it to authorize
+    Then the instance answers the request itself rather than redirecting anywhere
+    And it reports that the client is not one it knows
+    And no authorization code is issued
+
+  @wip
+  Scenario: A redirect URI the connector never registered is refused in place, not redirected to
+    Given a demo instance where password sign-in is enabled and no Google provider is configured
+    And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
+    And Claude is registered as a connector on that instance
+    And the person adding the connector is signed in as "demo@harborlegal.example"
+    When Claude asks the instance to authorize the connector, naming a redirect URI it never registered
+    Then the instance answers the request itself rather than redirecting anywhere
+    And the person is not sent to the unregistered redirect URI
+    And no authorization code is issued
+
+  @wip
+  Scenario: An unknown connector is refused in place rather than sent to sign in
+    Given a demo instance where password sign-in is enabled and no Google provider is configured
+    And the person adding the connector is not signed in
+    When a connector the instance has never registered asks it to authorize
+    Then the instance answers the request itself rather than redirecting anywhere
+    And the person is not sent to a sign-in page
+
+  # --- A request that carries no session ---
+
+  @wip
+  Scenario: An authorization with no session goes to the instance's own sign-in
+    Given a demo instance where password sign-in is enabled and no Google provider is configured
+    And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
+    And Claude is registered as a connector on that instance
+    And the person adding the connector is not signed in
+    When Claude asks the instance to authorize the connector
+    Then the person is sent to a sign-in page on this instance
+    And the person is not sent to Google
+    And Claude is not sent an authorization code
+
+  @wip
+  Scenario: Signing in returns the person to the authorization they interrupted
+    Given a demo instance where password sign-in is enabled and no Google provider is configured
+    And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
+    And Claude is registered as a connector on that instance
+    And the person adding the connector is not signed in
+    And Claude has asked the instance to authorize the connector
+    When the person signs in as "demo@harborlegal.example" and follows the way back they were given
+    Then the person is sent back to Claude with an authorization code
+    And the person is not asked to sign in a second time
+
+  @wip
+  Scenario: An expired session is treated as no session
+    Given a demo instance where password sign-in is enabled and no Google provider is configured
+    And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
+    And Claude is registered as a connector on that instance
+    And the person adding the connector signed in as "demo@harborlegal.example" and their session has since expired
+    When Claude asks the instance to authorize the connector
+    Then the person is sent to a sign-in page on this instance
+    And Claude is not sent an authorization code
+    And the instance does not report a failure of its own
+
+  @wip
+  Scenario: A browser that has signed out is treated as no session
+    Given a demo instance where password sign-in is enabled and no Google provider is configured
+    And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
+    And Claude is registered as a connector on that instance
+    And the person adding the connector signed in as "demo@harborlegal.example" and then signed out, keeping the cookie they were left with
+    When Claude asks the instance to authorize the connector
+    Then the person is sent to a sign-in page on this instance
+    And Claude is not sent an authorization code
+
+  @wip
+  Scenario: A session cookie the instance cannot read is treated as no session
+    Given a demo instance where password sign-in is enabled and no Google provider is configured
+    And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
+    And Claude is registered as a connector on that instance
+    And the person adding the connector carries a session cookie this instance cannot read
+    When Claude asks the instance to authorize the connector
+    Then the person is sent to a sign-in page on this instance
+    And Claude is not sent an authorization code
+    And the instance does not report a failure of its own
+
+  # --- The instance already in production must not regress ---
+
+  @wip
+  Scenario: On a Google instance an unauthenticated authorization still ends at Google
+    Given an instance where Google sign-in is configured and the allowlist names "ops@harborlegal.example"
+    And Claude is registered as a connector on that instance
+    And the person adding the connector is not signed in
+    When Claude asks the instance to authorize the connector
+    Then the person ends up at Google's sign-in
+    And Claude is not sent an authorization code yet
+
+  @wip
+  Scenario: On a Google instance an allowlisted person who is already signed in is not sent to Google again
+    Given an instance where Google sign-in is configured and the allowlist names "ops@harborlegal.example"
+    And Claude is registered as a connector on that instance
+    And the person adding the connector is signed in as "ops@harborlegal.example"
+    When Claude asks the instance to authorize the connector
+    Then the person is sent back to Claude with an authorization code
+    And the person is never sent to Google
+
+  @wip
+  Scenario: An allowlisted instance is not opened up by signing in another way
+    Given an instance where Google sign-in is configured and the allowlist names "ops@harborlegal.example"
+    And password sign-in is also enabled on that instance
+    And the account "stranger@harborlegal.example" with password "correct-horse-battery-staple", whom the allowlist does not name
+    And Claude is registered as a connector on that instance
+    And the person adding the connector is signed in as "stranger@harborlegal.example"
+    When Claude asks the instance to authorize the connector
+    Then Claude is not sent an authorization code
+    And nothing Claude can present afterwards acts as "stranger@harborlegal.example"
+
+  # --- What the connector is for ---
+
+  @wip
+  Scenario: A connector authorized on a password-only instance can list the instance's tools
+    Given a demo instance where password sign-in is enabled and no Google provider is configured
+    And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
+    And Claude has been authorized as a connector by "demo@harborlegal.example" signing in
+    When Claude asks the instance which tools it offers
+    Then the instance lists the tools it offers
+
+  @wip
+  Scenario: A connector authorized on a password-only instance can call a tool
+    Given a demo instance where password sign-in is enabled and no Google provider is configured
+    And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
+    And Claude has been authorized as a connector by "demo@harborlegal.example" signing in
+    When Claude creates the task "File the quarterly compliance report" through the instance's tools
+    Then the task "File the quarterly compliance report" is one of the demo account's tasks
+
+  @wip
+  Scenario: Two people who add the demo connector share the one demo identity
+    Given a demo instance where password sign-in is enabled and no Google provider is configured
+    And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
+    And two people have each authorized their own Claude by signing in as "demo@harborlegal.example"
+    When the first person's Claude creates the task "File the quarterly compliance report" through the instance's tools
+    Then the second person's Claude sees the task "File the quarterly compliance report"
+    And both connectors act as "demo@harborlegal.example"

--- a/tests/e2e/features/oauth_authorize_session.feature
+++ b/tests/e2e/features/oauth_authorize_session.feature
@@ -57,7 +57,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
 
   # --- The instance is an authorization server at all ---
 
-  @wip
   Scenario: A password-only instance tells a connector how to authorize
     Given a demo instance where password sign-in is enabled, no Google provider is configured, and dynamic client registration is on
     When a connector asks the instance how to authorize against it
@@ -65,7 +64,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
     And it offers to register connectors on the spot
     And it requires the S256 proof-key method
 
-  @wip
   Scenario: A connector registers itself on a password-only instance
     Given a demo instance where password sign-in is enabled, no Google provider is configured, and dynamic client registration is on
     When Claude registers itself as a connector with the redirect URI "https://claude.ai/api/mcp/auth_callback"
@@ -73,7 +71,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
     And the connector is issued its own client identifier
     And the redirect URI it registered is the one the instance will send people back to
 
-  @wip
   Scenario: With dynamic registration off, a connector has no way to register itself
     Given a demo instance where password sign-in is enabled, no Google provider is configured, and dynamic client registration is off
     When a connector asks the instance how to authorize against it
@@ -83,7 +80,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
 
   # --- A request that already carries a session ---
 
-  @wip
   Scenario: A signed-in person's authorization comes straight back to the connector
     Given a demo instance where password sign-in is enabled and no Google provider is configured
     And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
@@ -94,7 +90,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
     And the state Claude sent is returned with it
     And the person is never sent to Google
 
-  @wip
   Scenario: The code from a signed-in authorization exchanges for a working access token
     Given a demo instance where password sign-in is enabled and no Google provider is configured
     And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
@@ -105,7 +100,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
     Then Claude receives an access token
     And the token is issued for the scope Claude asked for
 
-  @wip
   Scenario: The access token acts as the account that was signed in
     Given a demo instance where password sign-in is enabled and no Google provider is configured
     And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
@@ -116,7 +110,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
     And Claude exchanges the authorization code it received, presenting the proof key it started with
     Then the access token acts as "counsel@harborlegal.example"
 
-  @wip
   Scenario: A code minted from a session can only be exchanged once
     Given a demo instance where password sign-in is enabled and no Google provider is configured
     And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
@@ -128,7 +121,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
     Then the second exchange is refused
     And no second access token is issued
 
-  @wip
   Scenario: A code minted from a session still requires the proof key it was minted with
     Given a demo instance where password sign-in is enabled and no Google provider is configured
     And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
@@ -139,7 +131,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
     Then the exchange is refused
     And no access token is issued
 
-  @wip
   Scenario Outline: A signed-in person gets no code for an authorization the protocol rejects
     Given a demo instance where password sign-in is enabled and no Google provider is configured
     And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
@@ -156,7 +147,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
       | with an unhashed proof key                    | invalid_request           |
       | asking for a scope this instance never issues | invalid_scope             |
 
-  @wip
   Scenario: An unknown connector is refused in place even for a signed-in person
     Given a demo instance where password sign-in is enabled and no Google provider is configured
     And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
@@ -166,7 +156,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
     And it reports that the client is not one it knows
     And no authorization code is issued
 
-  @wip
   Scenario: A redirect URI the connector never registered is refused in place, not redirected to
     Given a demo instance where password sign-in is enabled and no Google provider is configured
     And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
@@ -177,7 +166,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
     And the person is not sent to the unregistered redirect URI
     And no authorization code is issued
 
-  @wip
   Scenario: An unknown connector is refused in place rather than sent to sign in
     Given a demo instance where password sign-in is enabled and no Google provider is configured
     And the person adding the connector is not signed in
@@ -187,7 +175,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
 
   # --- A request that carries no session ---
 
-  @wip
   Scenario: An authorization with no session goes to the instance's own sign-in
     Given a demo instance where password sign-in is enabled and no Google provider is configured
     And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
@@ -198,7 +185,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
     And the person is not sent to Google
     And Claude is not sent an authorization code
 
-  @wip
   Scenario: Signing in returns the person to the authorization they interrupted
     Given a demo instance where password sign-in is enabled and no Google provider is configured
     And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
@@ -209,7 +195,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
     Then the person is sent back to Claude with an authorization code
     And the person is not asked to sign in a second time
 
-  @wip
   Scenario: An expired session is treated as no session
     Given a demo instance where password sign-in is enabled and no Google provider is configured
     And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
@@ -220,7 +205,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
     And Claude is not sent an authorization code
     And the instance does not report a failure of its own
 
-  @wip
   Scenario: A browser that has signed out is treated as no session
     Given a demo instance where password sign-in is enabled and no Google provider is configured
     And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
@@ -230,7 +214,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
     Then the person is sent to a sign-in page on this instance
     And Claude is not sent an authorization code
 
-  @wip
   Scenario: A session cookie the instance cannot read is treated as no session
     Given a demo instance where password sign-in is enabled and no Google provider is configured
     And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
@@ -243,7 +226,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
 
   # --- The instance already in production must not regress ---
 
-  @wip
   Scenario: On a Google instance an unauthenticated authorization still ends at Google
     Given an instance where Google sign-in is configured and the allowlist names "ops@harborlegal.example"
     And Claude is registered as a connector on that instance
@@ -252,7 +234,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
     Then the person ends up at Google's sign-in
     And Claude is not sent an authorization code yet
 
-  @wip
   Scenario: On a Google instance an allowlisted person who is already signed in is not sent to Google again
     Given an instance where Google sign-in is configured and the allowlist names "ops@harborlegal.example"
     And Claude is registered as a connector on that instance
@@ -261,7 +242,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
     Then the person is sent back to Claude with an authorization code
     And the person is never sent to Google
 
-  @wip
   Scenario: An allowlisted instance is not opened up by signing in another way
     Given an instance where Google sign-in is configured and the allowlist names "ops@harborlegal.example"
     And password sign-in is also enabled on that instance
@@ -274,7 +254,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
 
   # --- What the connector is for ---
 
-  @wip
   Scenario: A connector authorized on a password-only instance can list the instance's tools
     Given a demo instance where password sign-in is enabled and no Google provider is configured
     And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
@@ -282,7 +261,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
     When Claude asks the instance which tools it offers
     Then the instance lists the tools it offers
 
-  @wip
   Scenario: A connector authorized on a password-only instance can call a tool
     Given a demo instance where password sign-in is enabled and no Google provider is configured
     And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"
@@ -290,7 +268,6 @@ Feature: Authorizing an MCP connector against the instance's own sign-in
     When Claude creates the task "File the quarterly compliance report" through the instance's tools
     Then the task "File the quarterly compliance report" is one of the demo account's tasks
 
-  @wip
   Scenario: Two people who add the demo connector share the one demo identity
     Given a demo instance where password sign-in is enabled and no Google provider is configured
     And the bootstrap account "demo@harborlegal.example" with password "correct-horse-battery-staple"

--- a/tests/e2e/oauth_authorize_session_assertions_test.go
+++ b/tests/e2e/oauth_authorize_session_assertions_test.go
@@ -1,0 +1,453 @@
+package e2e
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/cucumber/godog"
+)
+
+// The Then half of story #140's contract. Split from the driving steps so the
+// file that answers "what did the instance do" stays readable next to the one
+// that answers "what did we ask it".
+func registerOAuthAssertions(sc *godog.ScenarioContext, w *oauthWorld) {
+	// --- discovery and registration ---
+	sc.Step(`^the instance names itself as the authorization server$`, w.namesItselfAsAuthorizationServer)
+	sc.Step(`^it offers to register connectors on the spot$`, func() error { return w.offersRegistration(true) })
+	sc.Step(`^the instance offers no way to register connectors on the spot$`, func() error { return w.offersRegistration(false) })
+	sc.Step(`^it requires the S256 proof-key method$`, w.requiresS256)
+	sc.Step(`^the registration succeeds$`, w.registrationSucceeded)
+	sc.Step(`^the registration is refused$`, w.registrationRefused)
+	sc.Step(`^the connector is issued its own client identifier$`, w.issuedAClientID)
+	sc.Step(`^the redirect URI it registered is the one the instance will send people back to$`, w.registeredRedirectURIEchoed)
+
+	// --- where the person ended up ---
+	sc.Step(`^the person is sent back to Claude with an authorization code$`, w.sentBackWithCode)
+	sc.Step(`^the state Claude sent is returned with it$`, func() error { return w.stateReturned() })
+	sc.Step(`^the state Claude sent is returned with the error$`, func() error { return w.stateReturned() })
+	sc.Step(`^the person is never sent to Google$`, w.neverSentToGoogle)
+	sc.Step(`^the person is not sent to Google$`, w.neverSentToGoogle)
+	sc.Step(`^the person ends up at Google's sign-in$`, w.endsUpAtGoogle)
+	sc.Step(`^the person is sent to a sign-in page on this instance$`, w.sentToOwnSignIn)
+	sc.Step(`^the person is not sent to a sign-in page$`, w.notSentToSignIn)
+	sc.Step(`^the person is not asked to sign in a second time$`, w.notAskedToSignInAgain)
+	sc.Step(`^the person is not sent to the unregistered redirect URI$`, w.notSentToUnregisteredURI)
+	sc.Step(`^the instance answers the request itself rather than redirecting anywhere$`, w.answeredInPlace)
+	sc.Step(`^it reports that the client is not one it knows$`, w.reportsUnknownClient)
+	sc.Step(`^Claude is sent the error "([^"]*)" instead of an authorization code$`, w.sentTheError)
+
+	// --- codes and tokens ---
+	sc.Step(`^Claude is not sent an authorization code$`, w.noCodeIssued)
+	sc.Step(`^Claude is not sent an authorization code yet$`, w.noCodeIssued)
+	sc.Step(`^no authorization code is issued$`, w.noCodeIssued)
+	sc.Step(`^Claude receives an access token$`, w.receivedAccessToken)
+	sc.Step(`^the token is issued for the scope Claude asked for$`, w.tokenCarriesScope)
+	sc.Step(`^the access token acts as "([^"]*)"$`, w.tokenActsAs)
+	sc.Step(`^the second exchange is refused$`, w.secondExchangeRefused)
+	sc.Step(`^no second access token is issued$`, w.noSecondToken)
+	sc.Step(`^the exchange is refused$`, w.lastExchangeRefused)
+	sc.Step(`^no access token is issued$`, w.noTokenAtAll)
+	sc.Step(`^nothing Claude can present afterwards acts as "([^"]*)"$`, w.nothingActsAs)
+	sc.Step(`^the instance does not report a failure of its own$`, w.noServerError)
+
+	// --- the connector in use ---
+	sc.Step(`^the instance lists the tools it offers$`, w.listedTools)
+	sc.Step(`^the task "([^"]*)" is one of the demo account's tasks$`, w.taskExists)
+	sc.Step(`^the second person's Claude sees the task "([^"]*)"$`, w.secondPersonSeesTask)
+	sc.Step(`^both connectors act as "([^"]*)"$`, w.bothConnectorsActAs)
+}
+
+// --- discovery and registration ---
+
+func (w *oauthWorld) namesItselfAsAuthorizationServer() error {
+	endpoint, _ := w.discovery["authorization_endpoint"].(string)
+	if endpoint == "" || !strings.Contains(endpoint, "/oauth/authorize") {
+		return fmt.Errorf("the instance did not name its own authorization endpoint: %s", w.last.body)
+	}
+	return nil
+}
+
+func (w *oauthWorld) offersRegistration(expected bool) error {
+	_, present := w.discovery["registration_endpoint"]
+	if present != expected {
+		return fmt.Errorf("expected registration_endpoint present=%v, got %v: %s",
+			expected, present, w.last.body)
+	}
+	return nil
+}
+
+func (w *oauthWorld) requiresS256() error {
+	methods, _ := w.discovery["code_challenge_methods_supported"].([]any)
+	for _, m := range methods {
+		if s, ok := m.(string); ok && s == "S256" {
+			return nil
+		}
+	}
+	return fmt.Errorf("S256 is not among the advertised proof-key methods: %s", w.last.body)
+}
+
+func (w *oauthWorld) registrationSucceeded() error {
+	if w.registered.status != http.StatusOK && w.registered.status != http.StatusCreated {
+		return fmt.Errorf("registration failed: %d %s", w.registered.status, w.registered.body)
+	}
+	return nil
+}
+
+func (w *oauthWorld) registrationRefused() error {
+	if w.registered.status == http.StatusOK || w.registered.status == http.StatusCreated {
+		return fmt.Errorf("expected the registration to be refused, it succeeded: %s", w.registered.body)
+	}
+	return nil
+}
+
+func (w *oauthWorld) issuedAClientID() error {
+	if w.clientID == "" {
+		return fmt.Errorf("no client identifier was issued: %s", w.registered.body)
+	}
+	return nil
+}
+
+func (w *oauthWorld) registeredRedirectURIEchoed() error {
+	if !strings.Contains(w.registered.body, claudeRedirectURI) {
+		return fmt.Errorf("the registration did not echo the redirect URI: %s", w.registered.body)
+	}
+	return nil
+}
+
+// --- where the person ended up ---
+
+func (w *oauthWorld) sentBackWithCode() error {
+	to := w.last.redirectedTo()
+	if to == nil {
+		return fmt.Errorf("the person was not redirected: %d %s", w.last.status, w.last.body)
+	}
+	if !strings.HasPrefix(w.last.location, claudeRedirectURI) {
+		return fmt.Errorf("the person was sent to %q rather than back to the connector", w.last.location)
+	}
+	if to.Query().Get("code") == "" {
+		return fmt.Errorf("no authorization code came back: %s", w.last.location)
+	}
+	return nil
+}
+
+func (w *oauthWorld) stateReturned() error {
+	to := w.last.redirectedTo()
+	if to == nil {
+		return fmt.Errorf("the person was not redirected: %d %s", w.last.status, w.last.body)
+	}
+	if got := to.Query().Get("state"); got != "st-140" {
+		return fmt.Errorf("expected the state to come back as %q, got %q", "st-140", got)
+	}
+	return nil
+}
+
+func (w *oauthWorld) neverSentToGoogle() error {
+	if strings.Contains(w.last.location, "accounts.google.com") {
+		return fmt.Errorf("the person was sent to Google: %s", w.last.location)
+	}
+	return nil
+}
+
+func (w *oauthWorld) endsUpAtGoogle() error {
+	if !strings.Contains(w.last.location, "accounts.google.com") {
+		return fmt.Errorf("expected a hand-off to Google, got: %d %s", w.last.status, w.last.location)
+	}
+	return nil
+}
+
+// sentToOwnSignIn requires a same-origin destination, which is what "on this
+// instance" means: a redirect to somebody else's sign-in would satisfy a looser
+// check and be precisely the bug.
+func (w *oauthWorld) sentToOwnSignIn() error {
+	to := w.last.redirectedTo()
+	if to == nil {
+		return fmt.Errorf("the person was not redirected anywhere: %d %s", w.last.status, w.last.body)
+	}
+	if to.IsAbs() && !strings.HasPrefix(w.last.location, w.server.URL) {
+		return fmt.Errorf("the person was sent off this instance: %s", w.last.location)
+	}
+	if to.Path != "/" {
+		return fmt.Errorf("expected the instance's sign-in, got %q", w.last.location)
+	}
+	if to.Query().Get("return_to") == "" {
+		return fmt.Errorf("the sign-in was given no way back: %s", w.last.location)
+	}
+	return nil
+}
+
+func (w *oauthWorld) notSentToSignIn() error {
+	to := w.last.redirectedTo()
+	if to != nil && to.Path == "/" {
+		return fmt.Errorf("the person was sent to sign in: %s", w.last.location)
+	}
+	return nil
+}
+
+func (w *oauthWorld) notAskedToSignInAgain() error {
+	to := w.last.redirectedTo()
+	if to != nil && to.Path == "/" && to.Query().Get("return_to") != "" {
+		return fmt.Errorf("the person was sent back to sign in a second time: %s", w.last.location)
+	}
+	return nil
+}
+
+func (w *oauthWorld) notSentToUnregisteredURI() error {
+	if strings.Contains(w.last.location, "example.invalid") {
+		return fmt.Errorf("the person was sent to the unregistered redirect URI: %s", w.last.location)
+	}
+	return nil
+}
+
+// answeredInPlace is the RFC 6749 §4.1.2.1 rule: until the redirect URI is
+// known to belong to the client, nothing may be redirected to it.
+func (w *oauthWorld) answeredInPlace() error {
+	if w.last.location != "" {
+		return fmt.Errorf("expected an answer in place, the person was redirected to %q", w.last.location)
+	}
+	if w.last.status < 400 || w.last.status >= 500 {
+		return fmt.Errorf("expected a client error answered in place, got %d: %s", w.last.status, w.last.body)
+	}
+	return nil
+}
+
+func (w *oauthWorld) reportsUnknownClient() error {
+	if !strings.Contains(w.last.body, "invalid_client") {
+		return fmt.Errorf("expected the instance to report an unknown client, it said: %s", w.last.body)
+	}
+	return nil
+}
+
+func (w *oauthWorld) sentTheError(errCode string) error {
+	to := w.last.redirectedTo()
+	if to == nil {
+		return fmt.Errorf("expected the error to go back to the connector, got %d %s", w.last.status, w.last.body)
+	}
+	if got := to.Query().Get("error"); got != errCode {
+		return fmt.Errorf("expected error %q, got %q (%s)", errCode, got, w.last.location)
+	}
+	if to.Query().Get("code") != "" {
+		return fmt.Errorf("an authorization code came back alongside the error: %s", w.last.location)
+	}
+	return nil
+}
+
+// --- codes and tokens ---
+
+func (w *oauthWorld) noCodeIssued() error {
+	if w.code != "" {
+		return fmt.Errorf("an authorization code was issued: %s", w.code)
+	}
+	if to := w.last.redirectedTo(); to != nil && to.Query().Get("code") != "" {
+		return fmt.Errorf("an authorization code came back: %s", w.last.location)
+	}
+	return nil
+}
+
+func (w *oauthWorld) receivedAccessToken() error {
+	if w.accessToken() == "" {
+		return fmt.Errorf("no access token was issued: %v", w.tokens)
+	}
+	return nil
+}
+
+func (w *oauthWorld) tokenCarriesScope() error {
+	for i := len(w.tokens) - 1; i >= 0; i-- {
+		if w.tokenStatus[i] != http.StatusOK {
+			continue
+		}
+		scope, _ := w.tokens[i]["scope"].(string)
+		if scope == "" {
+			return fmt.Errorf("the token carried no scope: %v", w.tokens[i])
+		}
+		for _, want := range []string{"mcp:read", "mcp:write"} {
+			if !strings.Contains(scope, want) {
+				return fmt.Errorf("expected the token's scope to include %q, got %q", want, scope)
+			}
+		}
+		return nil
+	}
+	return fmt.Errorf("no successful token exchange to read a scope from")
+}
+
+// tokenActsAs proves the identity by using the token, not by reading it: a
+// token that decodes to the right agent but is refused by the API would satisfy
+// an inspection and fail the person.
+func (w *oauthWorld) tokenActsAs(email string) error {
+	token := w.accessToken()
+	if token == "" {
+		return fmt.Errorf("no access token to check")
+	}
+	agentID, err := w.agentIDFor(email)
+	if err != nil {
+		return err
+	}
+	if err := w.initializeMCP(token); err != nil {
+		return fmt.Errorf("the token was refused by the instance: %w", err)
+	}
+	if err := w.createTaskWith(token, "identity probe for "+email); err != nil {
+		return err
+	}
+	owner, err := w.lastTaskOwner("identity probe for " + email)
+	if err != nil {
+		return err
+	}
+	if owner != agentID {
+		return fmt.Errorf("the token acted as %q rather than %q (%s)", owner, agentID, email)
+	}
+	return nil
+}
+
+func (w *oauthWorld) secondExchangeRefused() error {
+	if len(w.tokenStatus) < 2 {
+		return fmt.Errorf("expected two exchanges, saw %d", len(w.tokenStatus))
+	}
+	if w.tokenStatus[len(w.tokenStatus)-1] == http.StatusOK {
+		return fmt.Errorf("the second exchange succeeded: %v", w.tokens[len(w.tokens)-1])
+	}
+	return nil
+}
+
+func (w *oauthWorld) noSecondToken() error {
+	issued := 0
+	for _, s := range w.tokenStatus {
+		if s == http.StatusOK {
+			issued++
+		}
+	}
+	if issued > 1 {
+		return fmt.Errorf("expected at most one access token, %d were issued", issued)
+	}
+	return nil
+}
+
+func (w *oauthWorld) lastExchangeRefused() error {
+	if len(w.tokenStatus) == 0 {
+		return fmt.Errorf("no exchange was attempted")
+	}
+	if w.tokenStatus[len(w.tokenStatus)-1] == http.StatusOK {
+		return fmt.Errorf("the exchange succeeded: %v", w.tokens[len(w.tokens)-1])
+	}
+	return nil
+}
+
+func (w *oauthWorld) noTokenAtAll() error {
+	if w.accessToken() != "" {
+		return fmt.Errorf("an access token was issued: %v", w.tokens)
+	}
+	return nil
+}
+
+// nothingActsAs is the allowlist assertion reachable from here: whatever the
+// instance did with the request, no token exists that acts as this person.
+func (w *oauthWorld) nothingActsAs(email string) error {
+	token := w.accessToken()
+	if token == "" {
+		return nil
+	}
+	agentID, err := w.agentIDFor(email)
+	if err != nil {
+		return err
+	}
+	if err := w.initializeMCP(token); err != nil {
+		// The token is refused outright, which is a stronger form of the same
+		// guarantee.
+		return nil
+	}
+	probe := "allowlist probe for " + email
+	if err := w.createTaskWith(token, probe); err != nil {
+		return nil
+	}
+	owner, err := w.lastTaskOwner(probe)
+	if err != nil {
+		return err
+	}
+	if owner == agentID {
+		return fmt.Errorf("a token acting as %q was issued despite the allowlist", email)
+	}
+	return nil
+}
+
+func (w *oauthWorld) noServerError() error {
+	if w.last.status >= 500 {
+		return fmt.Errorf("the instance reported a failure of its own: %d %s", w.last.status, w.last.body)
+	}
+	if to := w.last.redirectedTo(); to != nil && to.Query().Get("error") == "server_error" {
+		return fmt.Errorf("the instance reported server_error: %s", w.last.location)
+	}
+	return nil
+}
+
+// --- the connector in use ---
+
+func (w *oauthWorld) listedTools() error {
+	if !strings.Contains(w.last.body, "resource_create") {
+		return fmt.Errorf("the instance listed no recognizable tools: %s", truncate(w.last.body))
+	}
+	return nil
+}
+
+func (w *oauthWorld) taskExists(name string) error {
+	owner, err := w.lastTaskOwner(name)
+	if err != nil {
+		return err
+	}
+	if owner == "" {
+		return fmt.Errorf("the task %q is not in the store", name)
+	}
+	return nil
+}
+
+func (w *oauthWorld) secondPersonSeesTask(name string) error {
+	if w.secondToken == "" {
+		return fmt.Errorf("the second person has no token")
+	}
+	if err := w.initializeMCP(w.secondToken); err != nil {
+		return fmt.Errorf("the second connector's token was refused: %w", err)
+	}
+	reply, err := w.mcpCall(w.secondToken, "tools/call", map[string]any{
+		"name":      "resource_list",
+		"arguments": map[string]any{"type_slug": "task"},
+	})
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(fmt.Sprintf("%v", reply), name) {
+		return fmt.Errorf("the second connector does not see %q", name)
+	}
+	return nil
+}
+
+func (w *oauthWorld) bothConnectorsActAs(email string) error {
+	agentID, err := w.agentIDFor(email)
+	if err != nil {
+		return err
+	}
+	for label, token := range map[string]string{"the first": w.accessToken(), "the second": w.secondToken} {
+		if token == "" {
+			return fmt.Errorf("%s connector has no token", label)
+		}
+		probe := fmt.Sprintf("shared identity probe %s", label)
+		if err := w.initializeMCP(token); err != nil {
+			return fmt.Errorf("%s connector's token was refused: %w", label, err)
+		}
+		if err := w.createTaskWith(token, probe); err != nil {
+			return err
+		}
+		owner, err := w.lastTaskOwner(probe)
+		if err != nil {
+			return err
+		}
+		if owner != agentID {
+			return fmt.Errorf("%s connector acted as %q rather than %q", label, owner, agentID)
+		}
+	}
+	return nil
+}
+
+func truncate(s string) string {
+	if len(s) <= 300 {
+		return s
+	}
+	return s[:300] + "…"
+}

--- a/tests/e2e/oauth_authorize_session_test.go
+++ b/tests/e2e/oauth_authorize_session_test.go
@@ -420,11 +420,6 @@ func (w *oauthWorld) fetchDiscovery() error {
 
 // --- sessions ---
 
-func (w *oauthWorld) signIn(email, password string) (*http.Response, error) {
-	body, _ := json.Marshal(map[string]string{"email": email, "password": password})
-	return w.client.Post(w.server.URL+"/api/auth/password-login", "application/json", strings.NewReader(string(body)))
-}
-
 // signedInAs gives the person a live session for that account.
 //
 // Deliberately not routed through the password endpoint. How someone signed in

--- a/tests/e2e/oauth_authorize_session_test.go
+++ b/tests/e2e/oauth_authorize_session_test.go
@@ -1,0 +1,903 @@
+package e2e
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wepala/weos/v3/api/handlers"
+	apimw "github.com/wepala/weos/v3/api/middleware"
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/application/presets"
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
+	"github.com/wepala/weos/v3/internal/config"
+	mcpserver "github.com/wepala/weos/v3/internal/mcp"
+	weosoauth "github.com/wepala/weos/v3/internal/oauth"
+
+	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
+	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
+	authhttp "github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/http"
+	"github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/session"
+	"github.com/cucumber/godog"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo/v4"
+	"go.uber.org/fx"
+	gormlib "gorm.io/gorm"
+)
+
+// TestOAuthAuthorizeSession runs the acceptance scenarios for story #140 (epic
+// #135): a connector authorizes against whatever sign-in the instance has,
+// rather than always against Google.
+//
+// Everything here is driven over real HTTP against a real boot, because the
+// story is about redirects, cookies and a token that has to work afterwards —
+// none of which survive being asserted at the function level. The Google
+// scenarios stop at the redirect to accounts.google.com: the provider's
+// endpoints are compiled in rather than configured, so no test can follow the
+// person through Google and back. What matters for the regression is that the
+// hand-off still happens and that the new path does not route around the
+// allowlist, and both are reachable here.
+func TestOAuthAuthorizeSession(t *testing.T) {
+	tags := "~@wip"
+	if override := os.Getenv("GODOG_TAGS"); override != "" {
+		tags = override
+	}
+	suite := godog.TestSuite{
+		Name:                "oauth-authorize-session",
+		ScenarioInitializer: initOAuthAuthorizeScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"features/oauth_authorize_session.feature"},
+			Tags:     tags,
+			Strict:   true,
+			TestingT: t,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("oauth authorize session acceptance scenarios failed")
+	}
+}
+
+const claudeRedirectURI = "https://claude.ai/api/mcp/auth_callback"
+
+// The proof key the scenarios use. Fixed rather than generated so a failure is
+// reproducible, and so "a proof key of their own" is visibly a different one.
+const (
+	claudeVerifier      = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	someoneElseVerifier = "M25iVq8Q9zGRTF4pQhx3Xk7pC2mWvJdT8sYbN5aLcRe"
+)
+
+type authorizeAnswer struct {
+	status   int
+	location string
+	body     string
+}
+
+// redirectedTo reports where the person was sent, parsed, or nil if nowhere.
+func (a authorizeAnswer) redirectedTo() *url.URL {
+	if a.location == "" {
+		return nil
+	}
+	u, err := url.Parse(a.location)
+	if err != nil {
+		return nil
+	}
+	return u
+}
+
+type oauthWorld struct {
+	app    *fx.App
+	tmpDir string
+	server *httptest.Server
+	client *http.Client
+
+	authService     authapp.AuthenticationService
+	sessionManager  session.SessionManager
+	credRepo        authrepos.CredentialRepository
+	agentRepo       authrepos.AgentRepository
+	accountRepo     authrepos.AccountRepository
+	resourceService application.ResourceService
+	logger          entities.Logger
+
+	clientID    string
+	redirectURI string
+
+	last        authorizeAnswer
+	registered  authorizeAnswer
+	discovery   map[string]any
+	code        string
+	tokens      []map[string]any
+	tokenStatus []int
+
+	// secondClient is the other person's Claude in the shared-identity scenario.
+	secondToken string
+
+	mcpSessionID      string
+	mcpInitializedFor string
+}
+
+func initOAuthAuthorizeScenario(sc *godog.ScenarioContext) {
+	w := &oauthWorld{}
+
+	sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		w.teardown()
+		return ctx, nil
+	})
+
+	// --- instance shapes ---
+	sc.Step(`^a demo instance where password sign-in is enabled, no Google provider is configured, and dynamic client registration is (on|off)$`,
+		func(reg string) error { return w.boot(bootOpts{password: true, dynamicRegistration: reg == "on"}) })
+	sc.Step(`^a demo instance where password sign-in is enabled and no Google provider is configured$`,
+		func() error { return w.boot(bootOpts{password: true, dynamicRegistration: true}) })
+	sc.Step(`^an instance where Google sign-in is configured and the allowlist names "([^"]*)"$`,
+		func(email string) error {
+			return w.boot(bootOpts{google: true, allowlist: email, dynamicRegistration: true})
+		})
+	sc.Step(`^password sign-in is also enabled on that instance$`, w.alsoEnablePasswordSignIn)
+
+	// --- accounts ---
+	sc.Step(`^the bootstrap account "([^"]*)" with password "([^"]*)"$`, w.anAccount)
+	sc.Step(`^a second account "([^"]*)" with password "([^"]*)"$`, w.anAccount)
+	sc.Step(`^the account "([^"]*)" with password "([^"]*)", whom the allowlist does not name$`, w.anAccount)
+
+	// --- connector registration ---
+	sc.Step(`^Claude is registered as a connector on that instance$`, w.claudeIsRegistered)
+	sc.Step(`^Claude registers itself as a connector with the redirect URI "([^"]*)"$`, w.claudeRegisters)
+	sc.Step(`^a connector asks the instance how to authorize against it$`, w.fetchDiscovery)
+
+	// --- who the person is ---
+	sc.Step(`^the person adding the connector is signed in as "([^"]*)"$`, w.signedInAs)
+	sc.Step(`^the person adding the connector is not signed in$`, func() error { return nil })
+	sc.Step(`^the person adding the connector signed in as "([^"]*)" and their session has since expired$`, w.signedInWithExpiredSession)
+	sc.Step(`^the person adding the connector signed in as "([^"]*)" and then signed out, keeping the cookie they were left with$`, w.signedInThenSignedOut)
+	sc.Step(`^the person adding the connector carries a session cookie this instance cannot read$`, w.carriesUnreadableCookie)
+
+	// --- authorizing ---
+	sc.Step(`^Claude asks the instance to authorize the connector$`, func() error { return w.authorize(nil) })
+	sc.Step(`^Claude has asked the instance to authorize the connector$`, func() error { return w.authorize(nil) })
+	sc.Step(`^Claude asks the instance to authorize the connector (.+)$`, w.authorizeWithFlaw)
+	sc.Step(`^Claude asks the instance to authorize the connector, naming a redirect URI it never registered$`,
+		func() error { return w.authorize(map[string]string{"redirect_uri": "https://example.invalid/stolen"}) })
+	sc.Step(`^a connector the instance has never registered asks it to authorize$`,
+		func() error { return w.authorize(map[string]string{"client_id": "never-registered"}) })
+	sc.Step(`^the person signs in as "([^"]*)" and follows the way back they were given$`, w.signInThenFollowReturnTo)
+
+	// --- exchanging ---
+	sc.Step(`^Claude exchanges the authorization code it received, presenting the proof key it started with$`,
+		func() error { return w.exchange(claudeVerifier) })
+	sc.Step(`^Claude exchanges the same authorization code a second time$`, func() error { return w.exchange(claudeVerifier) })
+	sc.Step(`^someone else exchanges the authorization code presenting a proof key of their own$`,
+		func() error { return w.exchange(someoneElseVerifier) })
+
+	// --- using the connector ---
+	sc.Step(`^Claude has been authorized as a connector by "([^"]*)" signing in$`, w.authorizedBySigningIn)
+	sc.Step(`^two people have each authorized their own Claude by signing in as "([^"]*)"$`, w.twoPeopleAuthorized)
+	sc.Step(`^Claude asks the instance which tools it offers$`, w.listTools)
+	sc.Step(`^Claude creates the task "([^"]*)" through the instance's tools$`, w.createTask)
+	sc.Step(`^the first person's Claude creates the task "([^"]*)" through the instance's tools$`, w.createTask)
+
+	registerOAuthAssertions(sc, w)
+}
+
+type bootOpts struct {
+	password            bool
+	google              bool
+	allowlist           string
+	dynamicRegistration bool
+}
+
+// boot brings up an instance in the shape the scenario describes and mounts the
+// routes serve.go mounts for it.
+//
+// The mounting is hand-copied from serve.go, which is a known hazard — weos#467
+// tracks extracting the real route table so tests can call it. Until then the
+// pieces that decide this story's behavior are taken from the same constructors
+// serve.go uses, and the one thing that must not drift (whether the OAuth block
+// is mounted at all) is derived from the same cfg.AuthEnabled() call.
+func (w *oauthWorld) boot(opts bootOpts) error {
+	w.teardown()
+	dir, err := os.MkdirTemp("", "weos-oauth-authorize-e2e-")
+	if err != nil {
+		return err
+	}
+	w.tmpDir = dir
+
+	cfg := config.Default()
+	cfg.DatabaseDSN = filepath.Join(dir, "test.db")
+	cfg.LogLevel = "error"
+	// Left at the shipped default on purpose. That default is what makes the
+	// session cookie non-Secure (see serve.go's secureCookies), and this server
+	// speaks plain HTTP — with a "real" secret the cookie is marked Secure, the
+	// client drops it, and every scenario about a signed-in person quietly
+	// becomes a scenario about an anonymous one.
+	cfg.PasswordAuthEnabled = opts.password
+	if opts.google {
+		cfg.OAuth.GoogleClientID = "acceptance-client-id.apps.googleusercontent.com"
+		cfg.OAuth.GoogleClientSecret = "acceptance-client-secret"
+	}
+	if opts.allowlist != "" {
+		cfg.OAuth.AllowedEmails = []string{opts.allowlist}
+	}
+	cfg.OAuth.DynamicRegistration = opts.dynamicRegistration
+	cfg.OAuth.BaseURL = ""
+
+	var resourceTypeService application.ResourceTypeService
+	var kgService application.KnowledgeGraphService
+	var lexicalSearch application.LexicalSearch
+	var episodicRecall application.EpisodicRecall
+	var jwtService authapp.JWTService
+	var sessionStore sessions.Store
+	var db *gormlib.DB
+
+	app := fx.New(
+		fx.NopLogger,
+		application.Module(cfg, presets.NewDefaultRegistry()),
+		fx.Provide(weosoauth.ProvideJWTService),
+		fx.Populate(&w.authService, &w.credRepo, &w.agentRepo, &w.accountRepo),
+		fx.Populate(&w.sessionManager, &sessionStore, &w.logger, &jwtService),
+		fx.Populate(&resourceTypeService, &w.resourceService),
+		fx.Populate(&kgService, &lexicalSearch, &episodicRecall),
+		fx.Populate(&db),
+	)
+	startCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	if err := app.Start(startCtx); err != nil {
+		return fmt.Errorf("failed to start the instance: %w", err)
+	}
+	w.app = app
+
+	if _, err := resourceTypeService.InstallPreset(context.Background(), "tasks", true); err != nil {
+		return fmt.Errorf("failed to install the tasks preset: %w", err)
+	}
+
+	e := echo.New()
+	e.HideBanner = true
+	api := e.Group("/api")
+	api.Use(apimw.Messages())
+
+	handlers.MountPasswordAuth(api, handlers.NewPasswordAuthHandler(handlers.PasswordAuthHandlerConfig{
+		AuthService:    w.authService,
+		SessionManager: w.sessionManager,
+		SecureCookies:  false,
+		Logger:         w.logger,
+	}), handlers.PasswordAuthRoutes{SignIn: cfg.PasswordAuthEnabled, Registration: false})
+
+	// The OAuth 2.1 surface, gated exactly as serve.go gates it.
+	if cfg.AuthEnabled() {
+		clientRepo := weosoauth.NewClientRepository(db)
+		codeRepo := weosoauth.NewAuthCodeRepository(db)
+		refreshRepo := weosoauth.NewRefreshTokenRepository(db)
+		baseURL := "http://" + "127.0.0.1"
+
+		asHandler := weosoauth.AuthorizationServerMetadata(baseURL, cfg.OAuth.DynamicRegistration)
+		regHandler := weosoauth.RegisterClient(clientRepo, cfg.OAuth.DynamicRegistration)
+		authzHandler := weosoauth.Authorize(w.authService, w.sessionManager, sessionStore,
+			clientRepo, codeRepo, w.accountRepo, w.credRepo, w.logger, baseURL,
+			cfg.OAuthEnabled(), cfg.OAuth.AllowedEmails)
+		tokHandler := weosoauth.Token(jwtService, codeRepo, refreshRepo, w.agentRepo, w.accountRepo, w.logger)
+
+		e.Pre(func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) error {
+				p := c.Request().URL.Path
+				m := c.Request().Method
+				switch {
+				case m == http.MethodGet && p == "/.well-known/oauth-authorization-server":
+					return asHandler(c)
+				case m == http.MethodPost && p == "/oauth/register":
+					return regHandler(c)
+				case m == http.MethodGet && p == "/oauth/authorize":
+					return authzHandler(c)
+				case m == http.MethodPost && p == "/oauth/token":
+					return tokHandler(c)
+				default:
+					return next(c)
+				}
+			}
+		})
+
+		// The MCP surface a connector uses afterwards, behind the same bearer
+		// auth serve.go puts in front of it.
+		mcpSrv, mcpErr := mcpserver.NewConfiguredServer(
+			resourceTypeService, w.resourceService, kgService, lexicalSearch, episodicRecall, slog.Default())
+		if mcpErr != nil {
+			return fmt.Errorf("failed to create the MCP server: %w", mcpErr)
+		}
+		mcpHandler := mcpserver.HandlerForServer(mcpSrv, slog.Default())
+		mcpGroup := api.Group("")
+		sessionAuth := authhttp.RequireAuth(w.sessionManager, w.authService)
+		mcpGroup.Use(apimw.BearerOrSession(jwtService, sessionAuth, baseURL))
+		mcpGroup.Any("/mcp", echo.WrapHandler(mcpHandler))
+		mcpGroup.Any("/mcp/*", echo.WrapHandler(mcpHandler))
+	}
+
+	w.server = httptest.NewServer(e)
+	jar, _ := cookiejar.New(nil)
+	// No redirects followed: where the person is sent IS the assertion.
+	w.client = &http.Client{
+		Jar:           jar,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	w.redirectURI = claudeRedirectURI
+	w.tokens = nil
+	w.tokenStatus = nil
+	w.code = ""
+	return nil
+}
+
+// alsoEnablePasswordSignIn rebuilds the Google instance with password sign-in
+// added, which is the shape the "not opened up by another way in" scenario needs.
+func (w *oauthWorld) alsoEnablePasswordSignIn() error {
+	return w.boot(bootOpts{google: true, password: true,
+		allowlist: "ops@harborlegal.example", dynamicRegistration: true})
+}
+
+func (w *oauthWorld) teardown() {
+	if w.server != nil {
+		w.server.Close()
+		w.server = nil
+	}
+	if w.app != nil {
+		stopCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		_ = w.app.Stop(stopCtx)
+		w.app = nil
+	}
+	if w.tmpDir != "" {
+		_ = os.RemoveAll(w.tmpDir)
+		w.tmpDir = ""
+	}
+}
+
+func (w *oauthWorld) anAccount(email, password string) error {
+	local, _, _ := strings.Cut(email, "@")
+	_, _, _, err := w.authService.RegisterPassword(context.Background(), email, local, password)
+	if err != nil {
+		return fmt.Errorf("could not create %q: %w", email, err)
+	}
+	return nil
+}
+
+// --- registration ---
+
+func (w *oauthWorld) claudeRegisters(redirectURI string) error {
+	body, _ := json.Marshal(map[string]any{
+		"redirect_uris": []string{redirectURI}, "client_name": "Claude",
+	})
+	res, err := w.client.Post(w.server.URL+"/oauth/register", "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	raw, _ := io.ReadAll(res.Body)
+	w.registered = authorizeAnswer{status: res.StatusCode, body: string(raw)}
+	var payload struct {
+		ClientID     string   `json:"client_id"`
+		RedirectURIs []string `json:"redirect_uris"`
+	}
+	if json.Unmarshal(raw, &payload) == nil && payload.ClientID != "" {
+		w.clientID = payload.ClientID
+		w.redirectURI = redirectURI
+	}
+	return nil
+}
+
+func (w *oauthWorld) claudeIsRegistered() error {
+	if err := w.claudeRegisters(claudeRedirectURI); err != nil {
+		return err
+	}
+	if w.clientID == "" {
+		return fmt.Errorf("the connector could not register: %s", w.registered.body)
+	}
+	return nil
+}
+
+func (w *oauthWorld) fetchDiscovery() error {
+	res, err := w.client.Get(w.server.URL + "/.well-known/oauth-authorization-server")
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	raw, _ := io.ReadAll(res.Body)
+	w.last = authorizeAnswer{status: res.StatusCode, body: string(raw)}
+	w.discovery = map[string]any{}
+	_ = json.Unmarshal(raw, &w.discovery)
+	return nil
+}
+
+// --- sessions ---
+
+func (w *oauthWorld) signIn(email, password string) (*http.Response, error) {
+	body, _ := json.Marshal(map[string]string{"email": email, "password": password})
+	return w.client.Post(w.server.URL+"/api/auth/password-login", "application/json", strings.NewReader(string(body)))
+}
+
+// signedInAs gives the person a live session for that account.
+//
+// Deliberately not routed through the password endpoint. How someone signed in
+// is not what this story is about, and half these scenarios run on a
+// Google-configured instance where no password route exists — staging it
+// through the store means one step works on every instance shape, and the
+// account is created here if the scenario never named it.
+func (w *oauthWorld) signedInAs(email string) error {
+	ctx := context.Background()
+	creds, err := w.credRepo.FindByEmail(ctx, strings.ToLower(email))
+	if err != nil {
+		return fmt.Errorf("could not look up %q: %w", email, err)
+	}
+	if len(creds) == 0 {
+		if err := w.anAccount(email, passwordFor(email)); err != nil {
+			return err
+		}
+		creds, err = w.credRepo.FindByEmail(ctx, strings.ToLower(email))
+		if err != nil || len(creds) == 0 {
+			return fmt.Errorf("could not create a session identity for %q", email)
+		}
+	}
+	authSession, err := w.authService.CreateSession(ctx, creds[0].AgentID(), creds[0].GetID(),
+		"127.0.0.1", "acceptance", time.Hour)
+	if err != nil {
+		return fmt.Errorf("could not create a session for %q: %w", email, err)
+	}
+	accountID := ""
+	if accounts, lookupErr := w.accountRepo.FindByMember(ctx, creds[0].AgentID()); lookupErr == nil && len(accounts) > 0 {
+		accountID = accounts[0].GetID()
+	}
+	return w.setSessionCookie(session.SessionData{
+		SessionID: authSession.GetID(),
+		AgentID:   creds[0].AgentID(),
+		AccountID: accountID,
+		CreatedAt: time.Now(),
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+}
+
+// signedInWithExpiredSession builds the cookie a person would still be holding
+// after their session lapsed: a real session for a real agent, created already
+// expired, so the cookie decodes and the store refuses it.
+func (w *oauthWorld) signedInWithExpiredSession(email string) error {
+	ctx := context.Background()
+	creds, err := w.credRepo.FindByEmail(ctx, strings.ToLower(email))
+	if err != nil || len(creds) == 0 {
+		return fmt.Errorf("no account for %q to expire", email)
+	}
+	authSession, err := w.authService.CreateSession(ctx, creds[0].AgentID(), creds[0].GetID(),
+		"127.0.0.1", "acceptance", -time.Hour)
+	if err != nil {
+		return fmt.Errorf("could not create an expired session: %w", err)
+	}
+	return w.setSessionCookie(session.SessionData{
+		SessionID: authSession.GetID(),
+		AgentID:   creds[0].AgentID(),
+		CreatedAt: time.Now().Add(-2 * time.Hour),
+		ExpiresAt: time.Now().Add(-time.Hour),
+	})
+}
+
+// signedInThenSignedOut revokes the session server-side while the browser keeps
+// the cookie, which is what signing out on another device looks like here.
+func (w *oauthWorld) signedInThenSignedOut(email string) error {
+	if err := w.signedInAs(email); err != nil {
+		return err
+	}
+	data, err := w.sessionDataFromJar()
+	if err != nil {
+		return err
+	}
+	if err := w.authService.RevokeSession(context.Background(), data.SessionID); err != nil {
+		return fmt.Errorf("could not revoke the session: %w", err)
+	}
+	return nil
+}
+
+func (w *oauthWorld) carriesUnreadableCookie() error {
+	u, _ := url.Parse(w.server.URL)
+	w.client.Jar.SetCookies(u, []*http.Cookie{{
+		Name: "pericarp_session", Value: "not-a-session-this-instance-signed", Path: "/",
+	}})
+	return nil
+}
+
+// setSessionCookie writes a session cookie by round-tripping through the real
+// session manager, so the cookie is signed the way the instance signs them.
+func (w *oauthWorld) setSessionCookie(data session.SessionData) error {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, w.server.URL, nil)
+	if err := w.sessionManager.CreateHTTPSession(rec, req, data); err != nil {
+		return fmt.Errorf("could not build a session cookie: %w", err)
+	}
+	u, _ := url.Parse(w.server.URL)
+	w.client.Jar.SetCookies(u, rec.Result().Cookies())
+	return nil
+}
+
+func (w *oauthWorld) sessionDataFromJar() (*session.SessionData, error) {
+	u, _ := url.Parse(w.server.URL)
+	req := httptest.NewRequest(http.MethodGet, w.server.URL, nil)
+	for _, ck := range w.client.Jar.Cookies(u) {
+		req.AddCookie(ck)
+	}
+	data, err := w.sessionManager.GetHTTPSession(req)
+	if err != nil {
+		return nil, fmt.Errorf("no readable session in the jar: %w", err)
+	}
+	return data, nil
+}
+
+// --- authorizing ---
+
+func challengeFor(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func (w *oauthWorld) authorizeURL(overrides map[string]string) string {
+	q := url.Values{}
+	q.Set("client_id", w.clientID)
+	q.Set("redirect_uri", w.redirectURI)
+	q.Set("response_type", "code")
+	q.Set("code_challenge", challengeFor(claudeVerifier))
+	q.Set("code_challenge_method", "S256")
+	q.Set("state", "st-140")
+	q.Set("scope", "mcp:read mcp:write")
+	for k, v := range overrides {
+		if v == "" {
+			q.Del(k)
+			continue
+		}
+		q.Set(k, v)
+	}
+	return w.server.URL + "/oauth/authorize?" + q.Encode()
+}
+
+func (w *oauthWorld) authorize(overrides map[string]string) error {
+	res, err := w.client.Get(w.authorizeURL(overrides))
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	raw, _ := io.ReadAll(res.Body)
+	w.last = authorizeAnswer{
+		status:   res.StatusCode,
+		location: res.Header.Get("Location"),
+		body:     string(raw),
+	}
+	if to := w.last.redirectedTo(); to != nil {
+		if code := to.Query().Get("code"); code != "" {
+			w.code = code
+		}
+	}
+	return nil
+}
+
+// authorizeWithFlaw maps the outline's plain-English flaw onto the parameter it
+// spoils, so the feature never has to name a query parameter.
+func (w *oauthWorld) authorizeWithFlaw(flaw string) error {
+	switch strings.TrimSpace(flaw) {
+	case "asking for a token rather than a code":
+		return w.authorize(map[string]string{"response_type": "token"})
+	case "with no proof key at all":
+		return w.authorize(map[string]string{"code_challenge": "", "code_challenge_method": ""})
+	case "with an unhashed proof key":
+		return w.authorize(map[string]string{"code_challenge_method": "plain"})
+	case "asking for a scope this instance never issues":
+		return w.authorize(map[string]string{"scope": "mcp:everything"})
+	default:
+		return fmt.Errorf("unknown flaw %q — add it to authorizeWithFlaw", flaw)
+	}
+}
+
+// signInThenFollowReturnTo does what the person does: signs in on the page they
+// were sent to, then follows the way back the instance handed them.
+func (w *oauthWorld) signInThenFollowReturnTo(email string) error {
+	to := w.last.redirectedTo()
+	if to == nil {
+		return fmt.Errorf("the person was not sent anywhere to sign in")
+	}
+	returnTo := to.Query().Get("return_to")
+	if returnTo == "" {
+		return fmt.Errorf("no way back was given: %s", w.last.location)
+	}
+	if err := w.signedInAs(email); err != nil {
+		return err
+	}
+	res, err := w.client.Get(w.server.URL + returnTo)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	raw, _ := io.ReadAll(res.Body)
+	w.last = authorizeAnswer{status: res.StatusCode, location: res.Header.Get("Location"), body: string(raw)}
+	if t := w.last.redirectedTo(); t != nil {
+		if code := t.Query().Get("code"); code != "" {
+			w.code = code
+		}
+	}
+	return nil
+}
+
+// --- exchanging ---
+
+func (w *oauthWorld) exchange(verifier string) error {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", w.code)
+	form.Set("redirect_uri", w.redirectURI)
+	form.Set("client_id", w.clientID)
+	form.Set("code_verifier", verifier)
+	res, err := w.client.PostForm(w.server.URL+"/oauth/token", form)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	raw, _ := io.ReadAll(res.Body)
+	payload := map[string]any{}
+	_ = json.Unmarshal(raw, &payload)
+	w.tokens = append(w.tokens, payload)
+	w.tokenStatus = append(w.tokenStatus, res.StatusCode)
+	return nil
+}
+
+func (w *oauthWorld) accessToken() string {
+	for i := len(w.tokens) - 1; i >= 0; i-- {
+		if w.tokenStatus[i] == http.StatusOK {
+			if tok, ok := w.tokens[i]["access_token"].(string); ok {
+				return tok
+			}
+		}
+	}
+	return ""
+}
+
+// authorizedBySigningIn runs the whole flow a connector runs, ending with a
+// usable token.
+func (w *oauthWorld) authorizedBySigningIn(email string) error {
+	if err := w.claudeIsRegistered(); err != nil {
+		return err
+	}
+	if err := w.signedInAs(email); err != nil {
+		return err
+	}
+	if err := w.authorize(nil); err != nil {
+		return err
+	}
+	if w.code == "" {
+		return fmt.Errorf("no authorization code was issued: %s %s", w.last.location, w.last.body)
+	}
+	return w.exchange(claudeVerifier)
+}
+
+func (w *oauthWorld) twoPeopleAuthorized(email string) error {
+	if err := w.authorizedBySigningIn(email); err != nil {
+		return err
+	}
+	first := w.accessToken()
+	if first == "" {
+		return fmt.Errorf("the first connector got no token")
+	}
+	// The second person is a different browser: a fresh jar, its own sign-in,
+	// its own authorization, against the same account.
+	jar, _ := cookiejar.New(nil)
+	w.client.Jar = jar
+	w.code = ""
+	if err := w.signedInAs(email); err != nil {
+		return err
+	}
+	if err := w.authorize(nil); err != nil {
+		return err
+	}
+	if err := w.exchange(claudeVerifier); err != nil {
+		return err
+	}
+	w.secondToken = w.accessToken()
+	if w.secondToken == "" {
+		return fmt.Errorf("the second connector got no token")
+	}
+	// Keep the first person's token as the one the "creates the task" step uses.
+	w.tokens = append(w.tokens, map[string]any{"access_token": first})
+	w.tokenStatus = append(w.tokenStatus, http.StatusOK)
+	return nil
+}
+
+// --- the MCP surface ---
+
+func (w *oauthWorld) mcpCall(token, method string, params any) (map[string]any, error) {
+	payload := map[string]any{"jsonrpc": "2.0", "id": 1, "method": method}
+	if params != nil {
+		payload["params"] = params
+	}
+	return w.mcpSend(token, payload, true)
+}
+
+// mcpNotify sends a notification — no id, and no reply expected. The transport
+// requires "initialized" before it will accept anything but the handshake.
+func (w *oauthWorld) mcpNotify(token, method string) error {
+	_, err := w.mcpSend(token, map[string]any{"jsonrpc": "2.0", "method": method}, false)
+	return err
+}
+
+func (w *oauthWorld) mcpSend(token string, payload map[string]any, wantReply bool) (map[string]any, error) {
+	body, _ := json.Marshal(payload)
+	req, _ := http.NewRequest(http.MethodPost, w.server.URL+"/api/mcp", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Authorization", "Bearer "+token)
+	// The streamable transport hands out a session id on initialize and expects
+	// it back on every later call; without it each request looks like a brand
+	// new, uninitialized session.
+	if w.mcpSessionID != "" {
+		req.Header.Set("Mcp-Session-Id", w.mcpSessionID)
+	}
+	res, err := w.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	raw, _ := io.ReadAll(res.Body)
+	if id := res.Header.Get("Mcp-Session-Id"); id != "" {
+		w.mcpSessionID = id
+	}
+	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusAccepted {
+		return nil, fmt.Errorf("MCP call %v: %d %s", payload["method"], res.StatusCode, raw)
+	}
+	if !wantReply {
+		return nil, nil
+	}
+	reply, err := decodeMCPBody(raw)
+	if err != nil {
+		return nil, err
+	}
+	if errObj, ok := reply["error"]; ok {
+		return nil, fmt.Errorf("MCP call %v failed: %v", payload["method"], errObj)
+	}
+	return reply, nil
+}
+
+// decodeMCPBody reads either a plain JSON-RPC reply or the SSE framing the
+// streamable transport uses, so the step never has to care which it got.
+func decodeMCPBody(raw []byte) (map[string]any, error) {
+	text := string(raw)
+	out := map[string]any{}
+	if json.Unmarshal(raw, &out) == nil {
+		return out, nil
+	}
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		if json.Unmarshal([]byte(strings.TrimSpace(strings.TrimPrefix(line, "data:"))), &out) == nil {
+			return out, nil
+		}
+	}
+	return nil, fmt.Errorf("could not read the MCP reply: %s", text)
+}
+
+// initializeMCP performs the handshake the transport requires before any other
+// call is accepted.
+func (w *oauthWorld) initializeMCP(token string) error {
+	if w.mcpInitializedFor == token {
+		return nil
+	}
+	w.mcpSessionID = ""
+	if _, err := w.mcpCall(token, "initialize", map[string]any{
+		"protocolVersion": "2025-03-26",
+		"capabilities":    map[string]any{},
+		"clientInfo":      map[string]any{"name": "acceptance", "version": "1"},
+	}); err != nil {
+		return err
+	}
+	if err := w.mcpNotify(token, "notifications/initialized"); err != nil {
+		return err
+	}
+	w.mcpInitializedFor = token
+	return nil
+}
+
+func (w *oauthWorld) listTools() error {
+	token := w.accessToken()
+	if token == "" {
+		return fmt.Errorf("the connector has no access token")
+	}
+	if err := w.initializeMCP(token); err != nil {
+		return err
+	}
+	reply, err := w.mcpCall(token, "tools/list", map[string]any{})
+	if err != nil {
+		return err
+	}
+	w.last = authorizeAnswer{status: http.StatusOK, body: fmt.Sprintf("%v", reply)}
+	return nil
+}
+
+func (w *oauthWorld) createTask(name string) error {
+	token := w.accessToken()
+	if token == "" {
+		return fmt.Errorf("the connector has no access token")
+	}
+	if err := w.initializeMCP(token); err != nil {
+		return err
+	}
+	args, _ := json.Marshal(map[string]any{"name": name, "status": "open", "priority": "medium"})
+	reply, err := w.mcpCall(token, "tools/call", map[string]any{
+		"name":      "resource_create",
+		"arguments": map[string]any{"type_slug": "task", "data": json.RawMessage(args)},
+	})
+	if err != nil {
+		return err
+	}
+	w.last = authorizeAnswer{status: http.StatusOK, body: fmt.Sprintf("%v", reply)}
+	return nil
+}
+
+// passwordFor maps the accounts the feature names to the passwords it gave
+// them, so a sign-in step doesn't have to repeat the password every time.
+func passwordFor(email string) string {
+	switch email {
+	case "counsel@harborlegal.example":
+		return "trellis-anchor-mango-9"
+	default:
+		return "correct-horse-battery-staple"
+	}
+}
+
+// agentIDFor resolves the agent behind an email, so an identity assertion can
+// compare what the token did against who it claims to be.
+func (w *oauthWorld) agentIDFor(email string) (string, error) {
+	creds, err := w.credRepo.FindByEmail(context.Background(), strings.ToLower(email))
+	if err != nil {
+		return "", fmt.Errorf("could not look up %q: %w", email, err)
+	}
+	if len(creds) == 0 {
+		return "", fmt.Errorf("no account for %q", email)
+	}
+	return creds[0].AgentID(), nil
+}
+
+// createTaskWith creates a task as whoever the given token is.
+func (w *oauthWorld) createTaskWith(token, name string) error {
+	args, _ := json.Marshal(map[string]any{"name": name, "status": "open", "priority": "medium"})
+	_, err := w.mcpCall(token, "tools/call", map[string]any{
+		"name":      "resource_create",
+		"arguments": map[string]any{"type_slug": "task", "data": json.RawMessage(args)},
+	})
+	return err
+}
+
+// lastTaskOwner reports which agent owns the named task, read from the store
+// rather than from the reply — the question is what was persisted, and by whom.
+func (w *oauthWorld) lastTaskOwner(name string) (string, error) {
+	page, err := w.resourceService.List(context.Background(), "task", "", 200, repositories.SortOptions{})
+	if err != nil {
+		return "", fmt.Errorf("could not list tasks: %w", err)
+	}
+	for _, resource := range page.Data {
+		var payload struct {
+			Graph []struct {
+				Name string `json:"name"`
+			} `json:"@graph"`
+		}
+		if json.Unmarshal(resource.Data(), &payload) != nil {
+			continue
+		}
+		for _, node := range payload.Graph {
+			if node.Name == name {
+				return resource.CreatedBy(), nil
+			}
+		}
+	}
+	return "", nil
+}


### PR DESCRIPTION
Implements **wepala/mini-me-weos#140**, the last story of epic **wepala/mini-me-weos#135**. Builds on #466 and #468, both merged.

Cross-repo: the ticket lives in `wepala/mini-me-weos`; GitHub won't auto-close across repos, so close #140 by hand on merge.

## What changed

The authorization endpoint had one idea of who the resource owner is: validate the connector's parameters, then hand the person to Google, always. An instance offering password sign-in and no Google provider could not complete an authorization at all, however well the person was signed in to it.

It now establishes the resource owner by whatever means the instance has:

| request | what happens |
|---|---|
| already carries a valid session | code issued against that identity, straight back to the connector |
| no session, provider configured | hands off to the provider — **unchanged** |
| no session, no provider | the instance's own sign-in, carrying the authorization it interrupted |

**A second obstacle wasn't in the ticket.** The whole OAuth 2.1 block was mounted behind `OAuthEnabled()`, which is false on a password-only instance — so it registered no metadata document, no registration endpoint, no authorize endpoint. A connector asking how to authorize got the SPA's static handler instead. Measured before the change: `/.well-known/oauth-authorization-server` returned the SPA placeholder on a password-only instance and real metadata on a Google one. It's now gated on `AuthEnabled()`, because this server can act as an authorization server whenever it can authenticate a resource owner at all.

## Two defects the harness found

Both were in the first commit, and both look correct until something drives them.

**The identity allowlist was bypassable.** It's enforced in the Google callback, so a code minted from a session never met it — on an instance with both Google and password sign-in, someone the allowlist excludes could sign in with a password and get a code anyway. That's a way *around* the gate, not a second gate. The session path now applies the same allowlist and refuses with `access_denied`; an allowlist that can't be read refuses rather than guesses.

**The code was minted in the wrong state.** The token endpoint only accepts `issued` codes, and the callback reaches that state via `UpdateIdentity`. Creating the row and stopping left it `pending`, so the person got a code the instance would then refuse. Binding now goes through the same `UpdateIdentity` call.

## On "a valid session"

`GetHTTPSession` decodes the cookie and returns what it holds — including an `ExpiresAt` it **never checks** — so a session that expired hours ago decodes perfectly well. `ValidateSession` is what asks whether it's still live, and pairing them is what `RequireAuth` does everywhere else. Issuing a code on the cookie alone would have made signing out meaningless for exactly the rail where it matters most.

Expired, revoked and unreadable are all "not signed in" rather than server errors: someone whose only mistake was leaving a tab open overnight gets a sign-in page.

## Protocol unchanged

Client and redirect-URI validation still come first and are still answered **in place**, because an unverified redirect URI must not be redirected to (RFC 6749 §4.1.2.1). The proof key, its method, the scope and the state are all still required before any of this. Several scenarios pin those *on the session path* specifically, so a later "simplification" that skips PKCE because the person is already signed in fails here rather than in the field.

## Tests

26 scenarios, all green, plus `./api/...`, `./internal/...`, `./tests/e2e/...`.

Three harness decisions worth knowing, each because the obvious alternative passes while proving nothing:

- It keeps the **shipped `SESSION_SECRET`** — that default is what leaves the session cookie non-`Secure`. With a "real" secret over plain HTTP the client drops the cookie and every signed-in scenario silently becomes an anonymous one. (This cost me a debugging round.)
- It **stages sessions through the store**, not the password endpoint, since half the scenarios run on a Google instance where no password route exists.
- It proves identity by **using** the token and reading back who owns what was written, not by inspecting the token. One that decodes correctly and is refused by the API would satisfy an inspection and fail the person.

The Google scenarios stop at the redirect to `accounts.google.com` — the provider's endpoints are compiled in rather than configured, so nothing can follow the person through Google and back. What's reachable, and asserted, is that the hand-off still happens and that the new path doesn't route around the allowlist.

## Not covered here

Adding the instance in Claude's connector UI is manual by nature. Everything that UI does over the wire is automated — discovery, registration, authorization, token exchange, tools/list and tools/call — so a manual pass confirms the UI, not the protocol.

**The SPA must honour `return_to`** to close the loop: core redirects an unauthenticated authorize to `/?return_to=<the authorization>`, and without frontend support the person signs in, lands on the dashboard, and has to start again. Degraded, not broken. That's fork-side work (mini-me-weos, and finexity if it wants the same).

Refs wepala/mini-me-weos#140