### PR TITLE
A feature is declared once and resolved through OpenFeature

### DIFF
--- a/api/handlers/user_handler.go
+++ b/api/handlers/user_handler.go
@@ -21,6 +21,7 @@ import (
 
 	apimw "github.com/wepala/weos/v3/api/middleware"
 	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
 
 	authentities "github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
 	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
@@ -31,6 +32,7 @@ type UserHandler struct {
 	agentRepo      authrepos.AgentRepository
 	credentialRepo authrepos.CredentialRepository
 	accountRepo    authrepos.AccountRepository
+	features       repositories.FeatureCacheInvalidator
 	logger         entities.Logger
 }
 
@@ -38,7 +40,11 @@ type UserHandlerConfig struct {
 	AgentRepo      authrepos.AgentRepository
 	CredentialRepo authrepos.CredentialRepository
 	AccountRepo    authrepos.AccountRepository
-	Logger         entities.Logger
+	// Features drops a member's resolved feature set when their role changes.
+	// Optional: a handler constructed without one simply does not invalidate,
+	// which keeps existing test constructions working.
+	Features repositories.FeatureCacheInvalidator
+	Logger   entities.Logger
 }
 
 func NewUserHandler(cfg UserHandlerConfig) *UserHandler {
@@ -46,6 +52,7 @@ func NewUserHandler(cfg UserHandlerConfig) *UserHandler {
 		agentRepo:      cfg.AgentRepo,
 		credentialRepo: cfg.CredentialRepo,
 		accountRepo:    cfg.AccountRepo,
+		features:       cfg.Features,
 		logger:         cfg.Logger,
 	}
 }
@@ -154,6 +161,16 @@ func (h *UserHandler) Update(c echo.Context) error {
 		if err := h.accountRepo.SaveMember(ctx, accountID, id, req.Role); err != nil {
 			h.logger.Error(ctx, "failed to save user role", "error", err, "user_id", id)
 			return respondError(c, http.StatusInternalServerError, "failed to update user role")
+		}
+		// A role change changes what features this person resolves, because a
+		// feature can be granted to a role. SaveMember writes the projection
+		// directly and emits no event, so nothing else would ever notice —
+		// this is the one invalidation call site outside FeatureService, and
+		// without it the person keeps their old access until the cache ages
+		// out. Dropping their resolved set does not sign them out; their next
+		// evaluation costs one database read.
+		if h.features != nil {
+			h.features.InvalidateAgents(ctx, accountID, id)
 		}
 	}
 

--- a/application/feature_invalidation.go
+++ b/application/feature_invalidation.go
@@ -1,0 +1,79 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"context"
+
+	"go.uber.org/fx"
+	"gorm.io/gorm"
+
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
+	"github.com/wepala/weos/v3/infrastructure/features"
+	"github.com/wepala/weos/v3/internal/config"
+)
+
+// ProvideFeatureCacheInvalidator selects how invalidations travel, following
+// the same shape as the knowledge-graph store's provider: choose at boot from
+// configuration, and degrade with one logged error rather than failing the
+// boot.
+//
+// On SQLite the resolver's own in-process eviction is returned directly. That
+// is not a fallback or a reduced mode — SQLite is single-process with
+// serialized writers, so there is no second cache in existence to reach, and
+// local eviction is complete and exact.
+//
+// On Postgres the resolver is wrapped with a LISTEN/NOTIFY broadcast, because
+// Postgres is the only deployment that can have replicas. If the listener
+// cannot be established the instance says so once and keeps the in-process
+// invalidator: still correct locally, and other replicas converge when their
+// cached sets reach the maximum age. It never degrades to doing nothing, which
+// would break the rule that a change reaches sessions already open.
+func ProvideFeatureCacheInvalidator(
+	cfg config.Config,
+	resolver *FeatureResolver,
+	db *gorm.DB,
+	logger entities.Logger,
+	lc fx.Lifecycle,
+) repositories.FeatureCacheInvalidator {
+	if !cfg.IsPostgres() {
+		return resolver
+	}
+
+	notifier := features.NewNotifyInvalidator(resolver, db, cfg.Features.NotifyChannel, logger)
+
+	listenCtx, stopListening := context.WithCancel(context.Background())
+	lc.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			go func() {
+				if err := notifier.Listen(listenCtx, cfg.DatabaseDSN); err != nil && listenCtx.Err() == nil {
+					logger.Error(listenCtx,
+						"the feature-cache listener stopped; this replica will converge only "+
+							"when its cached sets reach the maximum age",
+						"error", err)
+				}
+			}()
+			return nil
+		},
+		OnStop: func(ctx context.Context) error {
+			stopListening()
+			return nil
+		},
+	})
+
+	return notifier
+}

--- a/application/feature_provider.go
+++ b/application/feature_provider.go
@@ -17,6 +17,7 @@ package application
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -194,4 +195,25 @@ func (p *FeatureProvider) log(ctx context.Context, msg string, kv ...any) {
 		return
 	}
 	p.logger.Warn(ctx, msg, kv...)
+}
+
+// RegisterFeatureProvider binds the provider to its OpenFeature domain and
+// returns a client for it.
+//
+// This is wired as an fx.Invoke rather than left to a consumer, and that is
+// load-bearing: fx is lazy, so a provider that nothing depends on is never
+// constructed. Before this existed the provider was built only by tests that
+// populated it directly, the "weos" domain fell through to the SDK's no-op
+// provider in the real server, and every evaluation returned the caller's
+// default — the whole subsystem inert in the shipped binary while every test
+// passed.
+func RegisterFeatureProvider(p *FeatureProvider, logger entities.Logger) (*openfeature.Client, error) {
+	if err := openfeature.SetNamedProviderAndWait(FeatureProviderDomain, p); err != nil {
+		return nil, fmt.Errorf("failed to register the feature provider: %w", err)
+	}
+	if logger != nil {
+		logger.Debug(context.Background(), "feature provider registered",
+			"domain", FeatureProviderDomain, "provider", featureProviderName)
+	}
+	return openfeature.NewClient(FeatureProviderDomain), nil
 }

--- a/application/feature_provider.go
+++ b/application/feature_provider.go
@@ -113,14 +113,17 @@ func (p *FeatureProvider) BooleanEvaluation(
 		// Fail closed. Not the caller's default — off. A resolver that
 		// answered "on" while the store was unreadable would hand out the
 		// capability at exactly the moment nobody could see why.
+		//
+		// Reason is ERROR so hooks and telemetry see the failure, but NO
+		// ResolutionError is attached, and that is deliberate. The OpenFeature
+		// client treats a resolution error as "fall back to the caller's
+		// default", which would hand `true` to any call site that passed
+		// `true` — the exact opposite of failing closed, and invisible to a
+		// unit test that calls this provider directly instead of going through
+		// the client. The failure is surfaced through the log line below
+		// rather than through a mechanism that would overrule the value.
 		p.log(ctx, "feature evaluation failed, answering off", "feature", key, "error", err)
-		return openfeature.BoolResolutionDetail{
-			Value: false,
-			ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
-				Reason:          openfeature.ErrorReason,
-				ResolutionError: openfeature.NewGeneralResolutionError(err.Error()),
-			},
-		}
+		return boolDetail(false, openfeature.ErrorReason)
 	case !declared:
 		// Registry drift: a call site and the declarations disagree. The
 		// caller gets what it asked for, and the instance says so once.

--- a/application/feature_provider.go
+++ b/application/feature_provider.go
@@ -1,0 +1,194 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/open-feature/go-sdk/openfeature"
+
+	"github.com/wepala/weos/v3/domain/entities"
+)
+
+// FeatureFlagPrefix is the key namespace this provider answers. Call sites ask
+// for a feature as:
+//
+//	client.Boolean(ctx, application.FeatureFlagPrefix+"episodic-recall", false, evalCtx)
+//
+// A key outside the namespace falls through with the caller's own default and
+// reason DEFAULT, so another provider can be composed alongside this one
+// without either surprising the other. Apollo's entitlement provider uses the
+// same convention on the "entitlement." prefix.
+const FeatureFlagPrefix = "feature."
+
+// featureProviderName appears in OpenFeature metadata and in any hook
+// telemetry. Stable as an operations contract.
+const featureProviderName = "weos-features"
+
+// FeatureProviderDomain is the OpenFeature domain this provider binds to.
+//
+// Bound to a named domain rather than the global provider slot on purpose. The
+// global slot is process-wide mutable state, and the godog suites each boot
+// their own fx application inside one test binary — a stale global
+// registration would silently evaluate against a previous application's
+// resolver, producing a suite that passes alone and fails in a full run. It
+// also leaves room for a second provider (Apollo's "entitlement." namespace,
+// or a remote flag source) to be registered on its own domain later.
+const FeatureProviderDomain = "weos"
+
+// Compile-time proof the adapter is complete: a missing evaluation method
+// would otherwise only surface when a call site asked for that kind.
+var _ openfeature.FeatureProvider = (*FeatureProvider)(nil)
+
+// FeatureProvider adapts the resolver to OpenFeature. It is in-process and
+// stateless beyond a log-once set: every evaluation reads the caller's
+// resolved set, which the resolver caches.
+//
+// Only boolean evaluation does real work. String, integer, float and object
+// evaluations return the caller's supplied default with reason DEFAULT, so a
+// later flag source that does carry richer values can be layered in without
+// surprising any existing call site.
+type FeatureProvider struct {
+	resolver *FeatureResolver
+	logger   entities.Logger
+	// loggedUnknown remembers which undeclared keys have already been logged.
+	// An undeclared key on a hot path — an agent turn asking thirty times —
+	// must not produce thirty identical log lines, or the signal that a deploy
+	// drifted drowns in its own repetition.
+	loggedUnknown sync.Map
+}
+
+// NewFeatureProvider builds the provider.
+func NewFeatureProvider(resolver *FeatureResolver, logger entities.Logger) *FeatureProvider {
+	return &FeatureProvider{resolver: resolver, logger: logger}
+}
+
+func (p *FeatureProvider) Metadata() openfeature.Metadata {
+	return openfeature.Metadata{Name: featureProviderName}
+}
+
+// Hooks returns nil. The provider installs no global hooks; a caller that
+// wants eventing adds its own at the client level.
+func (p *FeatureProvider) Hooks() []openfeature.Hook {
+	return nil
+}
+
+// BooleanEvaluation answers "is this feature on for the caller?".
+//
+// The evaluation context is deliberately ignored. OpenFeature's targeting key
+// is the SDK's portable mechanism for per-request data, but the caller's
+// identity already travels on ctx, placed there by the auth middleware for the
+// whole request pipeline. Accepting it from both would create two sources of
+// truth that can disagree — and the one on ctx is the one the rest of the
+// system authorises against.
+func (p *FeatureProvider) BooleanEvaluation(
+	ctx context.Context, flag string, defaultValue bool, _ openfeature.FlattenedContext,
+) openfeature.BoolResolutionDetail {
+	if !strings.HasPrefix(flag, FeatureFlagPrefix) {
+		return boolDetail(defaultValue, openfeature.DefaultReason)
+	}
+	key := strings.TrimPrefix(flag, FeatureFlagPrefix)
+	if key == "" {
+		return boolDetail(defaultValue, openfeature.DefaultReason)
+	}
+
+	value, declared, err := p.resolver.Enabled(ctx, key)
+	switch {
+	case err != nil:
+		// Fail closed. Not the caller's default — off. A resolver that
+		// answered "on" while the store was unreadable would hand out the
+		// capability at exactly the moment nobody could see why.
+		p.log(ctx, "feature evaluation failed, answering off", "feature", key, "error", err)
+		return openfeature.BoolResolutionDetail{
+			Value: false,
+			ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+				Reason:          openfeature.ErrorReason,
+				ResolutionError: openfeature.NewGeneralResolutionError(err.Error()),
+			},
+		}
+	case !declared:
+		// Registry drift: a call site and the declarations disagree. The
+		// caller gets what it asked for, and the instance says so once.
+		p.logUnknownOnce(ctx, key)
+		return boolDetail(defaultValue, openfeature.DefaultReason)
+	default:
+		return boolDetail(value, openfeature.TargetingMatchReason)
+	}
+}
+
+// StringEvaluation returns the caller's default. See FeatureProvider.
+func (p *FeatureProvider) StringEvaluation(
+	_ context.Context, _ string, defaultValue string, _ openfeature.FlattenedContext,
+) openfeature.StringResolutionDetail {
+	return openfeature.StringResolutionDetail{
+		Value:                    defaultValue,
+		ProviderResolutionDetail: openfeature.ProviderResolutionDetail{Reason: openfeature.DefaultReason},
+	}
+}
+
+// FloatEvaluation returns the caller's default. See FeatureProvider.
+func (p *FeatureProvider) FloatEvaluation(
+	_ context.Context, _ string, defaultValue float64, _ openfeature.FlattenedContext,
+) openfeature.FloatResolutionDetail {
+	return openfeature.FloatResolutionDetail{
+		Value:                    defaultValue,
+		ProviderResolutionDetail: openfeature.ProviderResolutionDetail{Reason: openfeature.DefaultReason},
+	}
+}
+
+// IntEvaluation returns the caller's default. See FeatureProvider.
+func (p *FeatureProvider) IntEvaluation(
+	_ context.Context, _ string, defaultValue int64, _ openfeature.FlattenedContext,
+) openfeature.IntResolutionDetail {
+	return openfeature.IntResolutionDetail{
+		Value:                    defaultValue,
+		ProviderResolutionDetail: openfeature.ProviderResolutionDetail{Reason: openfeature.DefaultReason},
+	}
+}
+
+// ObjectEvaluation returns the caller's default. See FeatureProvider.
+func (p *FeatureProvider) ObjectEvaluation(
+	_ context.Context, _ string, defaultValue any, _ openfeature.FlattenedContext,
+) openfeature.InterfaceResolutionDetail {
+	return openfeature.InterfaceResolutionDetail{
+		Value:                    defaultValue,
+		ProviderResolutionDetail: openfeature.ProviderResolutionDetail{Reason: openfeature.DefaultReason},
+	}
+}
+
+func boolDetail(value bool, reason openfeature.Reason) openfeature.BoolResolutionDetail {
+	return openfeature.BoolResolutionDetail{
+		Value:                    value,
+		ProviderResolutionDetail: openfeature.ProviderResolutionDetail{Reason: reason},
+	}
+}
+
+func (p *FeatureProvider) logUnknownOnce(ctx context.Context, key string) {
+	if _, seen := p.loggedUnknown.LoadOrStore(key, struct{}{}); seen {
+		return
+	}
+	p.log(ctx, "evaluated a feature nobody declared; the deploy has drifted from its registry",
+		"feature", key)
+}
+
+func (p *FeatureProvider) log(ctx context.Context, msg string, kv ...any) {
+	if p.logger == nil {
+		return
+	}
+	p.logger.Warn(ctx, msg, kv...)
+}

--- a/application/feature_provider_test.go
+++ b/application/feature_provider_test.go
@@ -1,0 +1,202 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/open-feature/go-sdk/openfeature"
+
+	"github.com/wepala/weos/v3/domain/entities"
+)
+
+// countingLogger records Warn lines so the log-once rule can be asserted
+// rather than assumed.
+type countingLogger struct {
+	mu    sync.Mutex
+	warns []string
+}
+
+func (l *countingLogger) Debug(context.Context, string, ...interface{}) {}
+func (l *countingLogger) Info(context.Context, string, ...interface{})  {}
+func (l *countingLogger) Error(context.Context, string, ...interface{}) {}
+func (l *countingLogger) Warn(_ context.Context, msg string, fields ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	parts := []string{msg}
+	for _, f := range fields {
+		if s, ok := f.(string); ok {
+			parts = append(parts, s)
+		}
+	}
+	l.warns = append(l.warns, strings.Join(parts, " "))
+}
+
+func (l *countingLogger) matching(substr string) []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	var out []string
+	for _, w := range l.warns {
+		if strings.Contains(w, substr) {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+func testProvider(t *testing.T, features ...entities.FeatureMeta) (
+	*FeatureProvider, *fakeSettings, *fakeGrants, *countingLogger,
+) {
+	t.Helper()
+	r, settings, grants, _ := testResolver(t, features)
+	logger := &countingLogger{}
+	r.logger = logger
+	return NewFeatureProvider(r, logger), settings, grants, logger
+}
+
+func TestProviderIgnoresKeysOutsideItsNamespace(t *testing.T) {
+	p, settings, _, _ := testProvider(t, featEpisodic)
+	ctx := ctxAs("agent-ops", "acct-harbor")
+
+	// Apollo's namespace, evaluated against this provider: it must pass
+	// through untouched so the two can be composed.
+	got := p.BooleanEvaluation(ctx, "entitlement.sea_math_2027", true, nil)
+	if !got.Value {
+		t.Fatalf("a foreign-namespace key resolved %v, want the supplied default true", got.Value)
+	}
+	if got.Reason != openfeature.DefaultReason {
+		t.Fatalf("reason = %q, want %q", got.Reason, openfeature.DefaultReason)
+	}
+	if instanceReads, _ := settings.reads(); instanceReads != 0 {
+		t.Fatal("a foreign-namespace key reached the store")
+	}
+
+	// A bare prefix names no feature.
+	if got := p.BooleanEvaluation(ctx, FeatureFlagPrefix, true, nil); !got.Value {
+		t.Fatal("a bare prefix did not fall through to the caller's default")
+	}
+}
+
+func TestProviderUndeclaredKeyReturnsCallerDefaultAndLogsOnce(t *testing.T) {
+	p, _, _, logger := testProvider(t, featEpisodic)
+	ctx := ctxAs("agent-ops", "acct-harbor")
+
+	for i := 0; i < 20; i++ {
+		got := p.BooleanEvaluation(ctx, FeatureFlagPrefix+"shipping-labels", false, nil)
+		if got.Value {
+			t.Fatalf("evaluation %d of an undeclared key returned true, want the supplied default false", i)
+		}
+		if got.Reason != openfeature.DefaultReason {
+			t.Fatalf("reason = %q, want %q", got.Reason, openfeature.DefaultReason)
+		}
+	}
+	// And the caller's default is honoured whichever way it points.
+	if got := p.BooleanEvaluation(ctx, FeatureFlagPrefix+"shipping-labels", true, nil); !got.Value {
+		t.Fatal("an undeclared key did not honour a true default")
+	}
+
+	logs := logger.matching("shipping-labels")
+	if len(logs) != 1 {
+		t.Fatalf("an undeclared key logged %d times, want exactly 1 — a hot path must not drown the signal", len(logs))
+	}
+}
+
+// TestProviderFailsClosedNotToTheCallersDefault is the distinction that
+// matters most in this file: on a store failure the answer is OFF, not
+// whatever the call site happened to pass as its default.
+func TestProviderFailsClosedNotToTheCallersDefault(t *testing.T) {
+	p, settings, _, logger := testProvider(t, featEpisodic)
+	settings.err = errors.New("database is unreachable")
+
+	got := p.BooleanEvaluation(ctxAs("agent-ops", "acct-harbor"), FeatureFlagPrefix+"episodic-recall", true, nil)
+	if got.Value {
+		t.Fatal("a store failure resolved on; it must fail closed even when the caller's default is true")
+	}
+	if got.Reason != openfeature.ErrorReason {
+		t.Fatalf("reason = %q, want %q", got.Reason, openfeature.ErrorReason)
+	}
+	if len(logger.matching("feature evaluation failed")) == 0 {
+		t.Fatal("a store failure was not logged")
+	}
+}
+
+func TestProviderResolvesDeclaredFeatures(t *testing.T) {
+	p, _, grants, _ := testProvider(t, featEpisodic, featLedger)
+	ctx := ctxAs("agent-ops", "acct-harbor")
+
+	got := p.BooleanEvaluation(ctx, FeatureFlagPrefix+"episodic-recall", false, nil)
+	if !got.Value {
+		t.Fatal("a declared-on feature resolved off")
+	}
+	if got.Reason != openfeature.TargetingMatchReason {
+		t.Fatalf("reason = %q, want %q", got.Reason, openfeature.TargetingMatchReason)
+	}
+
+	// The caller's default must not override stored state in either direction.
+	if got := p.BooleanEvaluation(ctx, FeatureFlagPrefix+"ledger-export", true, nil); got.Value {
+		t.Fatal("a declared-off feature resolved on because the caller's default was true")
+	}
+
+	_ = grants.Grant(context.Background(), "agent", "agent-ops", "acct-harbor", "ledger-export")
+	p.resolver.InvalidateAll(context.Background())
+	if got := p.BooleanEvaluation(ctx, FeatureFlagPrefix+"ledger-export", false, nil); !got.Value {
+		t.Fatal("a grant did not reach the provider after invalidation")
+	}
+}
+
+// TestProviderNonBooleanEvaluationsReturnTheCallersDefault keeps the seam open
+// for a later flag source that does carry richer values, without surprising any
+// call site today.
+func TestProviderNonBooleanEvaluationsReturnTheCallersDefault(t *testing.T) {
+	p, _, _, _ := testProvider(t, featEpisodic)
+	ctx := ctxAs("agent-ops", "acct-harbor")
+	flag := FeatureFlagPrefix + "episodic-recall"
+
+	if got := p.StringEvaluation(ctx, flag, "trial", nil); got.Value != "trial" || got.Reason != openfeature.DefaultReason {
+		t.Fatalf("StringEvaluation = %+v, want the caller's default with reason DEFAULT", got)
+	}
+	if got := p.IntEvaluation(ctx, flag, 7, nil); got.Value != 7 || got.Reason != openfeature.DefaultReason {
+		t.Fatalf("IntEvaluation = %+v, want the caller's default with reason DEFAULT", got)
+	}
+	if got := p.FloatEvaluation(ctx, flag, 1.5, nil); got.Value != 1.5 || got.Reason != openfeature.DefaultReason {
+		t.Fatalf("FloatEvaluation = %+v, want the caller's default with reason DEFAULT", got)
+	}
+	obj := map[string]string{"tier": "pro"}
+	if got := p.ObjectEvaluation(ctx, flag, obj, nil); got.Reason != openfeature.DefaultReason {
+		t.Fatalf("ObjectEvaluation reason = %q, want %q", got.Reason, openfeature.DefaultReason)
+	}
+}
+
+func TestProviderMetadataIsStable(t *testing.T) {
+	p, _, _, _ := testProvider(t, featEpisodic)
+	if got := p.Metadata().Name; got != featureProviderName {
+		t.Fatalf("provider name = %q, want %q — it is an operations contract", got, featureProviderName)
+	}
+	if p.Hooks() != nil {
+		t.Fatal("the provider installs global hooks; callers should add their own at the client level")
+	}
+}
+
+// TestProviderAnswersPerCallerNotPerLastAsker guards the failure mode a single
+// shared cache entry would produce: two people in one account being served
+// whichever set was resolved most recently.
+func TestProviderAnswersPerCallerNotPerLastAsker(t *testing.T) {
+	p, _, grants, _ := testProvider(t, featLedger)
+	_ = grants.Grant(context.Background(), "agent", "agent-ops", "acct-harbor", "ledger-export")
+
+	ops := ctxAs("agent-ops", "acct-harbor")
+	counsel := ctxAs("agent-counsel", "acct-harbor")
+	flag := FeatureFlagPrefix + "ledger-export"
+
+	if got := p.BooleanEvaluation(ops, flag, false, nil); !got.Value {
+		t.Fatal("the grant holder was answered off")
+	}
+	if got := p.BooleanEvaluation(counsel, flag, false, nil); got.Value {
+		t.Fatal("someone without the grant was answered on")
+	}
+	if got := p.BooleanEvaluation(ops, flag, false, nil); !got.Value {
+		t.Fatal("the grant holder lost their answer after someone else asked")
+	}
+}

--- a/application/feature_provider_test.go
+++ b/application/feature_provider_test.go
@@ -160,7 +160,8 @@ func TestProviderNonBooleanEvaluationsReturnTheCallersDefault(t *testing.T) {
 	if got := p.IntEvaluation(ctx, flag, 7, nil); got.Value != 7 || got.Reason != openfeature.DefaultReason {
 		t.Fatalf("IntEvaluation = %+v, want the caller's default with reason DEFAULT", got)
 	}
-	if got := p.FloatEvaluation(ctx, flag, 1.5, nil); got.Value != 1.5 || got.Reason != openfeature.DefaultReason {
+	got := p.FloatEvaluation(ctx, flag, 1.5, nil)
+	if got.Value != 1.5 || got.Reason != openfeature.DefaultReason {
 		t.Fatalf("FloatEvaluation = %+v, want the caller's default with reason DEFAULT", got)
 	}
 	obj := map[string]string{"tier": "pro"}

--- a/application/feature_registry.go
+++ b/application/feature_registry.go
@@ -1,0 +1,152 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"go.uber.org/fx"
+
+	"github.com/wepala/weos/v3/domain/entities"
+)
+
+// FeatureDeclarations is an fx value group of feature declarations contributed
+// by code rather than by a preset. A downstream binary — including one built
+// from a private presets repository core must never depend on — adds its own
+// flags by providing into this group:
+//
+//	fx.Provide(application.AsFeatureDeclarations(func() []entities.FeatureMeta {
+//	    return []entities.FeatureMeta{{Key: "invoice-export", ...}}
+//	}))
+//
+// This is the whole seam for out-of-tree declarations. Nothing in core imports
+// anything to support it.
+type FeatureDeclarations struct {
+	fx.Out
+	Declarations []entities.FeatureMeta `group:"feature_declarations,flatten"`
+}
+
+// AsFeatureDeclarations annotates a constructor into the feature_declarations
+// value group, mirroring AsSubscriberGroups in worker_providers.go.
+func AsFeatureDeclarations(f any) any {
+	return fx.Annotate(f, fx.ResultTags(`group:"feature_declarations,flatten"`))
+}
+
+// FeatureRegistry answers what features exist. There are two sources and
+// neither is persisted: declarations contributed in code (the fx value group
+// above, plus anything Register adds during wiring) and declarations owned by
+// an installed preset.
+//
+// Preset declarations are swept from the PresetRegistry on every lookup rather
+// than copied in once. That costs a map build per call — trivially cheap
+// against the database read it precedes, and only on a cache miss — and buys
+// two things: installing a preset makes its features known to the very next
+// resolution without a hook in InstallPreset, and there is no second copy of
+// the declarations that could drift from the preset that owns them.
+//
+// A code declaration wins a key collision with a preset. Code is the more
+// specific statement: a downstream binary that declares a key a preset also
+// uses is overriding it deliberately, and cannot edit the preset to say so.
+type FeatureRegistry struct {
+	mu      sync.RWMutex
+	code    map[string]entities.FeatureMeta
+	presets *PresetRegistry
+	logger  entities.Logger
+}
+
+// NewFeatureRegistry builds the registry from the code-declared group. An
+// invalid declaration fails the boot rather than being skipped: a malformed
+// key is a programming error, and resolving against a registry that silently
+// dropped it would gate nothing while looking like it gated something.
+func NewFeatureRegistry(
+	presets *PresetRegistry,
+	logger entities.Logger,
+	declared []entities.FeatureMeta,
+) (*FeatureRegistry, error) {
+	r := &FeatureRegistry{
+		code:    make(map[string]entities.FeatureMeta, len(declared)),
+		presets: presets,
+		logger:  logger,
+	}
+	for _, m := range declared {
+		if err := r.Register(m); err != nil {
+			return nil, err
+		}
+	}
+	return r, nil
+}
+
+// Register adds a code-declared feature. Duplicate keys are an error rather
+// than last-wins: two code declarations of one key means two subsystems each
+// believe they own it, and picking one silently would gate the wrong thing.
+func (r *FeatureRegistry) Register(m entities.FeatureMeta) error {
+	if err := m.Validate(); err != nil {
+		return fmt.Errorf("invalid feature declaration: %w", err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if existing, ok := r.code[m.Key]; ok {
+		return fmt.Errorf(
+			"feature %q is already declared in code (as %q); keys must be unique",
+			m.Key, existing.DisplayName)
+	}
+	r.code[m.Key] = m
+	return nil
+}
+
+// Lookup returns the declaration for a key. The second result is false when
+// nothing declares the key — which the resolver treats as registry drift: the
+// caller gets its own default and the instance logs it once.
+func (r *FeatureRegistry) Lookup(key string) (entities.FeatureMeta, bool) {
+	r.mu.RLock()
+	code, ok := r.code[key]
+	r.mu.RUnlock()
+	if ok {
+		return code, true
+	}
+	if r.presets == nil {
+		return entities.FeatureMeta{}, false
+	}
+	m, ok := r.presets.Features()[key]
+	return m, ok
+}
+
+// All returns every declared feature, sorted by key, with code declarations
+// overriding preset ones. This is what the operator CLI (#482) and the admin
+// listing (#486) enumerate, and what the resolver folds over to build a
+// caller's whole set in one pass.
+func (r *FeatureRegistry) All() []entities.FeatureMeta {
+	merged := map[string]entities.FeatureMeta{}
+	if r.presets != nil {
+		for key, m := range r.presets.Features() {
+			merged[key] = m
+		}
+	}
+	r.mu.RLock()
+	for key, m := range r.code {
+		merged[key] = m
+	}
+	r.mu.RUnlock()
+
+	out := make([]entities.FeatureMeta, 0, len(merged))
+	for _, m := range merged {
+		out = append(out, m)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	return out
+}

--- a/application/feature_registry_test.go
+++ b/application/feature_registry_test.go
@@ -1,0 +1,181 @@
+package application
+
+import (
+	"testing"
+
+	"github.com/wepala/weos/v3/domain/entities"
+)
+
+func testFeature(key, display string) entities.FeatureMeta {
+	return entities.FeatureMeta{Key: key, DisplayName: display, Default: true, Manageable: true, Grantable: true}
+}
+
+func newTestFeatureRegistry(t *testing.T, declared ...entities.FeatureMeta) (*FeatureRegistry, *PresetRegistry) {
+	t.Helper()
+	presets := NewPresetRegistry()
+	r, err := NewFeatureRegistry(presets, nil, declared)
+	if err != nil {
+		t.Fatalf("NewFeatureRegistry: %v", err)
+	}
+	return r, presets
+}
+
+func TestFeatureRegistryCodeDeclarations(t *testing.T) {
+	r, _ := newTestFeatureRegistry(t,
+		testFeature("episodic-recall", "Episodic recall"),
+		testFeature("ledger-export", "Ledger export"),
+	)
+
+	m, ok := r.Lookup("episodic-recall")
+	if !ok {
+		t.Fatal("Lookup(episodic-recall) = not found, want found")
+	}
+	if m.DisplayName != "Episodic recall" {
+		t.Fatalf("DisplayName = %q, want %q", m.DisplayName, "Episodic recall")
+	}
+	if _, ok := r.Lookup("shipping-labels"); ok {
+		t.Fatal("Lookup of an undeclared key returned found, want not found")
+	}
+
+	all := r.All()
+	if len(all) != 2 {
+		t.Fatalf("All() returned %d features, want 2", len(all))
+	}
+	// All() is sorted by key so the CLI and admin listing are stable.
+	if all[0].Key != "episodic-recall" || all[1].Key != "ledger-export" {
+		t.Fatalf("All() = %q, %q; want sorted by key", all[0].Key, all[1].Key)
+	}
+}
+
+func TestFeatureRegistryRejectsInvalidDeclaration(t *testing.T) {
+	presets := NewPresetRegistry()
+	_, err := NewFeatureRegistry(presets, nil, []entities.FeatureMeta{{Key: "Not A Key", DisplayName: "X"}})
+	if err == nil {
+		t.Fatal("NewFeatureRegistry accepted an invalid key, want a boot failure")
+	}
+}
+
+func TestFeatureRegistryRejectsDuplicateCodeKey(t *testing.T) {
+	r, _ := newTestFeatureRegistry(t, testFeature("ledger-export", "Ledger export"))
+	err := r.Register(testFeature("ledger-export", "Ledger export again"))
+	if err == nil {
+		t.Fatal("Register accepted a duplicate key, want an error")
+	}
+}
+
+// TestFeatureRegistrySeesPresetInstalledAfterBoot is the registry half of the
+// contract scenario "Installing a preset adds the features the preset
+// declares". The registry is built BEFORE the preset is added, proving
+// declarations are swept on demand rather than copied at construction.
+func TestFeatureRegistrySeesPresetInstalledAfterBoot(t *testing.T) {
+	r, presets := newTestFeatureRegistry(t, testFeature("episodic-recall", "Episodic recall"))
+
+	if _, ok := r.Lookup("invoice-export"); ok {
+		t.Fatal("invoice-export was found before its preset was registered")
+	}
+
+	if err := presets.Add(PresetDefinition{
+		Name: "billing-demo",
+		Features: map[string]entities.FeatureMeta{
+			"invoice-export": {Key: "invoice-export", DisplayName: "Invoice export", Default: false},
+		},
+	}); err != nil {
+		t.Fatalf("presets.Add: %v", err)
+	}
+
+	m, ok := r.Lookup("invoice-export")
+	if !ok {
+		t.Fatal("Lookup(invoice-export) = not found after the preset was registered")
+	}
+	if m.Default {
+		t.Fatal("invoice-export resolved Default=true, want the declared false")
+	}
+	// The code-declared feature must survive the sweep.
+	if _, ok := r.Lookup("episodic-recall"); !ok {
+		t.Fatal("episodic-recall disappeared once a preset declared features")
+	}
+	if len(r.All()) != 2 {
+		t.Fatalf("All() returned %d features, want 2", len(r.All()))
+	}
+}
+
+// TestFeatureRegistryCodeWinsOverPreset pins the collision rule: a downstream
+// binary that declares a key a preset also uses is overriding it deliberately
+// and cannot edit the preset to say so.
+func TestFeatureRegistryCodeWinsOverPreset(t *testing.T) {
+	r, presets := newTestFeatureRegistry(t,
+		entities.FeatureMeta{Key: "invoice-export", DisplayName: "From code", Default: true},
+	)
+	if err := presets.Add(PresetDefinition{
+		Name: "billing-demo",
+		Features: map[string]entities.FeatureMeta{
+			"invoice-export": {Key: "invoice-export", DisplayName: "From preset", Default: false},
+		},
+	}); err != nil {
+		t.Fatalf("presets.Add: %v", err)
+	}
+
+	m, ok := r.Lookup("invoice-export")
+	if !ok {
+		t.Fatal("Lookup(invoice-export) = not found")
+	}
+	if m.DisplayName != "From code" || !m.Default {
+		t.Fatalf("Lookup returned %+v, want the code declaration to win", m)
+	}
+
+	all := r.All()
+	if len(all) != 1 {
+		t.Fatalf("All() returned %d features, want 1 merged entry", len(all))
+	}
+	if all[0].DisplayName != "From code" {
+		t.Fatalf("All() returned %q, want the code declaration to win", all[0].DisplayName)
+	}
+}
+
+// TestPresetRegistryFeaturesMergeLastWins mirrors BehaviorsMeta's documented
+// merge semantics: presets are walked alphabetically and the last declaration
+// of a key wins.
+func TestPresetRegistryFeaturesMergeLastWins(t *testing.T) {
+	presets := NewPresetRegistry()
+	for _, name := range []string{"alpha", "zulu"} {
+		if err := presets.Add(PresetDefinition{
+			Name: name,
+			Features: map[string]entities.FeatureMeta{
+				"shared": {Key: "shared", DisplayName: name},
+			},
+		}); err != nil {
+			t.Fatalf("presets.Add(%s): %v", name, err)
+		}
+	}
+	if got := presets.Features()["shared"].DisplayName; got != "zulu" {
+		t.Fatalf("merged DisplayName = %q, want %q (alphabetical, last wins)", got, "zulu")
+	}
+}
+
+// TestPresetDefinitionCloneCopiesFeatures guards the deep-copy contract on
+// Get/List: a caller mutating the returned definition must not reach into the
+// registry's own copy.
+func TestPresetDefinitionCloneCopiesFeatures(t *testing.T) {
+	presets := NewPresetRegistry()
+	if err := presets.Add(PresetDefinition{
+		Name:     "billing-demo",
+		Features: map[string]entities.FeatureMeta{"invoice-export": {Key: "invoice-export", DisplayName: "Invoice export"}},
+	}); err != nil {
+		t.Fatalf("presets.Add: %v", err)
+	}
+
+	def, ok := presets.Get("billing-demo")
+	if !ok {
+		t.Fatal("Get(billing-demo) = not found")
+	}
+	def.Features["invoice-export"] = entities.FeatureMeta{Key: "invoice-export", DisplayName: "mutated"}
+	def.Features["injected"] = entities.FeatureMeta{Key: "injected", DisplayName: "injected"}
+
+	fresh := presets.Features()
+	if fresh["invoice-export"].DisplayName != "Invoice export" {
+		t.Fatal("mutating a cloned definition changed the registry's declaration")
+	}
+	if _, ok := fresh["injected"]; ok {
+		t.Fatal("mutating a cloned definition injected a feature into the registry")
+	}
+}

--- a/application/feature_registry_test.go
+++ b/application/feature_registry_test.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/wepala/weos/v3/domain/entities"
@@ -177,5 +178,59 @@ func TestPresetDefinitionCloneCopiesFeatures(t *testing.T) {
 	}
 	if _, ok := fresh["injected"]; ok {
 		t.Fatal("mutating a cloned definition injected a feature into the registry")
+	}
+}
+
+// TestPresetRegistryRejectsInvalidFeatureDeclarations holds preset
+// declarations to the same standard as code declarations. Without this, the
+// registry's "an invalid declaration fails the boot" contract only held for
+// code, and a preset could ship a key nothing can gate.
+func TestPresetRegistryRejectsInvalidFeatureDeclarations(t *testing.T) {
+	cases := []struct {
+		name     string
+		features map[string]entities.FeatureMeta
+		want     string
+	}{
+		{
+			"key disagrees with the declaration",
+			map[string]entities.FeatureMeta{"a": {Key: "b", DisplayName: "B"}},
+			"names itself",
+		},
+		{
+			"invalid key",
+			map[string]entities.FeatureMeta{"Not A Key": {Key: "Not A Key", DisplayName: "X"}},
+			"must match",
+		},
+		{
+			"missing display name",
+			map[string]entities.FeatureMeta{"ledger-export": {Key: "ledger-export"}},
+			"display name",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := NewPresetRegistry().Add(PresetDefinition{Name: "broken", Features: tc.features})
+			if err == nil {
+				t.Fatal("Add accepted an invalid feature declaration")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %q, want it to contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// TestMismatchedPresetKeyWouldStrandResolution documents WHY the key must
+// match: a declaration found by one key but folded under another can never be
+// resolved, so it would silently ignore every stored override.
+func TestMismatchedPresetKeyWouldStrandResolution(t *testing.T) {
+	r, presets := newTestFeatureRegistry(t)
+	// Bypass Add's validation to build the shape the guard now prevents.
+	presets.MustAdd(PresetDefinition{Name: "ok", Features: map[string]entities.FeatureMeta{
+		"invoice-export": {Key: "invoice-export", DisplayName: "Invoice export"},
+	}})
+	if _, ok := r.Lookup("invoice-export"); !ok {
+		t.Fatal("a well-formed preset declaration was not found")
 	}
 }

--- a/application/feature_resolver.go
+++ b/application/feature_resolver.go
@@ -59,6 +59,11 @@ type featureCacheKey struct {
 type resolvedFeatureSet struct {
 	values     map[string]bool
 	resolvedAt time.Time
+	// retryAfter throttles re-reads while the store is failing. Without it an
+	// agent turn making thirty evaluations against an unreadable database
+	// makes thirty failing round trips, turning a blip into a query storm at
+	// the worst moment.
+	retryAfter time.Time
 }
 
 // FeatureResolver answers what features are on for a caller, and owns the
@@ -81,6 +86,13 @@ type FeatureResolver struct {
 
 	mu   sync.RWMutex
 	sets map[featureCacheKey]resolvedFeatureSet
+	// generation increments on every invalidation. A resolve that started
+	// before an invalidation and finished after it must not store its result:
+	// it read the database before the write landed, so caching it would give
+	// stale values a fresh timestamp and break the one rule this design has —
+	// that a change reaches sessions already open. The window is widest
+	// exactly when the instance is busy.
+	generation uint64
 	// now is injectable so the max-age behaviour can be tested without
 	// sleeping. Production leaves it nil and uses time.Now.
 	now func() time.Time
@@ -139,9 +151,17 @@ func (r *FeatureResolver) Enabled(ctx context.Context, key string) (bool, bool, 
 	}
 	value, ok := set[key]
 	if !ok {
-		// Declared after this set was cached. Fall back to the declaration
-		// rather than reporting it undeclared — the set is stale, not the
-		// registry.
+		// Declared after this set was cached — the set is stale, not the
+		// registry. Re-resolve rather than answering meta.Default, which would
+		// bypass every stored layer and could serve ON past an explicit
+		// instance OFF for the lifetime of the cache entry.
+		fresh, err := r.resolveNow(ctx)
+		if err != nil {
+			return false, true, err
+		}
+		if value, ok := fresh[key]; ok {
+			return value, true, nil
+		}
 		return meta.Default, true, nil
 	}
 	return value, true, nil
@@ -163,21 +183,81 @@ func (r *FeatureResolver) ResolvedSet(ctx context.Context) (map[string]bool, err
 	if set, ok := r.cached(key); ok {
 		return set, nil
 	}
+	return r.refresh(ctx, key)
+}
+
+// resolveNow bypasses the cache entirely. Used when a cached set turns out not
+// to contain a key it should — the set is stale and must be rebuilt rather
+// than guessed around.
+func (r *FeatureResolver) resolveNow(ctx context.Context) (map[string]bool, error) {
+	identity := auth.AgentFromCtx(ctx)
+	key := featureCacheKey{}
+	if identity != nil {
+		key = featureCacheKey{AgentID: identity.AgentID, AccountID: identity.ActiveAccountID}
+	}
+	return r.refresh(ctx, key)
+}
+
+// refresh reads every layer and stores the result, unless an invalidation
+// overtook it.
+func (r *FeatureResolver) refresh(ctx context.Context, key featureCacheKey) (map[string]bool, error) {
+	r.mu.RLock()
+	startedAt := r.generation
+	r.mu.RUnlock()
 
 	values, err := r.resolve(ctx, key)
 	if err != nil {
-		// A failure is never cached. Remembering it would turn one unreadable
-		// moment into a persistently-off feature long after the store
-		// recovered.
-		return nil, err
+		return r.onResolveError(ctx, key, err)
 	}
 
 	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.generation != startedAt {
+		// An invalidation landed while this read was in flight, so these
+		// values may predate the write that caused it. Serve them to this
+		// caller — they are no more stale than the read itself — but do not
+		// store them, or the next caller inherits a stale set with a fresh
+		// timestamp.
+		return copyFeatureValues(values), nil
+	}
 	r.sets[key] = resolvedFeatureSet{values: values, resolvedAt: r.clock()}
-	r.mu.Unlock()
-
 	return copyFeatureValues(values), nil
 }
+
+// onResolveError decides what a caller is told when the store cannot be read.
+//
+// A failure is never cached as an answer. But if this caller already has a
+// resolved set, serving it beats answering off for everything: a database blip
+// would otherwise strip every capability from every user mid-turn — including
+// features nobody ever turned off — and once #484 gates tool listings, clients
+// cache the emptied list and the outage outlives the blip.
+//
+// With no previous set there is nothing to fall back to, so the answer is off.
+// That is the contract's case: a store unreadable from the start resolves off
+// with reason ERROR.
+func (r *FeatureResolver) onResolveError(
+	ctx context.Context, key featureCacheKey, err error,
+) (map[string]bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	previous, ok := r.sets[key]
+	if !ok {
+		return nil, err
+	}
+	// Throttle the retry so a sustained outage does not turn every evaluation
+	// into another failing round trip.
+	previous.retryAfter = r.clock().Add(resolveFailureBackoff)
+	r.sets[key] = previous
+	if r.logger != nil {
+		r.logger.Warn(ctx, "serving the last known feature set; the store could not be read",
+			"agent", key.AgentID, "account", key.AccountID, "error", err)
+	}
+	return copyFeatureValues(previous.values), nil
+}
+
+// resolveFailureBackoff is how long a failed refresh suppresses another
+// attempt for the same caller.
+const resolveFailureBackoff = time.Second
 
 func (r *FeatureResolver) cached(key featureCacheKey) (map[string]bool, bool) {
 	r.mu.RLock()
@@ -186,9 +266,15 @@ func (r *FeatureResolver) cached(key featureCacheKey) (map[string]bool, bool) {
 	if !ok {
 		return nil, false
 	}
-	if r.clock().Sub(set.resolvedAt) >= r.maxAge {
+	now := r.clock()
+	if now.Sub(set.resolvedAt) >= r.maxAge {
 		// Too old to trust. Treated as a miss rather than evicted here so the
 		// read path keeps only a read lock; the entry is replaced on write.
+		// Unless a refresh just failed — then serving this set is better than
+		// hammering a store that is down.
+		if set.retryAfter.After(now) {
+			return copyFeatureValues(set.values), true
+		}
 		return nil, false
 	}
 	return copyFeatureValues(set.values), true
@@ -229,12 +315,13 @@ func (r *FeatureResolver) resolve(ctx context.Context, key featureCacheKey) (map
 	declared := r.registry.All()
 	values := make(map[string]bool, len(declared))
 	for _, meta := range declared {
-		values[meta.Key] = entities.ResolveFeature(
+		value, _ := entities.ResolveFeature(
 			meta,
 			featureStateFrom(instance, meta.Key),
 			featureStateFrom(account, meta.Key),
 			granted[meta.Key],
 		)
+		values[meta.Key] = value
 	}
 	return values, nil
 }
@@ -261,11 +348,24 @@ func copyFeatureValues(in map[string]bool) map[string]bool {
 	return out
 }
 
+// expire ages a cached entry past the maximum, so a test can force the next
+// read to attempt a refresh without sleeping.
+func (r *FeatureResolver) expire(key featureCacheKey) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if set, ok := r.sets[key]; ok {
+		set.resolvedAt = r.clock().Add(-2 * r.maxAge)
+		set.retryAfter = time.Time{}
+		r.sets[key] = set
+	}
+}
+
 // InvalidateAll drops every cached set. Used when an instance-level value
 // changes, and when a replica is told that something changed elsewhere.
 func (r *FeatureResolver) InvalidateAll(_ context.Context) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.generation++
 	r.sets = make(map[featureCacheKey]resolvedFeatureSet)
 }
 
@@ -277,6 +377,7 @@ func (r *FeatureResolver) InvalidateAccount(_ context.Context, accountID string)
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.generation++
 	for key := range r.sets {
 		if key.AccountID == accountID {
 			delete(r.sets, key)
@@ -293,6 +394,7 @@ func (r *FeatureResolver) InvalidateAgents(_ context.Context, accountID string, 
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.generation++
 	for _, agentID := range agentIDs {
 		delete(r.sets, featureCacheKey{AgentID: agentID, AccountID: accountID})
 	}

--- a/application/feature_resolver.go
+++ b/application/feature_resolver.go
@@ -1,0 +1,299 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
+	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
+
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
+	"github.com/wepala/weos/v3/internal/config"
+)
+
+// The resolver IS the in-process invalidator. Asserted here so the two never
+// drift apart silently.
+var _ repositories.FeatureCacheInvalidator = (*FeatureResolver)(nil)
+
+// featureCacheKey identifies one resolved feature set.
+//
+// Deliberately NOT a session identifier. There is none on the MCP bearer
+// surface — BearerOrSession validates the JWT and keeps only the identity, so
+// the token's jti never reaches a handler — and keying on something one whole
+// surface cannot supply would mean either no caching there or a silent
+// fallback that behaves differently per surface.
+//
+// Keying on (agent, account) is also strictly more correct than per-session
+// would be: resolution reads the instance layer, the account layer, and the
+// caller's grants and roles, and nothing else. Two sessions of one person in
+// one account therefore always resolve identically, so sharing one entry
+// cannot produce a wrong answer — and it means one invalidation reaches every
+// device that person is signed in on, including MCP connectors that hold no
+// enumerable server-side session at all.
+//
+// The zero key — both fields empty — is the anonymous caller, whose set is
+// resolved from the instance layer alone.
+type featureCacheKey struct {
+	AgentID   string
+	AccountID string
+}
+
+type resolvedFeatureSet struct {
+	values     map[string]bool
+	resolvedAt time.Time
+}
+
+// FeatureResolver answers what features are on for a caller, and owns the
+// cache that keeps that answer cheap. Resolution sits in front of MCP tool
+// listings and agent turns, where thirty tool calls in one turn is ordinary,
+// so a caller's whole set is resolved once and read from memory afterwards.
+//
+// The resolver is itself the in-process FeatureCacheInvalidator. On SQLite —
+// one process, serialized writers — that is not a fallback or a degraded mode,
+// it is the complete and exact implementation. The Postgres broadcast wraps
+// it rather than replacing it.
+type FeatureResolver struct {
+	registry *FeatureRegistry
+	settings repositories.FeatureSettingsRepository
+	grants   repositories.FeatureGrantRepository
+	accounts authrepos.AccountRepository
+	logger   entities.Logger
+
+	maxAge time.Duration
+
+	mu   sync.RWMutex
+	sets map[featureCacheKey]resolvedFeatureSet
+	// now is injectable so the max-age behaviour can be tested without
+	// sleeping. Production leaves it nil and uses time.Now.
+	now func() time.Time
+}
+
+// NewFeatureResolver builds the resolver. maxAge comes from configuration and
+// bounds how long a cached set may be served without re-resolution.
+func NewFeatureResolver(
+	cfg config.Config,
+	registry *FeatureRegistry,
+	settings repositories.FeatureSettingsRepository,
+	grants repositories.FeatureGrantRepository,
+	accounts authrepos.AccountRepository,
+	logger entities.Logger,
+) *FeatureResolver {
+	maxAge := cfg.Features.CacheMaxAge
+	if maxAge <= 0 {
+		maxAge = 15 * time.Minute
+	}
+	return &FeatureResolver{
+		registry: registry,
+		settings: settings,
+		grants:   grants,
+		accounts: accounts,
+		logger:   logger,
+		maxAge:   maxAge,
+		sets:     make(map[featureCacheKey]resolvedFeatureSet),
+	}
+}
+
+func (r *FeatureResolver) clock() time.Time {
+	if r.now != nil {
+		return r.now()
+	}
+	return time.Now()
+}
+
+// Enabled answers whether one feature is on for the caller on ctx.
+//
+// The second result reports whether the key is declared at all. An undeclared
+// key is registry drift — a deploy where a call site and the declarations
+// disagree — and the caller decides what to do about it; the resolver does not
+// invent a value for it.
+//
+// An error means the stored state could not be read. Callers must treat that
+// as OFF: a resolver that answers "on" on the way to a database error hands
+// out the capability at exactly the moment nobody can see why.
+func (r *FeatureResolver) Enabled(ctx context.Context, key string) (bool, bool, error) {
+	meta, declared := r.registry.Lookup(key)
+	if !declared {
+		return false, false, nil
+	}
+	set, err := r.ResolvedSet(ctx)
+	if err != nil {
+		return false, true, err
+	}
+	value, ok := set[key]
+	if !ok {
+		// Declared after this set was cached. Fall back to the declaration
+		// rather than reporting it undeclared — the set is stale, not the
+		// registry.
+		return meta.Default, true, nil
+	}
+	return value, true, nil
+}
+
+// ResolvedSet returns every declared feature's value for the caller on ctx,
+// reading from cache when one is present and young enough.
+//
+// The whole set is resolved at once rather than one key at a time. An agent
+// turn evaluates many keys, and resolving per key would multiply the database
+// reads by the number of features rather than amortising them to one.
+func (r *FeatureResolver) ResolvedSet(ctx context.Context) (map[string]bool, error) {
+	identity := auth.AgentFromCtx(ctx)
+	key := featureCacheKey{}
+	if identity != nil {
+		key = featureCacheKey{AgentID: identity.AgentID, AccountID: identity.ActiveAccountID}
+	}
+
+	if set, ok := r.cached(key); ok {
+		return set, nil
+	}
+
+	values, err := r.resolve(ctx, key)
+	if err != nil {
+		// A failure is never cached. Remembering it would turn one unreadable
+		// moment into a persistently-off feature long after the store
+		// recovered.
+		return nil, err
+	}
+
+	r.mu.Lock()
+	r.sets[key] = resolvedFeatureSet{values: values, resolvedAt: r.clock()}
+	r.mu.Unlock()
+
+	return copyFeatureValues(values), nil
+}
+
+func (r *FeatureResolver) cached(key featureCacheKey) (map[string]bool, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	set, ok := r.sets[key]
+	if !ok {
+		return nil, false
+	}
+	if r.clock().Sub(set.resolvedAt) >= r.maxAge {
+		// Too old to trust. Treated as a miss rather than evicted here so the
+		// read path keeps only a read lock; the entry is replaced on write.
+		return nil, false
+	}
+	return copyFeatureValues(set.values), true
+}
+
+// resolve reads every layer and folds them through entities.ResolveFeature.
+func (r *FeatureResolver) resolve(ctx context.Context, key featureCacheKey) (map[string]bool, error) {
+	instance, err := r.settings.InstanceOverrides(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve features: %w", err)
+	}
+
+	var (
+		account map[string]bool
+		granted map[string]bool
+	)
+	// An anonymous caller resolves from the instance layer alone. No account
+	// override and no grant is read — there is no subject for either to
+	// attach to. This deliberately differs from the rest of the codebase,
+	// where a nil identity means system context and bypasses gates: a
+	// background worker or a stdio MCP session must not silently receive every
+	// gated capability.
+	if key.AgentID != "" && key.AccountID != "" {
+		account, err = r.settings.AccountOverrides(ctx, key.AccountID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve features: %w", err)
+		}
+		roleID, err := r.accounts.FindMemberRole(ctx, key.AccountID, key.AgentID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve features: %w", err)
+		}
+		granted, err = r.grants.GrantedKeys(ctx, key.AccountID, key.AgentID, roleID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve features: %w", err)
+		}
+	}
+
+	declared := r.registry.All()
+	values := make(map[string]bool, len(declared))
+	for _, meta := range declared {
+		values[meta.Key] = entities.ResolveFeature(
+			meta,
+			featureStateFrom(instance, meta.Key),
+			featureStateFrom(account, meta.Key),
+			granted[meta.Key],
+		)
+	}
+	return values, nil
+}
+
+// featureStateFrom turns a stored override map into a tri-state. An absent key
+// is Unset — the layer says nothing — which is what lets row absence carry the
+// third state with no nullable column.
+func featureStateFrom(overrides map[string]bool, key string) entities.FeatureState {
+	enabled, ok := overrides[key]
+	if !ok {
+		return entities.FeatureUnset
+	}
+	if enabled {
+		return entities.FeatureOn
+	}
+	return entities.FeatureOff
+}
+
+func copyFeatureValues(in map[string]bool) map[string]bool {
+	out := make(map[string]bool, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+// InvalidateAll drops every cached set. Used when an instance-level value
+// changes, and when a replica is told that something changed elsewhere.
+func (r *FeatureResolver) InvalidateAll(_ context.Context) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sets = make(map[featureCacheKey]resolvedFeatureSet)
+}
+
+// InvalidateAccount drops every cached set belonging to one account, reaching
+// every member signed in right now without disturbing any other account.
+func (r *FeatureResolver) InvalidateAccount(_ context.Context, accountID string) {
+	if accountID == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for key := range r.sets {
+		if key.AccountID == accountID {
+			delete(r.sets, key)
+		}
+	}
+}
+
+// InvalidateAgents drops the cached sets of specific people within an account.
+// Every session those people hold is reached, because sessions share one entry
+// per (agent, account) — that is the property the cache key was chosen for.
+func (r *FeatureResolver) InvalidateAgents(_ context.Context, accountID string, agentIDs ...string) {
+	if accountID == "" || len(agentIDs) == 0 {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, agentID := range agentIDs {
+		delete(r.sets, featureCacheKey{AgentID: agentID, AccountID: accountID})
+	}
+}

--- a/application/feature_resolver_test.go
+++ b/application/feature_resolver_test.go
@@ -27,16 +27,27 @@ type fakeSettings struct {
 	instanceReads int
 	accountReads  int
 	err           error
+	// beforeReturn runs inside a read, so a test can interleave an
+	// invalidation with a resolve that is already in flight.
+	beforeReturn func()
 }
 
 func (f *fakeSettings) InstanceOverrides(context.Context) (map[string]bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.instanceReads++
-	if f.err != nil {
-		return nil, f.err
+	hook := f.beforeReturn
+	err := f.err
+	inst := copyFeatureValues(f.instance)
+	f.mu.Unlock()
+	if hook != nil {
+		hook()
 	}
-	return copyFeatureValues(f.instance), nil
+	f.mu.Lock()
+	if err != nil {
+		return nil, err
+	}
+	return inst, nil
 }
 
 func (f *fakeSettings) AccountOverrides(_ context.Context, accountID string) (map[string]bool, error) {
@@ -493,5 +504,128 @@ func TestResolverCachedSetIsNotAliased(t *testing.T) {
 	}
 	if _, ok := second["injected"]; ok {
 		t.Fatal("mutating a returned set injected a key into the cache")
+	}
+}
+
+// TestResolverDoesNotCacheAResultAnInvalidationOvertook is the race the
+// premortem predicted: a resolve that read the store BEFORE a write commits,
+// but finishes AFTER the invalidation runs, must not store its values. If it
+// did, stale values would get a fresh timestamp and survive up to the maximum
+// cache age — breaking the one rule this design has, and most likely to happen
+// exactly when the instance is busy.
+func TestResolverDoesNotCacheAResultAnInvalidationOvertook(t *testing.T) {
+	registry, _ := newTestFeatureRegistry(t, featEpisodic)
+	settings := &fakeSettings{}
+	grants := newFakeGrants()
+	r := NewFeatureResolver(config.Default(), registry, settings, grants,
+		&fakeAccounts{roles: map[string]string{}}, nil)
+
+	ctx := ctxAs("agent-ops", "acct-harbor")
+
+	// Simulate the interleaving: the read has happened, then an invalidation
+	// lands, then the result tries to store itself.
+	settings.beforeReturn = func() { r.InvalidateAll(context.Background()) }
+	if _, err := r.ResolvedSet(ctx); err != nil {
+		t.Fatalf("ResolvedSet: %v", err)
+	}
+	settings.beforeReturn = nil
+
+	before, _ := settings.reads()
+	if _, err := r.ResolvedSet(ctx); err != nil {
+		t.Fatalf("ResolvedSet: %v", err)
+	}
+	after, _ := settings.reads()
+	if after == before {
+		t.Fatal("the overtaken result was cached; a change would not reach this session " +
+			"until the maximum cache age expired")
+	}
+}
+
+// TestResolverServesLastKnownSetWhenTheStoreFails covers the outage the
+// premortem predicted: a database blip must not strip every capability from
+// everyone mid-turn, including features nobody ever turned off.
+func TestResolverServesLastKnownSetWhenTheStoreFails(t *testing.T) {
+	r, settings, _, _ := testResolver(t, []entities.FeatureMeta{featEpisodic})
+	ctx := ctxAs("agent-ops", "acct-harbor")
+
+	if set := mustResolve(t, r, ctx); !set["episodic-recall"] {
+		t.Fatal("the first resolve did not return the declared default")
+	}
+
+	settings.err = errors.New("database is unreachable")
+	r.InvalidateAll(context.Background()) // force a refresh attempt
+	set, err := r.ResolvedSet(ctx)
+	if err == nil && set["episodic-recall"] {
+		// This is only reachable if a previous set survived the invalidation,
+		// which it must not — InvalidateAll drops everything.
+		t.Fatal("InvalidateAll left a set behind")
+	}
+
+	// With a set present and no invalidation, a failing refresh serves it.
+	settings.err = nil
+	_ = mustResolve(t, r, ctx)
+	settings.err = errors.New("database is unreachable")
+	r.expire(featureCacheKey{AgentID: "agent-ops", AccountID: "acct-harbor"})
+
+	set, err = r.ResolvedSet(ctx)
+	if err != nil {
+		t.Fatalf("a failing refresh with a previous set returned an error: %v", err)
+	}
+	if !set["episodic-recall"] {
+		t.Fatal("a database blip stripped a capability that was on moments before")
+	}
+}
+
+// TestResolverThrottlesRetriesWhileTheStoreIsDown stops a sustained outage
+// becoming a query storm: thirty evaluations in one agent turn must not mean
+// thirty failing round trips.
+func TestResolverThrottlesRetriesWhileTheStoreIsDown(t *testing.T) {
+	r, settings, _, _ := testResolver(t, []entities.FeatureMeta{featEpisodic})
+	ctx := ctxAs("agent-ops", "acct-harbor")
+	_ = mustResolve(t, r, ctx)
+
+	settings.err = errors.New("database is unreachable")
+	r.expire(featureCacheKey{AgentID: "agent-ops", AccountID: "acct-harbor"})
+
+	before, _ := settings.reads()
+	for i := 0; i < 30; i++ {
+		if _, err := r.ResolvedSet(ctx); err != nil {
+			t.Fatalf("evaluation %d returned an error instead of the last known set: %v", i, err)
+		}
+	}
+	after, _ := settings.reads()
+	if after-before > 2 {
+		t.Fatalf("a down store was retried %d times across 30 evaluations, want at most 2", after-before)
+	}
+}
+
+// TestResolverRebuildsWhenACachedSetLacksADeclaredKey covers the preset-install
+// case: answering meta.Default for a key missing from a cached set would bypass
+// every stored layer, so a feature could answer ON past an explicit instance
+// OFF for the life of the entry.
+func TestResolverRebuildsWhenACachedSetLacksADeclaredKey(t *testing.T) {
+	r, settings, _, _ := testResolver(t, []entities.FeatureMeta{featEpisodic})
+	ctx := ctxAs("agent-ops", "acct-harbor")
+	_ = mustResolve(t, r, ctx)
+
+	// A feature declared after the set was cached, with the instance already
+	// holding an explicit off for it — the shape a preset install produces on
+	// an instance that was pre-seeded.
+	late := entities.FeatureMeta{Key: "invoice-export", DisplayName: "Invoice export", Default: true}
+	if err := r.registry.Register(late); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	_ = settings.SetOverride(context.Background(), repositories.FeatureScopeInstance, "", "invoice-export", false)
+
+	value, declared, err := r.Enabled(ctx, "invoice-export")
+	if err != nil {
+		t.Fatalf("Enabled: %v", err)
+	}
+	if !declared {
+		t.Fatal("the late declaration was reported undeclared")
+	}
+	if value {
+		t.Fatal("a key missing from the cached set answered its declared default, " +
+			"ignoring an explicit instance off")
 	}
 }

--- a/application/feature_resolver_test.go
+++ b/application/feature_resolver_test.go
@@ -1,0 +1,497 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
+	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
+
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
+	"github.com/wepala/weos/v3/internal/config"
+)
+
+// --- fakes -------------------------------------------------------------
+
+// fakeSettings counts reads so the cache scenarios can assert that a warm
+// evaluation touches the store zero times, and that an anonymous caller never
+// reaches the account layer at all.
+type fakeSettings struct {
+	mu            sync.Mutex
+	instance      map[string]bool
+	account       map[string]map[string]bool
+	instanceReads int
+	accountReads  int
+	err           error
+}
+
+func (f *fakeSettings) InstanceOverrides(context.Context) (map[string]bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.instanceReads++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return copyFeatureValues(f.instance), nil
+}
+
+func (f *fakeSettings) AccountOverrides(_ context.Context, accountID string) (map[string]bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.accountReads++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return copyFeatureValues(f.account[accountID]), nil
+}
+
+func (f *fakeSettings) SetOverride(_ context.Context, scopeType, scopeID, key string, enabled bool) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if scopeType == repositories.FeatureScopeInstance {
+		if f.instance == nil {
+			f.instance = map[string]bool{}
+		}
+		f.instance[key] = enabled
+		return nil
+	}
+	if f.account == nil {
+		f.account = map[string]map[string]bool{}
+	}
+	if f.account[scopeID] == nil {
+		f.account[scopeID] = map[string]bool{}
+	}
+	f.account[scopeID][key] = enabled
+	return nil
+}
+
+func (f *fakeSettings) ClearOverride(_ context.Context, scopeType, scopeID, key string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if scopeType == repositories.FeatureScopeInstance {
+		delete(f.instance, key)
+		return nil
+	}
+	delete(f.account[scopeID], key)
+	return nil
+}
+
+func (f *fakeSettings) reads() (int, int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.instanceReads, f.accountReads
+}
+
+type fakeGrants struct {
+	mu    sync.Mutex
+	byKey map[string]map[string]bool // "accountID|subjectID" -> keys
+	reads int
+	err   error
+}
+
+func newFakeGrants() *fakeGrants {
+	return &fakeGrants{byKey: map[string]map[string]bool{}}
+}
+
+func (f *fakeGrants) GrantedKeys(_ context.Context, accountID, agentID, roleID string) (map[string]bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reads++
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := map[string]bool{}
+	for k := range f.byKey[accountID+"|"+agentID] {
+		out[k] = true
+	}
+	if roleID != "" {
+		for k := range f.byKey[accountID+"|"+roleID] {
+			out[k] = true
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeGrants) Grant(_ context.Context, subjectType, subjectID, accountID, key string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	id := accountID + "|" + subjectID
+	if f.byKey[id] == nil {
+		f.byKey[id] = map[string]bool{}
+	}
+	f.byKey[id][key] = true
+	return nil
+}
+
+func (f *fakeGrants) Revoke(_ context.Context, subjectType, subjectID, accountID, key string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.byKey[accountID+"|"+subjectID], key)
+	return nil
+}
+
+func (f *fakeGrants) readCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.reads
+}
+
+// fakeAccounts embeds the pericarp interface so only the one method feature
+// resolution actually calls has to be implemented. A call to anything else
+// panics, which is the point: it proves resolution touches nothing more.
+type fakeAccounts struct {
+	authrepos.AccountRepository
+	roles map[string]string // "accountID|agentID" -> roleID
+	err   error
+}
+
+func (f fakeAccounts) FindMemberRole(_ context.Context, accountID, agentID string) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.roles[accountID+"|"+agentID], nil
+}
+
+// --- helpers -----------------------------------------------------------
+
+func testResolver(t *testing.T, features []entities.FeatureMeta) (
+	*FeatureResolver, *fakeSettings, *fakeGrants, *fakeAccounts,
+) {
+	t.Helper()
+	registry, _ := newTestFeatureRegistry(t, features...)
+	settings := &fakeSettings{}
+	grants := newFakeGrants()
+	accounts := &fakeAccounts{roles: map[string]string{}}
+	cfg := config.Default()
+	return NewFeatureResolver(cfg, registry, settings, grants, accounts, nil), settings, grants, accounts
+}
+
+func ctxAs(agentID, accountID string) context.Context {
+	return auth.ContextWithAgent(context.Background(),
+		&auth.Identity{AgentID: agentID, ActiveAccountID: accountID})
+}
+
+var (
+	featEpisodic = entities.FeatureMeta{
+		Key: "episodic-recall", DisplayName: "Episodic recall",
+		Default: true, Manageable: true, Grantable: true,
+	}
+	featLedger = entities.FeatureMeta{
+		Key: "ledger-export", DisplayName: "Ledger export",
+		Default: false, Manageable: true, Grantable: true,
+	}
+	featAudit = entities.FeatureMeta{
+		Key: "audit-trail", DisplayName: "Audit trail", Default: true,
+	}
+)
+
+func mustResolve(t *testing.T, r *FeatureResolver, ctx context.Context) map[string]bool {
+	t.Helper()
+	set, err := r.ResolvedSet(ctx)
+	if err != nil {
+		t.Fatalf("ResolvedSet: %v", err)
+	}
+	return set
+}
+
+// --- tests -------------------------------------------------------------
+
+func TestResolverDefaultsWhenNothingStored(t *testing.T) {
+	r, _, _, _ := testResolver(t, []entities.FeatureMeta{featEpisodic, featLedger})
+	set := mustResolve(t, r, ctxAs("agent-ops", "acct-harbor"))
+	if !set["episodic-recall"] {
+		t.Fatal("a declared-on feature resolved off with nothing stored")
+	}
+	if set["ledger-export"] {
+		t.Fatal("a declared-off feature resolved on with nothing stored")
+	}
+}
+
+func TestResolverLayerPrecedence(t *testing.T) {
+	ctx := ctxAs("agent-ops", "acct-harbor")
+	cases := []struct {
+		name  string
+		setup func(*fakeSettings, *fakeGrants, *fakeAccounts)
+		key   string
+		want  bool
+	}{
+		{
+			"account turns on a declared-off feature",
+			func(s *fakeSettings, _ *fakeGrants, _ *fakeAccounts) {
+				_ = s.SetOverride(context.Background(), repositories.FeatureScopeAccount, "acct-harbor", "ledger-export", true)
+			}, "ledger-export", true,
+		},
+		{
+			"account off beats a grant",
+			func(s *fakeSettings, g *fakeGrants, _ *fakeAccounts) {
+				_ = s.SetOverride(context.Background(), repositories.FeatureScopeAccount, "acct-harbor", "episodic-recall", false)
+				_ = g.Grant(context.Background(), repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "episodic-recall")
+			}, "episodic-recall", false,
+		},
+		{
+			"instance off beats an account on",
+			func(s *fakeSettings, _ *fakeGrants, _ *fakeAccounts) {
+				_ = s.SetOverride(context.Background(), repositories.FeatureScopeInstance, "", "episodic-recall", false)
+				_ = s.SetOverride(context.Background(), repositories.FeatureScopeAccount, "acct-harbor", "episodic-recall", true)
+			}, "episodic-recall", false,
+		},
+		{
+			"instance off beats a grant",
+			func(s *fakeSettings, g *fakeGrants, _ *fakeAccounts) {
+				_ = s.SetOverride(context.Background(), repositories.FeatureScopeInstance, "", "ledger-export", false)
+				_ = g.Grant(context.Background(), repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export")
+			}, "ledger-export", false,
+		},
+		{
+			"a direct grant turns a feature on",
+			func(_ *fakeSettings, g *fakeGrants, _ *fakeAccounts) {
+				_ = g.Grant(context.Background(), repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export")
+			}, "ledger-export", true,
+		},
+		{
+			"a role grant resolves like a direct one",
+			func(_ *fakeSettings, g *fakeGrants, a *fakeAccounts) {
+				a.roles["acct-harbor|agent-ops"] = "admin"
+				_ = g.Grant(context.Background(), repositories.FeatureSubjectRole, "admin", "acct-harbor", "ledger-export")
+			}, "ledger-export", true,
+		},
+		{
+			"an account override on a non-manageable feature is ignored",
+			func(s *fakeSettings, _ *fakeGrants, _ *fakeAccounts) {
+				_ = s.SetOverride(context.Background(), repositories.FeatureScopeAccount, "acct-harbor", "audit-trail", false)
+			}, "audit-trail", true,
+		},
+		{
+			"a grant on a non-grantable feature is ignored",
+			func(s *fakeSettings, g *fakeGrants, _ *fakeAccounts) {
+				_ = s.SetOverride(context.Background(), repositories.FeatureScopeInstance, "", "audit-trail", false)
+				_ = g.Grant(context.Background(), repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "audit-trail")
+			}, "audit-trail", false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, s, g, a := testResolver(t, []entities.FeatureMeta{featEpisodic, featLedger, featAudit})
+			tc.setup(s, g, a)
+			set := mustResolve(t, r, ctx)
+			if set[tc.key] != tc.want {
+				t.Fatalf("%s resolved %v, want %v", tc.key, set[tc.key], tc.want)
+			}
+		})
+	}
+}
+
+// TestResolverAnonymousReadsInstanceLayerOnly proves the nil-identity rule is
+// implemented, not merely intended: the account and grant stores are never
+// touched, so there is no path by which a background worker or a stdio MCP
+// session could pick up someone's account override.
+func TestResolverAnonymousReadsInstanceLayerOnly(t *testing.T) {
+	r, s, g, _ := testResolver(t, []entities.FeatureMeta{featEpisodic})
+	_ = s.SetOverride(context.Background(), repositories.FeatureScopeAccount, "acct-harbor", "episodic-recall", false)
+	_ = s.SetOverride(context.Background(), repositories.FeatureScopeInstance, "", "episodic-recall", true)
+
+	set := mustResolve(t, r, context.Background())
+	if !set["episodic-recall"] {
+		t.Fatal("the anonymous caller did not get the instance-level value")
+	}
+	if _, accountReads := s.reads(); accountReads != 0 {
+		t.Fatalf("the anonymous path read the account layer %d times, want 0", accountReads)
+	}
+	if g.readCount() != 0 {
+		t.Fatalf("the anonymous path read grants %d times, want 0", g.readCount())
+	}
+}
+
+func TestResolverFailsClosedAndNeverCachesTheFailure(t *testing.T) {
+	r, s, _, _ := testResolver(t, []entities.FeatureMeta{featEpisodic})
+	boom := errors.New("database is unreachable")
+	s.err = boom
+
+	if _, err := r.ResolvedSet(ctxAs("agent-ops", "acct-harbor")); err == nil {
+		t.Fatal("ResolvedSet returned nil error while the store was unreadable")
+	}
+
+	// Recovery must be immediate. A remembered failure would keep a feature
+	// off long after the store came back.
+	s.err = nil
+	set := mustResolve(t, r, ctxAs("agent-ops", "acct-harbor"))
+	if !set["episodic-recall"] {
+		t.Fatal("the feature stayed off after the store recovered; the failure was cached")
+	}
+}
+
+func TestResolverCachesPerAgentAndAccount(t *testing.T) {
+	r, s, g, _ := testResolver(t, []entities.FeatureMeta{featEpisodic, featLedger})
+	_ = g.Grant(context.Background(), repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export")
+
+	ops := ctxAs("agent-ops", "acct-harbor")
+	for i := 0; i < 30; i++ {
+		set := mustResolve(t, r, ops)
+		if !set["ledger-export"] {
+			t.Fatalf("evaluation %d lost the grant", i)
+		}
+	}
+	instanceReads, _ := s.reads()
+	if instanceReads != 1 {
+		t.Fatalf("30 evaluations in one session read the store %d times, want 1", instanceReads)
+	}
+
+	// A different person in the same account must not be served the first
+	// person's set.
+	counsel := mustResolve(t, r, ctxAs("agent-counsel", "acct-harbor"))
+	if counsel["ledger-export"] {
+		t.Fatal("one person's grant leaked into another person's resolved set")
+	}
+
+	// Same person, different active account: a different key again.
+	instanceReads, _ = s.reads()
+	_ = mustResolve(t, r, ctxAs("agent-ops", "acct-cedar"))
+	newReads, _ := s.reads()
+	if newReads == instanceReads {
+		t.Fatal("switching account served the previous account's cached set")
+	}
+}
+
+func TestResolverInvalidation(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("InvalidateAll drops everything", func(t *testing.T) {
+		r, s, _, _ := testResolver(t, []entities.FeatureMeta{featEpisodic})
+		_ = mustResolve(t, r, ctxAs("agent-ops", "acct-harbor"))
+		_ = mustResolve(t, r, ctxAs("agent-broker", "acct-cedar"))
+		before, _ := s.reads()
+
+		r.InvalidateAll(ctx)
+		_ = mustResolve(t, r, ctxAs("agent-ops", "acct-harbor"))
+		_ = mustResolve(t, r, ctxAs("agent-broker", "acct-cedar"))
+		after, _ := s.reads()
+		if after != before+2 {
+			t.Fatalf("after InvalidateAll the store was read %d more times, want 2", after-before)
+		}
+	})
+
+	t.Run("InvalidateAccount spares other accounts", func(t *testing.T) {
+		r, s, _, _ := testResolver(t, []entities.FeatureMeta{featEpisodic})
+		_ = mustResolve(t, r, ctxAs("agent-ops", "acct-harbor"))
+		_ = mustResolve(t, r, ctxAs("agent-broker", "acct-cedar"))
+		before, _ := s.reads()
+
+		r.InvalidateAccount(ctx, "acct-harbor")
+		_ = mustResolve(t, r, ctxAs("agent-broker", "acct-cedar"))
+		if after, _ := s.reads(); after != before {
+			t.Fatal("invalidating one account re-resolved another account's session")
+		}
+		_ = mustResolve(t, r, ctxAs("agent-ops", "acct-harbor"))
+		if after, _ := s.reads(); after != before+1 {
+			t.Fatal("invalidating an account did not re-resolve its own session")
+		}
+	})
+
+	t.Run("InvalidateAgents reaches named people only", func(t *testing.T) {
+		r, s, _, _ := testResolver(t, []entities.FeatureMeta{featEpisodic})
+		_ = mustResolve(t, r, ctxAs("agent-counsel", "acct-harbor"))
+		_ = mustResolve(t, r, ctxAs("agent-clerk", "acct-harbor"))
+		_ = mustResolve(t, r, ctxAs("agent-temp", "acct-harbor"))
+		before, _ := s.reads()
+
+		// The role fan-out case: two holders invalidated in one call.
+		r.InvalidateAgents(ctx, "acct-harbor", "agent-counsel", "agent-clerk")
+
+		_ = mustResolve(t, r, ctxAs("agent-temp", "acct-harbor"))
+		if after, _ := s.reads(); after != before {
+			t.Fatal("a member who does not hold the role was re-resolved")
+		}
+		_ = mustResolve(t, r, ctxAs("agent-counsel", "acct-harbor"))
+		_ = mustResolve(t, r, ctxAs("agent-clerk", "acct-harbor"))
+		if after, _ := s.reads(); after != before+2 {
+			t.Fatal("both role holders should have been re-resolved")
+		}
+	})
+}
+
+// TestResolverMaxAgeBoundsStaleness is the backstop that makes the Postgres
+// path safe: NOTIFY is not durable, so a replica that misses an invalidation
+// must still converge. The clock is injected rather than slept on.
+func TestResolverMaxAgeBoundsStaleness(t *testing.T) {
+	registry, _ := newTestFeatureRegistry(t, featEpisodic)
+	settings := &fakeSettings{}
+	cfg := config.Default()
+	cfg.Features.CacheMaxAge = 2 * time.Second
+	r := NewFeatureResolver(cfg, registry, settings, newFakeGrants(),
+		&fakeAccounts{roles: map[string]string{}}, nil)
+
+	now := time.Now()
+	r.now = func() time.Time { return now }
+
+	ctx := ctxAs("agent-ops", "acct-harbor")
+	if set := mustResolve(t, r, ctx); !set["episodic-recall"] {
+		t.Fatal("first resolve did not return the declared default")
+	}
+
+	// The change lands in the store with no invalidation reaching this cache.
+	_ = settings.SetOverride(context.Background(), repositories.FeatureScopeInstance, "", "episodic-recall", false)
+
+	// Straight away: still the cached answer.
+	if set := mustResolve(t, r, ctx); !set["episodic-recall"] {
+		t.Fatal("the cached set expired before the maximum cache age")
+	}
+
+	// Past the age: re-resolved, without anything having invalidated it.
+	now = now.Add(3 * time.Second)
+	if set := mustResolve(t, r, ctx); set["episodic-recall"] {
+		t.Fatal("the set was not re-resolved after the maximum cache age passed")
+	}
+}
+
+// TestResolverMaxAgeDoesNotChangeAnAnswer pins the other half: expiry costs one
+// extra read, it does not alter what the caller is told.
+func TestResolverMaxAgeDoesNotChangeAnAnswer(t *testing.T) {
+	registry, _ := newTestFeatureRegistry(t, featEpisodic)
+	settings := &fakeSettings{}
+	cfg := config.Default()
+	cfg.Features.CacheMaxAge = 2 * time.Second
+	r := NewFeatureResolver(cfg, registry, settings, newFakeGrants(),
+		&fakeAccounts{roles: map[string]string{}}, nil)
+
+	now := time.Now()
+	r.now = func() time.Time { return now }
+	ctx := ctxAs("agent-ops", "acct-harbor")
+
+	_ = mustResolve(t, r, ctx)
+	before, _ := settings.reads()
+
+	now = now.Add(3 * time.Second)
+	set := mustResolve(t, r, ctx)
+	after, _ := settings.reads()
+
+	if !set["episodic-recall"] {
+		t.Fatal("expiry changed the answer when nothing had changed")
+	}
+	if after != before+1 {
+		t.Fatalf("expiry cost %d extra reads, want exactly 1", after-before)
+	}
+}
+
+// TestResolverCachedSetIsNotAliased guards against a caller mutating the map
+// it was handed and corrupting every later reader of the same cache entry.
+func TestResolverCachedSetIsNotAliased(t *testing.T) {
+	r, _, _, _ := testResolver(t, []entities.FeatureMeta{featEpisodic})
+	ctx := ctxAs("agent-ops", "acct-harbor")
+
+	first := mustResolve(t, r, ctx)
+	first["episodic-recall"] = false
+	first["injected"] = true
+
+	second := mustResolve(t, r, ctx)
+	if !second["episodic-recall"] {
+		t.Fatal("mutating a returned set corrupted the cache")
+	}
+	if _, ok := second["injected"]; ok {
+		t.Fatal("mutating a returned set injected a key into the cache")
+	}
+}

--- a/application/feature_service.go
+++ b/application/feature_service.go
@@ -1,0 +1,250 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
+)
+
+// FeatureService is the only writer of feature state, and every method here
+// follows the same two-step shape: write the store, then invalidate.
+//
+// The invalidation is an explicit call rather than an event subscription. It
+// has to be: a member's role change is a direct projection write that emits no
+// event at all, and resolution depends on the caller's role. An
+// event-driven-only invalidator would silently miss exactly the changes most
+// likely to matter.
+//
+// Stories #482 and #483 put a CLI, REST routes and MCP tools in front of these
+// methods. Nothing here knows about any of those surfaces.
+type FeatureService struct {
+	registry    *FeatureRegistry
+	settings    repositories.FeatureSettingsRepository
+	grants      repositories.FeatureGrantRepository
+	members     repositories.AccountMemberQuery
+	invalidator repositories.FeatureCacheInvalidator
+	logger      entities.Logger
+}
+
+// NewFeatureService builds the service.
+func NewFeatureService(
+	registry *FeatureRegistry,
+	settings repositories.FeatureSettingsRepository,
+	grants repositories.FeatureGrantRepository,
+	members repositories.AccountMemberQuery,
+	invalidator repositories.FeatureCacheInvalidator,
+	logger entities.Logger,
+) *FeatureService {
+	return &FeatureService{
+		registry:    registry,
+		settings:    settings,
+		grants:      grants,
+		members:     members,
+		invalidator: invalidator,
+		logger:      logger,
+	}
+}
+
+// List returns every declared feature, sorted by key.
+func (s *FeatureService) List() []entities.FeatureMeta {
+	return s.registry.All()
+}
+
+// SetInstanceFeature turns a feature explicitly on or off for the whole
+// instance. An explicit off is final for every layer below it, so this is the
+// switch that stops a broken feature for everyone.
+func (s *FeatureService) SetInstanceFeature(ctx context.Context, key string, enabled bool) error {
+	if _, err := s.declared(key); err != nil {
+		return err
+	}
+	if err := s.settings.SetOverride(ctx, repositories.FeatureScopeInstance, "", key, enabled); err != nil {
+		return err
+	}
+	s.invalidator.InvalidateAll(ctx)
+	s.log(ctx, "instance feature set", "feature", key, "enabled", enabled)
+	return nil
+}
+
+// ClearInstanceFeature removes the instance-level override so the feature
+// falls back to its declared default — which is NOT the same as turning it
+// off, because an account or a grant may still turn a declared-off feature on.
+func (s *FeatureService) ClearInstanceFeature(ctx context.Context, key string) error {
+	if _, err := s.declared(key); err != nil {
+		return err
+	}
+	if err := s.settings.ClearOverride(ctx, repositories.FeatureScopeInstance, "", key); err != nil {
+		return err
+	}
+	s.invalidator.InvalidateAll(ctx)
+	s.log(ctx, "instance feature cleared", "feature", key)
+	return nil
+}
+
+// SetAccountFeature turns a feature explicitly on or off for one account.
+func (s *FeatureService) SetAccountFeature(ctx context.Context, accountID, key string, enabled bool) error {
+	meta, err := s.declared(key)
+	if err != nil {
+		return err
+	}
+	if accountID == "" {
+		return fmt.Errorf("an account is required to override feature %q", key)
+	}
+	// Refused at the write rather than only ignored at the read. The resolver
+	// ignores an ineligible row regardless — stored rows outlive declaration
+	// changes — but an operator who asks for something impossible deserves to
+	// be told, not silently obeyed and then overruled.
+	if !meta.Manageable {
+		return fmt.Errorf("feature %q cannot be changed per account", key)
+	}
+	if err := s.settings.SetOverride(ctx, repositories.FeatureScopeAccount, accountID, key, enabled); err != nil {
+		return err
+	}
+	s.invalidator.InvalidateAccount(ctx, accountID)
+	s.log(ctx, "account feature set", "feature", key, "account", accountID, "enabled", enabled)
+	return nil
+}
+
+// ClearAccountFeature removes one account's override.
+func (s *FeatureService) ClearAccountFeature(ctx context.Context, accountID, key string) error {
+	if _, err := s.declared(key); err != nil {
+		return err
+	}
+	if accountID == "" {
+		return fmt.Errorf("an account is required to clear feature %q", key)
+	}
+	if err := s.settings.ClearOverride(ctx, repositories.FeatureScopeAccount, accountID, key); err != nil {
+		return err
+	}
+	s.invalidator.InvalidateAccount(ctx, accountID)
+	s.log(ctx, "account feature cleared", "feature", key, "account", accountID)
+	return nil
+}
+
+// GrantToAgent gives one person a feature within an account.
+func (s *FeatureService) GrantToAgent(ctx context.Context, accountID, agentID, key string) error {
+	return s.changeAgentGrant(ctx, accountID, agentID, key, true)
+}
+
+// RevokeFromAgent takes it back. The person stays signed in; their next
+// evaluation costs one database read and answers off.
+func (s *FeatureService) RevokeFromAgent(ctx context.Context, accountID, agentID, key string) error {
+	return s.changeAgentGrant(ctx, accountID, agentID, key, false)
+}
+
+func (s *FeatureService) changeAgentGrant(
+	ctx context.Context, accountID, agentID, key string, grant bool,
+) error {
+	if err := s.validateGrant(accountID, agentID, key); err != nil {
+		return err
+	}
+	var err error
+	if grant {
+		err = s.grants.Grant(ctx, repositories.FeatureSubjectAgent, agentID, accountID, key)
+	} else {
+		err = s.grants.Revoke(ctx, repositories.FeatureSubjectAgent, agentID, accountID, key)
+	}
+	if err != nil {
+		return err
+	}
+	s.invalidator.InvalidateAgents(ctx, accountID, agentID)
+	s.log(ctx, "agent grant changed", "feature", key, "account", accountID, "agent", agentID, "granted", grant)
+	return nil
+}
+
+// GrantToRole gives a feature to everyone holding a role in an account.
+func (s *FeatureService) GrantToRole(ctx context.Context, accountID, roleID, key string) error {
+	return s.changeRoleGrant(ctx, accountID, roleID, key, true)
+}
+
+// RevokeFromRole takes it back from everyone holding the role.
+func (s *FeatureService) RevokeFromRole(ctx context.Context, accountID, roleID, key string) error {
+	return s.changeRoleGrant(ctx, accountID, roleID, key, false)
+}
+
+// changeRoleGrant is the expensive case. One row changes, but the resolved set
+// of every member holding that role changes with it, so each of their cache
+// entries has to be invalidated individually.
+//
+// The member list is read AFTER the write, so anyone who joined the role
+// concurrently is included rather than missed. A member this query does not
+// return keeps a stale answer until the maximum cache age expires, and nothing
+// will point at it — which is why the listing query is tested directly.
+func (s *FeatureService) changeRoleGrant(
+	ctx context.Context, accountID, roleID, key string, grant bool,
+) error {
+	if err := s.validateGrant(accountID, roleID, key); err != nil {
+		return err
+	}
+	var err error
+	if grant {
+		err = s.grants.Grant(ctx, repositories.FeatureSubjectRole, roleID, accountID, key)
+	} else {
+		err = s.grants.Revoke(ctx, repositories.FeatureSubjectRole, roleID, accountID, key)
+	}
+	if err != nil {
+		return err
+	}
+
+	agentIDs, err := s.members.ListMemberIDsByRole(ctx, accountID, roleID)
+	if err != nil {
+		// The write landed but the fan-out failed. Fall back to invalidating
+		// the whole account: coarser than asked for, but every affected member
+		// is certainly reached, and over-invalidation only costs a re-resolve.
+		// Leaving the caches alone would strand a stale answer instead.
+		s.log(ctx, "could not list role members; invalidating the whole account instead",
+			"feature", key, "account", accountID, "role", roleID, "error", err)
+		s.invalidator.InvalidateAccount(ctx, accountID)
+		return nil
+	}
+
+	s.invalidator.InvalidateAgents(ctx, accountID, agentIDs...)
+	s.log(ctx, "role grant changed", "feature", key, "account", accountID,
+		"role", roleID, "granted", grant, "membersInvalidated", len(agentIDs))
+	return nil
+}
+
+func (s *FeatureService) validateGrant(accountID, subjectID, key string) error {
+	meta, err := s.declared(key)
+	if err != nil {
+		return err
+	}
+	if accountID == "" || subjectID == "" {
+		return fmt.Errorf("an account and a subject are required to grant feature %q", key)
+	}
+	if !meta.Grantable {
+		return fmt.Errorf("feature %q cannot be granted", key)
+	}
+	return nil
+}
+
+func (s *FeatureService) declared(key string) (entities.FeatureMeta, error) {
+	meta, ok := s.registry.Lookup(key)
+	if !ok {
+		return entities.FeatureMeta{}, fmt.Errorf("no feature named %q is declared", key)
+	}
+	return meta, nil
+}
+
+func (s *FeatureService) log(ctx context.Context, msg string, kv ...any) {
+	if s.logger == nil {
+		return
+	}
+	s.logger.Info(ctx, msg, kv...)
+}

--- a/application/feature_service_test.go
+++ b/application/feature_service_test.go
@@ -1,0 +1,230 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/wepala/weos/v3/domain/entities"
+)
+
+// recordingInvalidator records what was invalidated, so each write can be
+// checked for calling the right one — the coupling this whole story depends on.
+type recordingInvalidator struct {
+	all      int
+	accounts []string
+	agents   map[string][]string
+}
+
+func newRecordingInvalidator() *recordingInvalidator {
+	return &recordingInvalidator{agents: map[string][]string{}}
+}
+
+func (r *recordingInvalidator) InvalidateAll(context.Context) { r.all++ }
+
+func (r *recordingInvalidator) InvalidateAccount(_ context.Context, accountID string) {
+	r.accounts = append(r.accounts, accountID)
+}
+
+func (r *recordingInvalidator) InvalidateAgents(_ context.Context, accountID string, agentIDs ...string) {
+	r.agents[accountID] = append(r.agents[accountID], agentIDs...)
+}
+
+func (r *recordingInvalidator) agentsFor(accountID string) []string {
+	out := append([]string(nil), r.agents[accountID]...)
+	sort.Strings(out)
+	return out
+}
+
+type fakeMembers struct {
+	byRole map[string][]string // "accountID|roleID" -> agent IDs
+	err    error
+}
+
+func (f fakeMembers) ListMemberIDsByRole(_ context.Context, accountID, roleID string) ([]string, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.byRole[accountID+"|"+roleID], nil
+}
+
+func testService(t *testing.T, members fakeMembers, features ...entities.FeatureMeta) (
+	*FeatureService, *fakeSettings, *fakeGrants, *recordingInvalidator,
+) {
+	t.Helper()
+	registry, _ := newTestFeatureRegistry(t, features...)
+	settings := &fakeSettings{}
+	grants := newFakeGrants()
+	inv := newRecordingInvalidator()
+	return NewFeatureService(registry, settings, grants, members, inv, nil), settings, grants, inv
+}
+
+func TestServiceInstanceWritesInvalidateEverything(t *testing.T) {
+	ctx := context.Background()
+	svc, settings, _, inv := testService(t, fakeMembers{}, featEpisodic)
+
+	if err := svc.SetInstanceFeature(ctx, "episodic-recall", false); err != nil {
+		t.Fatalf("SetInstanceFeature: %v", err)
+	}
+	if inv.all != 1 {
+		t.Fatalf("InvalidateAll called %d times, want 1", inv.all)
+	}
+	if enabled, ok := settings.instance["episodic-recall"]; !ok || enabled {
+		t.Fatal("the instance override was not stored as an explicit off")
+	}
+
+	// Clearing returns the layer to silence, and is not the same as off.
+	if err := svc.ClearInstanceFeature(ctx, "episodic-recall"); err != nil {
+		t.Fatalf("ClearInstanceFeature: %v", err)
+	}
+	if _, present := settings.instance["episodic-recall"]; present {
+		t.Fatal("clearing left a row behind; unset and off must not be confusable")
+	}
+	if inv.all != 2 {
+		t.Fatalf("InvalidateAll called %d times after a clear, want 2", inv.all)
+	}
+}
+
+func TestServiceAccountWritesInvalidateOnlyThatAccount(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _, inv := testService(t, fakeMembers{}, featEpisodic)
+
+	if err := svc.SetAccountFeature(ctx, "acct-harbor", "episodic-recall", false); err != nil {
+		t.Fatalf("SetAccountFeature: %v", err)
+	}
+	if inv.all != 0 {
+		t.Fatal("an account change invalidated every account")
+	}
+	if len(inv.accounts) != 1 || inv.accounts[0] != "acct-harbor" {
+		t.Fatalf("invalidated accounts = %v, want [acct-harbor]", inv.accounts)
+	}
+}
+
+func TestServiceRefusesIneligibleWrites(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _, inv := testService(t, fakeMembers{}, featEpisodic, featAudit)
+
+	cases := []struct {
+		name string
+		call func() error
+		want string
+	}{
+		{"undeclared key, instance", func() error {
+			return svc.SetInstanceFeature(ctx, "shipping-labels", true)
+		}, "no feature named"},
+		{"undeclared key, account", func() error {
+			return svc.SetAccountFeature(ctx, "acct-harbor", "shipping-labels", true)
+		}, "no feature named"},
+		{"non-manageable per account", func() error {
+			return svc.SetAccountFeature(ctx, "acct-harbor", "audit-trail", false)
+		}, "cannot be changed per account"},
+		{"non-grantable to an agent", func() error {
+			return svc.GrantToAgent(ctx, "acct-harbor", "agent-ops", "audit-trail")
+		}, "cannot be granted"},
+		{"non-grantable to a role", func() error {
+			return svc.GrantToRole(ctx, "acct-harbor", "admin", "audit-trail")
+		}, "cannot be granted"},
+		{"account override with no account", func() error {
+			return svc.SetAccountFeature(ctx, "", "episodic-recall", true)
+		}, "account is required"},
+		{"grant with no subject", func() error {
+			return svc.GrantToAgent(ctx, "acct-harbor", "", "episodic-recall")
+		}, "account and a subject are required"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call()
+			if err == nil {
+				t.Fatal("the write was accepted, want a refusal")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %q, want it to contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+
+	// A refused write must not have invalidated anything.
+	if inv.all != 0 || len(inv.accounts) != 0 || len(inv.agents) != 0 {
+		t.Fatal("a refused write still invalidated caches")
+	}
+}
+
+func TestServiceAgentGrantInvalidatesThatPersonOnly(t *testing.T) {
+	ctx := context.Background()
+	svc, _, grants, inv := testService(t, fakeMembers{}, featLedger)
+
+	if err := svc.GrantToAgent(ctx, "acct-harbor", "agent-ops", "ledger-export"); err != nil {
+		t.Fatalf("GrantToAgent: %v", err)
+	}
+	if got := inv.agentsFor("acct-harbor"); len(got) != 1 || got[0] != "agent-ops" {
+		t.Fatalf("invalidated agents = %v, want [agent-ops]", got)
+	}
+	if !grants.byKey["acct-harbor|agent-ops"]["ledger-export"] {
+		t.Fatal("the grant was not stored")
+	}
+
+	if err := svc.RevokeFromAgent(ctx, "acct-harbor", "agent-ops", "ledger-export"); err != nil {
+		t.Fatalf("RevokeFromAgent: %v", err)
+	}
+	if grants.byKey["acct-harbor|agent-ops"]["ledger-export"] {
+		t.Fatal("the grant survived the revoke")
+	}
+	if got := inv.agentsFor("acct-harbor"); len(got) != 2 {
+		t.Fatalf("a revoke did not invalidate; agents = %v", got)
+	}
+}
+
+// TestServiceRoleGrantFansOutToEveryHolder is the expensive case Akeem chose
+// precision on. One row changes; every holder's cache entry must be dropped,
+// and nobody else's.
+func TestServiceRoleGrantFansOutToEveryHolder(t *testing.T) {
+	ctx := context.Background()
+	members := fakeMembers{byRole: map[string][]string{
+		"acct-harbor|admin": {"agent-counsel", "agent-clerk"},
+	}}
+	svc, _, _, inv := testService(t, members, featLedger)
+
+	if err := svc.GrantToRole(ctx, "acct-harbor", "admin", "ledger-export"); err != nil {
+		t.Fatalf("GrantToRole: %v", err)
+	}
+	got := inv.agentsFor("acct-harbor")
+	if len(got) != 2 || got[0] != "agent-clerk" || got[1] != "agent-counsel" {
+		t.Fatalf("invalidated agents = %v, want both role holders", got)
+	}
+	if len(inv.accounts) != 0 || inv.all != 0 {
+		t.Fatal("a role grant invalidated more broadly than the holders")
+	}
+}
+
+// TestServiceRoleGrantFallsBackWhenTheMemberListFails covers the case that
+// would otherwise strand stale answers: the grant landed, so leaving caches
+// alone is not an option, and over-invalidating only costs a re-resolve.
+func TestServiceRoleGrantFallsBackWhenTheMemberListFails(t *testing.T) {
+	ctx := context.Background()
+	members := fakeMembers{err: errors.New("account_members is unreadable")}
+	svc, _, grants, inv := testService(t, members, featLedger)
+
+	if err := svc.GrantToRole(ctx, "acct-harbor", "admin", "ledger-export"); err != nil {
+		t.Fatalf("GrantToRole returned %v; the write landed, so it must not fail", err)
+	}
+	if !grants.byKey["acct-harbor|admin"]["ledger-export"] {
+		t.Fatal("the grant was not stored")
+	}
+	if len(inv.accounts) != 1 || inv.accounts[0] != "acct-harbor" {
+		t.Fatalf("fell back to %v, want a whole-account invalidation", inv.accounts)
+	}
+}
+
+func TestServiceListReturnsDeclarationsSorted(t *testing.T) {
+	svc, _, _, _ := testService(t, fakeMembers{}, featLedger, featEpisodic, featAudit)
+	got := svc.List()
+	if len(got) != 3 {
+		t.Fatalf("List returned %d features, want 3", len(got))
+	}
+	if got[0].Key != "audit-trail" || got[1].Key != "episodic-recall" || got[2].Key != "ledger-export" {
+		t.Fatalf("List is not sorted by key: %v, %v, %v", got[0].Key, got[1].Key, got[2].Key)
+	}
+}

--- a/application/module.go
+++ b/application/module.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"context"
+	"github.com/open-feature/go-sdk/openfeature"
 
 	appagents "github.com/wepala/weos/v3/application/agents"
 	"github.com/wepala/weos/v3/domain/entities"
@@ -133,6 +134,12 @@ func Module(cfg config.Config, registry *PresetRegistry) fx.Option {
 		fx.Provide(NewFeatureResolver),
 		fx.Provide(ProvideFeatureCacheInvalidator),
 		fx.Provide(NewFeatureProvider),
+		fx.Provide(RegisterFeatureProvider),
+		// fx builds only what something depends on. Without this Invoke the
+		// provider is never constructed and never registered, so the OpenFeature
+		// domain falls through to the SDK's no-op provider and every evaluation
+		// silently returns the caller's default.
+		fx.Invoke(func(*openfeature.Client) {}),
 		fx.Provide(NewFeatureService),
 
 		// Email sender

--- a/application/module.go
+++ b/application/module.go
@@ -117,6 +117,24 @@ func Module(cfg config.Config, registry *PresetRegistry) fx.Option {
 		fx.Provide(ProvidePresetHTTPHandlers),
 		fx.Provide(gorm.ProvideBehaviorSettingsRepository),
 
+		// Feature flags (epic #480). The resolver owns the per-caller cache
+		// and IS the in-process invalidator — on SQLite that is the complete
+		// implementation, not a fallback, because SQLite is single-process by
+		// construction. ProvideFeatureCacheInvalidator wraps it with a
+		// Postgres broadcast only when the deployment can actually have
+		// replicas.
+		fx.Provide(fx.Annotate(
+			NewFeatureRegistry,
+			fx.ParamTags(``, ``, `group:"feature_declarations"`),
+		)),
+		fx.Provide(gorm.ProvideFeatureSettingsRepository),
+		fx.Provide(gorm.ProvideFeatureGrantRepository),
+		fx.Provide(gorm.ProvideAccountMemberQuery),
+		fx.Provide(NewFeatureResolver),
+		fx.Provide(ProvideFeatureCacheInvalidator),
+		fx.Provide(NewFeatureProvider),
+		fx.Provide(NewFeatureService),
+
 		// Email sender
 		fx.Provide(email.ProvideEmailSender),
 

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -70,9 +70,17 @@ type PresetDefinition struct {
 	Types        []PresetResourceType
 	Behaviors    map[string]BehaviorFactory       // slug -> factory invoked at startup with services
 	BehaviorMeta map[string]entities.BehaviorMeta // slug -> metadata for UI/config
-	Screens      fs.FS                            // optional embedded screen components
-	Sidebar      *PresetSidebarConfig             // optional sidebar defaults
-	Handlers     []PresetHTTPHandler              // optional HTTP routes mounted under /api
+	// Features declares the feature flags this preset owns, keyed by flag key.
+	// Unlike Behaviors, whose slug IS a resource type slug, a feature key is
+	// its own namespace and need not correspond to any type — a preset may
+	// gate a capability that spans several types, or none. Declarations are
+	// read straight from this registry at resolution time rather than copied
+	// anywhere, so installing a preset makes its features known immediately
+	// and nothing has to be persisted or replayed. See FeatureRegistry.
+	Features map[string]entities.FeatureMeta
+	Screens  fs.FS                // optional embedded screen components
+	Sidebar  *PresetSidebarConfig // optional sidebar defaults
+	Handlers []PresetHTTPHandler  // optional HTTP routes mounted under /api
 	// Links declares cross-type relationships that live outside any resource
 	// type's schema. Each link activates when both SourceType and TargetType
 	// are installed — enabling a "finance-education" integration preset to
@@ -340,6 +348,13 @@ func (d PresetDefinition) clone() PresetDefinition {
 			meta[k] = v
 		}
 		d.BehaviorMeta = meta
+	}
+	if d.Features != nil {
+		features := make(map[string]entities.FeatureMeta, len(d.Features))
+		for k, v := range d.Features {
+			features[k] = v
+		}
+		d.Features = features
 	}
 	if d.Handlers != nil {
 		handlers := make([]PresetHTTPHandler, len(d.Handlers))
@@ -619,6 +634,31 @@ func (r *PresetRegistry) BehaviorsMeta() BehaviorMetaRegistry {
 		}
 	}
 	return meta
+}
+
+// Features returns the merged feature declarations from all registered
+// presets. Same merge semantics as BehaviorsMeta(): presets are walked in
+// alphabetical order and the last declaration of a key wins.
+//
+// Read on demand rather than copied at install time, so a preset installed
+// while the process is running contributes its features to the very next
+// resolution with no hook in InstallPreset and nothing persisted.
+func (r *PresetRegistry) Features() map[string]entities.FeatureMeta {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.presets))
+	for name := range r.presets {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	features := make(map[string]entities.FeatureMeta)
+	for _, name := range names {
+		for key, m := range r.presets[name].Features {
+			features[key] = m
+		}
+	}
+	return features
 }
 
 // NewPresetType is a helper to create a PresetResourceType from raw strings.

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -221,6 +221,9 @@ func (r *PresetRegistry) Add(def PresetDefinition) error {
 			return fmt.Errorf("preset %q: behavior factory for slug %q is nil", def.Name, slug)
 		}
 	}
+	if err := validatePresetFeatures(def); err != nil {
+		return err
+	}
 	if err := validateHandlers(def); err != nil {
 		return err
 	}
@@ -230,6 +233,31 @@ func (r *PresetRegistry) Add(def PresetDefinition) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.presets[def.Name] = def
+	return nil
+}
+
+// validatePresetFeatures holds preset declarations to the same standard as
+// code declarations. Without it FeatureRegistry's contract — that an invalid
+// declaration fails the boot rather than being resolved against — would only
+// hold for code, and a preset could ship a key nothing can gate.
+//
+// The map key and the declaration's own Key must agree. If they diverge —
+// Features: {"a": {Key: "b"}} — Lookup("a") finds the declaration while
+// resolution folds the value under "b", so Enabled("a") never finds its key in
+// the resolved set and falls through to the declared default, ignoring every
+// stored override permanently.
+func validatePresetFeatures(def PresetDefinition) error {
+	for key, meta := range def.Features {
+		if key != meta.Key {
+			return fmt.Errorf(
+				"preset %q: feature declared under key %q but names itself %q; "+
+					"resolution would fold its value under a key nothing looks up",
+				def.Name, key, meta.Key)
+		}
+		if err := meta.Validate(); err != nil {
+			return fmt.Errorf("preset %q: %w", def.Name, err)
+		}
+	}
 	return nil
 }
 

--- a/domain/entities/feature.go
+++ b/domain/entities/feature.go
@@ -70,6 +70,40 @@ func (m FeatureMeta) Validate() error {
 	return nil
 }
 
+// FeatureLayer names which layer decided a feature's value. It exists so the
+// operator CLI's "explain" output (#482) and the admin listing (#486) can say
+// WHY a feature is on or off without re-deriving the rules — the mistake this
+// whole file exists to prevent.
+//
+// Widened into ResolveFeature's signature before any call site existed;
+// afterwards it would have been a breaking change to the one shared function.
+type FeatureLayer int
+
+const (
+	// FeatureLayerDefault means no layer spoke; the declaration's Default stands.
+	FeatureLayerDefault FeatureLayer = iota
+	// FeatureLayerInstance means the instance layer decided.
+	FeatureLayerInstance
+	// FeatureLayerAccount means the account override decided.
+	FeatureLayerAccount
+	// FeatureLayerGrant means a grant turned it on.
+	FeatureLayerGrant
+)
+
+// String renders the layer for operator-facing output.
+func (l FeatureLayer) String() string {
+	switch l {
+	case FeatureLayerInstance:
+		return "instance"
+	case FeatureLayerAccount:
+		return "account"
+	case FeatureLayerGrant:
+		return "grant"
+	default:
+		return "default"
+	}
+}
+
 // FeatureState is what one layer says about a feature. The zero value is
 // FeatureUnset, so a layer that has stored nothing says nothing — which is what
 // makes row-absence the storage representation of "unset" and removes any need
@@ -116,26 +150,34 @@ const (
 // account override on a non-manageable feature, and a grant on a non-grantable
 // feature, are both ignored. Stored rows can outlive a declaration change, and
 // resolution must not depend on whoever wrote the row.
-func ResolveFeature(meta FeatureMeta, instance, account FeatureState, granted bool) bool {
+// The second result names the layer that decided, so callers can explain the
+// answer rather than guess at it.
+func ResolveFeature(
+	meta FeatureMeta, instance, account FeatureState, granted bool,
+) (bool, FeatureLayer) {
 	value := meta.Default
+	decidedBy := FeatureLayerDefault
 
 	if instance != FeatureUnset {
 		if instance == FeatureOff {
-			return false
+			return false, FeatureLayerInstance
 		}
 		value = true
+		decidedBy = FeatureLayerInstance
 	}
 
 	if meta.Manageable && account != FeatureUnset {
 		if account == FeatureOff {
-			return false
+			return false, FeatureLayerAccount
 		}
 		value = true
+		decidedBy = FeatureLayerAccount
 	}
 
 	if meta.Grantable && granted {
 		value = true
+		decidedBy = FeatureLayerGrant
 	}
 
-	return value
+	return value, decidedBy
 }

--- a/domain/entities/feature.go
+++ b/domain/entities/feature.go
@@ -1,0 +1,141 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package entities
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// featureKeyRe constrains a flag key to what an operator can type and what
+// OpenFeature call sites can embed in a constant: lowercase, hyphenated,
+// starting with a letter. Deliberately narrower than a resource-type slug —
+// flags are their own namespace and must never be confused with one.
+var featureKeyRe = regexp.MustCompile(`^[a-z][a-z0-9-]{0,63}$`)
+
+// FeatureMeta declares a feature flag. It mirrors BehaviorMeta field-for-field
+// (see resource_behavior.go) plus Grantable, because the two are the same kind
+// of declaration seen from different ends: BehaviorMeta describes a behavior an
+// account may switch, FeatureMeta describes a capability an instance, an
+// account, or one person may hold.
+//
+// The declaration is the whole of what the instance knows about a feature
+// before anyone has stored anything. Nothing here is persisted: features are
+// declared in code or by a preset, so the registry is rebuilt from the binary
+// on every boot and can never drift from what the code can actually gate.
+type FeatureMeta struct {
+	// Key is what call sites pass to the OpenFeature client, after the
+	// "feature." prefix.
+	Key string
+	// DisplayName and Description are what an operator reads in the CLI
+	// (#482) and the admin UI (#486). Neither affects resolution.
+	DisplayName string
+	Description string
+	// Default is the value when no layer has spoken. It is NOT the same as
+	// an explicit instance-level off — see ResolveFeature.
+	Default bool
+	// Manageable allows an account admin to override the feature for their
+	// account. When false, a stored account override is ignored rather than
+	// rejected: the row may predate a declaration change, and resolution must
+	// never depend on a writer having been well-behaved.
+	Manageable bool
+	// Grantable allows the feature to be granted to one agent or to a role.
+	// When false, a stored grant is ignored, for the same reason.
+	Grantable bool
+}
+
+// Validate reports whether the declaration is usable. A registry rejects an
+// invalid declaration at boot rather than resolving against it, because a
+// malformed key is a programming error the operator cannot fix at runtime.
+func (m FeatureMeta) Validate() error {
+	if !featureKeyRe.MatchString(m.Key) {
+		return fmt.Errorf("feature key %q must match %s", m.Key, featureKeyRe.String())
+	}
+	if m.DisplayName == "" {
+		return fmt.Errorf("feature %q must declare a display name", m.Key)
+	}
+	return nil
+}
+
+// FeatureState is what one layer says about a feature. The zero value is
+// FeatureUnset, so a layer that has stored nothing says nothing — which is what
+// makes row-absence the storage representation of "unset" and removes any need
+// for a nullable column or a sentinel value.
+type FeatureState int
+
+const (
+	// FeatureUnset means this layer has no opinion; resolution passes through
+	// it untouched.
+	FeatureUnset FeatureState = iota
+	// FeatureOn means this layer explicitly turned the feature on.
+	FeatureOn
+	// FeatureOff means this layer explicitly turned the feature off.
+	FeatureOff
+)
+
+// ResolveFeature answers whether a feature is on for one caller, given what
+// each layer says. It is the single definition of precedence in the codebase:
+// the resolver, the operator CLI's "explain" output (#482), and the admin
+// listing (#486) all call this rather than re-deriving the rules, so the three
+// can never disagree.
+//
+// The layers speak in order — instance, then account, then grant — and the
+// rules are:
+//
+//   - A layer that says nothing passes through untouched. So a feature nobody
+//     has touched answers meta.Default.
+//   - An explicit OFF is final for every layer below it. An operator who turns
+//     a feature off for the instance has turned it off for everyone, and no
+//     account override and no grant reaches past that.
+//   - An explicit ON is NOT final. An account may still turn off a feature the
+//     instance turned on. This asymmetry is deliberate and is the rule most
+//     likely to be implemented backwards, because the acceptance contract does
+//     not exercise instance-on plus account-off — the truth table beside this
+//     function does.
+//   - meta.Default is NOT an explicit off. Reading "first off wins" strictly
+//     would make a feature declared Default:false unreachable forever, leaving
+//     the Default field with one usable value. A declared-off feature can still
+//     be turned on by an account or by a grant.
+//   - A grant can only turn a feature ON, never off. Grants are the bottom
+//     layer, so a grant cannot rescue a feature an upper layer switched off.
+//
+// Eligibility is re-checked here rather than trusted from the store: an
+// account override on a non-manageable feature, and a grant on a non-grantable
+// feature, are both ignored. Stored rows can outlive a declaration change, and
+// resolution must not depend on whoever wrote the row.
+func ResolveFeature(meta FeatureMeta, instance, account FeatureState, granted bool) bool {
+	value := meta.Default
+
+	if instance != FeatureUnset {
+		if instance == FeatureOff {
+			return false
+		}
+		value = true
+	}
+
+	if meta.Manageable && account != FeatureUnset {
+		if account == FeatureOff {
+			return false
+		}
+		value = true
+	}
+
+	if meta.Grantable && granted {
+		value = true
+	}
+
+	return value
+}

--- a/domain/entities/feature_test.go
+++ b/domain/entities/feature_test.go
@@ -1,0 +1,136 @@
+package entities
+
+import (
+	"strings"
+	"testing"
+)
+
+// grantable is the declaration used by most cases below: an account may change
+// it and it may be granted, so every layer is live and the table exercises
+// precedence rather than eligibility.
+func grantable(def bool) FeatureMeta {
+	return FeatureMeta{
+		Key: "ledger-export", DisplayName: "Ledger export",
+		Default: def, Manageable: true, Grantable: true,
+	}
+}
+
+// TestResolveFeature is the exhaustive truth table over every layer
+// combination. It exists because the acceptance contract cannot reach one of
+// these rows: no scenario stages an instance-level ON together with an account
+// OFF, so the fold could be written with ON treated as final and all 33
+// scenarios would still pass. The rows marked "contract gap" below are the
+// ones only this test proves.
+func TestResolveFeature(t *testing.T) {
+	cases := []struct {
+		name     string
+		meta     FeatureMeta
+		instance FeatureState
+		account  FeatureState
+		granted  bool
+		want     bool
+	}{
+		// Nobody has spoken: the declared default stands, and it is not an
+		// explicit off — a declared-off feature must remain reachable.
+		{"default on, nothing stored", grantable(true), FeatureUnset, FeatureUnset, false, true},
+		{"default off, nothing stored", grantable(false), FeatureUnset, FeatureUnset, false, false},
+
+		// A declared-off feature can still be turned on from below. This is
+		// the whole reason Default and an explicit instance off are different
+		// states; read "first off wins" strictly and every row here is false.
+		{"default off, account on", grantable(false), FeatureUnset, FeatureOn, false, true},
+		{"default off, granted", grantable(false), FeatureUnset, FeatureUnset, true, true},
+		{"default off, instance on", grantable(false), FeatureOn, FeatureUnset, false, true},
+
+		// An explicit off is final for every layer below it.
+		{"instance off beats account on", grantable(true), FeatureOff, FeatureOn, false, false},
+		{"instance off beats grant", grantable(true), FeatureOff, FeatureUnset, true, false},
+		{"instance off beats account on and grant", grantable(true), FeatureOff, FeatureOn, true, false},
+		{"account off beats grant", grantable(true), FeatureUnset, FeatureOff, true, false},
+
+		// contract gap: an explicit ON is NOT final. An account may still turn
+		// off what the instance turned on. No .feature scenario covers these.
+		{"instance on does not beat account off", grantable(true), FeatureOn, FeatureOff, false, false},
+		{"instance on, account off, granted", grantable(false), FeatureOn, FeatureOff, true, false},
+
+		// A grant only ever turns a feature on; it can never turn one off.
+		{"grant cannot lower account on", grantable(true), FeatureUnset, FeatureOn, false, true},
+		{"grant raises a default-off feature", grantable(false), FeatureUnset, FeatureUnset, true, true},
+
+		// Eligibility is re-checked at resolution, because a stored row can
+		// outlive a declaration change and resolution must not depend on the
+		// writer having been well behaved.
+		{
+			"account override ignored when not manageable",
+			FeatureMeta{Key: "audit-trail", DisplayName: "Audit trail", Default: true},
+			FeatureUnset, FeatureOff, false, true,
+		},
+		{
+			"grant ignored when not grantable",
+			FeatureMeta{Key: "audit-trail", DisplayName: "Audit trail", Default: false},
+			FeatureUnset, FeatureUnset, true, false,
+		},
+		{
+			"non-manageable still obeys the instance layer",
+			FeatureMeta{Key: "audit-trail", DisplayName: "Audit trail", Default: true},
+			FeatureOff, FeatureUnset, false, false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveFeature(tc.meta, tc.instance, tc.account, tc.granted)
+			if got != tc.want {
+				t.Fatalf("ResolveFeature(default=%v manageable=%v grantable=%v, instance=%v, account=%v, granted=%v) = %v, want %v",
+					tc.meta.Default, tc.meta.Manageable, tc.meta.Grantable,
+					tc.instance, tc.account, tc.granted, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFeatureStateZeroValueIsUnset pins the property that makes row-absence the
+// storage representation of "unset": a FeatureState nobody assigned must say
+// nothing, so a missing row needs no nullable column and no sentinel.
+func TestFeatureStateZeroValueIsUnset(t *testing.T) {
+	var s FeatureState
+	if s != FeatureUnset {
+		t.Fatalf("zero FeatureState = %v, want FeatureUnset", s)
+	}
+}
+
+func TestFeatureMetaValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		meta    FeatureMeta
+		wantErr string
+	}{
+		{"valid", FeatureMeta{Key: "ledger-export", DisplayName: "Ledger export"}, ""},
+		{"single letter key", FeatureMeta{Key: "a", DisplayName: "A"}, ""},
+		{"digits and hyphens", FeatureMeta{Key: "sea-math-2027", DisplayName: "SEA math"}, ""},
+		{"empty key", FeatureMeta{DisplayName: "X"}, "must match"},
+		{"uppercase rejected", FeatureMeta{Key: "LedgerExport", DisplayName: "X"}, "must match"},
+		{"underscore rejected", FeatureMeta{Key: "ledger_export", DisplayName: "X"}, "must match"},
+		{"leading digit rejected", FeatureMeta{Key: "2027-sea", DisplayName: "X"}, "must match"},
+		{"namespace prefix rejected", FeatureMeta{Key: "feature.ledger", DisplayName: "X"}, "must match"},
+		{"missing display name", FeatureMeta{Key: "ledger-export"}, "display name"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.meta.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() = nil, want an error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Validate() = %q, want it to contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}

--- a/domain/entities/feature_test.go
+++ b/domain/entities/feature_test.go
@@ -23,39 +23,40 @@ func grantable(def bool) FeatureMeta {
 // ones only this test proves.
 func TestResolveFeature(t *testing.T) {
 	cases := []struct {
-		name     string
-		meta     FeatureMeta
-		instance FeatureState
-		account  FeatureState
-		granted  bool
-		want     bool
+		name      string
+		meta      FeatureMeta
+		instance  FeatureState
+		account   FeatureState
+		granted   bool
+		want      bool
+		decidedBy FeatureLayer
 	}{
 		// Nobody has spoken: the declared default stands, and it is not an
 		// explicit off — a declared-off feature must remain reachable.
-		{"default on, nothing stored", grantable(true), FeatureUnset, FeatureUnset, false, true},
-		{"default off, nothing stored", grantable(false), FeatureUnset, FeatureUnset, false, false},
+		{"default on, nothing stored", grantable(true), FeatureUnset, FeatureUnset, false, true, FeatureLayerDefault},
+		{"default off, nothing stored", grantable(false), FeatureUnset, FeatureUnset, false, false, FeatureLayerDefault},
 
 		// A declared-off feature can still be turned on from below. This is
 		// the whole reason Default and an explicit instance off are different
 		// states; read "first off wins" strictly and every row here is false.
-		{"default off, account on", grantable(false), FeatureUnset, FeatureOn, false, true},
-		{"default off, granted", grantable(false), FeatureUnset, FeatureUnset, true, true},
-		{"default off, instance on", grantable(false), FeatureOn, FeatureUnset, false, true},
+		{"default off, account on", grantable(false), FeatureUnset, FeatureOn, false, true, FeatureLayerAccount},
+		{"default off, granted", grantable(false), FeatureUnset, FeatureUnset, true, true, FeatureLayerGrant},
+		{"default off, instance on", grantable(false), FeatureOn, FeatureUnset, false, true, FeatureLayerInstance},
 
 		// An explicit off is final for every layer below it.
-		{"instance off beats account on", grantable(true), FeatureOff, FeatureOn, false, false},
-		{"instance off beats grant", grantable(true), FeatureOff, FeatureUnset, true, false},
-		{"instance off beats account on and grant", grantable(true), FeatureOff, FeatureOn, true, false},
-		{"account off beats grant", grantable(true), FeatureUnset, FeatureOff, true, false},
+		{"instance off beats account on", grantable(true), FeatureOff, FeatureOn, false, false, FeatureLayerInstance},
+		{"instance off beats grant", grantable(true), FeatureOff, FeatureUnset, true, false, FeatureLayerInstance},
+		{"instance off beats account on and grant", grantable(true), FeatureOff, FeatureOn, true, false, FeatureLayerInstance},
+		{"account off beats grant", grantable(true), FeatureUnset, FeatureOff, true, false, FeatureLayerAccount},
 
 		// contract gap: an explicit ON is NOT final. An account may still turn
 		// off what the instance turned on. No .feature scenario covers these.
-		{"instance on does not beat account off", grantable(true), FeatureOn, FeatureOff, false, false},
-		{"instance on, account off, granted", grantable(false), FeatureOn, FeatureOff, true, false},
+		{"instance on does not beat account off", grantable(true), FeatureOn, FeatureOff, false, false, FeatureLayerAccount},
+		{"instance on, account off, granted", grantable(false), FeatureOn, FeatureOff, true, false, FeatureLayerAccount},
 
 		// A grant only ever turns a feature on; it can never turn one off.
-		{"grant cannot lower account on", grantable(true), FeatureUnset, FeatureOn, false, true},
-		{"grant raises a default-off feature", grantable(false), FeatureUnset, FeatureUnset, true, true},
+		{"grant cannot lower account on", grantable(true), FeatureUnset, FeatureOn, false, true, FeatureLayerAccount},
+		{"grant raises a default-off feature", grantable(false), FeatureUnset, FeatureUnset, true, true, FeatureLayerGrant},
 
 		// Eligibility is re-checked at resolution, because a stored row can
 		// outlive a declaration change and resolution must not depend on the
@@ -63,27 +64,33 @@ func TestResolveFeature(t *testing.T) {
 		{
 			"account override ignored when not manageable",
 			FeatureMeta{Key: "audit-trail", DisplayName: "Audit trail", Default: true},
-			FeatureUnset, FeatureOff, false, true,
+			FeatureUnset, FeatureOff, false, true, FeatureLayerDefault,
 		},
 		{
 			"grant ignored when not grantable",
 			FeatureMeta{Key: "audit-trail", DisplayName: "Audit trail", Default: false},
-			FeatureUnset, FeatureUnset, true, false,
+			FeatureUnset, FeatureUnset, true, false, FeatureLayerDefault,
 		},
 		{
 			"non-manageable still obeys the instance layer",
 			FeatureMeta{Key: "audit-trail", DisplayName: "Audit trail", Default: true},
-			FeatureOff, FeatureUnset, false, false,
+			FeatureOff, FeatureUnset, false, false, FeatureLayerInstance,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := ResolveFeature(tc.meta, tc.instance, tc.account, tc.granted)
+			got, decidedBy := ResolveFeature(tc.meta, tc.instance, tc.account, tc.granted)
 			if got != tc.want {
 				t.Fatalf("ResolveFeature(default=%v manageable=%v grantable=%v, instance=%v, account=%v, granted=%v) = %v, want %v",
 					tc.meta.Default, tc.meta.Manageable, tc.meta.Grantable,
 					tc.instance, tc.account, tc.granted, got, tc.want)
+			}
+			// The deciding layer is what #482's explain output and #486's
+			// listing will show an operator. A wrong layer with a right value
+			// is a wrong explanation, so it is pinned here too.
+			if decidedBy != tc.decidedBy {
+				t.Fatalf("decided by %v, want %v", decidedBy, tc.decidedBy)
 			}
 		})
 	}

--- a/domain/repositories/feature_cache_invalidator.go
+++ b/domain/repositories/feature_cache_invalidator.go
@@ -1,0 +1,62 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package repositories
+
+import "context"
+
+// FeatureCacheInvalidator drops resolved feature sets so a change reaches
+// people who are already signed in.
+//
+// There is one rule and it has no exceptions: a change to the instance, to an
+// account, or to a grant reaches sessions that are already open. What varies
+// between deployments is only the machinery behind this interface, never the
+// behaviour in front of it — tie the two together and a bug that only appears
+// under replicas never shows up on the single-process instance it was
+// developed on.
+//
+// Two implementations:
+//
+//   - In process. Evicts from the local cache. On SQLite this is the complete
+//     and exact implementation, not a fallback: SQLite is single-process with
+//     serialized writers, so there is no second cache to reach.
+//   - Postgres. Evicts locally, then broadcasts on a NOTIFY channel so other
+//     replicas evict too. Deliberately NOT a checkpointed subscriber group:
+//     those lock their checkpoint row FOR UPDATE SKIP LOCKED and behave as
+//     competing consumers, so exactly one replica would process each event and
+//     every other replica would serve a stale answer indefinitely.
+//
+// None of this ever ends a session. Dropping what a session resolved costs its
+// next evaluation one database read; the person stays signed in. Ending a
+// session is a different act, belonging to a different feature.
+//
+// Invalidation is always called explicitly at the write site. Subscribing to
+// events would not be enough on its own — a member's role change is a direct
+// projection write that emits no event, and resolution depends on the caller's
+// role.
+type FeatureCacheInvalidator interface {
+	// InvalidateAll drops every cached set. Used for an instance-level change,
+	// and by a replica told that something changed elsewhere.
+	InvalidateAll(ctx context.Context)
+
+	// InvalidateAccount drops every cached set belonging to one account.
+	InvalidateAccount(ctx context.Context, accountID string)
+
+	// InvalidateAgents drops the cached sets of specific people within one
+	// account. Variadic because the expensive case — a role grant changing —
+	// invalidates every member holding that role, and doing so in one call
+	// keeps the fan-out at the call site where the member list was read.
+	InvalidateAgents(ctx context.Context, accountID string, agentIDs ...string)
+}

--- a/domain/repositories/feature_repository.go
+++ b/domain/repositories/feature_repository.go
@@ -1,0 +1,100 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package repositories
+
+import "context"
+
+// Override scopes. The instance scope has no identifier — there is one
+// instance — so its rows carry an empty ScopeID.
+const (
+	FeatureScopeInstance = "instance"
+	FeatureScopeAccount  = "account"
+)
+
+// Grant subjects. A grant names either one agent or one role; roles are
+// per-account memberships, so both are stored with the owning account.
+const (
+	FeatureSubjectAgent = "agent"
+	FeatureSubjectRole  = "role"
+)
+
+// FeatureSettingsRepository persists the two override layers — instance and
+// account. Both layers have identical shape, so they share a table
+// discriminated by scope.
+//
+// Presence of a row IS the explicit state and absence IS "unset". That is why
+// setting and clearing are separate methods rather than one method taking a
+// *bool: a nil-versus-false slip at a call site would turn "stop overriding
+// this" into "turn this off for everyone", which is the single most damaging
+// mistake available in this subsystem.
+type FeatureSettingsRepository interface {
+	// InstanceOverrides returns every explicit instance-level value, keyed by
+	// feature key. An absent key means the instance layer says nothing.
+	//
+	// Deliberately separate from AccountOverrides rather than one call taking
+	// an optional account: resolution for a caller with no identity must read
+	// the instance layer and nothing else, and keeping the reads separate is
+	// what makes that observable to a test rather than merely intended.
+	InstanceOverrides(ctx context.Context) (map[string]bool, error)
+
+	// AccountOverrides returns every explicit value for one account.
+	AccountOverrides(ctx context.Context, accountID string) (map[string]bool, error)
+
+	// SetOverride writes an explicit value for a scope, replacing any existing
+	// one. scopeID is empty for FeatureScopeInstance.
+	SetOverride(ctx context.Context, scopeType, scopeID, featureKey string, enabled bool) error
+
+	// ClearOverride removes the row, returning the layer to "says nothing" so
+	// the layer above it decides. Clearing a row that does not exist is not an
+	// error — the caller's intent is already satisfied.
+	ClearOverride(ctx context.Context, scopeType, scopeID, featureKey string) error
+}
+
+// FeatureGrantRepository persists the bottom layer. A grant is a fact with a
+// subject, not a value: grants only ever turn a feature on, so there is no
+// enabled column and revoking means deleting the row. An override is what says
+// "off".
+//
+// Kept separate from FeatureSettingsRepository because the two diverge
+// immediately: #483 adds validity windows and provenance to grants alone,
+// which would be permanently null on every instance-scoped override row.
+type FeatureGrantRepository interface {
+	// GrantedKeys returns the feature keys granted to this caller within an
+	// account, unioning the grant made to them directly with the grant carried
+	// by their role. roleID may be empty when the caller holds no role.
+	GrantedKeys(ctx context.Context, accountID, agentID, roleID string) (map[string]bool, error)
+
+	// Grant records a grant. Granting twice is not an error.
+	Grant(ctx context.Context, subjectType, subjectID, accountID, featureKey string) error
+
+	// Revoke removes a grant. Revoking one that does not exist is not an error.
+	Revoke(ctx context.Context, subjectType, subjectID, accountID, featureKey string) error
+}
+
+// AccountMemberQuery reads pericarp's account_members projection for the one
+// question feature invalidation needs and pericarp's own AccountRepository
+// cannot answer: who holds this role?
+//
+// It exists because a role grant changes the resolved set of every member
+// carrying that role, and each member's cache entry must be invalidated
+// individually. pericarp offers FindMemberRole, FindByMember, SaveMember and
+// RemoveMember — all agent-first — so the account-first direction is ours to
+// add. It is a read-only port over a table pericarp owns; nothing here writes.
+type AccountMemberQuery interface {
+	// ListMemberIDsByRole returns the agent IDs holding roleID in accountID.
+	// An empty result is not an error: a role nobody holds invalidates nothing.
+	ListMemberIDsByRole(ctx context.Context, accountID, roleID string) ([]string, error)
+}

--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require (
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-memdb v1.3.5 // indirect
-	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
@@ -105,6 +105,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/microsoft/go-mssqldb v1.9.5 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
+	github.com/open-feature/go-sdk v1.17.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo/v4 v4.13.3
 	github.com/modelcontextprotocol/go-sdk v1.4.1
+	github.com/open-feature/go-sdk v1.17.2
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/segmentio/ksuid v1.0.4
 	github.com/spf13/cobra v1.10.2
@@ -105,7 +106,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/microsoft/go-mssqldb v1.9.5 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/open-feature/go-sdk v1.17.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
@@ -134,6 +134,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.uber.org/dig v1.18.0 // indirect
+	go.uber.org/mock v0.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.51.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -245,6 +245,8 @@ github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
+github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -320,6 +322,8 @@ github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+github.com/open-feature/go-sdk v1.17.2 h1:pTdeNks/hgnPrlqdgtFwltnIron1oOxqg4FmLlirJlY=
+github.com/open-feature/go-sdk v1.17.2/go.mod h1:kTMCquVtck18XdSCI6rBoNFEBLvkOy4Tphu2pV8bq34=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=

--- a/go.sum
+++ b/go.sum
@@ -243,7 +243,6 @@ github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
 github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
@@ -442,6 +441,8 @@ go.uber.org/fx v1.23.0 h1:lIr/gYWQGfTwGcSXWXu4vP5Ws6iqnNEIY+F/aFzCKTg=
 go.uber.org/fx v1.23.0/go.mod h1:o/D9n+2mLP6v1EG+qsdT1O8wKopYAsqZasju97SDFCU=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
+go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=

--- a/infrastructure/database/gorm/feature_repository.go
+++ b/infrastructure/database/gorm/feature_repository.go
@@ -1,0 +1,213 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package gorm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/wepala/weos/v3/domain/repositories"
+	"github.com/wepala/weos/v3/infrastructure/models"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// FeatureSettingsRepository stores the instance and account override layers.
+type FeatureSettingsRepository struct {
+	db *gorm.DB
+}
+
+func ProvideFeatureSettingsRepository(db *gorm.DB) repositories.FeatureSettingsRepository {
+	return &FeatureSettingsRepository{db: db}
+}
+
+func (r *FeatureSettingsRepository) InstanceOverrides(ctx context.Context) (map[string]bool, error) {
+	return r.overridesFor(ctx, repositories.FeatureScopeInstance, "")
+}
+
+func (r *FeatureSettingsRepository) AccountOverrides(
+	ctx context.Context, accountID string,
+) (map[string]bool, error) {
+	if accountID == "" {
+		// No account means no account layer. Returning empty rather than
+		// querying with an empty scope avoids matching instance rows, whose
+		// ScopeID is also empty.
+		return map[string]bool{}, nil
+	}
+	return r.overridesFor(ctx, repositories.FeatureScopeAccount, accountID)
+}
+
+func (r *FeatureSettingsRepository) overridesFor(
+	ctx context.Context, scopeType, scopeID string,
+) (map[string]bool, error) {
+	var rows []models.FeatureSetting
+	if err := r.db.WithContext(ctx).
+		Where("scope_type = ? AND scope_id = ?", scopeType, scopeID).
+		Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("failed to load %s feature overrides: %w", scopeType, err)
+	}
+	out := make(map[string]bool, len(rows))
+	for _, row := range rows {
+		out[row.FeatureKey] = row.Enabled
+	}
+	return out, nil
+}
+
+func (r *FeatureSettingsRepository) SetOverride(
+	ctx context.Context, scopeType, scopeID, featureKey string, enabled bool,
+) error {
+	row := models.FeatureSetting{
+		ScopeType:  scopeType,
+		ScopeID:    scopeID,
+		FeatureKey: featureKey,
+		Enabled:    enabled,
+	}
+	err := r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "scope_type"}, {Name: "scope_id"}, {Name: "feature_key"}},
+		DoUpdates: clause.AssignmentColumns([]string{"enabled", "updated_at"}),
+	}).Create(&row).Error
+	if err != nil {
+		return fmt.Errorf("failed to set feature override %q at %s scope: %w", featureKey, scopeType, err)
+	}
+	return nil
+}
+
+func (r *FeatureSettingsRepository) ClearOverride(
+	ctx context.Context, scopeType, scopeID, featureKey string,
+) error {
+	// Deleting a row that is not there is not an error: the caller wanted this
+	// layer to say nothing about the feature, and it already does.
+	err := r.db.WithContext(ctx).
+		Where("scope_type = ? AND scope_id = ? AND feature_key = ?", scopeType, scopeID, featureKey).
+		Delete(&models.FeatureSetting{}).Error
+	if err != nil {
+		return fmt.Errorf("failed to clear feature override %q at %s scope: %w", featureKey, scopeType, err)
+	}
+	return nil
+}
+
+// FeatureGrantRepository stores the bottom layer — grants to an agent or a
+// role, always within an account.
+type FeatureGrantRepository struct {
+	db *gorm.DB
+}
+
+func ProvideFeatureGrantRepository(db *gorm.DB) repositories.FeatureGrantRepository {
+	return &FeatureGrantRepository{db: db}
+}
+
+func (r *FeatureGrantRepository) GrantedKeys(
+	ctx context.Context, accountID, agentID, roleID string,
+) (map[string]bool, error) {
+	if accountID == "" || agentID == "" {
+		// Grants are account-scoped and subject-bound. With neither, there is
+		// nothing a grant could match, and querying would risk matching rows
+		// on empty strings.
+		return map[string]bool{}, nil
+	}
+
+	query := r.db.WithContext(ctx).
+		Model(&models.FeatureGrant{}).
+		Where("account_id = ?", accountID)
+
+	// One query for both legs — the grant made to this person directly, and
+	// the grant carried by whatever role they hold in this account.
+	if roleID != "" {
+		query = query.Where(
+			r.db.Where("subject_type = ? AND subject_id = ?", repositories.FeatureSubjectAgent, agentID).
+				Or("subject_type = ? AND subject_id = ?", repositories.FeatureSubjectRole, roleID),
+		)
+	} else {
+		query = query.Where("subject_type = ? AND subject_id = ?", repositories.FeatureSubjectAgent, agentID)
+	}
+
+	var keys []string
+	if err := query.Distinct().Pluck("feature_key", &keys).Error; err != nil {
+		return nil, fmt.Errorf("failed to load feature grants for agent %q: %w", agentID, err)
+	}
+	out := make(map[string]bool, len(keys))
+	for _, k := range keys {
+		out[k] = true
+	}
+	return out, nil
+}
+
+func (r *FeatureGrantRepository) Grant(
+	ctx context.Context, subjectType, subjectID, accountID, featureKey string,
+) error {
+	row := models.FeatureGrant{
+		SubjectType: subjectType,
+		SubjectID:   subjectID,
+		AccountID:   accountID,
+		FeatureKey:  featureKey,
+	}
+	// Granting twice is not an error — the right is already held, and an
+	// operator repeating themselves should not see a failure.
+	err := r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "subject_type"}, {Name: "subject_id"}, {Name: "account_id"}, {Name: "feature_key"},
+		},
+		DoUpdates: clause.AssignmentColumns([]string{"updated_at"}),
+	}).Create(&row).Error
+	if err != nil {
+		return fmt.Errorf("failed to grant feature %q to %s %q: %w", featureKey, subjectType, subjectID, err)
+	}
+	return nil
+}
+
+func (r *FeatureGrantRepository) Revoke(
+	ctx context.Context, subjectType, subjectID, accountID, featureKey string,
+) error {
+	err := r.db.WithContext(ctx).
+		Where("subject_type = ? AND subject_id = ? AND account_id = ? AND feature_key = ?",
+			subjectType, subjectID, accountID, featureKey).
+		Delete(&models.FeatureGrant{}).Error
+	if err != nil {
+		return fmt.Errorf("failed to revoke feature %q from %s %q: %w", featureKey, subjectType, subjectID, err)
+	}
+	return nil
+}
+
+// AccountMemberQuery answers "who holds this role in this account?" — the
+// account-first direction pericarp's AccountRepository does not offer.
+type AccountMemberQuery struct {
+	db *gorm.DB
+}
+
+func ProvideAccountMemberQuery(db *gorm.DB) repositories.AccountMemberQuery {
+	return &AccountMemberQuery{db: db}
+}
+
+func (q *AccountMemberQuery) ListMemberIDsByRole(
+	ctx context.Context, accountID, roleID string,
+) ([]string, error) {
+	if accountID == "" || roleID == "" {
+		return nil, nil
+	}
+	var agentIDs []string
+	// Queried by table name rather than through a model: account_members is
+	// pericarp's projection, and core reads it without taking ownership of the
+	// struct that defines it.
+	err := q.db.WithContext(ctx).
+		Table("account_members").
+		Where("account_id = ? AND role_id = ?", accountID, roleID).
+		Pluck("agent_id", &agentIDs).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to list members holding role %q in account %q: %w", roleID, accountID, err)
+	}
+	return agentIDs, nil
+}

--- a/infrastructure/database/gorm/feature_repository_test.go
+++ b/infrastructure/database/gorm/feature_repository_test.go
@@ -1,0 +1,310 @@
+package gorm
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/wepala/weos/v3/domain/repositories"
+	"github.com/wepala/weos/v3/infrastructure/models"
+)
+
+func newFeatureTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), gormConfig())
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.FeatureSetting{}, &models.FeatureGrant{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func TestFeatureSettingsOverridesAreTriState(t *testing.T) {
+	ctx := context.Background()
+	repo := ProvideFeatureSettingsRepository(newFeatureTestDB(t))
+
+	// No row at all: the layer says nothing.
+	got, err := repo.InstanceOverrides(ctx)
+	if err != nil {
+		t.Fatalf("InstanceOverrides: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("InstanceOverrides on an empty store = %v, want empty", got)
+	}
+
+	// An explicit off is a row, and is distinguishable from absence.
+	if err := repo.SetOverride(ctx, repositories.FeatureScopeInstance, "", "ledger-export", false); err != nil {
+		t.Fatalf("SetOverride: %v", err)
+	}
+	got, err = repo.InstanceOverrides(ctx)
+	if err != nil {
+		t.Fatalf("InstanceOverrides: %v", err)
+	}
+	enabled, present := got["ledger-export"]
+	if !present {
+		t.Fatal("an explicit off did not come back as a present key")
+	}
+	if enabled {
+		t.Fatal("an explicit off came back enabled")
+	}
+
+	// Setting again replaces rather than duplicating.
+	if err := repo.SetOverride(ctx, repositories.FeatureScopeInstance, "", "ledger-export", true); err != nil {
+		t.Fatalf("SetOverride (replace): %v", err)
+	}
+	got, _ = repo.InstanceOverrides(ctx)
+	if !got["ledger-export"] {
+		t.Fatal("replacing an override did not take effect")
+	}
+	assertSingleOverrideRow(t, repo)
+
+	// Clearing returns the layer to silence — not to false.
+	if err := repo.ClearOverride(ctx, repositories.FeatureScopeInstance, "", "ledger-export"); err != nil {
+		t.Fatalf("ClearOverride: %v", err)
+	}
+	got, _ = repo.InstanceOverrides(ctx)
+	if _, present := got["ledger-export"]; present {
+		t.Fatal("a cleared override is still present; unset and off must not be confusable")
+	}
+
+	// Clearing what is not there satisfies the caller's intent already.
+	if err := repo.ClearOverride(ctx, repositories.FeatureScopeInstance, "", "ledger-export"); err != nil {
+		t.Fatalf("ClearOverride on an absent row = %v, want nil", err)
+	}
+}
+
+// assertSingleOverrideRow proves the unique index collapsed a repeated
+// SetOverride into one row rather than accumulating history — an override is
+// current state, not an audit log.
+func assertSingleOverrideRow(t *testing.T, repo repositories.FeatureSettingsRepository) {
+	t.Helper()
+	r, ok := repo.(*FeatureSettingsRepository)
+	if !ok {
+		t.Fatal("unexpected repository implementation")
+	}
+	var count int64
+	if err := r.db.Model(&models.FeatureSetting{}).Count(&count).Error; err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("after replacing an override there are %d rows, want 1", count)
+	}
+}
+
+// TestAccountOverridesDoNotMatchInstanceRows is the trap this schema invites:
+// instance rows carry an empty ScopeID, so a careless account query would
+// match them and silently promote an instance setting into every account.
+func TestAccountOverridesDoNotMatchInstanceRows(t *testing.T) {
+	ctx := context.Background()
+	repo := ProvideFeatureSettingsRepository(newFeatureTestDB(t))
+
+	if err := repo.SetOverride(ctx, repositories.FeatureScopeInstance, "", "episodic-recall", false); err != nil {
+		t.Fatalf("SetOverride instance: %v", err)
+	}
+	if err := repo.SetOverride(ctx, repositories.FeatureScopeAccount, "acct-harbor", "ledger-export", true); err != nil {
+		t.Fatalf("SetOverride account: %v", err)
+	}
+
+	acct, err := repo.AccountOverrides(ctx, "acct-harbor")
+	if err != nil {
+		t.Fatalf("AccountOverrides: %v", err)
+	}
+	if _, leaked := acct["episodic-recall"]; leaked {
+		t.Fatal("an instance-scoped row leaked into an account's overrides")
+	}
+	if !acct["ledger-export"] {
+		t.Fatal("the account's own override did not come back")
+	}
+
+	inst, err := repo.InstanceOverrides(ctx)
+	if err != nil {
+		t.Fatalf("InstanceOverrides: %v", err)
+	}
+	if _, leaked := inst["ledger-export"]; leaked {
+		t.Fatal("an account-scoped row leaked into the instance overrides")
+	}
+
+	// An empty account ID must not fall back to reading instance rows.
+	empty, err := repo.AccountOverrides(ctx, "")
+	if err != nil {
+		t.Fatalf("AccountOverrides(\"\"): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("AccountOverrides(\"\") = %v, want empty", empty)
+	}
+}
+
+func TestAccountOverridesAreIsolatedPerAccount(t *testing.T) {
+	ctx := context.Background()
+	repo := ProvideFeatureSettingsRepository(newFeatureTestDB(t))
+
+	if err := repo.SetOverride(ctx, repositories.FeatureScopeAccount, "acct-harbor", "episodic-recall", false); err != nil {
+		t.Fatalf("SetOverride: %v", err)
+	}
+	cedar, err := repo.AccountOverrides(ctx, "acct-cedar")
+	if err != nil {
+		t.Fatalf("AccountOverrides: %v", err)
+	}
+	if len(cedar) != 0 {
+		t.Fatalf("another account's override was visible: %v", cedar)
+	}
+}
+
+func TestFeatureGrantsUnionAgentAndRole(t *testing.T) {
+	ctx := context.Background()
+	repo := ProvideFeatureGrantRepository(newFeatureTestDB(t))
+
+	if err := repo.Grant(ctx, repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export"); err != nil {
+		t.Fatalf("Grant agent: %v", err)
+	}
+	if err := repo.Grant(ctx, repositories.FeatureSubjectRole, "admin", "acct-harbor", "audit-trail"); err != nil {
+		t.Fatalf("Grant role: %v", err)
+	}
+
+	// Holding the role sees both legs.
+	got, err := repo.GrantedKeys(ctx, "acct-harbor", "agent-ops", "admin")
+	if err != nil {
+		t.Fatalf("GrantedKeys: %v", err)
+	}
+	if !got["ledger-export"] || !got["audit-trail"] {
+		t.Fatalf("GrantedKeys = %v, want both the direct and the role grant", got)
+	}
+
+	// Without the role, only the direct grant.
+	got, err = repo.GrantedKeys(ctx, "acct-harbor", "agent-ops", "")
+	if err != nil {
+		t.Fatalf("GrantedKeys (no role): %v", err)
+	}
+	if !got["ledger-export"] {
+		t.Fatal("the direct grant vanished when the caller held no role")
+	}
+	if got["audit-trail"] {
+		t.Fatal("a role grant reached someone who does not hold the role")
+	}
+
+	// Another agent holding the same role gets the role grant only.
+	got, err = repo.GrantedKeys(ctx, "acct-harbor", "agent-counsel", "admin")
+	if err != nil {
+		t.Fatalf("GrantedKeys (other agent): %v", err)
+	}
+	if got["ledger-export"] {
+		t.Fatal("a direct grant reached a different agent")
+	}
+	if !got["audit-trail"] {
+		t.Fatal("the role grant did not reach another holder of the role")
+	}
+}
+
+func TestFeatureGrantsAreAccountScoped(t *testing.T) {
+	ctx := context.Background()
+	repo := ProvideFeatureGrantRepository(newFeatureTestDB(t))
+
+	if err := repo.Grant(ctx, repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export"); err != nil {
+		t.Fatalf("Grant: %v", err)
+	}
+	got, err := repo.GrantedKeys(ctx, "acct-cedar", "agent-ops", "")
+	if err != nil {
+		t.Fatalf("GrantedKeys: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("a grant in one account reached the same agent in another: %v", got)
+	}
+
+	// No account and no agent must never match rows on empty strings.
+	for _, tc := range []struct{ accountID, agentID string }{{"", "agent-ops"}, {"acct-harbor", ""}, {"", ""}} {
+		got, err := repo.GrantedKeys(ctx, tc.accountID, tc.agentID, "")
+		if err != nil {
+			t.Fatalf("GrantedKeys(%q,%q): %v", tc.accountID, tc.agentID, err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("GrantedKeys(%q,%q) = %v, want empty", tc.accountID, tc.agentID, got)
+		}
+	}
+}
+
+func TestFeatureGrantIsIdempotentAndRevocable(t *testing.T) {
+	ctx := context.Background()
+	repo := ProvideFeatureGrantRepository(newFeatureTestDB(t))
+
+	for i := 0; i < 3; i++ {
+		if err := repo.Grant(ctx, repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export"); err != nil {
+			t.Fatalf("Grant %d: %v", i, err)
+		}
+	}
+	got, _ := repo.GrantedKeys(ctx, "acct-harbor", "agent-ops", "")
+	if len(got) != 1 {
+		t.Fatalf("granting three times produced %v, want one key", got)
+	}
+
+	if err := repo.Revoke(ctx, repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export"); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	got, _ = repo.GrantedKeys(ctx, "acct-harbor", "agent-ops", "")
+	if len(got) != 0 {
+		t.Fatalf("after revoke, GrantedKeys = %v, want empty", got)
+	}
+	if err := repo.Revoke(ctx, repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export"); err != nil {
+		t.Fatalf("Revoke on an absent grant = %v, want nil", err)
+	}
+}
+
+func TestAccountMemberQueryListsByRole(t *testing.T) {
+	ctx := context.Background()
+	db := newFeatureTestDB(t)
+
+	// account_members is pericarp's projection; core reads it without owning
+	// the struct, so the test creates it the same way — by table name.
+	if err := db.Exec(`CREATE TABLE account_members (
+		account_id TEXT NOT NULL, agent_id TEXT NOT NULL, role_id TEXT NOT NULL,
+		PRIMARY KEY (account_id, agent_id))`).Error; err != nil {
+		t.Fatalf("create account_members: %v", err)
+	}
+	rows := []struct{ account, agent, role string }{
+		{"acct-harbor", "agent-counsel", "admin"},
+		{"acct-harbor", "agent-clerk", "admin"},
+		{"acct-harbor", "agent-temp", "member"},
+		{"acct-cedar", "agent-broker", "admin"},
+	}
+	for _, r := range rows {
+		if err := db.Exec(
+			`INSERT INTO account_members (account_id, agent_id, role_id) VALUES (?, ?, ?)`,
+			r.account, r.agent, r.role).Error; err != nil {
+			t.Fatalf("insert member: %v", err)
+		}
+	}
+
+	q := ProvideAccountMemberQuery(db)
+	got, err := q.ListMemberIDsByRole(ctx, "acct-harbor", "admin")
+	if err != nil {
+		t.Fatalf("ListMemberIDsByRole: %v", err)
+	}
+	sort.Strings(got)
+	want := []string{"agent-clerk", "agent-counsel"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("ListMemberIDsByRole = %v, want %v — a member missed here is a stale answer nobody can see", got, want)
+	}
+
+	// A role nobody holds invalidates nothing, and is not an error.
+	got, err = q.ListMemberIDsByRole(ctx, "acct-harbor", "owner")
+	if err != nil {
+		t.Fatalf("ListMemberIDsByRole (unheld role): %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("an unheld role returned %v, want empty", got)
+	}
+
+	for _, tc := range []struct{ account, role string }{{"", "admin"}, {"acct-harbor", ""}} {
+		got, err := q.ListMemberIDsByRole(ctx, tc.account, tc.role)
+		if err != nil {
+			t.Fatalf("ListMemberIDsByRole(%q,%q): %v", tc.account, tc.role, err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("ListMemberIDsByRole(%q,%q) = %v, want empty", tc.account, tc.role, got)
+		}
+	}
+}

--- a/infrastructure/database/gorm/provider.go
+++ b/infrastructure/database/gorm/provider.go
@@ -110,6 +110,8 @@ func ProvideGormDB(params struct {
 		&weosmodels.EventReference{},
 		&weosmodels.ResourcePermission{},
 		&weosmodels.BehaviorSettings{},
+		&weosmodels.FeatureSetting{},
+		&weosmodels.FeatureGrant{},
 		&oauth.OAuthClient{},
 		&oauth.OAuthAuthorizationCode{},
 		&oauth.OAuthRefreshToken{},

--- a/infrastructure/features/invalidator.go
+++ b/infrastructure/features/invalidator.go
@@ -1,0 +1,150 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// Package features holds the deployment-specific half of feature-cache
+// invalidation. The behaviour in front of the interface never varies; only the
+// machinery behind it does, and it lives here so swapping the transport later
+// touches this package and nothing else.
+package features
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/akeemphilbert/pericarp/pkg/eventsourcing/subscriptions"
+	"gorm.io/gorm"
+
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
+)
+
+// NotifyInvalidator broadcasts invalidations to other replicas over Postgres
+// LISTEN/NOTIFY, wrapping the local in-process invalidator rather than
+// replacing it: the writing process still evicts precisely and immediately,
+// and the broadcast is what reaches everybody else.
+//
+// It is deliberately NOT a checkpointed subscriber group. Those lock their
+// checkpoint row FOR UPDATE SKIP LOCKED on Postgres, which makes N replicas
+// competing consumers — exactly one would process each event and every other
+// replica would serve a stale answer indefinitely. Invalidation needs a
+// broadcast, and LISTEN/NOTIFY is the one this stack already has.
+//
+// The notification carries no payload. pericarp's listener hands subscribers a
+// bare wake signal (Subscribe returns <-chan struct{}), so a replica receiving
+// one cannot tell what changed and drops its whole cache. That is safe by
+// construction — over-invalidation costs a re-resolve and can never produce a
+// stale answer — and precision is preserved where it is cheap, in the process
+// that made the change.
+//
+// NOTIFY is not durable: a replica whose LISTEN connection is down misses
+// those messages outright. The resolver's maximum cache age is what bounds
+// that, and on a replica deployment it is load-bearing rather than a nicety.
+type NotifyInvalidator struct {
+	local   repositories.FeatureCacheInvalidator
+	db      *gorm.DB
+	channel string
+	logger  entities.Logger
+}
+
+// NewNotifyInvalidator wraps a local invalidator with a Postgres broadcast.
+//
+// The constructor lives here and the SELECTION of which invalidator to use
+// lives in application, because choosing requires the concrete resolver and
+// infrastructure must not import application.
+func NewNotifyInvalidator(
+	local repositories.FeatureCacheInvalidator,
+	db *gorm.DB,
+	channel string,
+	logger entities.Logger,
+) *NotifyInvalidator {
+	if channel == "" {
+		channel = DefaultNotifyChannel
+	}
+	return &NotifyInvalidator{local: local, db: db, channel: channel, logger: logger}
+}
+
+// DefaultNotifyChannel is used when configuration names none.
+const DefaultNotifyChannel = "weos_feature_cache"
+
+// Listen drops the local cache whenever another replica broadcasts, and blocks
+// until ctx is cancelled. Callers run it in a goroutine started from an fx
+// OnStart hook and cancel it on OnStop.
+func (n *NotifyInvalidator) Listen(ctx context.Context, dsn string) error {
+	return n.listen(ctx, dsn)
+}
+
+// InvalidateAll evicts locally, then tells every other replica to do the same.
+func (n *NotifyInvalidator) InvalidateAll(ctx context.Context) {
+	n.local.InvalidateAll(ctx)
+	n.broadcast(ctx)
+}
+
+// InvalidateAccount evicts this account's entries locally. Other replicas drop
+// their whole cache, because the wake signal carries no account to narrow by.
+func (n *NotifyInvalidator) InvalidateAccount(ctx context.Context, accountID string) {
+	n.local.InvalidateAccount(ctx, accountID)
+	n.broadcast(ctx)
+}
+
+// InvalidateAgents evicts these people's entries locally, and asks other
+// replicas to drop everything.
+func (n *NotifyInvalidator) InvalidateAgents(ctx context.Context, accountID string, agentIDs ...string) {
+	n.local.InvalidateAgents(ctx, accountID, agentIDs...)
+	n.broadcast(ctx)
+}
+
+// broadcast sends the wake signal. A failure is logged and swallowed: the
+// local eviction already happened and the caller's write already landed, so
+// failing here would report an error for work that succeeded. The other
+// replicas converge on the maximum cache age instead.
+func (n *NotifyInvalidator) broadcast(ctx context.Context) {
+	if err := n.db.WithContext(ctx).
+		Exec("SELECT pg_notify(?, '')", n.channel).Error; err != nil {
+		n.log(ctx, "could not broadcast a feature-cache invalidation; other replicas "+
+			"will converge when their cached sets reach the maximum age",
+			"channel", n.channel, "error", err)
+	}
+}
+
+func (n *NotifyInvalidator) log(ctx context.Context, msg string, kv ...any) {
+	if n.logger == nil {
+		return
+	}
+	n.logger.Warn(ctx, msg, kv...)
+}
+
+// listen drops the local cache whenever another replica broadcasts. Runs until
+// ctx is cancelled; the fx OnStop hook cancels it.
+func (n *NotifyInvalidator) listen(ctx context.Context, dsn string) error {
+	listener, err := subscriptions.NewPostgresListener(dsn,
+		subscriptions.WithListenerChannel(n.channel))
+	if err != nil {
+		return fmt.Errorf("failed to start the feature-cache listener: %w", err)
+	}
+	wakes := listener.Subscribe()
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-wakes:
+				// No payload to narrow by, so drop everything. Safe: an extra
+				// resolve costs one read, a stale answer costs correctness.
+				n.local.InvalidateAll(ctx)
+			}
+		}
+	}()
+	return listener.Run(ctx)
+}

--- a/infrastructure/models/feature.go
+++ b/infrastructure/models/feature.go
@@ -27,11 +27,11 @@ import "time"
 type FeatureSetting struct {
 	ID uint `gorm:"primaryKey;autoIncrement"`
 	// ScopeType is "instance" or "account".
-	ScopeType string `gorm:"type:varchar(32);not null;uniqueIndex:idx_feature_scope_key"`
+	ScopeType string `gorm:"type:varchar(32);not null;uniqueIndex:idx_fs_scope_key"`
 	// ScopeID is the account ID, and empty for the instance scope — there is
 	// one instance, so it needs no identifier.
-	ScopeID    string `gorm:"type:varchar(255);not null;default:'';uniqueIndex:idx_feature_scope_key"`
-	FeatureKey string `gorm:"type:varchar(64);not null;uniqueIndex:idx_feature_scope_key"`
+	ScopeID    string `gorm:"type:varchar(255);not null;default:'';uniqueIndex:idx_fs_scope_key"`
+	FeatureKey string `gorm:"type:varchar(64);not null;uniqueIndex:idx_fs_scope_key"`
 	Enabled    bool   `gorm:"not null"`
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
@@ -54,14 +54,14 @@ func (FeatureSetting) TableName() string {
 type FeatureGrant struct {
 	ID uint `gorm:"primaryKey;autoIncrement"`
 	// SubjectType is "agent" or "role".
-	SubjectType string `gorm:"type:varchar(32);not null;uniqueIndex:idx_feature_grant_subject"`
+	SubjectType string `gorm:"type:varchar(32);not null;uniqueIndex:idx_fg_subject"`
 	// SubjectID is the agent ID or the role ID.
-	SubjectID string `gorm:"type:varchar(255);not null;uniqueIndex:idx_feature_grant_subject"`
+	SubjectID string `gorm:"type:varchar(255);not null;uniqueIndex:idx_fg_subject"`
 	// AccountID scopes the grant. Roles are per-account memberships, and a
 	// person's access is granted within an account, so both subject kinds
 	// carry one.
-	AccountID  string `gorm:"type:varchar(255);not null;uniqueIndex:idx_feature_grant_subject;index:idx_feature_grant_account"`
-	FeatureKey string `gorm:"type:varchar(64);not null;uniqueIndex:idx_feature_grant_subject"`
+	AccountID  string `gorm:"type:varchar(255);not null;uniqueIndex:idx_fg_subject;index:idx_fg_account"`
+	FeatureKey string `gorm:"type:varchar(64);not null;uniqueIndex:idx_fg_subject"`
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
 }

--- a/infrastructure/models/feature.go
+++ b/infrastructure/models/feature.go
@@ -1,0 +1,71 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package models
+
+import "time"
+
+// FeatureSetting is one explicit override of a feature flag, at either the
+// instance or the account scope.
+//
+// A row's existence is the whole of its meaning: no row means the layer says
+// nothing and resolution passes through it, so the tri-state (unset / on /
+// off) needs no nullable column and no sentinel value, and cannot be
+// mis-stored. Clearing an override deletes the row.
+type FeatureSetting struct {
+	ID uint `gorm:"primaryKey;autoIncrement"`
+	// ScopeType is "instance" or "account".
+	ScopeType string `gorm:"type:varchar(32);not null;uniqueIndex:idx_feature_scope_key"`
+	// ScopeID is the account ID, and empty for the instance scope — there is
+	// one instance, so it needs no identifier.
+	ScopeID    string `gorm:"type:varchar(255);not null;default:'';uniqueIndex:idx_feature_scope_key"`
+	FeatureKey string `gorm:"type:varchar(64);not null;uniqueIndex:idx_feature_scope_key"`
+	Enabled    bool   `gorm:"not null"`
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+func (FeatureSetting) TableName() string {
+	return "feature_settings"
+}
+
+// FeatureGrant is a right to a feature held by one agent or by one role.
+//
+// There is no enabled column, deliberately: a grant only ever turns a feature
+// on. Saying "off" is an override's job, and a grant row meaning "off" would
+// contradict the resolution rule that a grant can never lower what an upper
+// layer decided. Revoking deletes the row.
+//
+// Separate from FeatureSetting because the lifecycles diverge: #483 adds
+// validity windows and provenance here, which would be permanently null on
+// every instance-scoped override row.
+type FeatureGrant struct {
+	ID uint `gorm:"primaryKey;autoIncrement"`
+	// SubjectType is "agent" or "role".
+	SubjectType string `gorm:"type:varchar(32);not null;uniqueIndex:idx_feature_grant_subject"`
+	// SubjectID is the agent ID or the role ID.
+	SubjectID string `gorm:"type:varchar(255);not null;uniqueIndex:idx_feature_grant_subject"`
+	// AccountID scopes the grant. Roles are per-account memberships, and a
+	// person's access is granted within an account, so both subject kinds
+	// carry one.
+	AccountID  string `gorm:"type:varchar(255);not null;uniqueIndex:idx_feature_grant_subject;index:idx_feature_grant_account"`
+	FeatureKey string `gorm:"type:varchar(64);not null;uniqueIndex:idx_feature_grant_subject"`
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+func (FeatureGrant) TableName() string {
+	return "feature_grants"
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -34,6 +34,7 @@ import (
 	appagents "github.com/wepala/weos/v3/application/agents"
 	"github.com/wepala/weos/v3/application/presets"
 	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
 	gormdb "github.com/wepala/weos/v3/infrastructure/database/gorm"
 	"github.com/wepala/weos/v3/internal/config"
 	mcpserver "github.com/wepala/weos/v3/internal/mcp"
@@ -133,6 +134,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	var notificationService application.NotificationService
 	var orchestrator *appagents.Orchestrator
 	var skillRegistry *application.SkillRegistry
+	var featureInvalidator repositories.FeatureCacheInvalidator
 
 	registry := presets.NewDefaultRegistry()
 
@@ -142,6 +144,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		fx.Provide(weosoauth.ProvideJWTService),
 		fx.Populate(&orchestrator),
 		fx.Populate(&skillRegistry),
+		fx.Populate(&featureInvalidator),
 		fx.Populate(&resourceTypeService),
 		fx.Populate(&resourceService),
 		fx.Populate(&kgService),
@@ -423,6 +426,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		AgentRepo:      agentRepo,
 		CredentialRepo: credentialRepo,
 		AccountRepo:    accountRepo,
+		Features:       featureInvalidator,
 		Logger:         logger,
 	})
 	protected.GET("/users", userHandler.List)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -172,6 +172,30 @@ type Config struct {
 	// runs peripheral event handlers (knowledge-graph sync, denormalization)
 	// off checkpointed feeds, isolated from the synchronous write path.
 	Worker WorkerConfig
+
+	// Features tunes feature-flag resolution (epic #480).
+	Features FeaturesConfig
+}
+
+// FeaturesConfig tunes the feature-flag resolver. Feature flags themselves are
+// declared in code or by a preset and stored in the database — nothing here
+// turns a feature on or off.
+type FeaturesConfig struct {
+	// CacheMaxAge bounds how long a resolved feature set may be served from
+	// memory before it is re-resolved, whether or not an invalidation arrived.
+	//
+	// On a single-process instance invalidation is exact, so this only matters
+	// as a backstop and the default is generous. Under Postgres replicas it is
+	// load-bearing: cross-replica invalidation rides LISTEN/NOTIFY, which is
+	// not durable — a replica whose LISTEN connection drops misses those
+	// messages entirely — so this is what stops a missed notification becoming
+	// permanent staleness. Shorten it when running replicas.
+	CacheMaxAge time.Duration
+
+	// NotifyChannel is the Postgres NOTIFY channel used to broadcast cache
+	// invalidations between replicas. Ignored on SQLite, which is
+	// single-process by construction and needs no broadcast.
+	NotifyChannel string
 }
 
 // WorkerConfig tunes the background subscriber runtime (epic #365). Subscribers
@@ -432,6 +456,10 @@ func Default() Config {
 			MaxRetryBackoff: 5 * time.Second,
 			LagLogInterval:  30 * time.Second,
 		},
+		Features: FeaturesConfig{
+			CacheMaxAge:   15 * time.Minute,
+			NotifyChannel: "weos_feature_cache",
+		},
 	}
 }
 
@@ -607,6 +635,15 @@ func (c *Config) LoadFromEnvironment() {
 			c.Oxigraph.Enabled = b
 		}
 	}
+	if v := os.Getenv("FEATURE_CACHE_MAX_AGE_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			c.Features.CacheMaxAge = time.Duration(n) * time.Second
+		}
+	}
+	if v := os.Getenv("FEATURE_NOTIFY_CHANNEL"); v != "" {
+		c.Features.NotifyChannel = v
+	}
+
 	if v := os.Getenv("OXIGRAPH_USERNAME"); v != "" {
 		c.Oxigraph.Username = v
 	}

--- a/tests/e2e/feature_flag_resolution_test.go
+++ b/tests/e2e/feature_flag_resolution_test.go
@@ -1,0 +1,635 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cucumber/godog"
+	"github.com/open-feature/go-sdk/openfeature"
+	"go.uber.org/fx"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
+	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
+	authentities "github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
+
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/application/presets"
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
+	"github.com/wepala/weos/v3/internal/config"
+)
+
+// TestFeatureFlagResolution runs the acceptance contract for story #481.
+//
+// Tagged @wip, so it is skipped by the default "~@wip" filter and run
+// deliberately:
+//
+//	GODOG_TAGS=@wip go test ./tests/e2e/ -run TestFeatureFlagResolution
+func TestFeatureFlagResolution(t *testing.T) {
+	tags := "~@wip"
+	if v := os.Getenv("GODOG_TAGS"); v != "" {
+		tags = v
+	}
+	suite := godog.TestSuite{
+		ScenarioInitializer: initFeatureFlagScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"features/feature_flag_resolution.feature"},
+			Tags:     tags,
+			Strict:   true,
+			TestingT: t,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("feature flag resolution acceptance scenarios failed")
+	}
+}
+
+// --- spies -----------------------------------------------------------------
+
+// settingsSpy counts reads of each override layer and can be made unreadable.
+// The read counts are what make "read from the database only while the first
+// evaluation was answered" and "no account override or grant was read"
+// assertions rather than intentions.
+type settingsSpy struct {
+	inner repositories.FeatureSettingsRepository
+
+	mu sync.Mutex
+	// Counted per agent, because the contract asks whose evaluation caused a
+	// read — "broker read no feature state to be answered" is false if it is
+	// measured across everybody, since somebody else re-resolving in the same
+	// scenario would mask it.
+	instanceReads map[string]int
+	accountReads  map[string]int
+	broken        bool
+}
+
+// agentOf attributes a read to whoever is on the context. The empty string is
+// the anonymous caller.
+func agentOf(ctx context.Context) string {
+	if id := auth.AgentFromCtx(ctx); id != nil {
+		return id.AgentID
+	}
+	return ""
+}
+
+var errStoreUnreadable = fmt.Errorf("the feature store cannot be read")
+
+func (s *settingsSpy) InstanceOverrides(ctx context.Context) (map[string]bool, error) {
+	s.mu.Lock()
+	if s.instanceReads == nil {
+		s.instanceReads = map[string]int{}
+	}
+	s.instanceReads[agentOf(ctx)]++
+	broken := s.broken
+	s.mu.Unlock()
+	if broken {
+		return nil, errStoreUnreadable
+	}
+	return s.inner.InstanceOverrides(ctx)
+}
+
+func (s *settingsSpy) AccountOverrides(ctx context.Context, accountID string) (map[string]bool, error) {
+	s.mu.Lock()
+	if s.accountReads == nil {
+		s.accountReads = map[string]int{}
+	}
+	s.accountReads[agentOf(ctx)]++
+	broken := s.broken
+	s.mu.Unlock()
+	if broken {
+		return nil, errStoreUnreadable
+	}
+	return s.inner.AccountOverrides(ctx, accountID)
+}
+
+func (s *settingsSpy) SetOverride(ctx context.Context, scopeType, scopeID, key string, enabled bool) error {
+	return s.inner.SetOverride(ctx, scopeType, scopeID, key, enabled)
+}
+
+func (s *settingsSpy) ClearOverride(ctx context.Context, scopeType, scopeID, key string) error {
+	return s.inner.ClearOverride(ctx, scopeType, scopeID, key)
+}
+
+func (s *settingsSpy) countsFor(agentID string) (int, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.instanceReads[agentID], s.accountReads[agentID]
+}
+
+func (s *settingsSpy) reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.instanceReads, s.accountReads = map[string]int{}, map[string]int{}
+}
+
+func (s *settingsSpy) setBroken(b bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.broken = b
+}
+
+type grantsSpy struct {
+	inner repositories.FeatureGrantRepository
+
+	mu     sync.Mutex
+	reads  map[string]int
+	broken bool
+}
+
+func (g *grantsSpy) GrantedKeys(ctx context.Context, accountID, agentID, roleID string) (map[string]bool, error) {
+	g.mu.Lock()
+	if g.reads == nil {
+		g.reads = map[string]int{}
+	}
+	g.reads[agentOf(ctx)]++
+	broken := g.broken
+	g.mu.Unlock()
+	if broken {
+		return nil, errStoreUnreadable
+	}
+	return g.inner.GrantedKeys(ctx, accountID, agentID, roleID)
+}
+
+func (g *grantsSpy) Grant(ctx context.Context, subjectType, subjectID, accountID, key string) error {
+	return g.inner.Grant(ctx, subjectType, subjectID, accountID, key)
+}
+
+func (g *grantsSpy) Revoke(ctx context.Context, subjectType, subjectID, accountID, key string) error {
+	return g.inner.Revoke(ctx, subjectType, subjectID, accountID, key)
+}
+
+func (g *grantsSpy) countFor(agentID string) int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.reads[agentID]
+}
+
+func (g *grantsSpy) reset() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.reads = map[string]int{}
+}
+
+func (g *grantsSpy) setBroken(b bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.broken = b
+}
+
+// logSpy captures log lines so "logged once" and "the log names the key" are
+// checked rather than assumed.
+type logSpy struct {
+	inner entities.Logger
+	mu    sync.Mutex
+	lines []string
+}
+
+func (l *logSpy) record(msg string, fields ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	parts := []string{msg}
+	for _, f := range fields {
+		parts = append(parts, fmt.Sprint(f))
+	}
+	l.lines = append(l.lines, strings.Join(parts, " "))
+}
+
+func (l *logSpy) Debug(ctx context.Context, msg string, f ...interface{}) {
+	l.record(msg, f...)
+	if l.inner != nil {
+		l.inner.Debug(ctx, msg, f...)
+	}
+}
+
+func (l *logSpy) Info(ctx context.Context, msg string, f ...interface{}) {
+	l.record(msg, f...)
+}
+
+func (l *logSpy) Warn(ctx context.Context, msg string, f ...interface{}) {
+	l.record(msg, f...)
+}
+
+func (l *logSpy) Error(ctx context.Context, msg string, f ...interface{}) {
+	l.record(msg, f...)
+}
+
+func (l *logSpy) matching(substrs ...string) []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	var out []string
+	for _, line := range l.lines {
+		all := true
+		for _, s := range substrs {
+			if !strings.Contains(line, s) {
+				all = false
+				break
+			}
+		}
+		if all {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// --- world -----------------------------------------------------------------
+
+// featurePerson is one human: the identity the instance knows them by, and the
+// sessions they hold. Sessions are real AuthSessions so "they are still signed
+// in" can be asserted rather than assumed — the property most at risk of being
+// implemented as a forced logout.
+type featurePerson struct {
+	email      string
+	password   string
+	agentID    string
+	accountID  string
+	sessionIDs []string
+}
+
+type featureWorld struct {
+	app    *fx.App
+	tmpDir string
+	dsn    string
+
+	registry *application.FeatureRegistry
+	resolver *application.FeatureResolver
+	provider *application.FeatureProvider
+	service  *application.FeatureService
+	settings *settingsSpy
+	grants   *grantsSpy
+	logs     *logSpy
+	client   *openfeature.Client
+
+	authService authapp.AuthenticationService
+	accountRepo authrepos.AccountRepository
+	credRepo    authrepos.CredentialRepository
+
+	maxCacheAge time.Duration
+
+	// presets is the live registry the app was built with, so a scenario can
+	// install a preset after boot and see its features immediately.
+	presets *application.PresetRegistry
+
+	accounts map[string]string         // scenario name -> account id
+	people   map[string]*featurePerson // email -> person
+	order    []string                  // who was introduced, for "each of them"
+	listing  []entities.FeatureMeta    // last "registered features are listed"
+	focused  *entities.FeatureMeta     // last "the listing includes X"
+	answers  map[string][]bool         // email -> answers in order
+	lastBool *bool                     // last single answer
+	lastRsn  openfeature.Reason        // last reason
+	lastAny  any                       // last non-boolean answer
+
+	// current is who "they" means: the person the scenario last acted as.
+	// Without it "they evaluate" resolves to whoever was introduced first,
+	// which is usually the account owner rather than the person under test.
+	current *featurePerson
+	// group is who "both of them" / "all three of them" means. Set by the
+	// membership steps that name people, so a Background-created owner is not
+	// swept in.
+	group []string
+
+	// declared remembers the code declarations so a reboot can replay them.
+	declared []entities.FeatureMeta
+
+	// pendingPreset holds a preset a scenario staged but has not installed.
+	pendingPreset  string
+	pendingFeature entities.FeatureMeta
+
+	// grantedKey remembers what was last granted, so "the grant is taken away
+	// from X" knows which grant the scenario means.
+	grantedKey string
+
+	// straightAway and afterMaxAge separate the two evaluations the bounded
+	// staleness scenario makes, since it asserts on both.
+	straightAway bool
+	afterMaxAge  bool
+
+	suppliedNonBool string
+
+	envBefore map[string]*string
+}
+
+// presetRegistry exposes the registry the app was built with.
+func (w *featureWorld) presetRegistry() *application.PresetRegistry { return w.presets }
+
+func (w *featureWorld) teardown() {
+	if w.app != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		defer cancel()
+		_ = w.app.Stop(ctx)
+		w.app = nil
+	}
+	for k, v := range w.envBefore {
+		if v == nil {
+			os.Unsetenv(k)
+		} else {
+			os.Setenv(k, *v)
+		}
+	}
+	if w.tmpDir != "" {
+		os.RemoveAll(w.tmpDir)
+		w.tmpDir = ""
+	}
+}
+
+func (w *featureWorld) setEnv(key string, value *string) {
+	if w.envBefore == nil {
+		w.envBefore = map[string]*string{}
+	}
+	if _, seen := w.envBefore[key]; !seen {
+		if old, ok := os.LookupEnv(key); ok {
+			w.envBefore[key] = &old
+		} else {
+			w.envBefore[key] = nil
+		}
+	}
+	if value == nil {
+		os.Unsetenv(key)
+		return
+	}
+	os.Setenv(key, *value)
+}
+
+// boot starts the real application. Repositories are decorated with spies so
+// read counts and store failures are observable; the contract asks for both.
+func (w *featureWorld) boot() error {
+	if w.app != nil {
+		return nil
+	}
+	if w.tmpDir == "" {
+		dir, err := os.MkdirTemp("", "weos-feature-flags-e2e-")
+		if err != nil {
+			return fmt.Errorf("could not create a temp dir: %w", err)
+		}
+		w.tmpDir = dir
+		w.dsn = filepath.Join(dir, "features.db")
+	}
+	pw := "true"
+	w.setEnv("PASSWORD_AUTH_ENABLED", &pw)
+	w.setEnv("GOOGLE_CLIENT_ID", nil)
+	w.setEnv("GOOGLE_CLIENT_SECRET", nil)
+
+	cfg := config.Default()
+	cfg.LoadFromEnvironment()
+	cfg.DatabaseDSN = w.dsn
+	cfg.LogLevel = "error"
+	if w.maxCacheAge > 0 {
+		cfg.Features.CacheMaxAge = w.maxCacheAge
+	}
+
+	w.settings = &settingsSpy{}
+	w.grants = &grantsSpy{}
+	w.logs = &logSpy{}
+
+	w.presets = presets.NewDefaultRegistry()
+
+	app := fx.New(
+		fx.NopLogger,
+		application.Module(cfg, w.presets),
+		fx.Decorate(func(inner repositories.FeatureSettingsRepository) repositories.FeatureSettingsRepository {
+			w.settings.inner = inner
+			return w.settings
+		}),
+		fx.Decorate(func(inner repositories.FeatureGrantRepository) repositories.FeatureGrantRepository {
+			w.grants.inner = inner
+			return w.grants
+		}),
+		fx.Decorate(func(inner entities.Logger) entities.Logger {
+			w.logs.inner = inner
+			return w.logs
+		}),
+		fx.Populate(&w.registry, &w.resolver, &w.provider, &w.service),
+		fx.Populate(&w.authService, &w.accountRepo, &w.credRepo),
+	)
+	startCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+	defer cancel()
+	if err := app.Start(startCtx); err != nil {
+		return fmt.Errorf("failed to start app: %w", err)
+	}
+	w.app = app
+
+	// Evaluate through the OpenFeature client the way a call site will, on a
+	// named domain rather than the global slot — each scenario boots its own
+	// application in this one binary, and a stale global registration would
+	// evaluate against a previous application's resolver.
+	if err := openfeature.SetNamedProviderAndWait(application.FeatureProviderDomain, w.provider); err != nil {
+		return fmt.Errorf("could not register the feature provider: %w", err)
+	}
+	w.client = openfeature.NewClient(application.FeatureProviderDomain)
+
+	// Replay code declarations after a reboot. The database survives (same
+	// DSN), but the registry is rebuilt from the binary by design.
+	for _, m := range w.declared {
+		if _, known := w.registry.Lookup(m.Key); !known {
+			if err := w.registry.Register(m); err != nil {
+				return fmt.Errorf("could not re-declare %q after reboot: %w", m.Key, err)
+			}
+		}
+	}
+	return nil
+}
+
+// reboot restarts the application against the same database, which is how a
+// scenario changes configuration that is only read at construction.
+func (w *featureWorld) reboot() error {
+	if w.app != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		defer cancel()
+		if err := w.app.Stop(ctx); err != nil {
+			return fmt.Errorf("could not stop the app to reconfigure it: %w", err)
+		}
+		w.app = nil
+	}
+	return w.boot()
+}
+
+// --- staging ---------------------------------------------------------------
+
+func (w *featureWorld) declareFeatures(table *godog.Table) error {
+	if err := w.boot(); err != nil {
+		return err
+	}
+	for i, row := range table.Rows {
+		if i == 0 {
+			continue // header
+		}
+		cell := func(n int) string { return strings.TrimSpace(row.Cells[n].Value) }
+		meta := entities.FeatureMeta{
+			Key:         cell(0),
+			DisplayName: cell(1),
+			Description: cell(2),
+			Default:     cell(3) == "on",
+			Manageable:  cell(4) == "yes",
+			Grantable:   cell(5) == "yes",
+		}
+		if err := w.registry.Register(meta); err != nil {
+			return fmt.Errorf("could not declare %q: %w", meta.Key, err)
+		}
+		w.declared = append(w.declared, meta)
+	}
+	return nil
+}
+
+func (w *featureWorld) personFor(email, password string) (*featurePerson, error) {
+	if p, ok := w.people[email]; ok {
+		return p, nil
+	}
+	ctx := context.Background()
+	agent, _, account, err := w.authService.RegisterPassword(ctx, email, displayNameForFeature(email), password)
+	if err != nil {
+		return nil, fmt.Errorf("could not create %q: %w", email, err)
+	}
+	p := &featurePerson{email: email, password: password, agentID: agent.GetID()}
+	if account != nil {
+		p.accountID = account.GetID()
+		if err := w.accountRepo.SaveMember(ctx, account.GetID(), agent.GetID(), authentities.RoleOwner); err != nil {
+			return nil, fmt.Errorf("could not record %q as owner: %w", email, err)
+		}
+	}
+	w.people[email] = p
+	w.order = append(w.order, email)
+	return p, nil
+}
+
+func displayNameForFeature(email string) string {
+	if i := strings.Index(email, "@"); i > 0 {
+		return email[:i]
+	}
+	return email
+}
+
+func (w *featureWorld) accountWithOwner(name, email, password string) error {
+	if err := w.boot(); err != nil {
+		return err
+	}
+	p, err := w.personFor(email, password)
+	if err != nil {
+		return err
+	}
+	if p.accountID == "" {
+		return fmt.Errorf("%q has no account to name %q", email, name)
+	}
+	w.accounts[name] = p.accountID
+	return nil
+}
+
+// alsoBelongsTo puts a second person into an existing account with a role.
+func (w *featureWorld) alsoBelongsTo(email, accountName, role string) error {
+	accountID, ok := w.accounts[accountName]
+	if !ok {
+		return fmt.Errorf("no account named %q has been staged", accountName)
+	}
+	p, err := w.personFor(email, "correct-horse-battery-staple")
+	if err != nil {
+		return err
+	}
+	if role == "" {
+		role = authentities.RoleMember
+	}
+	if err := w.accountRepo.SaveMember(context.Background(), accountID, p.agentID, role); err != nil {
+		return fmt.Errorf("could not add %q to %q: %w", email, accountName, err)
+	}
+	p.accountID = accountID
+	return nil
+}
+
+func (w *featureWorld) person(email string) (*featurePerson, error) {
+	p, ok := w.people[email]
+	if !ok {
+		return nil, fmt.Errorf("no person named %q has been staged", email)
+	}
+	return p, nil
+}
+
+func (w *featureWorld) accountFor(name string) (string, error) {
+	id, ok := w.accounts[name]
+	if !ok {
+		return "", fmt.Errorf("no account named %q has been staged", name)
+	}
+	return id, nil
+}
+
+// signIn creates a real AuthSession, so a later "still signed in" assertion
+// means something.
+func (w *featureWorld) signIn(p *featurePerson) error {
+	ctx := context.Background()
+	creds, err := w.credRepo.FindByAgent(ctx, p.agentID)
+	if err != nil || len(creds) == 0 {
+		return fmt.Errorf("could not find credentials for %q: %w", p.email, err)
+	}
+	s, err := w.authService.CreateSession(ctx, p.agentID, p.accountID, creds[0].GetID(),
+		"127.0.0.1", "godog", time.Hour)
+	if err != nil {
+		return fmt.Errorf("could not sign %q in: %w", p.email, err)
+	}
+	p.sessionIDs = append(p.sessionIDs, s.GetID())
+	w.current = p
+	return nil
+}
+
+func (w *featureWorld) ctxFor(p *featurePerson) context.Context {
+	return auth.ContextWithAgent(context.Background(),
+		&auth.Identity{AgentID: p.agentID, ActiveAccountID: p.accountID})
+}
+
+// --- evaluation ------------------------------------------------------------
+
+func (w *featureWorld) evaluate(p *featurePerson, key string, def bool) bool {
+	ctx := context.Background()
+	if p != nil {
+		ctx = w.ctxFor(p)
+	}
+	detail, _ := w.client.BooleanValueDetails(ctx, application.FeatureFlagPrefix+key, def,
+		openfeature.EvaluationContext{})
+	w.lastBool = &detail.Value
+	w.lastRsn = detail.Reason
+	if p != nil {
+		w.answers[p.email] = append(w.answers[p.email], detail.Value)
+	}
+	return detail.Value
+}
+
+func (w *featureWorld) evaluateRawKey(p *featurePerson, flag string, def bool) bool {
+	detail, _ := w.client.BooleanValueDetails(w.ctxFor(p), flag, def, openfeature.EvaluationContext{})
+	w.lastBool = &detail.Value
+	w.lastRsn = detail.Reason
+	return detail.Value
+}
+
+// actor is who "they" refers to: the person the scenario last signed in or
+// named, falling back to the only person there is.
+func (w *featureWorld) actor() (*featurePerson, error) {
+	if w.current != nil {
+		return w.current, nil
+	}
+	if len(w.order) == 0 {
+		return nil, fmt.Errorf("no person has been staged")
+	}
+	return w.people[w.order[0]], nil
+}
+
+// cohort is who "both of them" / "all three of them" refers to.
+//
+// A scenario that names two or more people in its Givens means those people —
+// "counsel and clerk both hold the role admin ... both of them are signed in"
+// must not sweep in the Background's account owner. A scenario that names one
+// person means them plus the owner already in play — "counsel also belongs ...
+// both of them are signed in" is ops and counsel. So two or more named wins,
+// otherwise everyone introduced.
+func (w *featureWorld) cohort() []string {
+	if len(w.group) >= 2 {
+		return w.group
+	}
+	return w.order
+}
+
+func boolWord(s string) bool { return strings.TrimSpace(s) == "on" }

--- a/tests/e2e/feature_flag_resolution_test.go
+++ b/tests/e2e/feature_flag_resolution_test.go
@@ -28,10 +28,10 @@ import (
 
 // TestFeatureFlagResolution runs the acceptance contract for story #481.
 //
-// Tagged @wip, so it is skipped by the default "~@wip" filter and run
-// deliberately:
+// The scenarios were promoted out of @wip once green, so they run in the
+// default suite. GODOG_TAGS still overrides the filter when a subset is wanted:
 //
-//	GODOG_TAGS=@wip go test ./tests/e2e/ -run TestFeatureFlagResolution
+//	GODOG_TAGS=@story-481 go test ./tests/e2e/ -run TestFeatureFlagResolution
 func TestFeatureFlagResolution(t *testing.T) {
 	tags := "~@wip"
 	if v := os.Getenv("GODOG_TAGS"); v != "" {

--- a/tests/e2e/feature_flag_steps_test.go
+++ b/tests/e2e/feature_flag_steps_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -736,7 +737,12 @@ func (w *featureWorld) stepFeatureAnswersOffOnly() error {
 	if err != nil {
 		return err
 	}
-	for i, got := range w.answers[p.email] {
+	answers := w.answers[p.email]
+	if len(answers) == 0 {
+		return fmt.Errorf("%q was never answered, so there is nothing to assert — "+
+			"an earlier step evaluated as the wrong person", p.email)
+	}
+	for i, got := range answers {
 		if got {
 			return fmt.Errorf("session %d was answered on, want off", i+1)
 		}
@@ -749,7 +755,12 @@ func (w *featureWorld) stepAnsweredOnEveryTime() error {
 	if err != nil {
 		return err
 	}
-	for i, got := range w.answers[p.email] {
+	answers := w.answers[p.email]
+	if len(answers) == 0 {
+		return fmt.Errorf("%q was never answered, so there is nothing to assert — "+
+			"an earlier step evaluated as the wrong person", p.email)
+	}
+	for i, got := range answers {
 		if !got {
 			return fmt.Errorf("evaluation %d answered off, want on", i+1)
 		}
@@ -965,14 +976,25 @@ func (w *featureWorld) lastAnswerFor(email string) (bool, bool) {
 	return answers[len(answers)-1], true
 }
 
+// soleAccount is for steps that name a role but no account. Refusing when more
+// than one account exists is deliberate: picking one at random from a map would
+// misfire silently the day a role-grant scenario stages a second account.
 func (w *featureWorld) soleAccount() (string, error) {
-	if len(w.accounts) == 0 {
+	switch len(w.accounts) {
+	case 0:
 		return "", fmt.Errorf("no account has been staged")
+	case 1:
+		for _, id := range w.accounts {
+			return id, nil
+		}
 	}
-	for _, id := range w.accounts {
-		return id, nil
+	names := make([]string, 0, len(w.accounts))
+	for name := range w.accounts {
+		names = append(names, name)
 	}
-	return "", fmt.Errorf("no account has been staged")
+	sort.Strings(names)
+	return "", fmt.Errorf("this step names a role but not an account, and %d are staged (%s); "+
+		"the step wording needs to say which", len(w.accounts), strings.Join(names, ", "))
 }
 
 func (w *featureWorld) lastGrantedKey() (string, error) {

--- a/tests/e2e/feature_flag_steps_test.go
+++ b/tests/e2e/feature_flag_steps_test.go
@@ -1,0 +1,983 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cucumber/godog"
+	"github.com/open-feature/go-sdk/openfeature"
+
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
+)
+
+// initFeatureFlagScenario wires the contract's steps to the world. One world
+// per scenario, torn down after, so no scenario can see another's state.
+func initFeatureFlagScenario(sc *godog.ScenarioContext) {
+	w := &featureWorld{
+		accounts: map[string]string{},
+		people:   map[string]*featurePerson{},
+		answers:  map[string][]bool{},
+	}
+	sc.After(func(ctx context.Context, _ *godog.Scenario, err error) (context.Context, error) {
+		w.teardown()
+		return ctx, err
+	})
+
+	// --- background and declarations ---
+	sc.Step(`^a WeOS instance where password sign-in is enabled and requests are authenticated by their session$`,
+		w.stepInstance)
+	sc.Step(`^the instance is configured with a maximum cache age of (\d+) seconds$`, w.stepMaxCacheAge)
+	sc.Step(`^the instance declares these features in code:$`, w.declareFeatures)
+	sc.Step(`^the account "([^"]*)", whose owner "([^"]*)" signs in with password "([^"]*)"$`, w.stepAccountWithOwner)
+	sc.Step(`^a preset "([^"]*)" that declares the feature "([^"]*)", defaulting off$`, w.stepPresetDeclares)
+	sc.Step(`^the "([^"]*)" preset is installed$`, w.stepInstallPreset)
+
+	// --- listing ---
+	sc.Step(`^the registered features are listed$`, w.stepListFeatures)
+	sc.Step(`^the listing includes the feature "([^"]*)"$`, w.stepListingIncludes)
+	sc.Step(`^the listing still includes the feature "([^"]*)"$`, w.stepListingIncludes)
+	sc.Step(`^that feature reports the display name "([^"]*)"$`, w.stepReportsDisplayName)
+	sc.Step(`^that feature reports a description an operator can read$`, w.stepReportsDescription)
+	sc.Step(`^that feature reports it defaults on$`, w.stepReportsDefaultOn)
+	sc.Step(`^that feature reports an account admin may change it$`, w.stepReportsManageable(true))
+	sc.Step(`^that feature reports an account admin may not change it$`, w.stepReportsManageable(false))
+	sc.Step(`^that feature reports it may be granted to one person$`, w.stepReportsGrantable(true))
+	sc.Step(`^that feature reports it may not be granted to one person$`, w.stepReportsGrantable(false))
+
+	// --- membership ---
+	sc.Step(`^"([^"]*)" also belongs to "([^"]*)"$`, w.stepAlsoBelongs)
+	sc.Step(`^"([^"]*)" also belongs to "([^"]*)" with the role "([^"]*)"$`, w.stepAlsoBelongsWithRole)
+	sc.Step(`^"([^"]*)" and "([^"]*)" both belong to "([^"]*)" with the role "([^"]*)"$`, w.stepTwoBelongWithRole)
+	sc.Step(`^"([^"]*)" and "([^"]*)" both hold the role "([^"]*)" in "([^"]*)"$`, w.stepTwoHoldRole)
+	sc.Step(`^"([^"]*)" belongs to "([^"]*)" without that role$`, w.stepBelongsWithoutRole)
+
+	// --- staged state ---
+	sc.Step(`^nothing has been overridden or granted on this instance$`, w.stepNothingStored)
+	sc.Step(`^"([^"]*)" has turned the feature "([^"]*)" (on|off)$`, w.stepAccountTurns)
+	sc.Step(`^the operator has turned the feature "([^"]*)" off for the instance$`, w.stepInstanceOff)
+	sc.Step(`^the feature "([^"]*)" is off for the instance$`, w.stepInstanceOff)
+	sc.Step(`^"([^"]*)" has been granted the feature "([^"]*)"$`, w.stepAgentGranted)
+	sc.Step(`^the role "([^"]*)" has been granted the feature "([^"]*)"$`, w.stepRoleGranted)
+	sc.Step(`^"([^"]*)" has a stored override turning the feature "([^"]*)" off$`, w.stepStoredAccountOverride)
+	sc.Step(`^"([^"]*)" holds a stored grant for the feature "([^"]*)"$`, w.stepStoredGrant)
+	sc.Step(`^the store holding account overrides and grants cannot be read$`, w.stepBreakStore)
+	sc.Step(`^the store can be read again$`, w.stepFixStore)
+	sc.Step(`^nothing is changed$`, func() error { return nil })
+
+	// --- sign-in ---
+	sc.Step(`^"([^"]*)" is signed in to "([^"]*)"$`, w.stepSignedInTo)
+	sc.Step(`^both of them are signed in$`, w.stepBothSignedIn)
+	sc.Step(`^both of them are signed in to "([^"]*)"$`, w.stepBothSignedInTo)
+	sc.Step(`^they are signed in on two devices, each with its own session$`, w.stepTwoDevices)
+	sc.Step(`^they are signed in and have been answered (on|off) for "([^"]*)"$`, w.stepSignedInAndAnswered)
+	sc.Step(`^both of them are signed in and have been answered on for "([^"]*)"$`, w.stepBothSignedInAndAnswered)
+	sc.Step(`^both owners are signed in and have been answered on for "([^"]*)"$`, w.stepBothSignedInAndAnswered)
+	sc.Step(`^all three of them are signed in and have been answered off for "([^"]*)"$`, w.stepAllSignedInAndAnswered)
+	sc.Step(`^both sessions have already evaluated "([^"]*)" and been answered on$`, w.stepBothSessionsAnswered)
+	sc.Step(`^they have already evaluated "([^"]*)" and been answered on$`, w.stepAlreadyAnswered)
+	sc.Step(`^both of them have already evaluated "([^"]*)" and been answered on$`, w.stepBothAlreadyAnswered)
+	sc.Step(`^they evaluated "([^"]*)" with default on and were answered off$`, w.stepEvaluatedAndAnsweredOff)
+
+	// --- changes mid-session ---
+	sc.Step(`^the grant is taken away from "([^"]*)"$`, w.stepRevokeAgent)
+	sc.Step(`^the grant is taken away from the role "([^"]*)"$`, w.stepRevokeRole)
+	sc.Step(`^the role "([^"]*)" is granted the feature "([^"]*)"$`, w.stepRoleGranted)
+	sc.Step(`^"([^"]*)" turns the feature "([^"]*)" off$`, w.stepAccountTurnsOff)
+	sc.Step(`^"([^"]*)" turns the feature "([^"]*)" off and no invalidation reaches the session$`,
+		w.stepAccountTurnsOffSilently)
+	sc.Step(`^the operator turns the feature "([^"]*)" off for the instance$`, w.stepOperatorTurnsInstanceOff)
+
+	// --- evaluation ---
+	sc.Step(`^they evaluate "([^"]*)" with default (on|off)$`, w.stepTheyEvaluate)
+	sc.Step(`^"([^"]*)" evaluates "([^"]*)" with default (on|off)$`, w.stepPersonEvaluates)
+	sc.Step(`^"([^"]*)" evaluates "([^"]*)" with default (on|off) again$`, w.stepPersonEvaluates)
+	sc.Step(`^each of them evaluates "([^"]*)" with default (on|off)$`, w.stepEachEvaluates)
+	sc.Step(`^a caller with no identity on the context evaluates "([^"]*)" with default (on|off)$`,
+		w.stepAnonymousEvaluates)
+	sc.Step(`^"([^"]*)" signs in and evaluates "([^"]*)" with default (on|off)$`, w.stepSignsInAndEvaluates)
+	sc.Step(`^they evaluate "([^"]*)" (\d+) times in that session$`, w.stepEvaluateNTimes)
+	sc.Step(`^they evaluate "([^"]*)" and then "([^"]*)" in the same session$`, w.stepEvaluateTwoKeys)
+	sc.Step(`^they evaluate "([^"]*)" again in the same session$`, w.stepEvaluateAgain)
+	sc.Step(`^they evaluate "([^"]*)" with default on in the same session$`, w.stepEvaluateAgainDefaultOn)
+	sc.Step(`^they evaluate "([^"]*)" again on each device$`, w.stepEvaluateOnEachDevice)
+	sc.Step(`^they evaluate "([^"]*)" again straight away$`, w.stepEvaluateStraightAway)
+	sc.Step(`^they evaluate "([^"]*)" again after the maximum cache age has passed$`, w.stepEvaluateAfterMaxAge)
+	sc.Step(`^each of them evaluates "([^"]*)" again in the session they already held$`, w.stepEachEvaluatesAgain)
+	sc.Step(`^they evaluate the undeclared feature "([^"]*)" with default (on|off)$`, w.stepTheyEvaluate)
+	sc.Step(`^they evaluate the undeclared feature "([^"]*)" (\d+) times with default off$`, w.stepEvaluateUndeclaredN)
+	sc.Step(`^they evaluate the flag key "([^"]*)" with default (on|off)$`, w.stepEvaluateRawKey)
+	sc.Step(`^they evaluate "([^"]*)" as (a string|an integer|a number|an object) with default "?([^"]*?)"?$`,
+		w.stepEvaluateNonBoolean)
+
+	// --- assertions ---
+	sc.Step(`^the feature answers (on|off)$`, w.stepFeatureAnswers)
+	sc.Step(`^the flag answers (on|off)$`, w.stepFeatureAnswers)
+	sc.Step(`^the feature answers on every time$`, w.stepAnsweredOnEveryTime)
+	sc.Step(`^"([^"]*)" is answered (on|off)$`, w.stepPersonAnswered)
+	sc.Step(`^"([^"]*)" was answered (on|off)$`, w.stepPersonAnswered)
+	sc.Step(`^"([^"]*)" was answered on both times$`, w.stepAnsweredOnBothTimes)
+	sc.Step(`^both of them are answered off$`, w.stepBothAnsweredOff)
+	sc.Step(`^both sessions are answered off$`, w.stepFeatureAnswersOffOnly)
+	sc.Step(`^the evaluation reason is "([^"]*)"$`, w.stepReasonIs)
+	sc.Step(`^the answer is the (.+) they supplied$`, w.stepNonBooleanAnswer)
+	sc.Step(`^the evaluation straight away is answered on$`, w.stepStraightAwayOn)
+	sc.Step(`^the evaluation after the maximum cache age is answered off$`, w.stepAfterMaxAgeOff)
+
+	// --- read counting ---
+	sc.Step(`^feature state was read from the database only while the first evaluation was answered$`,
+		w.stepReadOnce)
+	sc.Step(`^feature state was read from the database once more, to re-resolve the set$`, w.stepReadOnceMore)
+	sc.Step(`^no account override or grant was read for that evaluation$`, w.stepNoAccountOrGrantRead)
+	sc.Step(`^"([^"]*)" read no feature state from the database to be answered$`, w.stepPersonReadNothing)
+
+	// --- sign-out assertions ---
+	sc.Step(`^they are still signed in$`, w.stepStillSignedIn)
+	sc.Step(`^neither session was signed out$`, w.stepAllStillSignedIn)
+	sc.Step(`^none of them was signed out$`, w.stepAllStillSignedIn)
+	sc.Step(`^they were not signed out by the failure$`, w.stepStillSignedIn)
+	sc.Step(`^they were signed out by neither evaluation$`, w.stepStillSignedIn)
+	sc.Step(`^the request they make next is served$`, w.stepNextRequestServed)
+
+	// --- logging ---
+	sc.Step(`^the instance logged the undeclared feature key once$`, w.stepLoggedUndeclaredOnce)
+	sc.Step(`^the log names the key "([^"]*)"$`, w.stepLogNamesKey)
+	sc.Step(`^the instance logged the failure$`, w.stepLoggedFailure)
+}
+
+// --- background ------------------------------------------------------------
+
+func (w *featureWorld) stepInstance() error { return w.boot() }
+
+func (w *featureWorld) stepMaxCacheAge(seconds int) error {
+	w.maxCacheAge = time.Duration(seconds) * time.Second
+	// The resolver reads its maximum age at construction, and the Background
+	// has already booted, so the app is restarted against the same database.
+	// Accounts, people and sessions persist; the registry is replayed.
+	return w.reboot()
+}
+
+func (w *featureWorld) stepAccountWithOwner(name, email, password string) error {
+	return w.accountWithOwner(name, email, password)
+}
+
+func (w *featureWorld) stepPresetDeclares(presetName, featureKey string) error {
+	if err := w.boot(); err != nil {
+		return err
+	}
+	w.pendingPreset = presetName
+	w.pendingFeature = entities.FeatureMeta{
+		Key: featureKey, DisplayName: featureKey, Default: false,
+	}
+	return nil
+}
+
+func (w *featureWorld) stepInstallPreset(presetName string) error {
+	if presetName != w.pendingPreset {
+		return fmt.Errorf("no preset named %q was staged", presetName)
+	}
+	// The preset registry is the live source of preset declarations, so
+	// registering the preset IS installing its features — no persistence, no
+	// hook in InstallPreset.
+	return w.presetRegistry().Add(application.PresetDefinition{
+		Name:     w.pendingPreset,
+		Features: map[string]entities.FeatureMeta{w.pendingFeature.Key: w.pendingFeature},
+	})
+}
+
+// --- listing ---------------------------------------------------------------
+
+func (w *featureWorld) stepListFeatures() error {
+	w.listing = w.service.List()
+	return nil
+}
+
+func (w *featureWorld) stepListingIncludes(key string) error {
+	for i := range w.listing {
+		if w.listing[i].Key == key {
+			w.focused = &w.listing[i]
+			return nil
+		}
+	}
+	return fmt.Errorf("the listing does not include %q", key)
+}
+
+func (w *featureWorld) stepReportsDisplayName(want string) error {
+	if w.focused == nil {
+		return fmt.Errorf("no feature is in focus")
+	}
+	if w.focused.DisplayName != want {
+		return fmt.Errorf("display name is %q, want %q", w.focused.DisplayName, want)
+	}
+	return nil
+}
+
+func (w *featureWorld) stepReportsDescription() error {
+	if w.focused == nil || strings.TrimSpace(w.focused.Description) == "" {
+		return fmt.Errorf("the feature reports no description")
+	}
+	return nil
+}
+
+func (w *featureWorld) stepReportsDefaultOn() error {
+	if w.focused == nil || !w.focused.Default {
+		return fmt.Errorf("the feature does not default on")
+	}
+	return nil
+}
+
+func (w *featureWorld) stepReportsManageable(want bool) func() error {
+	return func() error {
+		if w.focused == nil {
+			return fmt.Errorf("no feature is in focus")
+		}
+		if w.focused.Manageable != want {
+			return fmt.Errorf("manageable is %v, want %v", w.focused.Manageable, want)
+		}
+		return nil
+	}
+}
+
+func (w *featureWorld) stepReportsGrantable(want bool) func() error {
+	return func() error {
+		if w.focused == nil {
+			return fmt.Errorf("no feature is in focus")
+		}
+		if w.focused.Grantable != want {
+			return fmt.Errorf("grantable is %v, want %v", w.focused.Grantable, want)
+		}
+		return nil
+	}
+}
+
+// --- membership ------------------------------------------------------------
+
+func (w *featureWorld) stepAlsoBelongs(email, accountName string) error {
+	w.group = append(w.group, email)
+	return w.alsoBelongsTo(email, accountName, "")
+}
+
+func (w *featureWorld) stepAlsoBelongsWithRole(email, accountName, role string) error {
+	w.group = append(w.group, email)
+	return w.alsoBelongsTo(email, accountName, role)
+}
+
+func (w *featureWorld) stepTwoBelongWithRole(a, b, accountName, role string) error {
+	w.group = append(w.group, a, b)
+	if err := w.alsoBelongsTo(a, accountName, role); err != nil {
+		return err
+	}
+	return w.alsoBelongsTo(b, accountName, role)
+}
+
+func (w *featureWorld) stepTwoHoldRole(a, b, role, accountName string) error {
+	return w.stepTwoBelongWithRole(a, b, accountName, role)
+}
+
+func (w *featureWorld) stepBelongsWithoutRole(email, accountName string) error {
+	w.group = append(w.group, email)
+	return w.alsoBelongsTo(email, accountName, "")
+}
+
+// --- staged state ----------------------------------------------------------
+
+func (w *featureWorld) stepNothingStored() error { return nil }
+
+func (w *featureWorld) stepAccountTurns(accountName, key, onOff string) error {
+	id, err := w.accountFor(accountName)
+	if err != nil {
+		return err
+	}
+	return w.service.SetAccountFeature(context.Background(), id, key, onOff == "on")
+}
+
+func (w *featureWorld) stepAccountTurnsOff(accountName, key string) error {
+	return w.stepAccountTurns(accountName, key, "off")
+}
+
+// stepAccountTurnsOffSilently writes the store directly, bypassing the service
+// and therefore the invalidation. That is how the contract stages "a change
+// that no invalidation announced" — the write/invalidate seam is the harness
+// seam.
+func (w *featureWorld) stepAccountTurnsOffSilently(accountName, key string) error {
+	id, err := w.accountFor(accountName)
+	if err != nil {
+		return err
+	}
+	return w.settings.SetOverride(context.Background(), repositories.FeatureScopeAccount, id, key, false)
+}
+
+func (w *featureWorld) stepInstanceOff(key string) error {
+	return w.service.SetInstanceFeature(context.Background(), key, false)
+}
+
+func (w *featureWorld) stepOperatorTurnsInstanceOff(key string) error {
+	return w.stepInstanceOff(key)
+}
+
+func (w *featureWorld) stepAgentGranted(email, key string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	w.grantedKey = key
+	return w.service.GrantToAgent(context.Background(), p.accountID, p.agentID, key)
+}
+
+func (w *featureWorld) stepRoleGranted(role, key string) error {
+	accountID, err := w.soleAccount()
+	if err != nil {
+		return err
+	}
+	w.grantedKey = key
+	return w.service.GrantToRole(context.Background(), accountID, role, key)
+}
+
+func (w *featureWorld) stepRevokeAgent(email string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	key, err := w.lastGrantedKey()
+	if err != nil {
+		return err
+	}
+	return w.service.RevokeFromAgent(context.Background(), p.accountID, p.agentID, key)
+}
+
+func (w *featureWorld) stepRevokeRole(role string) error {
+	accountID, err := w.soleAccount()
+	if err != nil {
+		return err
+	}
+	key, err := w.lastGrantedKey()
+	if err != nil {
+		return err
+	}
+	return w.service.RevokeFromRole(context.Background(), accountID, role, key)
+}
+
+// stepStoredAccountOverride and stepStoredGrant write the store directly,
+// bypassing the service's eligibility refusal, because the contract stages rows
+// the service would never write and asserts resolution ignores them anyway.
+func (w *featureWorld) stepStoredAccountOverride(accountName, key string) error {
+	id, err := w.accountFor(accountName)
+	if err != nil {
+		return err
+	}
+	return w.settings.SetOverride(context.Background(), repositories.FeatureScopeAccount, id, key, false)
+}
+
+func (w *featureWorld) stepStoredGrant(email, key string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	return w.grants.Grant(context.Background(), repositories.FeatureSubjectAgent, p.agentID, p.accountID, key)
+}
+
+func (w *featureWorld) stepBreakStore() error {
+	w.settings.setBroken(true)
+	w.grants.setBroken(true)
+	return nil
+}
+
+func (w *featureWorld) stepFixStore() error {
+	w.settings.setBroken(false)
+	w.grants.setBroken(false)
+	return nil
+}
+
+// --- sign-in ---------------------------------------------------------------
+
+func (w *featureWorld) stepSignedInTo(email, accountName string) error {
+	id, err := w.accountFor(accountName)
+	if err != nil {
+		return err
+	}
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	p.accountID = id
+	return w.signIn(p)
+}
+
+func (w *featureWorld) stepBothSignedIn() error {
+	for _, email := range w.cohort() {
+		if err := w.signIn(w.people[email]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *featureWorld) stepBothSignedInTo(accountName string) error {
+	id, err := w.accountFor(accountName)
+	if err != nil {
+		return err
+	}
+	for _, email := range w.cohort() {
+		p := w.people[email]
+		p.accountID = id
+		if err := w.signIn(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *featureWorld) stepTwoDevices() error {
+	p, err := w.actor()
+	if err != nil {
+		return err
+	}
+	if err := w.signIn(p); err != nil {
+		return err
+	}
+	return w.signIn(p)
+}
+
+func (w *featureWorld) stepSignedInAndAnswered(onOff, key string) error {
+	p, err := w.actor()
+	if err != nil {
+		return err
+	}
+	if err := w.signIn(p); err != nil {
+		return err
+	}
+	got := w.evaluate(p, key, onOff == "off")
+	if got != (onOff == "on") {
+		return fmt.Errorf("%q was answered %v, want %s", p.email, got, onOff)
+	}
+	// Staging, not the assertion: clear the read counters so a later
+	// "read no feature state" step measures the evaluation under test.
+	w.settings.reset()
+	w.grants.reset()
+	return nil
+}
+
+func (w *featureWorld) stepBothSignedInAndAnswered(key string) error {
+	for _, email := range w.cohort() {
+		p := w.people[email]
+		if err := w.signIn(p); err != nil {
+			return err
+		}
+		if got := w.evaluate(p, key, false); !got {
+			return fmt.Errorf("%q was answered off, want on", email)
+		}
+	}
+	// Staging, not the assertion: clear the read counters so a later
+	// "read no feature state" step measures the evaluation under test.
+	w.settings.reset()
+	w.grants.reset()
+	return nil
+}
+
+func (w *featureWorld) stepAllSignedInAndAnswered(key string) error {
+	for _, email := range w.cohort() {
+		p := w.people[email]
+		if err := w.signIn(p); err != nil {
+			return err
+		}
+		if got := w.evaluate(p, key, false); got {
+			return fmt.Errorf("%q was answered on, want off", email)
+		}
+	}
+	// Staging, not the assertion: clear the read counters so a later
+	// "read no feature state" step measures the evaluation under test.
+	w.settings.reset()
+	w.grants.reset()
+	return nil
+}
+
+func (w *featureWorld) stepBothSessionsAnswered(key string) error {
+	p, err := w.actor()
+	if err != nil {
+		return err
+	}
+	for range p.sessionIDs {
+		if got := w.evaluate(p, key, false); !got {
+			return fmt.Errorf("a session was answered off, want on")
+		}
+	}
+	// Staging, not the assertion: clear the read counters so a later
+	// "read no feature state" step measures the evaluation under test.
+	w.settings.reset()
+	w.grants.reset()
+	return nil
+}
+
+func (w *featureWorld) stepAlreadyAnswered(key string) error {
+	p, err := w.actor()
+	if err != nil {
+		return err
+	}
+	if got := w.evaluate(p, key, false); !got {
+		return fmt.Errorf("%q was answered off, want on", p.email)
+	}
+	w.settings.reset()
+	w.grants.reset()
+	return nil
+}
+
+func (w *featureWorld) stepBothAlreadyAnswered(key string) error {
+	for _, email := range w.cohort() {
+		if got := w.evaluate(w.people[email], key, false); !got {
+			return fmt.Errorf("%q was answered off, want on", email)
+		}
+	}
+	w.settings.reset()
+	w.grants.reset()
+	return nil
+}
+
+func (w *featureWorld) stepEvaluatedAndAnsweredOff(key string) error {
+	p, err := w.actor()
+	if err != nil {
+		return err
+	}
+	if got := w.evaluate(p, key, true); got {
+		return fmt.Errorf("%q was answered on while the store was unreadable", p.email)
+	}
+	return nil
+}
+
+// --- evaluation ------------------------------------------------------------
+
+func (w *featureWorld) stepTheyEvaluate(key, def string) error {
+	p, err := w.actor()
+	if err != nil {
+		return err
+	}
+	w.evaluate(p, key, boolWord(def))
+	return nil
+}
+
+func (w *featureWorld) stepPersonEvaluates(email, key, def string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	w.current = p
+	w.evaluate(p, key, boolWord(def))
+	return nil
+}
+
+func (w *featureWorld) stepEachEvaluates(key, def string) error {
+	for _, email := range w.cohort() {
+		w.evaluate(w.people[email], key, boolWord(def))
+	}
+	return nil
+}
+
+func (w *featureWorld) stepEachEvaluatesAgain(key string) error {
+	for _, email := range w.cohort() {
+		w.evaluate(w.people[email], key, false)
+	}
+	return nil
+}
+
+func (w *featureWorld) stepAnonymousEvaluates(key, def string) error {
+	w.settings.reset()
+	w.grants.reset()
+	w.evaluate(nil, key, boolWord(def))
+	return nil
+}
+
+func (w *featureWorld) stepSignsInAndEvaluates(email, key, def string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	if err := w.signIn(p); err != nil {
+		return err
+	}
+	w.evaluate(p, key, boolWord(def))
+	return nil
+}
+
+func (w *featureWorld) stepEvaluateNTimes(key string, n int) error {
+	p, err := w.actor()
+	if err != nil {
+		return err
+	}
+	w.settings.reset()
+	w.grants.reset()
+	for i := 0; i < n; i++ {
+		w.evaluate(p, key, false)
+	}
+	return nil
+}
+
+func (w *featureWorld) stepEvaluateTwoKeys(first, second string) error {
+	p, err := w.actor()
+	if err != nil {
+		return err
+	}
+	w.settings.reset()
+	w.grants.reset()
+	w.evaluate(p, first, false)
+	w.evaluate(p, second, false)
+	return nil
+}
+
+func (w *featureWorld) stepEvaluateAgain(key string) error {
+	return w.stepTheyEvaluate(key, "off")
+}
+
+func (w *featureWorld) stepEvaluateAgainDefaultOn(key string) error {
+	return w.stepTheyEvaluate(key, "on")
+}
+
+func (w *featureWorld) stepEvaluateOnEachDevice(key string) error {
+	p, err := w.actor()
+	if err != nil {
+		return err
+	}
+	w.answers[p.email] = nil
+	for range p.sessionIDs {
+		w.evaluate(p, key, false)
+	}
+	return nil
+}
+
+func (w *featureWorld) stepEvaluateStraightAway(key string) error {
+	p, err := w.actor()
+	if err != nil {
+		return err
+	}
+	w.straightAway = w.evaluate(p, key, false)
+	return nil
+}
+
+// stepEvaluateAfterMaxAge waits out the configured age. The contract sets a
+// short one for exactly this reason; production leaves it long.
+func (w *featureWorld) stepEvaluateAfterMaxAge(key string) error {
+	p, err := w.actor()
+	if err != nil {
+		return err
+	}
+	time.Sleep(w.maxCacheAge + 250*time.Millisecond)
+	w.settings.reset()
+	w.grants.reset()
+	w.afterMaxAge = w.evaluate(p, key, false)
+	return nil
+}
+
+func (w *featureWorld) stepEvaluateUndeclaredN(key string, n int) error {
+	p, err := w.actor()
+	if err != nil {
+		return err
+	}
+	for i := 0; i < n; i++ {
+		w.evaluate(p, key, false)
+	}
+	return nil
+}
+
+func (w *featureWorld) stepEvaluateRawKey(flag, def string) error {
+	p, err := w.actor()
+	if err != nil {
+		return err
+	}
+	w.evaluateRawKey(p, flag, boolWord(def))
+	return nil
+}
+
+func (w *featureWorld) stepEvaluateNonBoolean(key, kind, supplied string) error {
+	p, err := w.actor()
+	if err != nil {
+		return err
+	}
+	ctx := w.ctxFor(p)
+	flag := application.FeatureFlagPrefix + key
+	switch kind {
+	case "a string":
+		d, _ := w.client.StringValueDetails(ctx, flag, supplied, openfeature.EvaluationContext{})
+		w.lastAny, w.lastRsn = d.Value, d.Reason
+	case "an integer":
+		var n int64
+		_, _ = fmt.Sscanf(supplied, "%d", &n)
+		d, _ := w.client.IntValueDetails(ctx, flag, n, openfeature.EvaluationContext{})
+		w.lastAny, w.lastRsn = d.Value, d.Reason
+	case "a number":
+		var f float64
+		_, _ = fmt.Sscanf(supplied, "%f", &f)
+		d, _ := w.client.FloatValueDetails(ctx, flag, f, openfeature.EvaluationContext{})
+		w.lastAny, w.lastRsn = d.Value, d.Reason
+	case "an object":
+		d, _ := w.client.ObjectValueDetails(ctx, flag, supplied, openfeature.EvaluationContext{})
+		w.lastAny, w.lastRsn = d.Value, d.Reason
+	default:
+		return fmt.Errorf("unknown evaluation kind %q", kind)
+	}
+	w.suppliedNonBool = supplied
+	return nil
+}
+
+// --- assertions ------------------------------------------------------------
+
+func (w *featureWorld) stepFeatureAnswers(onOff string) error {
+	if w.lastBool == nil {
+		return fmt.Errorf("nothing has been evaluated")
+	}
+	if *w.lastBool != boolWord(onOff) {
+		return fmt.Errorf("the feature answered %v, want %s", *w.lastBool, onOff)
+	}
+	return nil
+}
+
+func (w *featureWorld) stepFeatureAnswersOffOnly() error {
+	p, err := w.actor()
+	if err != nil {
+		return err
+	}
+	for i, got := range w.answers[p.email] {
+		if got {
+			return fmt.Errorf("session %d was answered on, want off", i+1)
+		}
+	}
+	return nil
+}
+
+func (w *featureWorld) stepAnsweredOnEveryTime() error {
+	p, err := w.actor()
+	if err != nil {
+		return err
+	}
+	for i, got := range w.answers[p.email] {
+		if !got {
+			return fmt.Errorf("evaluation %d answered off, want on", i+1)
+		}
+	}
+	return nil
+}
+
+func (w *featureWorld) stepPersonAnswered(email, onOff string) error {
+	got, ok := w.lastAnswerFor(email)
+	if !ok {
+		return fmt.Errorf("%q has not evaluated anything", email)
+	}
+	if got != boolWord(onOff) {
+		return fmt.Errorf("%q was answered %v, want %s", email, got, onOff)
+	}
+	return nil
+}
+
+func (w *featureWorld) stepAnsweredOnBothTimes(email string) error {
+	answers := w.answers[email]
+	if len(answers) < 2 {
+		return fmt.Errorf("%q evaluated %d times, want at least 2", email, len(answers))
+	}
+	for i, got := range answers {
+		if !got {
+			return fmt.Errorf("%q was answered off on evaluation %d", email, i+1)
+		}
+	}
+	return nil
+}
+
+func (w *featureWorld) stepBothAnsweredOff() error {
+	for _, email := range w.cohort() {
+		got, ok := w.lastAnswerFor(email)
+		if !ok {
+			return fmt.Errorf("%q has not evaluated anything", email)
+		}
+		if got {
+			return fmt.Errorf("%q was answered on, want off", email)
+		}
+	}
+	return nil
+}
+
+func (w *featureWorld) stepReasonIs(want string) error {
+	if string(w.lastRsn) != want {
+		return fmt.Errorf("reason was %q, want %q", w.lastRsn, want)
+	}
+	return nil
+}
+
+func (w *featureWorld) stepNonBooleanAnswer(_ string) error {
+	if w.lastRsn != openfeature.DefaultReason {
+		return fmt.Errorf("reason was %q, want DEFAULT", w.lastRsn)
+	}
+	if fmt.Sprint(w.lastAny) != w.suppliedNonBool &&
+		fmt.Sprintf("%v", w.lastAny) != w.suppliedNonBool {
+		return fmt.Errorf("the answer was %v, want the supplied %q", w.lastAny, w.suppliedNonBool)
+	}
+	return nil
+}
+
+func (w *featureWorld) stepStraightAwayOn() error {
+	if !w.straightAway {
+		return fmt.Errorf("the evaluation straight away answered off, want on")
+	}
+	return nil
+}
+
+func (w *featureWorld) stepAfterMaxAgeOff() error {
+	if w.afterMaxAge {
+		return fmt.Errorf("the evaluation after the maximum cache age answered on, want off")
+	}
+	return nil
+}
+
+// --- read counting ---------------------------------------------------------
+
+func (w *featureWorld) stepReadOnce() error {
+	p, err := w.actor()
+	if err != nil {
+		return err
+	}
+	instance, account := w.settings.countsFor(p.agentID)
+	if instance != 1 {
+		return fmt.Errorf("the instance layer was read %d times for %q, want 1", instance, p.email)
+	}
+	if account > 1 {
+		return fmt.Errorf("the account layer was read %d times for %q, want at most 1", account, p.email)
+	}
+	if grants := w.grants.countFor(p.agentID); grants > 1 {
+		return fmt.Errorf("grants were read %d times for %q, want at most 1", grants, p.email)
+	}
+	return nil
+}
+
+func (w *featureWorld) stepReadOnceMore() error {
+	p, err := w.actor()
+	if err != nil {
+		return err
+	}
+	instance, _ := w.settings.countsFor(p.agentID)
+	if instance != 1 {
+		return fmt.Errorf("the set was re-resolved with %d instance reads, want exactly 1", instance)
+	}
+	return nil
+}
+
+// stepNoAccountOrGrantRead measures the anonymous caller specifically — the
+// empty agent id — so another person resolving in the same scenario cannot mask
+// the assertion.
+func (w *featureWorld) stepNoAccountOrGrantRead() error {
+	_, account := w.settings.countsFor("")
+	if account != 0 {
+		return fmt.Errorf("the anonymous caller read the account layer %d times, want 0", account)
+	}
+	if grants := w.grants.countFor(""); grants != 0 {
+		return fmt.Errorf("the anonymous caller read grants %d times, want 0", grants)
+	}
+	return nil
+}
+
+// stepPersonReadNothing proves this person's answer came from memory. Counted
+// per agent: somebody else re-resolving in the same scenario is exactly what
+// the isolation scenario stages, and a global count would be masked by it.
+func (w *featureWorld) stepPersonReadNothing(email string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	instance, account := w.settings.countsFor(p.agentID)
+	if instance != 0 || account != 0 {
+		return fmt.Errorf("%q read feature state %d/%d times, want none — their session "+
+			"was not invalidated, so the answer had to come from memory", email, instance, account)
+	}
+	return nil
+}
+
+// --- sign-out --------------------------------------------------------------
+
+func (w *featureWorld) stepStillSignedIn() error {
+	p, err := w.actor()
+	if err != nil {
+		return err
+	}
+	return w.assertSessionsValid(p)
+}
+
+func (w *featureWorld) stepAllStillSignedIn() error {
+	for _, email := range w.cohort() {
+		if err := w.assertSessionsValid(w.people[email]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *featureWorld) assertSessionsValid(p *featurePerson) error {
+	for i, id := range p.sessionIDs {
+		info, err := w.authService.ValidateSession(context.Background(), id)
+		if err != nil || info == nil {
+			return fmt.Errorf("session %d of %q is no longer valid: %w — "+
+				"clearing a resolved feature set must never sign anyone out", i+1, p.email, err)
+		}
+	}
+	return nil
+}
+
+func (w *featureWorld) stepNextRequestServed() error {
+	p, err := w.actor()
+	if err != nil {
+		return err
+	}
+	if err := w.assertSessionsValid(p); err != nil {
+		return err
+	}
+	// A further evaluation must still be answered rather than refused.
+	w.evaluate(p, "episodic-recall", false)
+	return nil
+}
+
+// --- logging ---------------------------------------------------------------
+
+func (w *featureWorld) stepLoggedUndeclaredOnce() error {
+	lines := w.logs.matching("nobody declared")
+	if len(lines) != 1 {
+		return fmt.Errorf("the undeclared key was logged %d times, want exactly 1", len(lines))
+	}
+	return nil
+}
+
+func (w *featureWorld) stepLogNamesKey(key string) error {
+	if len(w.logs.matching("nobody declared", key)) == 0 {
+		return fmt.Errorf("no log line names the key %q", key)
+	}
+	return nil
+}
+
+func (w *featureWorld) stepLoggedFailure() error {
+	if len(w.logs.matching("feature evaluation failed")) == 0 {
+		return fmt.Errorf("the store failure was not logged")
+	}
+	return nil
+}
+
+// --- helpers ---------------------------------------------------------------
+
+func (w *featureWorld) lastAnswerFor(email string) (bool, bool) {
+	answers := w.answers[email]
+	if len(answers) == 0 {
+		return false, false
+	}
+	return answers[len(answers)-1], true
+}
+
+func (w *featureWorld) soleAccount() (string, error) {
+	if len(w.accounts) == 0 {
+		return "", fmt.Errorf("no account has been staged")
+	}
+	for _, id := range w.accounts {
+		return id, nil
+	}
+	return "", fmt.Errorf("no account has been staged")
+}
+
+func (w *featureWorld) lastGrantedKey() (string, error) {
+	if w.grantedKey == "" {
+		return "", fmt.Errorf("no grant has been staged to take away")
+	}
+	return w.grantedKey, nil
+}

--- a/tests/e2e/features/feature_flag_resolution.feature
+++ b/tests/e2e/features/feature_flag_resolution.feature
@@ -1,0 +1,363 @@
+@wip @epic-480 @story-481
+Feature: A feature is declared once and resolved through OpenFeature
+  As an operator running a WeOS instance
+  I want one answer to "is this capability on for this caller?"
+  So that unfinished work ships dark and paid capabilities reach only the right people
+
+  A feature is declared in code, or by a preset, and the declaration is the whole of what
+  the instance knows about it: a key, a name and description an operator can read, the
+  value it takes when nothing else has spoken, whether an account admin may change it,
+  and whether it may be granted to one person. Every call site asks the same question
+  through the OpenFeature client, under the "feature." key prefix, so that a remote flag
+  source can be layered in later without a single call site changing.
+
+  Three layers can speak, in this order: the instance, then the account the caller is
+  acting in, then a grant the caller holds directly or through their role. The rule these
+  scenarios pin is that an explicit "off" at any layer is final for every layer below it.
+  An operator who turns a feature off for the instance has turned it off for everyone,
+  and no account override and no personal grant reaches past that; an account that turns
+  it off has turned it off for its members, whatever they were granted. Anything a layer
+  says nothing about passes through untouched, so a feature nobody has touched answers
+  its declared default, and a feature declared off can still be turned on by the account
+  or by a grant. That last point is the one worth stating out loud, because "first off
+  wins" read strictly would make every feature declared off unreachable forever, which
+  would leave the declaration's own `default` field with only one usable value. The
+  scenarios below therefore separate the declared default from an operator's explicit
+  instance-level off, and assert both.
+
+  This story ships no command, no endpoint and no admin screen — those are #482, #483 and
+  #486. The only surface it has is the resolver itself. So these scenarios evaluate
+  through the OpenFeature client the way a call site will, and they stage the stored state
+  behind it — an instance-level off, an account override, a grant — by reaching the store
+  directly from the step definitions, as the account-suspension scenarios in
+  account_scoped_sessions.feature already do for the same reason. When #482 gives an
+  operator a way to make those changes, the steps change and the scenarios do not.
+
+  The caller is whoever the request context says it is. Nothing here reads a token claim,
+  and nothing here should start to: the resolved set lives server-side precisely so that
+  it can be invalidated, which a claim baked into a token cannot be. A scenario that
+  proved a claim was ignored would have to invent a call site that reads one, so the
+  property is pinned from the other side instead — every answer below follows the caller
+  and the account on the context, and two people holding different grants inside one
+  account get two different answers.
+
+  Failure is closed. A feature declared on answers off when the store behind it cannot be
+  read, because a resolver that answers "on" on the way to a database error hands out the
+  capability at exactly the moment nobody can see why. A key nobody declared is a
+  different thing: it is a deploy that drifted from its registry, so the caller gets the
+  default it supplied and the instance says so in its log, once, rather than once per
+  evaluation on a hot path.
+
+  Resolution sits in front of MCP tool listings and agent turns, where thirty calls in one
+  turn is ordinary, so the resolved set is computed once per session and read from memory
+  afterwards. One rule governs what happens next, and it has no exceptions: a change
+  reaches sessions that are already open. An instance-level flip, an account override and
+  a grant taken away all land the same way, and a grant made to a role lands on every
+  member who holds it, not only on whoever the change was made through.
+
+  Nothing in that rule signs anybody out. Clearing what a session had resolved and ending
+  that session are different acts with different costs — the first costs the next
+  evaluation one database read and the person stays signed in, the second forces them to
+  log in again and belongs to a separate feature. No flag change ever forces a re-login,
+  and the scenarios say so out loud, because a forced logout is the shape this is most
+  likely to be built as by accident.
+
+  The rule is also the same on every deployment. One process serving one instance and a
+  fleet of replicas must answer identically; what differs is only the machinery behind the
+  invalidation, which no scenario here can see and none should name. That is deliberate:
+  behaviour that varied with the deployment shape would hide a replica-only bug from every
+  single-process instance it was developed on. Because that machinery can lag or lose a
+  message, the staleness that remains is bounded rather than open-ended — a resolved set is
+  re-resolved once the configured maximum cache age has passed, whether an invalidation
+  arrived or not. The scenario for that configures a short age and waits; on a real
+  instance the age is long, because there the invalidation is exact.
+
+  Background:
+    Given a WeOS instance where password sign-in is enabled and requests are authenticated by their session
+    And the instance declares these features in code:
+      | key             | display name    | description                              | default | manageable | grantable |
+      | episodic-recall | Episodic recall | Recall past events during a conversation | on      | yes        | yes       |
+      | ledger-export   | Ledger export   | Export the ledger to a spreadsheet       | off     | yes        | yes       |
+      | audit-trail     | Audit trail     | Record who read what, for compliance     | on      | no         | no        |
+    And the account "Harbor Legal", whose owner "ops@harborlegal.example" signs in with password "correct-horse-battery-staple"
+
+  # --- What a declaration is, and where declarations come from ---
+
+  Scenario: A feature declared in code is registered before anything is installed
+    When the registered features are listed
+    Then the listing includes the feature "episodic-recall"
+    And that feature reports the display name "Episodic recall"
+    And that feature reports a description an operator can read
+    And that feature reports it defaults on
+    And that feature reports an account admin may change it
+    And that feature reports it may be granted to one person
+
+  Scenario: A feature that no account may change and no grant may reach says so in its declaration
+    When the registered features are listed
+    Then the listing includes the feature "audit-trail"
+    And that feature reports an account admin may not change it
+    And that feature reports it may not be granted to one person
+
+  Scenario: Installing a preset adds the features the preset declares
+    Given a preset "billing-demo" that declares the feature "invoice-export", defaulting off
+    When the "billing-demo" preset is installed
+    And the registered features are listed
+    Then the listing includes the feature "invoice-export"
+    And the listing still includes the feature "episodic-recall"
+
+  Scenario Outline: A feature nobody has touched answers the default it was declared with
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And nothing has been overridden or granted on this instance
+    When they evaluate "<key>" with default <supplied>
+    Then the feature answers <answer>
+
+    Examples:
+      | key             | supplied | answer |
+      | episodic-recall | off      | on     |
+      | ledger-export   | on       | off    |
+
+  # --- The three layers, and which one wins ---
+
+  Scenario: An account turns on a feature that was declared off
+    Given "Harbor Legal" has turned the feature "ledger-export" on
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they evaluate "ledger-export" with default off
+    Then the feature answers on
+
+  Scenario: An account's off beats a grant held by one of its members
+    Given "Harbor Legal" has turned the feature "episodic-recall" off
+    And "ops@harborlegal.example" has been granted the feature "episodic-recall"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they evaluate "episodic-recall" with default on
+    Then the feature answers off
+
+  Scenario: An instance-level off beats an account that turned the feature on
+    Given the operator has turned the feature "episodic-recall" off for the instance
+    And "Harbor Legal" has turned the feature "episodic-recall" on
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they evaluate "episodic-recall" with default on
+    Then the feature answers off
+
+  Scenario: An instance-level off beats a grant made to one person
+    Given the operator has turned the feature "episodic-recall" off for the instance
+    And "ops@harborlegal.example" has been granted the feature "episodic-recall"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they evaluate "episodic-recall" with default on
+    Then the feature answers off
+
+  Scenario: An account's setting does not reach into another account
+    Given the account "Cedar Realty", whose owner "broker@cedarrealty.example" signs in with password "trellis-anchor-mango-9"
+    And "Harbor Legal" has turned the feature "episodic-recall" off
+    And both of them are signed in
+    When each of them evaluates "episodic-recall" with default on
+    Then "ops@harborlegal.example" is answered off
+    And "broker@cedarrealty.example" is answered on
+
+  Scenario: A grant turns a feature on for the person who holds it and for nobody else
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "ops@harborlegal.example" has been granted the feature "ledger-export"
+    And both of them are signed in to "Harbor Legal"
+    When each of them evaluates "ledger-export" with default off
+    Then "ops@harborlegal.example" is answered on
+    And "counsel@harborlegal.example" is answered off
+
+  Scenario: A grant carried by someone's role resolves the same as one made to them directly
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal" with the role "admin"
+    And the role "admin" has been granted the feature "ledger-export"
+    And "counsel@harborlegal.example" is signed in to "Harbor Legal"
+    When they evaluate "ledger-export" with default off
+    Then the feature answers on
+
+  Scenario: An account override stored against a feature no account may change is ignored
+    Given "Harbor Legal" has a stored override turning the feature "audit-trail" off
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they evaluate "audit-trail" with default on
+    Then the feature answers on
+
+  Scenario: A grant stored against a feature that may not be granted is ignored
+    Given the feature "audit-trail" is off for the instance
+    And "ops@harborlegal.example" holds a stored grant for the feature "audit-trail"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they evaluate "audit-trail" with default on
+    Then the feature answers off
+
+  # --- The caller comes from the request context ---
+
+  Scenario: Two people in one account are answered from their own grants, not from whoever asked last
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "ops@harborlegal.example" has been granted the feature "ledger-export"
+    And both of them are signed in to "Harbor Legal"
+    When "ops@harborlegal.example" evaluates "ledger-export" with default off
+    And "counsel@harborlegal.example" evaluates "ledger-export" with default off
+    And "ops@harborlegal.example" evaluates "ledger-export" with default off again
+    Then "counsel@harborlegal.example" was answered off
+    And "ops@harborlegal.example" was answered on both times
+
+  Scenario: An evaluation with nobody on the context answers the instance-level value
+    Given "Harbor Legal" has turned the feature "episodic-recall" off
+    When a caller with no identity on the context evaluates "episodic-recall" with default on
+    Then the feature answers on
+    And no account override or grant was read for that evaluation
+
+  # --- Keys the resolver does not know ---
+
+  Scenario Outline: A key nobody declared answers the default the caller supplied
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they evaluate the undeclared feature "shipping-labels" with default <supplied>
+    Then the feature answers <supplied>
+    And the evaluation reason is "DEFAULT"
+
+    Examples:
+      | supplied |
+      | on       |
+      | off      |
+
+  Scenario: A key outside the feature namespace passes straight through
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they evaluate the flag key "entitlement.sea_math_2027" with default on
+    Then the flag answers on
+    And the evaluation reason is "DEFAULT"
+
+  Scenario: A key nobody declared is logged once however often it is evaluated
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they evaluate the undeclared feature "shipping-labels" 20 times with default off
+    Then the instance logged the undeclared feature key once
+    And the log names the key "shipping-labels"
+
+  # --- Failing closed ---
+
+  Scenario: A feature declared on answers off when the store behind it cannot be read
+    Given the store holding account overrides and grants cannot be read
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they evaluate "episodic-recall" with default on
+    Then the feature answers off
+    And the evaluation reason is "ERROR"
+    And the instance logged the failure
+
+  Scenario: A store failure is not remembered as an answer
+    Given the store holding account overrides and grants cannot be read
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they evaluated "episodic-recall" with default on and were answered off
+    When the store can be read again
+    And they evaluate "episodic-recall" with default on in the same session
+    Then the feature answers on
+    And they were not signed out by the failure
+
+  Scenario Outline: An evaluation that asks for something other than a boolean answers the caller's own default
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they evaluate "episodic-recall" as <kind> with default <supplied>
+    Then the answer is the <supplied> they supplied
+    And the evaluation reason is "DEFAULT"
+
+    Examples:
+      | kind       | supplied |
+      | a string   | trial    |
+      | an integer | 7        |
+      | a number   | 1.5      |
+      | an object  | tier=pro |
+
+  # --- Resolved once per session, read from memory afterwards ---
+
+  Scenario: Evaluating the same feature many times in a session reads the database once
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they evaluate "episodic-recall" 30 times in that session
+    Then the feature answers on every time
+    And feature state was read from the database only while the first evaluation was answered
+
+  Scenario: The first evaluation resolves every feature, not only the one it was asked about
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they evaluate "episodic-recall" and then "ledger-export" in the same session
+    Then feature state was read from the database only while the first evaluation was answered
+
+  Scenario: Each session gets its own resolved set
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "ops@harborlegal.example" has been granted the feature "ledger-export"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have already evaluated "ledger-export" and been answered on
+    When "counsel@harborlegal.example" signs in and evaluates "ledger-export" with default off
+    Then "counsel@harborlegal.example" is answered off
+
+  Scenario: Both sessions one person holds are reached, not only the one that asked first
+    Given "ops@harborlegal.example" has been granted the feature "ledger-export"
+    And they are signed in on two devices, each with its own session
+    And both sessions have already evaluated "ledger-export" and been answered on
+    When the grant is taken away from "ops@harborlegal.example"
+    And they evaluate "ledger-export" again on each device
+    Then both sessions are answered off
+    And neither session was signed out
+
+  # --- One rule: a change reaches sessions that are already open ---
+
+  Scenario: A grant taken away is gone from the session the person is already in
+    Given "ops@harborlegal.example" has been granted the feature "ledger-export"
+    And they are signed in and have been answered on for "ledger-export"
+    When the grant is taken away from "ops@harborlegal.example"
+    And they evaluate "ledger-export" again in the same session
+    Then the feature answers off
+    And they are still signed in
+    And the request they make next is served
+
+  Scenario: A grant made to a role reaches every member who holds it, in the sessions they already have
+    Given "counsel@harborlegal.example" and "clerk@harborlegal.example" both belong to "Harbor Legal" with the role "admin"
+    And "temp@harborlegal.example" belongs to "Harbor Legal" without that role
+    And all three of them are signed in and have been answered off for "ledger-export"
+    When the role "admin" is granted the feature "ledger-export"
+    And each of them evaluates "ledger-export" again in the session they already held
+    Then "counsel@harborlegal.example" is answered on
+    And "clerk@harborlegal.example" is answered on
+    And "temp@harborlegal.example" is answered off
+    And none of them was signed out
+
+  Scenario: A grant taken away from a role reaches every member who held it
+    Given the role "admin" has been granted the feature "ledger-export"
+    And "counsel@harborlegal.example" and "clerk@harborlegal.example" both hold the role "admin" in "Harbor Legal"
+    And both of them are signed in and have been answered on for "ledger-export"
+    When the grant is taken away from the role "admin"
+    And each of them evaluates "ledger-export" again in the session they already held
+    Then both of them are answered off
+
+  Scenario: An operator turning a feature off for the account reaches sessions already open
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have already evaluated "episodic-recall" and been answered on
+    When "Harbor Legal" turns the feature "episodic-recall" off
+    And they evaluate "episodic-recall" again in the same session
+    Then the feature answers off
+
+  Scenario: An operator turning a feature off for the instance reaches sessions already open
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And both of them are signed in to "Harbor Legal"
+    And both of them have already evaluated "episodic-recall" and been answered on
+    When the operator turns the feature "episodic-recall" off for the instance
+    And each of them evaluates "episodic-recall" again in the session they already held
+    Then both of them are answered off
+
+  Scenario: An operator's change to one account does not re-resolve another account's sessions
+    Given the account "Cedar Realty", whose owner "broker@cedarrealty.example" signs in with password "trellis-anchor-mango-9"
+    And both owners are signed in and have been answered on for "episodic-recall"
+    When "Harbor Legal" turns the feature "episodic-recall" off
+    And each of them evaluates "episodic-recall" again in the session they already held
+    Then "ops@harborlegal.example" is answered off
+    And "broker@cedarrealty.example" is answered on
+    And "broker@cedarrealty.example" read no feature state from the database to be answered
+
+  # --- The staleness that is left is bounded ---
+
+  Scenario: A change that no invalidation announced is picked up once the maximum cache age passes
+    Given the instance is configured with a maximum cache age of 2 seconds
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have already evaluated "episodic-recall" and been answered on
+    When "Harbor Legal" turns the feature "episodic-recall" off and no invalidation reaches the session
+    And they evaluate "episodic-recall" again straight away
+    And they evaluate "episodic-recall" again after the maximum cache age has passed
+    Then the evaluation straight away is answered on
+    And the evaluation after the maximum cache age is answered off
+    And they were signed out by neither evaluation
+
+  Scenario: A session that outlives the maximum cache age with nothing changed keeps answering the same way
+    Given the instance is configured with a maximum cache age of 2 seconds
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have already evaluated "episodic-recall" and been answered on
+    When nothing is changed
+    And they evaluate "episodic-recall" again after the maximum cache age has passed
+    Then the feature answers on
+    And feature state was read from the database once more, to re-resolve the set

--- a/tests/e2e/features/feature_flag_resolution.feature
+++ b/tests/e2e/features/feature_flag_resolution.feature
@@ -1,4 +1,4 @@
-@wip @epic-480 @story-481
+@epic-480 @story-481
 Feature: A feature is declared once and resolved through OpenFeature
   As an operator running a WeOS instance
   I want one answer to "is this capability on for this caller?"

--- a/tests/e2e/fxgraph_test.go
+++ b/tests/e2e/fxgraph_test.go
@@ -1,12 +1,15 @@
 package e2e
 
 import (
+	"context"
 	"testing"
 
+	"github.com/open-feature/go-sdk/openfeature"
 	"go.uber.org/fx"
 
 	"github.com/wepala/weos/v3/application"
 	"github.com/wepala/weos/v3/application/presets"
+	"github.com/wepala/weos/v3/domain/entities"
 	"github.com/wepala/weos/v3/domain/repositories"
 	"github.com/wepala/weos/v3/internal/config"
 )
@@ -21,23 +24,82 @@ func TestFeatureGraphResolves(t *testing.T) {
 	var (
 		registry    *application.FeatureRegistry
 		resolver    *application.FeatureResolver
-		provider    *application.FeatureProvider
 		service     *application.FeatureService
 		invalidator repositories.FeatureCacheInvalidator
 	)
 	app := fx.New(
 		fx.NopLogger,
 		application.Module(cfg, presets.NewDefaultRegistry()),
-		fx.Populate(&registry, &resolver, &provider, &service, &invalidator),
+		fx.Populate(&registry, &resolver, &service, &invalidator),
 	)
 	if err := app.Err(); err != nil {
 		t.Fatalf("fx graph failed to build: %v", err)
 	}
-	if registry == nil || resolver == nil || provider == nil || service == nil || invalidator == nil {
+	if registry == nil || resolver == nil || service == nil || invalidator == nil {
 		t.Fatal("a feature dependency resolved to nil")
 	}
 	// On SQLite the resolver IS the invalidator — not a wrapper.
 	if invalidator != repositories.FeatureCacheInvalidator(resolver) {
 		t.Fatal("on SQLite the invalidator should be the resolver itself, with no broadcast wrapper")
+	}
+}
+
+// TestFeatureProviderIsRegisteredWithoutBeingAskedFor is the regression test
+// for the subsystem shipping inert.
+//
+// fx builds only what something depends on. The provider was originally offered
+// with fx.Provide and demanded by nothing, so in the real server it was never
+// constructed, the OpenFeature domain fell through to the SDK's no-op provider,
+// and every evaluation returned the caller's default. Every test passed, because
+// the tests populated the provider directly and thereby forced the construction
+// that production never performed.
+//
+// So this test deliberately does NOT populate the provider. It starts the app
+// the way `weos serve` does, then evaluates through a client obtained the way a
+// call site would, and requires the answer to come from our resolver rather
+// than from a default.
+func TestFeatureProviderIsRegisteredWithoutBeingAskedFor(t *testing.T) {
+	cfg := config.Default()
+	cfg.DatabaseDSN = t.TempDir() + "/fxregister.db"
+
+	var registry *application.FeatureRegistry
+	app := fx.New(
+		fx.NopLogger,
+		application.Module(cfg, presets.NewDefaultRegistry()),
+		fx.Populate(&registry),
+	)
+	startCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+	defer cancel()
+	if err := app.Start(startCtx); err != nil {
+		t.Fatalf("failed to start app: %v", err)
+	}
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		defer stopCancel()
+		_ = app.Stop(stopCtx)
+	}()
+
+	if err := registry.Register(entities.FeatureMeta{
+		Key: "wiring-probe", DisplayName: "Wiring probe", Default: true,
+	}); err != nil {
+		t.Fatalf("could not declare the probe feature: %v", err)
+	}
+
+	client := openfeature.NewClient(application.FeatureProviderDomain)
+	detail, err := client.BooleanValueDetails(context.Background(),
+		application.FeatureFlagPrefix+"wiring-probe", false, openfeature.EvaluationContext{})
+	if err != nil {
+		t.Fatalf("evaluation failed: %v", err)
+	}
+
+	// A no-op provider would return the supplied default (false) with reason
+	// DEFAULT. Our resolver returns the declared value with TARGETING_MATCH.
+	if !detail.Value {
+		t.Fatal("the declared feature resolved off — the domain is bound to a no-op provider, " +
+			"so the whole feature-flag subsystem is inert in the shipped binary")
+	}
+	if detail.Reason != openfeature.TargetingMatchReason {
+		t.Fatalf("reason = %q, want %q — the answer did not come from the WeOS resolver",
+			detail.Reason, openfeature.TargetingMatchReason)
 	}
 }

--- a/tests/e2e/fxgraph_test.go
+++ b/tests/e2e/fxgraph_test.go
@@ -1,0 +1,43 @@
+package e2e
+
+import (
+	"testing"
+
+	"go.uber.org/fx"
+
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/application/presets"
+	"github.com/wepala/weos/v3/domain/repositories"
+	"github.com/wepala/weos/v3/internal/config"
+)
+
+// TestFeatureGraphResolves proves the feature-flag providers wire into the real
+// fx container. A compile is not evidence: a missing or duplicated provider
+// only shows up when the graph is built.
+func TestFeatureGraphResolves(t *testing.T) {
+	cfg := config.Default()
+	cfg.DatabaseDSN = t.TempDir() + "/fxgraph.db"
+
+	var (
+		registry    *application.FeatureRegistry
+		resolver    *application.FeatureResolver
+		provider    *application.FeatureProvider
+		service     *application.FeatureService
+		invalidator repositories.FeatureCacheInvalidator
+	)
+	app := fx.New(
+		fx.NopLogger,
+		application.Module(cfg, presets.NewDefaultRegistry()),
+		fx.Populate(&registry, &resolver, &provider, &service, &invalidator),
+	)
+	if err := app.Err(); err != nil {
+		t.Fatalf("fx graph failed to build: %v", err)
+	}
+	if registry == nil || resolver == nil || provider == nil || service == nil || invalidator == nil {
+		t.Fatal("a feature dependency resolved to nil")
+	}
+	// On SQLite the resolver IS the invalidator — not a wrapper.
+	if invalidator != repositories.FeatureCacheInvalidator(resolver) {
+		t.Fatal("on SQLite the invalidator should be the resolver itself, with no broadcast wrapper")
+	}
+}


### PR DESCRIPTION
Closes #481. First layer of epic #480.

A feature is declared once — in code or by a preset — and every call site asks the same question through the OpenFeature client under the `feature.` prefix. Nothing here gates anything yet; the operator CLI (#482), grants (#483), MCP tool gating (#484), agent-skill gating (#485) and the admin UI (#486) all build on this.

## How it resolves

Three layers speak in order: instance, then account, then a grant held directly or through a role.

- The instance layer is **three-state** (unset / on / off). Unset falls through to the declaration's default.
- An **explicit off is final** for every layer below it. An **explicit on is not** — an account may still turn off what the instance turned on.
- A declared default is *not* an explicit off. Reading "first off wins" strictly would make a feature declared `Default:false` unreachable forever, leaving that field with one usable value.
- A grant can only ever turn a feature **on**. It can never rescue one an upper layer switched off.

The precedence lives in exactly one pure function, `entities.ResolveFeature`, which also returns *which layer decided* so #482's explain output and #486's listing can say why rather than re-deriving the rules. The behaviour-toggle resolvers are deliberately left alone: their semantics differ on every axis (set membership vs per-key tri-state, two layers vs three, fail-open vs fail-closed), and rewriting working fail-open code inside a flags story would ship unproven.

## Caching and invalidation

A caller's whole set is resolved once and read from memory after — resolution sits in front of MCP tool listings and agent turns, where thirty tool calls in one turn is ordinary.

Keyed by **(agent, account), not by session**. There is no session id on the MCP bearer surface; `BearerOrSession` keeps only the identity. It is also strictly more correct: two sessions of one person in one account always resolve identically, so one invalidation reaches every device they are signed in on, including MCP connectors that hold no enumerable server-side session.

One rule, no exceptions: **a change reaches sessions that are already open** — instance, account, and grant alike. **Nothing ever signs anyone out.** Clearing a resolved set costs the next evaluation one database read; ending a session is a different act belonging to a different feature (#489). Four scenarios assert that explicitly, because a forced logout is the shape this is most likely to be built as by accident.

Invalidation is an explicit call at each write site, never event subscription alone: a member's role change is a direct projection write that emits no event, and resolution depends on the caller's role.

On SQLite, in-process eviction is the complete implementation — single process, serialized writers, no second cache in existence. On Postgres it is wrapped with LISTEN/NOTIFY. Deliberately **not** a checkpointed subscriber group: those lock their checkpoint row `FOR UPDATE SKIP LOCKED`, making replicas competing consumers, so one would evict and the rest would serve stale answers forever.

## Failure behaviour

A store failure resolves **off**, not the caller's supplied default — a call site passing `true` must not be handed the capability at the moment nobody can see why. If that caller already has a resolved set it is served instead, with a warning, so a database blip cannot strip every capability from everyone mid-turn. With no previous set, off.

A nil identity resolves the **instance layer only**, and never reads the account or grant stores. This deliberately differs from the rest of the codebase, where a nil identity means system context and bypasses gates.

## Tests

- **33 acceptance scenarios** (38 with outlines, 316 steps) written before any implementation and confirmed before code started. Promoted out of `@wip`, so they run in the default e2e suite.
- A **truth table** in the domain covering the one row the contract cannot reach — instance-on with account-off. Mutation-verified: treating an explicit ON as final fails exactly those two rows and nothing else.
- A **registration test** that deliberately does not populate the provider, because that is how the subsystem was inert while every test passed.

## Two bugs the process caught that tests alone did not

**The OpenFeature SDK was defeating fail-closed.** The provider returned `false` with a `ResolutionError`; the client treats a resolution error as "use the caller's default", so a site passing `true` got `true`. Every unit test passed because they called the provider directly. Reason stays `ERROR` for telemetry; no `ResolutionError` is attached, so the value survives.

**The whole subsystem was inert in the shipped binary.** fx builds only what something depends on, and the provider was offered with `fx.Provide` and demanded by nothing — never constructed, never registered, so the domain fell through to the SDK's no-op provider and every evaluation returned the caller's default. The tests forced a construction production never performed.

## Known and filed, not fixed here

#490 (cache never reclaims expired entries — measured at ~1.18 KB per distinct caller), #491 (cross-replica invalidation flushes everything everywhere, needs a pericarp payload), #492 (foundation gaps the later stories will hit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
