### PR TITLE
chore: record oxigraph as a direct dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.4
 
 require (
 	cloud.google.com/go/storage v1.62.1
+	github.com/akeemphilbert/oxigraph/go v0.1.0-alpha.3
 	github.com/akeemphilbert/pericarp v1.0.0-beta.2
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.25
@@ -42,7 +43,6 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
-	github.com/akeemphilbert/oxigraph/go v0.1.0-alpha.3 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.24 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.34 // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,6 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/akeemphilbert/oxigraph/go v0.1.0-alpha.2 h1:T1z0dVACQ2tX8iWDJy7Z55WuFEgZdzbKJijfy0W7oX4=
-github.com/akeemphilbert/oxigraph/go v0.1.0-alpha.2/go.mod h1:8Z3D7uFH5sWGcZ04INK5G7gj31O8qOEqVmyDCSXtI+E=
 github.com/akeemphilbert/oxigraph/go v0.1.0-alpha.3 h1:DinV1OUkoXnHUpRJEJeiag0vqvIiKRMKKsYwcqGExH4=
 github.com/akeemphilbert/oxigraph/go v0.1.0-alpha.3/go.mod h1:8Z3D7uFH5sWGcZ04INK5G7gj31O8qOEqVmyDCSXtI+E=
 github.com/akeemphilbert/pericarp v1.0.0-beta.2 h1:n3NA/fGLSpK3/jYYz6sVbVTImQeFkHL0Rbx6j3+K9DE=


### PR DESCRIPTION
## What

`go mod tidy` output. Moves `github.com/akeemphilbert/oxigraph/go` from the
indirect require block to the direct one, and drops the stale
`v0.1.0-alpha.2` hashes from `go.sum`.

## Why

`infrastructure/graph/oxigraph/embedded.go:26` imports the module directly:

```go
oxidb "github.com/akeemphilbert/oxigraph/go"
```

A directly imported module should not be marked `// indirect`. The
`v0.1.0-alpha.2` hashes in `go.sum` are no longer referenced by anything.

## Not in this change

No version bump — the module stays on `v0.1.0-alpha.3`. No code changes.

## Verification

`go build ./...` passes. `golangci-lint run` reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)