### PR TITLE
An operator turns a feature on or off for the whole instance

### DIFF
--- a/api/handlers/feature_handler.go
+++ b/api/handlers/feature_handler.go
@@ -17,6 +17,7 @@ package handlers
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -49,8 +50,13 @@ func NewFeatureHandler(cfg FeatureHandlerConfig) *FeatureHandler {
 }
 
 // setFeatureRequest is the body of both PUT endpoints.
+//
+// Enabled is a pointer so an omitted field is distinguishable from false. A
+// bare bool would bind an empty body to false, so a client that forgot the
+// field — or sent {} — would silently DISABLE the feature it meant to enable,
+// and get a 200 saying so.
 type setFeatureRequest struct {
-	Enabled bool `json:"enabled"`
+	Enabled *bool `json:"enabled"`
 }
 
 // List returns every declared feature with its resolved value and the layer
@@ -71,13 +77,12 @@ func (h *FeatureHandler) List(c echo.Context) error {
 
 // SetInstance turns a feature on or off for the whole instance.
 func (h *FeatureHandler) SetInstance(c echo.Context) error {
-	var req setFeatureRequest
-	if err := c.Bind(&req); err != nil {
-		return respondError(c, http.StatusBadRequest, "invalid request")
+	req, err := bindSetFeature(c)
+	if err != nil {
+		return respondError(c, http.StatusBadRequest, err.Error())
 	}
-	err := h.admin.SetInstance(
-		c.Request().Context(), c.Param("key"), req.Enabled, entities.FeatureChangeSourceAPI)
-	return h.respondAfterChange(c, err)
+	return h.respondAfterChange(c, h.admin.SetInstance(
+		c.Request().Context(), c.Param("key"), *req.Enabled, entities.FeatureChangeSourceAPI))
 }
 
 // ResetInstance removes the instance override so the feature returns to its
@@ -96,19 +101,31 @@ func (h *FeatureHandler) ResetInstance(c echo.Context) error {
 // one account cannot reach into another by naming it — and an endpoint that
 // accepted an account id would make that property untestable.
 func (h *FeatureHandler) SetAccount(c echo.Context) error {
-	var req setFeatureRequest
-	if err := c.Bind(&req); err != nil {
-		return respondError(c, http.StatusBadRequest, "invalid request")
+	req, err := bindSetFeature(c)
+	if err != nil {
+		return respondError(c, http.StatusBadRequest, err.Error())
 	}
-	err := h.admin.SetAccount(
-		c.Request().Context(), c.Param("key"), req.Enabled, entities.FeatureChangeSourceAPI)
-	return h.respondAfterChange(c, err)
+	return h.respondAfterChange(c, h.admin.SetAccount(
+		c.Request().Context(), c.Param("key"), *req.Enabled, entities.FeatureChangeSourceAPI))
 }
 
 // ResetAccount removes the caller's account override.
 func (h *FeatureHandler) ResetAccount(c echo.Context) error {
 	err := h.admin.ResetAccount(c.Request().Context(), c.Param("key"), entities.FeatureChangeSourceAPI)
 	return h.respondAfterChange(c, err)
+}
+
+// bindSetFeature refuses a body that does not say which way to set the
+// feature, rather than defaulting to off.
+func bindSetFeature(c echo.Context) (setFeatureRequest, error) {
+	var req setFeatureRequest
+	if err := c.Bind(&req); err != nil {
+		return req, fmt.Errorf("invalid request")
+	}
+	if req.Enabled == nil {
+		return req, fmt.Errorf(`"enabled" is required: say true or false rather than leaving it out`)
+	}
+	return req, nil
 }
 
 // respondAfterChange maps the service's error to a status, then answers with

--- a/api/handlers/feature_handler.go
+++ b/api/handlers/feature_handler.go
@@ -1,0 +1,150 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package handlers
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
+)
+
+// FeatureHandler serves the endpoints the admin UI (#486) calls to see and
+// change feature state.
+//
+// It holds no permission logic of its own. Every check lives in
+// FeatureAdminService, shared with the CLI and the MCP tools, so the three
+// surfaces cannot come to disagree about who may change what — which is
+// exactly what a listing that says one thing and a write that does another
+// would look like from the outside.
+type FeatureHandler struct {
+	admin  *application.FeatureAdminService
+	logger entities.Logger
+}
+
+type FeatureHandlerConfig struct {
+	Admin  *application.FeatureAdminService
+	Logger entities.Logger
+}
+
+func NewFeatureHandler(cfg FeatureHandlerConfig) *FeatureHandler {
+	return &FeatureHandler{admin: cfg.Admin, logger: cfg.Logger}
+}
+
+// setFeatureRequest is the body of both PUT endpoints.
+type setFeatureRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
+// List returns every declared feature with its resolved value and the layer
+// that decided it, for the caller asking.
+//
+// Readable by any authenticated caller, including an ordinary member. Seeing
+// which capabilities exist is not the same as being able to change them, and
+// the admin UI needs the list to decide what to render for the person looking
+// at it.
+func (h *FeatureHandler) List(c echo.Context) error {
+	statuses, err := h.admin.Listing(c.Request().Context())
+	if err != nil {
+		h.logger.Error(c.Request().Context(), "failed to list features", "error", err)
+		return respondError(c, http.StatusInternalServerError, "failed to list features")
+	}
+	return respond(c, http.StatusOK, statuses)
+}
+
+// SetInstance turns a feature on or off for the whole instance.
+func (h *FeatureHandler) SetInstance(c echo.Context) error {
+	var req setFeatureRequest
+	if err := c.Bind(&req); err != nil {
+		return respondError(c, http.StatusBadRequest, "invalid request")
+	}
+	err := h.admin.SetInstance(
+		c.Request().Context(), c.Param("key"), req.Enabled, entities.FeatureChangeSourceAPI)
+	return h.respondAfterChange(c, err)
+}
+
+// ResetInstance removes the instance override so the feature returns to its
+// declared default. DELETE rather than a PUT of false, because removing an
+// override and setting it to off are genuinely different outcomes: an account
+// or a grant can still turn a reset feature on.
+func (h *FeatureHandler) ResetInstance(c echo.Context) error {
+	err := h.admin.ResetInstance(c.Request().Context(), c.Param("key"), entities.FeatureChangeSourceAPI)
+	return h.respondAfterChange(c, err)
+}
+
+// SetAccount turns a feature on or off for the account the caller is signed in
+// to.
+//
+// The account is never a parameter. It comes off the session, so an admin of
+// one account cannot reach into another by naming it — and an endpoint that
+// accepted an account id would make that property untestable.
+func (h *FeatureHandler) SetAccount(c echo.Context) error {
+	var req setFeatureRequest
+	if err := c.Bind(&req); err != nil {
+		return respondError(c, http.StatusBadRequest, "invalid request")
+	}
+	err := h.admin.SetAccount(
+		c.Request().Context(), c.Param("key"), req.Enabled, entities.FeatureChangeSourceAPI)
+	return h.respondAfterChange(c, err)
+}
+
+// ResetAccount removes the caller's account override.
+func (h *FeatureHandler) ResetAccount(c echo.Context) error {
+	err := h.admin.ResetAccount(c.Request().Context(), c.Param("key"), entities.FeatureChangeSourceAPI)
+	return h.respondAfterChange(c, err)
+}
+
+// respondAfterChange maps the service's error to a status, then answers with
+// the caller's freshly resolved listing.
+//
+// Returning the listing rather than an empty 200 means the admin UI never has
+// to guess what the change produced — a reset in particular resolves to
+// whatever layer now decides, which the client cannot compute for itself.
+func (h *FeatureHandler) respondAfterChange(c echo.Context, err error) error {
+	ctx := c.Request().Context()
+	switch {
+	case err == nil:
+	case errors.Is(err, repositories.ErrNotFound):
+		return respondError(c, http.StatusNotFound, err.Error())
+	case errors.Is(err, application.ErrForbidden):
+		return respondError(c, http.StatusForbidden, err.Error())
+	case errors.Is(err, application.ErrValidation):
+		return respondError(c, http.StatusBadRequest, err.Error())
+	default:
+		h.logger.Error(ctx, "failed to change feature state", "error", err)
+		return respondError(c, http.StatusInternalServerError, "failed to change feature state")
+	}
+
+	statuses, listErr := h.admin.Listing(ctx)
+	if listErr != nil {
+		// The change landed. Reporting a failure now would be a lie about what
+		// happened, so the caller gets a 200 with no body rather than an error
+		// for work that succeeded.
+		h.logger.Error(ctx, "feature changed but the listing could not be read", "error", listErr)
+		return respond(c, http.StatusOK, nil)
+	}
+	key := c.Param("key")
+	for _, s := range statuses {
+		if s.Key == key {
+			return respond(c, http.StatusOK, s)
+		}
+	}
+	return respond(c, http.StatusOK, statuses)
+}

--- a/application/feature_admin_service.go
+++ b/application/feature_admin_service.go
@@ -1,0 +1,251 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
+	authentities "github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
+	esapp "github.com/akeemphilbert/pericarp/pkg/eventsourcing/application"
+	esdomain "github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
+
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/pkg/identity"
+)
+
+// FeatureAdminService is what the command line, the REST routes and the MCP
+// tools all call. It owns exactly three things the surfaces would otherwise
+// each have to get right on their own — who is allowed to change instance
+// state, what gets recorded when they do, and what a listing looks like — and
+// delegates every actual write to FeatureService untouched.
+//
+// The split is forced, not stylistic. FeatureService is called directly by
+// #481's acceptance steps with a bare context and no identity; putting a
+// permission check inside it would fail scenarios that are green and in the
+// regression suite. It is also the seam FeatureService's own doc comment
+// anticipates.
+//
+// Three surfaces, one guard, one audit path: a permission rule copied three
+// times is a permission rule that will disagree with itself.
+type FeatureAdminService struct {
+	features *FeatureService
+	resolver *FeatureResolver
+	accounts authrepos.AccountRepository
+	creds    authrepos.CredentialRepository
+
+	eventStore esdomain.EventStore
+	dispatcher *esdomain.EventDispatcher
+
+	logger entities.Logger
+}
+
+// NewFeatureAdminService builds the surface layer.
+func NewFeatureAdminService(
+	features *FeatureService,
+	resolver *FeatureResolver,
+	accounts authrepos.AccountRepository,
+	creds authrepos.CredentialRepository,
+	eventStore esdomain.EventStore,
+	dispatcher *esdomain.EventDispatcher,
+	logger entities.Logger,
+) *FeatureAdminService {
+	return &FeatureAdminService{
+		features:   features,
+		resolver:   resolver,
+		accounts:   accounts,
+		creds:      creds,
+		eventStore: eventStore,
+		dispatcher: dispatcher,
+		logger:     logger,
+	}
+}
+
+// Listing returns every declared feature with its resolved value and the layer
+// that decided it, for whoever is on ctx.
+//
+// Readable by any authenticated caller. Seeing which capabilities exist is not
+// the same as being able to change them, and an operator who cannot read the
+// list cannot use the commands that change it.
+func (s *FeatureAdminService) Listing(ctx context.Context) ([]entities.FeatureStatus, error) {
+	return s.resolver.Explain(ctx)
+}
+
+// SetInstance turns a feature on or off for the whole instance.
+func (s *FeatureAdminService) SetInstance(ctx context.Context, key string, enabled bool, src string) error {
+	if err := s.requireOperator(ctx); err != nil {
+		return err
+	}
+	if err := s.features.SetInstanceFeature(ctx, key, enabled); err != nil {
+		return err
+	}
+	state := entities.FeatureChangeStateOff
+	if enabled {
+		state = entities.FeatureChangeStateOn
+	}
+	s.record(ctx, key, "instance", "", state, src)
+	return nil
+}
+
+// ResetInstance drops the instance override so the feature returns to its
+// declared default — which is not the same as turning it off, because an
+// account or a grant can still turn a declared-off feature on.
+func (s *FeatureAdminService) ResetInstance(ctx context.Context, key, src string) error {
+	if err := s.requireOperator(ctx); err != nil {
+		return err
+	}
+	if err := s.features.ClearInstanceFeature(ctx, key); err != nil {
+		return err
+	}
+	s.record(ctx, key, "instance", "", entities.FeatureChangeStateReset, src)
+	return nil
+}
+
+// SetAccount turns a feature on or off for the account the caller is signed in
+// to. The account is never taken as a parameter: it comes off the session, so
+// an admin cannot reach into an account they are not acting in.
+func (s *FeatureAdminService) SetAccount(ctx context.Context, key string, enabled bool, src string) error {
+	accountID, err := s.requireAccountAdmin(ctx)
+	if err != nil {
+		return err
+	}
+	if err := s.features.SetAccountFeature(ctx, accountID, key, enabled); err != nil {
+		return err
+	}
+	state := entities.FeatureChangeStateOff
+	if enabled {
+		state = entities.FeatureChangeStateOn
+	}
+	s.record(ctx, key, "account", accountID, state, src)
+	return nil
+}
+
+// ResetAccount drops the caller's account override.
+func (s *FeatureAdminService) ResetAccount(ctx context.Context, key, src string) error {
+	accountID, err := s.requireAccountAdmin(ctx)
+	if err != nil {
+		return err
+	}
+	if err := s.features.ClearAccountFeature(ctx, accountID, key); err != nil {
+		return err
+	}
+	s.record(ctx, key, "account", accountID, entities.FeatureChangeStateReset, src)
+	return nil
+}
+
+// requireOperator decides who may change instance-wide state.
+//
+// A caller on the local stdio transport passes without further checks. That is
+// not a hole: whoever can run `weos mcp` on the machine can already run
+// `weos feature disable` against the same database, so refusing would buy
+// nothing and would make the operator tooling unusable on the surface mini-me
+// actually uses. HTTP requests never carry the marker.
+//
+// The audit source is deliberately NOT consulted here. If passing
+// FeatureChangeSourceCLI were enough to skip the check, a handler with the
+// wrong constant would be a full instance-write bypass.
+func (s *FeatureAdminService) requireOperator(ctx context.Context) error {
+	if isLocalTransport(ctx) {
+		return nil
+	}
+	identityCtx := auth.AgentFromCtx(ctx)
+	if identityCtx == nil {
+		return fmt.Errorf("changing instance feature state requires a signed-in operator: %w", ErrForbidden)
+	}
+	role, err := s.accounts.FindMemberRole(ctx, identityCtx.ActiveAccountID, identityCtx.AgentID)
+	if err != nil {
+		return fmt.Errorf("failed to read the caller's role: %w", err)
+	}
+	if role != authentities.RoleOwner && role != authentities.RoleAdmin {
+		return fmt.Errorf("only an owner or admin may change instance feature state: %w", ErrForbidden)
+	}
+	return nil
+}
+
+// requireAccountAdmin checks the same roles and returns the account the caller
+// is acting in. Local stdio has no account to act in, so it is refused here
+// even though it passes requireOperator — an instance-wide switch needs no
+// account, an account override does.
+func (s *FeatureAdminService) requireAccountAdmin(ctx context.Context) (string, error) {
+	identityCtx := auth.AgentFromCtx(ctx)
+	if identityCtx == nil || identityCtx.ActiveAccountID == "" {
+		return "", fmt.Errorf("changing account feature state requires a session in an account: %w", ErrForbidden)
+	}
+	role, err := s.accounts.FindMemberRole(ctx, identityCtx.ActiveAccountID, identityCtx.AgentID)
+	if err != nil {
+		return "", fmt.Errorf("failed to read the caller's role: %w", err)
+	}
+	if role != authentities.RoleOwner && role != authentities.RoleAdmin {
+		return "", fmt.Errorf("only an owner or admin may change account feature state: %w", ErrForbidden)
+	}
+	return identityCtx.ActiveAccountID, nil
+}
+
+// record appends the change to the event log.
+//
+// Deliberately after the write and never fatal. The setting has already
+// changed by the time this runs, so returning an error here would report
+// failure for work that succeeded. A failed audit write is logged and
+// surfaced as a message instead, which is the honest account: the change
+// happened, the record of it did not.
+func (s *FeatureAdminService) record(ctx context.Context, key, scope, scopeID, state, src string) {
+	event := entities.FeatureChanged{
+		Key:     key,
+		Scope:   scope,
+		ScopeID: scopeID,
+		State:   state,
+		Source:  src,
+	}
+	if identityCtx := auth.AgentFromCtx(ctx); identityCtx != nil {
+		event.ActorID = identityCtx.AgentID
+		event.ActorEmail = s.emailFor(ctx, identityCtx.AgentID)
+	}
+
+	change, err := new(entities.FeatureChange).With(identity.NewFeatureChange(), event)
+	if err == nil {
+		uow := esapp.NewSimpleUnitOfWork(s.eventStore, s.dispatcher)
+		if err = uow.Track(change); err == nil {
+			err = uow.Commit(ctx)
+		}
+	}
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Error(ctx, "the feature change was applied but not recorded",
+				"feature", key, "scope", scope, "state", state, "error", err)
+		}
+		entities.AddMessage(ctx, entities.Message{
+			Type: "warning",
+			Text: fmt.Sprintf("feature %q was changed, but the change could not be recorded", key),
+		})
+	}
+}
+
+// emailFor resolves an agent's email so the audit record is readable later.
+// The identity on a request carries only a KSUID, and a log of KSUIDs answers
+// "who" in a way nobody can use without a lookup they will not do. One extra
+// read on a rare operator action is a fair price.
+func (s *FeatureAdminService) emailFor(ctx context.Context, agentID string) string {
+	if s.creds == nil {
+		return ""
+	}
+	creds, err := s.creds.FindByAgent(ctx, agentID)
+	if err != nil || len(creds) == 0 {
+		return ""
+	}
+	return creds[0].Email()
+}

--- a/application/feature_admin_service.go
+++ b/application/feature_admin_service.go
@@ -26,6 +26,7 @@ import (
 	esdomain "github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
 
 	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/internal/config"
 	"github.com/wepala/weos/v3/pkg/identity"
 )
 
@@ -49,6 +50,11 @@ type FeatureAdminService struct {
 	accounts authrepos.AccountRepository
 	creds    authrepos.CredentialRepository
 
+	// primaryAccountID names the account whose owners and admins may change
+	// instance-wide state. Empty means "work it out from how many accounts
+	// exist" — see requireOperator.
+	primaryAccountID string
+
 	eventStore esdomain.EventStore
 	dispatcher *esdomain.EventDispatcher
 
@@ -57,6 +63,7 @@ type FeatureAdminService struct {
 
 // NewFeatureAdminService builds the surface layer.
 func NewFeatureAdminService(
+	cfg config.Config,
 	features *FeatureService,
 	resolver *FeatureResolver,
 	accounts authrepos.AccountRepository,
@@ -66,13 +73,14 @@ func NewFeatureAdminService(
 	logger entities.Logger,
 ) *FeatureAdminService {
 	return &FeatureAdminService{
-		features:   features,
-		resolver:   resolver,
-		accounts:   accounts,
-		creds:      creds,
-		eventStore: eventStore,
-		dispatcher: dispatcher,
-		logger:     logger,
+		features:         features,
+		resolver:         resolver,
+		accounts:         accounts,
+		creds:            creds,
+		primaryAccountID: cfg.Features.PrimaryAccountID,
+		eventStore:       eventStore,
+		dispatcher:       dispatcher,
+		logger:           logger,
 	}
 }
 
@@ -164,17 +172,60 @@ func (s *FeatureAdminService) requireOperator(ctx context.Context) error {
 		return nil
 	}
 	identityCtx := auth.AgentFromCtx(ctx)
-	if identityCtx == nil {
+	if identityCtx == nil || identityCtx.ActiveAccountID == "" {
+		// A session that names no account has no role to check. Refused
+		// explicitly rather than left to the lookup, which returns an empty
+		// role for an empty account and would reach the same answer less
+		// obviously.
 		return fmt.Errorf("changing instance feature state requires a signed-in operator: %w", ErrForbidden)
 	}
-	role, err := s.accounts.FindMemberRole(ctx, identityCtx.ActiveAccountID, identityCtx.AgentID)
+	primary, err := s.instanceAccount(ctx)
+	if err != nil {
+		return err
+	}
+	// The role must be held in the INSTANCE's account, not merely in some
+	// account the caller happens to own. Registration mints every new user as
+	// owner of their own personal account, so checking the caller's active
+	// account would make "owner or admin" mean "anyone who signed up".
+	role, err := s.accounts.FindMemberRole(ctx, primary, identityCtx.AgentID)
 	if err != nil {
 		return fmt.Errorf("failed to read the caller's role: %w", err)
 	}
 	if role != authentities.RoleOwner && role != authentities.RoleAdmin {
-		return fmt.Errorf("only an owner or admin may change instance feature state: %w", ErrForbidden)
+		return fmt.Errorf(
+			"only an owner or admin of this instance's account may change instance feature state: %w",
+			ErrForbidden)
 	}
 	return nil
+}
+
+// instanceAccount answers which account owns the instance-wide switch.
+//
+// Configured wins. Otherwise, exactly one account means that account is the
+// instance — the single-user shape, where no configuration should be needed.
+// More than one and nothing configured is refused rather than guessed: picking
+// one would hand the switch to whoever happened to register first, and picking
+// the caller's would hand it to everyone.
+func (s *FeatureAdminService) instanceAccount(ctx context.Context) (string, error) {
+	if s.primaryAccountID != "" {
+		return s.primaryAccountID, nil
+	}
+	page, err := s.accounts.FindAll(ctx, "", 2)
+	if err != nil {
+		return "", fmt.Errorf("failed to read the instance's accounts: %w", err)
+	}
+	switch {
+	case page == nil || len(page.Data) == 0:
+		return "", fmt.Errorf(
+			"this instance has no account to own its feature switch: %w", ErrForbidden)
+	case len(page.Data) == 1:
+		return page.Data[0].GetID(), nil
+	default:
+		return "", fmt.Errorf(
+			"this instance has more than one account, so it cannot tell which one owns the "+
+				"feature switch: set FEATURE_PRIMARY_ACCOUNT_ID (the command line still works): %w",
+			ErrForbidden)
+	}
 }
 
 // requireAccountAdmin checks the same roles and returns the account the caller
@@ -204,6 +255,17 @@ func (s *FeatureAdminService) requireAccountAdmin(ctx context.Context) (string, 
 // surfaced as a message instead, which is the honest account: the change
 // happened, the record of it did not.
 func (s *FeatureAdminService) record(ctx context.Context, key, scope, scopeID, state, src string) {
+	if s.eventStore == nil || s.dispatcher == nil {
+		// Nothing to record into. Guarded rather than left to fail inside the
+		// unit of work, which panics on a nil store — and a panic here would
+		// take down a request whose actual work already succeeded, which is
+		// the opposite of this method's whole failure policy.
+		if s.logger != nil {
+			s.logger.Error(ctx, "the feature change was applied but there is nowhere to record it",
+				"feature", key, "scope", scope, "state", state)
+		}
+		return
+	}
 	event := entities.FeatureChanged{
 		Key:     key,
 		Scope:   scope,

--- a/application/feature_admin_service.go
+++ b/application/feature_admin_service.go
@@ -173,10 +173,11 @@ func (s *FeatureAdminService) requireOperator(ctx context.Context) error {
 	}
 	identityCtx := auth.AgentFromCtx(ctx)
 	if identityCtx == nil || identityCtx.ActiveAccountID == "" {
-		// A session that names no account has no role to check. Refused
-		// explicitly rather than left to the lookup, which returns an empty
-		// role for an empty account and would reach the same answer less
-		// obviously.
+		// The role is read in the INSTANCE's account, not this one, so a
+		// session naming no account could in principle still be checked. It is
+		// refused anyway: a session that has not settled on an account has not
+		// finished authenticating, and instance-wide state is the last thing
+		// that should be reachable from a half-formed one.
 		return fmt.Errorf("changing instance feature state requires a signed-in operator: %w", ErrForbidden)
 	}
 	primary, err := s.instanceAccount(ctx)
@@ -208,8 +209,22 @@ func (s *FeatureAdminService) requireOperator(ctx context.Context) error {
 // the caller's would hand it to everyone.
 func (s *FeatureAdminService) instanceAccount(ctx context.Context) (string, error) {
 	if s.primaryAccountID != "" {
+		// Checked, not trusted. A typo makes FindMemberRole return an empty
+		// role for everyone, so every operator would be told they lack the
+		// role — a message that blames the caller for a mistake in an
+		// environment variable, and one nobody would think to doubt.
+		account, err := s.accounts.FindByID(ctx, s.primaryAccountID)
+		if err != nil || account == nil {
+			return "", fmt.Errorf(
+				"FEATURE_PRIMARY_ACCOUNT_ID names account %q, which does not exist: %w",
+				s.primaryAccountID, ErrForbidden)
+		}
 		return s.primaryAccountID, nil
 	}
+	// Deactivated accounts still count here — FindAll does not filter on
+	// Active — so an instance that retired an old account reads as ambiguous
+	// and is refused rather than guessed at. Naming the account explicitly is
+	// the way out, and the message says so.
 	page, err := s.accounts.FindAll(ctx, "", 2)
 	if err != nil {
 		return "", fmt.Errorf("failed to read the instance's accounts: %w", err)

--- a/application/feature_admin_service_test.go
+++ b/application/feature_admin_service_test.go
@@ -3,6 +3,7 @@ package application
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -23,6 +24,23 @@ type adminAccounts struct {
 	roles    map[string]string
 	accounts []string
 	err      error
+}
+
+func (a adminAccounts) FindByID(_ context.Context, id string) (*authentities.Account, error) {
+	if a.err != nil {
+		return nil, a.err
+	}
+	for _, known := range a.accounts {
+		if known == id {
+			acct := new(authentities.Account)
+			if err := acct.Restore(id, id+" Account",
+				authentities.AccountTypePersonal, true, time.Unix(0, 0)); err != nil {
+				return nil, err
+			}
+			return acct, nil
+		}
+	}
+	return nil, nil
 }
 
 func (a adminAccounts) FindMemberRole(_ context.Context, accountID, agentID string) (string, error) {
@@ -188,5 +206,79 @@ func TestAnonymousCallerIsRefused(t *testing.T) {
 	if err := svc.SetInstance(ctxAsAgent("agent-ops", ""), "episodic-recall", false,
 		entities.FeatureChangeSourceAPI); !errors.Is(err, ErrForbidden) {
 		t.Fatalf("a session naming no account was not refused: %v", err)
+	}
+}
+
+// TestAccountScopeRefusesAnOrdinaryMember covers the guard on the account
+// scope, which the acceptance contract does not reach — no scenario has an
+// ordinary member attempt an account-scope change.
+func TestAccountScopeRefusesAnOrdinaryMember(t *testing.T) {
+	accounts := adminAccounts{
+		accounts: []string{"acct-only"},
+		roles:    map[string]string{"acct-only|agent-clerk": "member"},
+	}
+	svc := testAdminService(t, config.Default(), accounts)
+
+	err := svc.SetAccount(ctxAsAgent("agent-clerk", "acct-only"),
+		"ledger-export", true, entities.FeatureChangeSourceAPI)
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("an ordinary member set an account override: %v", err)
+	}
+	err = svc.ResetAccount(ctxAsAgent("agent-clerk", "acct-only"),
+		"ledger-export", entities.FeatureChangeSourceAPI)
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("an ordinary member reset an account override: %v", err)
+	}
+}
+
+// TestResetAccountClearsTheOverride covers the one method with no coverage on
+// any surface — three entry points reach it and no scenario exercises any.
+func TestResetAccountClearsTheOverride(t *testing.T) {
+	accounts := adminAccounts{
+		accounts: []string{"acct-only"},
+		roles:    map[string]string{"acct-only|agent-ops": authentities.RoleOwner},
+	}
+	registry, _ := newTestFeatureRegistry(t, featEpisodic, featLedger)
+	settings := &fakeSettings{}
+	svc := NewFeatureService(registry, settings, newFakeGrants(), fakeMembers{},
+		newRecordingInvalidator(), nil)
+	resolver := NewFeatureResolver(config.Default(), registry, settings, newFakeGrants(),
+		&fakeAccounts{roles: map[string]string{}}, nil)
+	admin := NewFeatureAdminService(config.Default(), svc, resolver, accounts, nil, nil, nil, nil)
+
+	ctx := ctxAsAgent("agent-ops", "acct-only")
+	if err := admin.SetAccount(ctx, "ledger-export", true, entities.FeatureChangeSourceAPI); err != nil {
+		t.Fatalf("SetAccount: %v", err)
+	}
+	if !settings.account["acct-only"]["ledger-export"] {
+		t.Fatal("the override was not stored")
+	}
+	if err := admin.ResetAccount(ctx, "ledger-export", entities.FeatureChangeSourceAPI); err != nil {
+		t.Fatalf("ResetAccount: %v", err)
+	}
+	if _, present := settings.account["acct-only"]["ledger-export"]; present {
+		t.Fatal("reset left the override behind; unset and off must not be confusable")
+	}
+}
+
+// TestConfiguredPrimaryAccountMustExist: a typo would otherwise tell every
+// operator they lack a role, blaming the caller for a mistake in an
+// environment variable.
+func TestConfiguredPrimaryAccountMustExist(t *testing.T) {
+	cfg := config.Default()
+	cfg.Features.PrimaryAccountID = "acct-typo"
+	accounts := adminAccounts{
+		accounts: []string{"acct-real"},
+		roles:    map[string]string{"acct-real|agent-ops": authentities.RoleOwner},
+	}
+	svc := testAdminService(t, cfg, accounts)
+
+	err := svc.SetInstance(ctxAsAgent("agent-ops", "acct-real"),
+		"episodic-recall", false, entities.FeatureChangeSourceAPI)
+	if err == nil {
+		t.Fatal("a configured account that does not exist was accepted")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("the error blames the caller rather than the configuration: %v", err)
 	}
 }

--- a/application/feature_admin_service_test.go
+++ b/application/feature_admin_service_test.go
@@ -1,0 +1,192 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
+	authentities "github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
+
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/internal/config"
+)
+
+// adminAccounts is the slice of pericarp's AccountRepository the permission
+// check actually uses. Everything else panics, which keeps the test honest
+// about how much the guard touches.
+type adminAccounts struct {
+	authrepos.AccountRepository
+	// roles is keyed "accountID|agentID".
+	roles    map[string]string
+	accounts []string
+	err      error
+}
+
+func (a adminAccounts) FindMemberRole(_ context.Context, accountID, agentID string) (string, error) {
+	if a.err != nil {
+		return "", a.err
+	}
+	return a.roles[accountID+"|"+agentID], nil
+}
+
+func (a adminAccounts) FindAll(
+	_ context.Context, _ string, limit int,
+) (*authrepos.PaginatedResponse[*authentities.Account], error) {
+	if a.err != nil {
+		return nil, a.err
+	}
+	out := make([]*authentities.Account, 0, len(a.accounts))
+	for i, id := range a.accounts {
+		if limit > 0 && i >= limit {
+			break
+		}
+		acct := new(authentities.Account)
+		if err := acct.Restore(id, id+" Account", authentities.AccountTypePersonal, true, time.Unix(0, 0)); err != nil {
+			return nil, err
+		}
+		out = append(out, acct)
+	}
+	return &authrepos.PaginatedResponse[*authentities.Account]{Data: out}, nil
+}
+
+func testAdminService(t *testing.T, cfg config.Config, accounts adminAccounts) *FeatureAdminService {
+	t.Helper()
+	registry, _ := newTestFeatureRegistry(t, featEpisodic, featLedger, featAudit)
+	settings := &fakeSettings{}
+	grants := newFakeGrants()
+	inv := newRecordingInvalidator()
+	svc := NewFeatureService(registry, settings, grants, fakeMembers{}, inv, nil)
+	resolver := NewFeatureResolver(cfg, registry, settings, grants,
+		&fakeAccounts{roles: map[string]string{}}, nil)
+	// No event store: the audit write fails and is swallowed by design, which
+	// is exactly what these tests want to leave out of the way.
+	return NewFeatureAdminService(cfg, svc, resolver, accounts, nil, nil, nil, nil)
+}
+
+func ctxAsAgent(agentID, accountID string) context.Context {
+	return auth.ContextWithAgent(context.Background(),
+		&auth.Identity{AgentID: agentID, ActiveAccountID: accountID})
+}
+
+// TestInstanceChangeRequiresTheInstanceAccount is the regression test for a
+// privilege escalation.
+//
+// Registration mints every new user as OWNER of their own personal account, so
+// a guard that accepts "owner or admin of the account you are acting in" means
+// "anyone who signed up" on a multi-user instance. The role has to be held in
+// the instance's own account.
+func TestInstanceChangeRequiresTheInstanceAccount(t *testing.T) {
+	cfg := config.Default()
+	cfg.Features.PrimaryAccountID = "acct-instance"
+	accounts := adminAccounts{
+		accounts: []string{"acct-instance", "acct-newcomer"},
+		roles: map[string]string{
+			// The newcomer owns their OWN account, exactly as registration
+			// leaves them.
+			"acct-newcomer|agent-newcomer": authentities.RoleOwner,
+			"acct-instance|agent-ops":      authentities.RoleOwner,
+		},
+	}
+	svc := testAdminService(t, cfg, accounts)
+
+	err := svc.SetInstance(ctxAsAgent("agent-newcomer", "acct-newcomer"),
+		"episodic-recall", false, entities.FeatureChangeSourceAPI)
+	if err == nil {
+		t.Fatal("a self-registered owner of their own account changed instance-wide state")
+	}
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("the refusal was %v, want ErrForbidden", err)
+	}
+
+	// The instance account's owner is still allowed.
+	if err := svc.SetInstance(ctxAsAgent("agent-ops", "acct-instance"),
+		"episodic-recall", false, entities.FeatureChangeSourceAPI); err != nil {
+		t.Fatalf("the instance account's owner was refused: %v", err)
+	}
+}
+
+// TestSingleAccountInstanceNeedsNoConfiguration keeps the mini-me shape
+// working: one account IS the instance, so nothing has to be configured.
+func TestSingleAccountInstanceNeedsNoConfiguration(t *testing.T) {
+	accounts := adminAccounts{
+		accounts: []string{"acct-only"},
+		roles:    map[string]string{"acct-only|agent-ops": authentities.RoleOwner},
+	}
+	svc := testAdminService(t, config.Default(), accounts)
+
+	if err := svc.SetInstance(ctxAsAgent("agent-ops", "acct-only"),
+		"episodic-recall", false, entities.FeatureChangeSourceAPI); err != nil {
+		t.Fatalf("the sole account's owner was refused: %v", err)
+	}
+}
+
+// TestManyAccountsWithoutConfigurationRefuses fails closed rather than
+// guessing. Picking one would hand the switch to whoever registered first.
+func TestManyAccountsWithoutConfigurationRefuses(t *testing.T) {
+	accounts := adminAccounts{
+		accounts: []string{"acct-a", "acct-b"},
+		roles:    map[string]string{"acct-a|agent-ops": authentities.RoleOwner},
+	}
+	svc := testAdminService(t, config.Default(), accounts)
+
+	err := svc.SetInstance(ctxAsAgent("agent-ops", "acct-a"),
+		"episodic-recall", false, entities.FeatureChangeSourceAPI)
+	if err == nil {
+		t.Fatal("an unconfigured multi-account instance guessed which account owns the switch")
+	}
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("the refusal was %v, want ErrForbidden", err)
+	}
+}
+
+// TestLocalTransportSkipsThePermissionCheck: the command line and `weos mcp`
+// over stdio are trusted, because whoever can run them against the database
+// can already change it directly.
+func TestLocalTransportSkipsThePermissionCheck(t *testing.T) {
+	accounts := adminAccounts{accounts: []string{"acct-a", "acct-b"}}
+	svc := testAdminService(t, config.Default(), accounts)
+
+	// Unconfigured and multi-account, which refuses over HTTP — but local.
+	ctx := WithLocalTransport(context.Background())
+	if err := svc.SetInstance(ctx, "episodic-recall", false, entities.FeatureChangeSourceCLI); err != nil {
+		t.Fatalf("a local caller was refused: %v", err)
+	}
+}
+
+// TestAccountScopeIsUnaffectedByTheInstanceAccount: an account admin changes
+// their OWN account, which has nothing to do with who owns the instance.
+func TestAccountScopeIsUnaffectedByTheInstanceAccount(t *testing.T) {
+	cfg := config.Default()
+	cfg.Features.PrimaryAccountID = "acct-instance"
+	accounts := adminAccounts{
+		accounts: []string{"acct-instance", "acct-other"},
+		roles:    map[string]string{"acct-other|agent-counsel": authentities.RoleAdmin},
+	}
+	svc := testAdminService(t, cfg, accounts)
+
+	if err := svc.SetAccount(ctxAsAgent("agent-counsel", "acct-other"),
+		"ledger-export", true, entities.FeatureChangeSourceAPI); err != nil {
+		t.Fatalf("an admin of their own account was refused an account override: %v", err)
+	}
+	// And they still cannot reach the instance.
+	if err := svc.SetInstance(ctxAsAgent("agent-counsel", "acct-other"),
+		"ledger-export", true, entities.FeatureChangeSourceAPI); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("an admin of another account reached the instance switch: %v", err)
+	}
+}
+
+// TestAnonymousCallerIsRefused covers a session that names no account.
+func TestAnonymousCallerIsRefused(t *testing.T) {
+	svc := testAdminService(t, config.Default(), adminAccounts{accounts: []string{"acct-only"}})
+	if err := svc.SetInstance(context.Background(), "episodic-recall", false,
+		entities.FeatureChangeSourceAPI); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("an unidentified caller was not refused: %v", err)
+	}
+	if err := svc.SetInstance(ctxAsAgent("agent-ops", ""), "episodic-recall", false,
+		entities.FeatureChangeSourceAPI); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("a session naming no account was not refused: %v", err)
+	}
+}

--- a/application/feature_provider.go
+++ b/application/feature_provider.go
@@ -96,7 +96,7 @@ func (p *FeatureProvider) Hooks() []openfeature.Hook {
 // identity already travels on ctx, placed there by the auth middleware for the
 // whole request pipeline. Accepting it from both would create two sources of
 // truth that can disagree — and the one on ctx is the one the rest of the
-// system authorises against.
+// system authorizes against.
 func (p *FeatureProvider) BooleanEvaluation(
 	ctx context.Context, flag string, defaultValue bool, _ openfeature.FlattenedContext,
 ) openfeature.BoolResolutionDetail {

--- a/application/feature_provider_test.go
+++ b/application/feature_provider_test.go
@@ -92,9 +92,9 @@ func TestProviderUndeclaredKeyReturnsCallerDefaultAndLogsOnce(t *testing.T) {
 			t.Fatalf("reason = %q, want %q", got.Reason, openfeature.DefaultReason)
 		}
 	}
-	// And the caller's default is honoured whichever way it points.
+	// And the caller's default is honored whichever way it points.
 	if got := p.BooleanEvaluation(ctx, FeatureFlagPrefix+"shipping-labels", true, nil); !got.Value {
-		t.Fatal("an undeclared key did not honour a true default")
+		t.Fatal("an undeclared key did not honor a true default")
 	}
 
 	logs := logger.matching("shipping-labels")

--- a/application/feature_registry.go
+++ b/application/feature_registry.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/internal/config"
 )
 
 // FeatureDeclarations is an fx value group of feature declarations contributed
@@ -69,15 +70,26 @@ type FeatureRegistry struct {
 	logger  entities.Logger
 }
 
-// NewFeatureRegistry builds the registry from the code-declared group. An
-// invalid declaration fails the boot rather than being skipped: a malformed
-// key is a programming error, and resolving against a registry that silently
-// dropped it would gate nothing while looking like it gated something.
+// NewFeatureRegistry builds the registry from the code-declared group and
+// from configuration. An invalid declaration fails the boot rather than being
+// skipped: a malformed key is a programming error, and resolving against a
+// registry that silently dropped it would gate nothing while looking like it
+// gated something.
+//
+// Configuration is a third source alongside code and presets, and it exists
+// because declarations are deliberately never persisted. Two processes — a
+// running server and a `weos feature` invocation — can only agree about which
+// features exist by both reading the same declarations, and the environment is
+// the only channel they share that does not store anything.
 func NewFeatureRegistry(
+	cfg config.Config,
 	presets *PresetRegistry,
 	logger entities.Logger,
 	declared []entities.FeatureMeta,
 ) (*FeatureRegistry, error) {
+	if cfg.Features.DeclarationError != nil {
+		return nil, cfg.Features.DeclarationError
+	}
 	r := &FeatureRegistry{
 		code:    make(map[string]entities.FeatureMeta, len(declared)),
 		presets: presets,
@@ -86,6 +98,14 @@ func NewFeatureRegistry(
 	for _, m := range declared {
 		if err := r.Register(m); err != nil {
 			return nil, err
+		}
+	}
+	// Configuration is registered after code, and a clash is still an error
+	// rather than an override: two declarations of one key means two things
+	// believe they own it, and picking one silently gates the wrong thing.
+	for _, m := range cfg.Features.Declared {
+		if err := r.Register(m); err != nil {
+			return nil, fmt.Errorf("FEATURES: %w", err)
 		}
 	}
 	return r, nil

--- a/application/feature_registry.go
+++ b/application/feature_registry.go
@@ -100,10 +100,20 @@ func NewFeatureRegistry(
 			return nil, err
 		}
 	}
-	// Configuration is registered after code, and a clash is still an error
-	// rather than an override: two declarations of one key means two things
-	// believe they own it, and picking one silently gates the wrong thing.
+	// Configuration is registered after code, and a clash with either code or
+	// a preset is an error rather than an override: two declarations of one
+	// key means two things believe they own it, and picking one silently gates
+	// the wrong thing. Register alone only sees code declarations, so the
+	// preset half is checked here — without it, configuration could quietly
+	// rewrite a preset feature's default and nothing would say so.
 	for _, m := range cfg.Features.Declared {
+		if presets != nil {
+			if existing, clash := presets.Features()[m.Key]; clash {
+				return nil, fmt.Errorf(
+					"FEATURES: feature %q is already declared by a preset (as %q); keys must be unique",
+					m.Key, existing.DisplayName)
+			}
+		}
 		if err := r.Register(m); err != nil {
 			return nil, fmt.Errorf("FEATURES: %w", err)
 		}

--- a/application/feature_registry_test.go
+++ b/application/feature_registry_test.go
@@ -1,10 +1,12 @@
 package application
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/internal/config"
 )
 
 func testFeature(key, display string) entities.FeatureMeta {
@@ -14,7 +16,7 @@ func testFeature(key, display string) entities.FeatureMeta {
 func newTestFeatureRegistry(t *testing.T, declared ...entities.FeatureMeta) (*FeatureRegistry, *PresetRegistry) {
 	t.Helper()
 	presets := NewPresetRegistry()
-	r, err := NewFeatureRegistry(presets, nil, declared)
+	r, err := NewFeatureRegistry(config.Default(), presets, nil, declared)
 	if err != nil {
 		t.Fatalf("NewFeatureRegistry: %v", err)
 	}
@@ -50,7 +52,8 @@ func TestFeatureRegistryCodeDeclarations(t *testing.T) {
 
 func TestFeatureRegistryRejectsInvalidDeclaration(t *testing.T) {
 	presets := NewPresetRegistry()
-	_, err := NewFeatureRegistry(presets, nil, []entities.FeatureMeta{{Key: "Not A Key", DisplayName: "X"}})
+	_, err := NewFeatureRegistry(config.Default(), presets, nil,
+		[]entities.FeatureMeta{{Key: "Not A Key", DisplayName: "X"}})
 	if err == nil {
 		t.Fatal("NewFeatureRegistry accepted an invalid key, want a boot failure")
 	}
@@ -232,5 +235,63 @@ func TestMismatchedPresetKeyWouldStrandResolution(t *testing.T) {
 	}})
 	if _, ok := r.Lookup("invoice-export"); !ok {
 		t.Fatal("a well-formed preset declaration was not found")
+	}
+}
+
+// TestFeatureRegistryReadsConfigDeclarations covers the third declaration
+// source. It exists because declarations are never persisted, so a running
+// server and a `weos feature` invocation — separate processes — can only agree
+// about which features exist by both reading the same environment.
+func TestFeatureRegistryReadsConfigDeclarations(t *testing.T) {
+	cfg := config.Default()
+	cfg.Features.Declared = []entities.FeatureMeta{
+		{Key: "ledger-export", DisplayName: "Ledger export", Default: false, Manageable: true},
+	}
+	r, err := NewFeatureRegistry(cfg, NewPresetRegistry(), nil, nil)
+	if err != nil {
+		t.Fatalf("NewFeatureRegistry: %v", err)
+	}
+	m, ok := r.Lookup("ledger-export")
+	if !ok {
+		t.Fatal("a configured declaration was not registered")
+	}
+	if !m.Manageable || m.Default {
+		t.Fatalf("the configured declaration lost its fields: %+v", m)
+	}
+}
+
+func TestFeatureRegistryRefusesMalformedConfigDeclarations(t *testing.T) {
+	cfg := config.Default()
+	cfg.Features.Declared = []entities.FeatureMeta{{Key: "Not A Key", DisplayName: "X"}}
+	if _, err := NewFeatureRegistry(cfg, NewPresetRegistry(), nil, nil); err == nil {
+		t.Fatal("an invalid configured declaration was accepted, want a boot failure")
+	}
+}
+
+// TestFeatureRegistryRefusesAConfigKeyCodeAlreadyOwns keeps configuration from
+// silently redefining something the binary declares — two owners of one key
+// means one of them is gating the wrong thing.
+func TestFeatureRegistryRefusesAConfigKeyCodeAlreadyOwns(t *testing.T) {
+	cfg := config.Default()
+	cfg.Features.Declared = []entities.FeatureMeta{{Key: "ledger-export", DisplayName: "From config"}}
+	_, err := NewFeatureRegistry(cfg, NewPresetRegistry(), nil,
+		[]entities.FeatureMeta{{Key: "ledger-export", DisplayName: "From code"}})
+	if err == nil {
+		t.Fatal("configuration silently redeclared a key code already owns")
+	}
+	if !strings.Contains(err.Error(), "FEATURES") {
+		t.Fatalf("the error does not say the clash came from configuration: %v", err)
+	}
+}
+
+// TestFeatureRegistryRefusesToBootOnAMalformedFeaturesValue: a malformed
+// FEATURES value must stop the boot rather than declare nothing. Declaring
+// nothing looks exactly like a working instance with every feature off, which
+// is the hardest failure to notice and the hardest to explain.
+func TestFeatureRegistryRefusesToBootOnAMalformedFeaturesValue(t *testing.T) {
+	cfg := config.Default()
+	cfg.Features.DeclarationError = fmt.Errorf("FEATURES must be a JSON array")
+	if _, err := NewFeatureRegistry(cfg, NewPresetRegistry(), nil, nil); err == nil {
+		t.Fatal("a malformed FEATURES value was ignored, want a boot failure")
 	}
 }

--- a/application/feature_resolver.go
+++ b/application/feature_resolver.go
@@ -280,8 +280,47 @@ func (r *FeatureResolver) cached(key featureCacheKey) (map[string]bool, bool) {
 	return copyFeatureValues(set.values), true
 }
 
-// resolve reads every layer and folds them through entities.ResolveFeature.
+// resolve reads every layer and folds them into a plain value map for the
+// cache. It is Explain's answer with the layer information dropped, so the two
+// cannot disagree about what a feature resolves to.
 func (r *FeatureResolver) resolve(ctx context.Context, key featureCacheKey) (map[string]bool, error) {
+	statuses, err := r.resolveDetailed(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	values := make(map[string]bool, len(statuses))
+	for _, s := range statuses {
+		values[s.Key] = s.Enabled
+	}
+	return values, nil
+}
+
+// Explain resolves every declared feature for the caller on ctx and reports
+// which layer decided each one.
+//
+// Deliberately uncached, and it does not populate the cache. The cached set
+// holds values only — adding the deciding layer to it would grow every entry
+// to serve a listing that an operator hits occasionally and a hot path never
+// does. Listings are rare; evaluations are not.
+func (r *FeatureResolver) Explain(ctx context.Context) ([]entities.FeatureStatus, error) {
+	identity := auth.AgentFromCtx(ctx)
+	key := featureCacheKey{}
+	if identity != nil {
+		key = featureCacheKey{AgentID: identity.AgentID, AccountID: identity.ActiveAccountID}
+	}
+	return r.resolveDetailed(ctx, key)
+}
+
+// resolveDetailed reads every layer and folds them through
+// entities.ResolveFeature, keeping the layer each answer came from.
+//
+// This is the single place the layers are read. resolve() maps its output
+// down for the cache and Explain() returns it whole, so the value a call site
+// evaluates and the source an operator is shown can never drift apart — which
+// is exactly what a listing is for.
+func (r *FeatureResolver) resolveDetailed(
+	ctx context.Context, key featureCacheKey,
+) ([]entities.FeatureStatus, error) {
 	instance, err := r.settings.InstanceOverrides(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve features: %w", err)
@@ -313,17 +352,26 @@ func (r *FeatureResolver) resolve(ctx context.Context, key featureCacheKey) (map
 	}
 
 	declared := r.registry.All()
-	values := make(map[string]bool, len(declared))
+	out := make([]entities.FeatureStatus, 0, len(declared))
 	for _, meta := range declared {
-		value, _ := entities.ResolveFeature(
+		value, decidedBy := entities.ResolveFeature(
 			meta,
 			featureStateFrom(instance, meta.Key),
 			featureStateFrom(account, meta.Key),
 			granted[meta.Key],
 		)
-		values[meta.Key] = value
+		out = append(out, entities.FeatureStatus{
+			Key:         meta.Key,
+			DisplayName: meta.DisplayName,
+			Description: meta.Description,
+			Enabled:     value,
+			Source:      decidedBy.String(),
+			Default:     meta.Default,
+			Manageable:  meta.Manageable,
+			Grantable:   meta.Grantable,
+		})
 	}
-	return values, nil
+	return out, nil
 }
 
 // featureStateFrom turns a stored override map into a tri-state. An absent key

--- a/application/feature_resolver.go
+++ b/application/feature_resolver.go
@@ -93,7 +93,7 @@ type FeatureResolver struct {
 	// that a change reaches sessions already open. The window is widest
 	// exactly when the instance is busy.
 	generation uint64
-	// now is injectable so the max-age behaviour can be tested without
+	// now is injectable so the max-age behavior can be tested without
 	// sleeping. Production leaves it nil and uses time.Now.
 	now func() time.Time
 }
@@ -172,7 +172,7 @@ func (r *FeatureResolver) Enabled(ctx context.Context, key string) (bool, bool, 
 //
 // The whole set is resolved at once rather than one key at a time. An agent
 // turn evaluates many keys, and resolving per key would multiply the database
-// reads by the number of features rather than amortising them to one.
+// reads by the number of features rather than amortizing them to one.
 func (r *FeatureResolver) ResolvedSet(ctx context.Context) (map[string]bool, error) {
 	identity := auth.AgentFromCtx(ctx)
 	key := featureCacheKey{}

--- a/application/feature_service.go
+++ b/application/feature_service.go
@@ -104,14 +104,14 @@ func (s *FeatureService) SetAccountFeature(ctx context.Context, accountID, key s
 		return err
 	}
 	if accountID == "" {
-		return fmt.Errorf("an account is required to override feature %q", key)
+		return fmt.Errorf("an account is required to override feature %q: %w", key, ErrValidation)
 	}
 	// Refused at the write rather than only ignored at the read. The resolver
 	// ignores an ineligible row regardless — stored rows outlive declaration
 	// changes — but an operator who asks for something impossible deserves to
 	// be told, not silently obeyed and then overruled.
 	if !meta.Manageable {
-		return fmt.Errorf("feature %q cannot be changed per account", key)
+		return fmt.Errorf("feature %q cannot be changed per account: %w", key, ErrValidation)
 	}
 	if err := s.settings.SetOverride(ctx, repositories.FeatureScopeAccount, accountID, key, enabled); err != nil {
 		return err
@@ -127,7 +127,7 @@ func (s *FeatureService) ClearAccountFeature(ctx context.Context, accountID, key
 		return err
 	}
 	if accountID == "" {
-		return fmt.Errorf("an account is required to clear feature %q", key)
+		return fmt.Errorf("an account is required to clear feature %q: %w", key, ErrValidation)
 	}
 	if err := s.settings.ClearOverride(ctx, repositories.FeatureScopeAccount, accountID, key); err != nil {
 		return err
@@ -226,10 +226,10 @@ func (s *FeatureService) validateGrant(accountID, subjectID, key string) error {
 		return err
 	}
 	if accountID == "" || subjectID == "" {
-		return fmt.Errorf("an account and a subject are required to grant feature %q", key)
+		return fmt.Errorf("an account and a subject are required to grant feature %q: %w", key, ErrValidation)
 	}
 	if !meta.Grantable {
-		return fmt.Errorf("feature %q cannot be granted", key)
+		return fmt.Errorf("feature %q cannot be granted: %w", key, ErrValidation)
 	}
 	return nil
 }
@@ -237,7 +237,11 @@ func (s *FeatureService) validateGrant(accountID, subjectID, key string) error {
 func (s *FeatureService) declared(key string) (entities.FeatureMeta, error) {
 	meta, ok := s.registry.Lookup(key)
 	if !ok {
-		return entities.FeatureMeta{}, fmt.Errorf("no feature named %q is declared", key)
+		// Wrapped so a handler can answer 404 without matching on the message.
+		// An undeclared key is genuinely "not found" rather than a bad
+		// request: the caller named something that does not exist.
+		return entities.FeatureMeta{}, fmt.Errorf(
+			"no feature named %q is declared: %w", key, repositories.ErrNotFound)
 	}
 	return meta, nil
 }

--- a/application/module.go
+++ b/application/module.go
@@ -141,6 +141,7 @@ func Module(cfg config.Config, registry *PresetRegistry) fx.Option {
 		// silently returns the caller's default.
 		fx.Invoke(func(*openfeature.Client) {}),
 		fx.Provide(NewFeatureService),
+		fx.Provide(NewFeatureAdminService),
 
 		// Email sender
 		fx.Provide(email.ProvideEmailSender),

--- a/application/module.go
+++ b/application/module.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"context"
+
 	"github.com/open-feature/go-sdk/openfeature"
 
 	appagents "github.com/wepala/weos/v3/application/agents"

--- a/application/module.go
+++ b/application/module.go
@@ -126,7 +126,7 @@ func Module(cfg config.Config, registry *PresetRegistry) fx.Option {
 		// replicas.
 		fx.Provide(fx.Annotate(
 			NewFeatureRegistry,
-			fx.ParamTags(``, ``, `group:"feature_declarations"`),
+			fx.ParamTags(``, ``, ``, `group:"feature_declarations"`),
 		)),
 		fx.Provide(gorm.ProvideFeatureSettingsRepository),
 		fx.Provide(gorm.ProvideFeatureGrantRepository),

--- a/domain/entities/feature.go
+++ b/domain/entities/feature.go
@@ -181,3 +181,26 @@ func ResolveFeature(
 
 	return value, decidedBy
 }
+
+// FeatureStatus is one feature as an operator sees it: what it is, whether it
+// is on for the caller asking, and which layer decided that.
+//
+// Source is what makes a listing actionable rather than merely informative. An
+// operator looking at an "off" feature needs to know whether they are seeing a
+// declared default they can override, an instance switch someone threw, or an
+// account override — the three call for different actions, and guessing
+// between them is how a flag gets flipped twice in the wrong place.
+type FeatureStatus struct {
+	Key         string `json:"key"`
+	DisplayName string `json:"displayName"`
+	Description string `json:"description,omitempty"`
+	// Enabled is the resolved answer for the caller who asked.
+	Enabled bool `json:"enabled"`
+	// Source names the layer that decided Enabled.
+	Source string `json:"source"`
+	// Default, Manageable and Grantable echo the declaration, so a caller can
+	// tell what may be changed and where without a second request.
+	Default    bool `json:"default"`
+	Manageable bool `json:"manageable"`
+	Grantable  bool `json:"grantable"`
+}

--- a/domain/entities/feature_change.go
+++ b/domain/entities/feature_change.go
@@ -1,0 +1,94 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package entities
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/akeemphilbert/pericarp/pkg/ddd"
+)
+
+// Which surface made a feature change. Recorded for the audit trail only —
+// never consulted when deciding whether a caller is allowed to make the
+// change. Permission keys off the request context, so a caller who could pass
+// the wrong constant could not thereby grant themselves anything.
+const (
+	FeatureChangeSourceCLI  = "cli"
+	FeatureChangeSourceAPI  = "api"
+	FeatureChangeSourceMCP  = "mcp"
+	FeatureChangeSourceBoot = "boot"
+)
+
+// What happened to the setting.
+const (
+	FeatureChangeStateOn    = "on"
+	FeatureChangeStateOff   = "off"
+	FeatureChangeStateReset = "reset"
+)
+
+// FeatureChanged records one change to feature state.
+//
+// ActorEmail is stored alongside ActorID because an audit record has to be
+// readable months later by someone who was not there. The identity on the
+// request context carries only an agent id — a KSUID — and a log of KSUIDs
+// answers "who" in a way nobody can use without a second lookup they will not
+// bother to do. Over the command line both actor fields are empty and Source
+// carries "cli", which is the honest record: the operating system authorised
+// that change, not WeOS.
+type FeatureChanged struct {
+	Key        string
+	Scope      string
+	ScopeID    string
+	State      string
+	Source     string
+	ActorID    string
+	ActorEmail string
+	Timestamp  time.Time
+}
+
+func (e FeatureChanged) EventType() string { return "Feature.Changed" }
+
+// FeatureChange is the aggregate that carries one FeatureChanged event.
+//
+// Each change is its own aggregate, deliberately. Pericarp's events table has
+// a unique index on (aggregate_id, sequence_no), and an aggregate built from a
+// fresh BaseEntity always records at sequence 1 — so a stable
+// "urn:feature:<key>" aggregate would write fine the first time a key was
+// flipped and collide every time after, which is exactly when an audit trail
+// stops being decorative.
+type FeatureChange struct {
+	*ddd.BaseEntity
+}
+
+// With builds the change and records its event. id comes from
+// identity.NewFeatureChange().
+func (c *FeatureChange) With(id string, event FeatureChanged) (*FeatureChange, error) {
+	if id == "" {
+		return nil, fmt.Errorf("feature change id cannot be empty")
+	}
+	if event.Key == "" {
+		return nil, fmt.Errorf("feature change must name a feature")
+	}
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now()
+	}
+	c.BaseEntity = ddd.NewBaseEntity(id)
+	if err := c.RecordEvent(event, event.EventType()); err != nil {
+		return nil, fmt.Errorf("failed to record Feature.Changed event: %w", err)
+	}
+	return c, nil
+}

--- a/domain/entities/feature_change.go
+++ b/domain/entities/feature_change.go
@@ -47,7 +47,7 @@ const (
 // request context carries only an agent id — a KSUID — and a log of KSUIDs
 // answers "who" in a way nobody can use without a second lookup they will not
 // bother to do. Over the command line both actor fields are empty and Source
-// carries "cli", which is the honest record: the operating system authorised
+// carries "cli", which is the honest record: the operating system authorized
 // that change, not WeOS.
 type FeatureChanged struct {
 	Key        string

--- a/domain/repositories/feature_cache_invalidator.go
+++ b/domain/repositories/feature_cache_invalidator.go
@@ -23,7 +23,7 @@ import "context"
 // There is one rule and it has no exceptions: a change to the instance, to an
 // account, or to a grant reaches sessions that are already open. What varies
 // between deployments is only the machinery behind this interface, never the
-// behaviour in front of it — tie the two together and a bug that only appears
+// behavior in front of it — tie the two together and a bug that only appears
 // under replicas never shows up on the single-process instance it was
 // developed on.
 //

--- a/infrastructure/features/invalidator.go
+++ b/infrastructure/features/invalidator.go
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 // Package features holds the deployment-specific half of feature-cache
-// invalidation. The behaviour in front of the interface never varies; only the
+// invalidation. The behavior in front of the interface never varies; only the
 // machinery behind it does, and it lives here so swapping the transport later
 // touches this package and nothing else.
 package features
@@ -79,7 +79,7 @@ func NewNotifyInvalidator(
 const DefaultNotifyChannel = "weos_feature_cache"
 
 // Listen drops the local cache whenever another replica broadcasts, and blocks
-// until ctx is cancelled. Callers run it in a goroutine started from an fx
+// until ctx is canceled. Callers run it in a goroutine started from an fx
 // OnStart hook and cancel it on OnStop.
 func (n *NotifyInvalidator) Listen(ctx context.Context, dsn string) error {
 	return n.listen(ctx, dsn)
@@ -126,7 +126,7 @@ func (n *NotifyInvalidator) log(ctx context.Context, msg string, kv ...any) {
 }
 
 // listen drops the local cache whenever another replica broadcasts. Runs until
-// ctx is cancelled; the fx OnStop hook cancels it.
+// ctx is canceled; the fx OnStop hook cancels it.
 func (n *NotifyInvalidator) listen(ctx context.Context, dsn string) error {
 	listener, err := subscriptions.NewPostgresListener(dsn,
 		subscriptions.WithListenerChannel(n.channel))

--- a/infrastructure/logging/zap_logger.go
+++ b/infrastructure/logging/zap_logger.go
@@ -24,6 +24,7 @@ import (
 
 	"go.uber.org/fx"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // ZapLogger is a zap-based implementation of entities.Logger.
@@ -106,12 +107,20 @@ func ProvideZapLogger(params struct {
 		logLevel = "info"
 	}
 
-	switch logLevel {
-	case "debug":
-		logger, err = zap.NewDevelopment()
-	default:
-		logger, err = zap.NewProduction()
+	// The level is applied to the config, not just used to pick between two
+	// presets. It used to switch "debug" to the development preset and send
+	// everything else to zap.NewProduction(), which logs at info and above —
+	// so LOG_LEVEL=warn and LOG_LEVEL=error were accepted and then ignored,
+	// despite both being documented. A one-shot CLI command asking for quiet
+	// got a wall of info lines instead.
+	var zapCfg zap.Config
+	if logLevel == "debug" {
+		zapCfg = zap.NewDevelopmentConfig()
+	} else {
+		zapCfg = zap.NewProductionConfig()
 	}
+	zapCfg.Level = zap.NewAtomicLevelAt(zapLevelFor(logLevel))
+	logger, err = zapCfg.Build()
 
 	if err != nil {
 		return ZapLoggerResult{}, fmt.Errorf("failed to create zap logger: %w", err)
@@ -119,6 +128,23 @@ func ProvideZapLogger(params struct {
 	return ZapLoggerResult{
 		ZapLogger: logger,
 	}, nil
+}
+
+// zapLevelFor maps a configured level name onto a zap level. An unrecognised
+// name falls back to info rather than failing the boot: a typo in an
+// environment variable should not stop a server starting, and info is the
+// level an operator who typed something unexpected most likely wanted.
+func zapLevelFor(level string) zapcore.Level {
+	switch level {
+	case "debug":
+		return zapcore.DebugLevel
+	case "warn", "warning":
+		return zapcore.WarnLevel
+	case "error":
+		return zapcore.ErrorLevel
+	default:
+		return zapcore.InfoLevel
+	}
 }
 
 // LoggerResult holds the logger result.

--- a/infrastructure/logging/zap_logger.go
+++ b/infrastructure/logging/zap_logger.go
@@ -18,6 +18,7 @@ package logging
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/wepala/weos/v3/domain/entities"
 	"github.com/wepala/weos/v3/internal/config"
@@ -102,7 +103,10 @@ func ProvideZapLogger(params struct {
 	var logger *zap.Logger
 	var err error
 
-	logLevel := params.Config.LogLevel
+	// Normalised before use. Comparing the raw string would leave
+	// LOG_LEVEL=ERROR or Warn falling through to info — the exact bug this
+	// mapping exists to remove, one keystroke away.
+	logLevel := strings.ToLower(strings.TrimSpace(params.Config.LogLevel))
 	if logLevel == "" {
 		logLevel = "info"
 	}
@@ -130,18 +134,22 @@ func ProvideZapLogger(params struct {
 	}, nil
 }
 
-// zapLevelFor maps a configured level name onto a zap level. An unrecognised
+// zapLevelFor maps a configured level name onto a zap level. An unrecognized
 // name falls back to info rather than failing the boot: a typo in an
 // environment variable should not stop a server starting, and info is the
 // level an operator who typed something unexpected most likely wanted.
 func zapLevelFor(level string) zapcore.Level {
-	switch level {
+	switch strings.ToLower(strings.TrimSpace(level)) {
 	case "debug":
 		return zapcore.DebugLevel
 	case "warn", "warning":
 		return zapcore.WarnLevel
 	case "error":
 		return zapcore.ErrorLevel
+	case "fatal":
+		return zapcore.FatalLevel
+	case "panic":
+		return zapcore.PanicLevel
 	default:
 		return zapcore.InfoLevel
 	}

--- a/infrastructure/logging/zap_logger_test.go
+++ b/infrastructure/logging/zap_logger_test.go
@@ -75,3 +75,24 @@ func TestZapLogger_KvFieldsParsed(t *testing.T) {
 		t.Errorf("elapsed_ms field = %v, want 42", got)
 	}
 }
+
+// TestZapLevelForIsCaseInsensitive: comparing the raw string would leave
+// LOG_LEVEL=ERROR falling through to info, which is the bug this mapping
+// exists to remove.
+func TestZapLevelForIsCaseInsensitive(t *testing.T) {
+	cases := map[string]zapcore.Level{
+		"debug": zapcore.DebugLevel, "DEBUG": zapcore.DebugLevel, " Debug ": zapcore.DebugLevel,
+		"warn": zapcore.WarnLevel, "WARN": zapcore.WarnLevel, "Warning": zapcore.WarnLevel,
+		"error": zapcore.ErrorLevel, "ERROR": zapcore.ErrorLevel, "Error": zapcore.ErrorLevel,
+		"fatal": zapcore.FatalLevel, "panic": zapcore.PanicLevel,
+		"info": zapcore.InfoLevel, "": zapcore.InfoLevel,
+		// An unrecognized value falls back to info rather than failing the
+		// boot: a typo in an environment variable must not stop a server.
+		"chatty": zapcore.InfoLevel,
+	}
+	for in, want := range cases {
+		if got := zapLevelFor(in); got != want {
+			t.Errorf("zapLevelFor(%q) = %v, want %v", in, got, want)
+		}
+	}
+}

--- a/internal/cli/account.go
+++ b/internal/cli/account.go
@@ -134,17 +134,8 @@ func runAccountCreate(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	// Refuse to guess which store to write to. config.Default() carries a
-	// "weos.db" fallback, which for a server means "start somewhere"; for this
-	// command it would mean minting the instance's only account into whatever
-	// directory the process happened to start in, reporting success, and
-	// exiting 0 — leaving a deployment that looks provisioned and has no
-	// account. An entrypoint's DSN is never implicit, so neither is this.
-	if os.Getenv("DATABASE_DSN") == "" && databaseDSN == "" {
-		return errors.New(
-			"no database specified: set DATABASE_DSN or pass --database-dsn " +
-				"(this command will not fall back to the built-in default, so an account " +
-				"is never created in a store nobody asked for)")
+	if err := requireExplicitDSN("account create"); err != nil {
+		return err
 	}
 
 	appCfg := GetConfig().Config

--- a/internal/cli/dsn.go
+++ b/internal/cli/dsn.go
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package cli
+
+import (
+	"fmt"
+	"os"
+)
+
+// requireExplicitDSN refuses to guess which store a one-shot command should
+// act on.
+//
+// config.Default() carries a "weos.db" fallback. For a server that means
+// "start somewhere"; for a command that changes state it would mean writing
+// into whatever directory the process happened to start in, reporting success,
+// and exiting 0 — leaving an operator convinced they changed an instance they
+// never touched, and a stray database file behind to prove otherwise. An
+// entrypoint's DSN is never implicit, so neither is a command's.
+//
+// Shared by every such command rather than copied into each, so they cannot
+// drift into disagreeing about when it is safe to guess.
+func requireExplicitDSN(command string) error {
+	if os.Getenv("DATABASE_DSN") != "" || databaseDSN != "" {
+		return nil
+	}
+	return fmt.Errorf(
+		"no database specified: set DATABASE_DSN or pass --database-dsn "+
+			"(%s will not fall back to the built-in default, so it never acts on "+
+			"a store nobody asked for)", command)
+}

--- a/internal/cli/feature.go
+++ b/internal/cli/feature.go
@@ -1,0 +1,219 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/application/presets"
+	"github.com/wepala/weos/v3/domain/entities"
+)
+
+var featureCmd = &cobra.Command{
+	Use:   "feature",
+	Short: "Inspect and change which features are on for this instance",
+	Long: `Features are capabilities an instance can turn on or off without a redeploy.
+
+A feature is declared in code or by a preset; this command changes whether it is
+on. An instance-level setting is final for everyone: no account override and no
+individual grant reaches past an explicit off.
+
+Reset is not the same as disable. Disabling turns a feature off for everyone;
+resetting removes the instance setting so the feature returns to the default it
+was declared with, which an account or a grant can still turn on.`,
+	SilenceUsage: true,
+}
+
+var featureListCmd = &cobra.Command{
+	Use:          "list",
+	Short:        "List every declared feature, its state, and where that state came from",
+	Args:         cobra.NoArgs,
+	RunE:         runFeatureList,
+	SilenceUsage: true,
+}
+
+var featureEnableCmd = &cobra.Command{
+	Use:          "enable <key>",
+	Short:        "Turn a feature on for the whole instance",
+	Args:         cobra.ExactArgs(1),
+	RunE:         runFeatureSet(true),
+	SilenceUsage: true,
+}
+
+var featureDisableCmd = &cobra.Command{
+	Use:          "disable <key>",
+	Short:        "Turn a feature off for the whole instance, for everyone",
+	Args:         cobra.ExactArgs(1),
+	RunE:         runFeatureSet(false),
+	SilenceUsage: true,
+}
+
+var featureResetCmd = &cobra.Command{
+	Use:   "reset <key>",
+	Short: "Remove the instance setting so the feature returns to its declared default",
+	Long: `Removes the instance-level setting for a feature.
+
+This is not the same as disabling it. A disabled feature is off for everyone and
+nothing below can turn it back on. A reset feature returns to the default it was
+declared with, which an account admin or an individual grant can still turn on.`,
+	Args:         cobra.ExactArgs(1),
+	RunE:         runFeatureReset,
+	SilenceUsage: true,
+}
+
+func init() {
+	featureCmd.AddCommand(featureListCmd, featureEnableCmd, featureDisableCmd, featureResetCmd)
+	rootCmd.AddCommand(featureCmd)
+}
+
+func runFeatureList(cmd *cobra.Command, _ []string) error {
+	return withFeatureAdmin(cmd, func(ctx context.Context, admin *application.FeatureAdminService) error {
+		statuses, err := admin.Listing(ctx)
+		if err != nil {
+			return fmt.Errorf("could not read the features: %w", err)
+		}
+		if len(statuses) == 0 {
+			cmd.Println("No features are declared on this instance.")
+			return nil
+		}
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "KEY\tNAME\tSTATE\tSOURCE")
+		for _, s := range statuses {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", s.Key, s.DisplayName, stateWord(s.Enabled), sourceWord(s.Source))
+		}
+		return w.Flush()
+	})
+}
+
+func runFeatureSet(enabled bool) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		key := args[0]
+		return withFeatureAdmin(cmd, func(ctx context.Context, admin *application.FeatureAdminService) error {
+			if err := admin.SetInstance(ctx, key, enabled, entities.FeatureChangeSourceCLI); err != nil {
+				return err
+			}
+			cmd.Printf("Feature %q is now %s for this instance.\n", key, stateWord(enabled))
+			printCacheAgeNotice(cmd)
+			return nil
+		})
+	}
+}
+
+func runFeatureReset(cmd *cobra.Command, args []string) error {
+	key := args[0]
+	return withFeatureAdmin(cmd, func(ctx context.Context, admin *application.FeatureAdminService) error {
+		if err := admin.ResetInstance(ctx, key, entities.FeatureChangeSourceCLI); err != nil {
+			return err
+		}
+		cmd.Printf("Feature %q returns to the default it was declared with.\n", key)
+		printCacheAgeNotice(cmd)
+		return nil
+	})
+}
+
+// printCacheAgeNotice tells the operator the change will not be instant.
+//
+// A running server resolves a caller's features once and reads from memory
+// afterwards, and this command is a different process — it cannot reach into
+// that server's memory. So the flip lands when the running instance's cached
+// sets reach their maximum age. Saying so here is the difference between a
+// documented delay and an operator concluding the command did not work.
+func printCacheAgeNotice(cmd *cobra.Command) {
+	age := GetConfig().Config.Features.CacheMaxAge
+	if age <= 0 {
+		age = 15 * time.Minute
+	}
+	cmd.Printf("A running instance may take up to %s to pick this up "+
+		"(set FEATURE_CACHE_MAX_AGE_SECONDS to change that).\n", age)
+}
+
+func stateWord(enabled bool) string {
+	if enabled {
+		return "on"
+	}
+	return "off"
+}
+
+// sourceWord renders the deciding layer for an operator. "default" is the one
+// that needs expanding: it means nobody has set anything, which is a different
+// situation from someone having set it to the same value, and the two call for
+// different actions.
+func sourceWord(source string) string {
+	switch source {
+	case "instance":
+		return "instance override"
+	case "account":
+		return "account override"
+	case "grant":
+		return "grant"
+	default:
+		return "declared default"
+	}
+}
+
+// withFeatureAdmin boots the application, hands the callback the admin service,
+// and shuts down again.
+//
+// The context is marked as local transport. Whoever can run this binary against
+// the database can already change anything in it directly, so the permission
+// check that guards the HTTP surfaces has nothing to add here — the operating
+// system already made the decision. The marker is applied here and not in
+// StartContainer on purpose: it also switches knowledge-graph routing, which
+// no other command should inherit from this one.
+func withFeatureAdmin(cmd *cobra.Command, fn func(context.Context, *application.FeatureAdminService) error) error {
+	if err := requireExplicitDSN("feature"); err != nil {
+		return err
+	}
+
+	// Quiet unless asked. Booting the module logs every built-in resource
+	// type, projection and behavior registration at info — useful when a
+	// server starts, noise that buries the answer when a one-shot command
+	// prints a table. --verbose still turns it all back on.
+	appCfg := GetConfig().Config
+	if !verbose {
+		appCfg.LogLevel = "error"
+	}
+
+	var admin *application.FeatureAdminService
+	app := fx.New(
+		fx.NopLogger,
+		application.Module(appCfg, presets.NewDefaultRegistry()),
+		fx.Populate(&admin),
+	)
+
+	// Generous, for the same reason account create is: starting the module runs
+	// migrations and projection setup against a possibly cold database, and a
+	// timeout here reports nothing useful.
+	startCtx, startCancel := context.WithTimeout(cmd.Context(), 2*time.Minute)
+	defer startCancel()
+	if err := app.Start(startCtx); err != nil {
+		return fmt.Errorf("could not start: %w", rootCause(err))
+	}
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer stopCancel()
+		_ = app.Stop(stopCtx)
+	}()
+
+	return fn(application.WithLocalTransport(cmd.Context()), admin)
+}

--- a/internal/cli/feature.go
+++ b/internal/cli/feature.go
@@ -97,9 +97,14 @@ func runFeatureList(cmd *cobra.Command, _ []string) error {
 			return nil
 		}
 		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
-		fmt.Fprintln(w, "KEY\tNAME\tSTATE\tSOURCE")
+		if _, err := fmt.Fprintln(w, "KEY\tNAME\tSTATE\tSOURCE"); err != nil {
+			return err
+		}
 		for _, s := range statuses {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", s.Key, s.DisplayName, stateWord(s.Enabled), sourceWord(s.Source))
+			if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+				s.Key, s.DisplayName, stateWord(s.Enabled), sourceWord(s.Source)); err != nil {
+				return err
+			}
 		}
 		return w.Flush()
 	})
@@ -139,12 +144,15 @@ func runFeatureReset(cmd *cobra.Command, args []string) error {
 // sets reach their maximum age. Saying so here is the difference between a
 // documented delay and an operator concluding the command did not work.
 func printCacheAgeNotice(cmd *cobra.Command) {
-	age := GetConfig().Config.Features.CacheMaxAge
+	age := GetConfig().Features.CacheMaxAge
 	if age <= 0 {
 		age = 15 * time.Minute
 	}
-	cmd.Printf("A running instance may take up to %s to pick this up "+
-		"(set FEATURE_CACHE_MAX_AGE_SECONDS to change that).\n", age)
+	// Named as this command's own setting, not the server's. They are separate
+	// processes reading separate environments, and stating a number this
+	// process cannot know would be worse than saying nothing.
+	cmd.Printf("A running instance picks this up when its cached feature sets expire "+
+		"(FEATURE_CACHE_MAX_AGE_SECONDS; %s here, but the server's own setting is what applies).\n", age)
 }
 
 func stateWord(enabled bool) string {

--- a/internal/cli/feature.go
+++ b/internal/cli/feature.go
@@ -40,7 +40,17 @@ individual grant reaches past an explicit off.
 
 Reset is not the same as disable. Disabling turns a feature off for everyone;
 resetting removes the instance setting so the feature returns to the default it
-was declared with, which an account or a grant can still turn on.`,
+was declared with, which an account or a grant can still turn on.
+
+This command sees only the features its OWN environment declares — from the
+binary, from installed presets, and from FEATURES. Run it with the same
+environment as the server, or the two will disagree about which features exist:
+a key the server declares and your shell does not is refused here, and a key
+your shell declares and the server does not is written and then ignored.
+
+Account overrides and individual grants are not visible from the command line,
+which has no signed-in caller to resolve them for. Use the API or the admin UI
+to see those.`,
 	SilenceUsage: true,
 }
 

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -32,12 +32,14 @@ var mcpCmd = &cobra.Command{
 	Short: "Start the MCP server",
 	Long: fmt.Sprintf(`Start the WeOS MCP (Model Context Protocol) server for LLM-driven edits.
 
-By default all tool groups are registered. Use --services to expose only a subset.
+By default every tool group is registered except those that must be asked for by
+name over this transport — currently "feature", which changes instance-wide state
+and is left out because stdio callers are trusted without a permission check. Use --services to expose only a subset.
 
 Available services: %s
 
 Examples:
-  weos mcp                                   # all services (default)
+  weos mcp                                   # every group except the opt-in ones (default)
   weos mcp --services website,page           # only website and page tools
   weos mcp --services website --services page # same, repeated flag syntax
   MCP_SERVICES=organization weos mcp         # env var override`,

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -135,6 +135,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	var orchestrator *appagents.Orchestrator
 	var skillRegistry *application.SkillRegistry
 	var featureInvalidator repositories.FeatureCacheInvalidator
+	var featureAdmin *application.FeatureAdminService
 
 	registry := presets.NewDefaultRegistry()
 
@@ -145,6 +146,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		fx.Populate(&orchestrator),
 		fx.Populate(&skillRegistry),
 		fx.Populate(&featureInvalidator),
+		fx.Populate(&featureAdmin),
 		fx.Populate(&resourceTypeService),
 		fx.Populate(&resourceService),
 		fx.Populate(&kgService),
@@ -429,6 +431,19 @@ func runServe(cmd *cobra.Command, args []string) error {
 		Features:       featureInvalidator,
 		Logger:         logger,
 	})
+	featureHandler := handlers.NewFeatureHandler(handlers.FeatureHandlerConfig{
+		Admin:  featureAdmin,
+		Logger: logger,
+	})
+	// Listing is readable by any authenticated caller — the admin UI needs it
+	// to decide what to render. Changing state is gated inside the service,
+	// which the CLI and the MCP tools share, so the rule lives in one place.
+	protected.GET("/features", featureHandler.List)
+	protected.PUT("/features/:key/instance", featureHandler.SetInstance)
+	protected.DELETE("/features/:key/instance", featureHandler.ResetInstance)
+	protected.PUT("/features/:key/account", featureHandler.SetAccount)
+	protected.DELETE("/features/:key/account", featureHandler.ResetAccount)
+
 	protected.GET("/users", userHandler.List)
 	protected.GET("/users/:id", userHandler.Get)
 	protected.PUT("/users/:id", userHandler.Update)
@@ -523,7 +538,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	if serveViper.GetBool("enabled") {
 		mcpSrv, mcpErr := mcpserver.NewConfiguredServer(
-			resourceTypeService, resourceService, kgService, lexicalSearch, episodicRecall, slog.Default(),
+			resourceTypeService, resourceService, kgService, lexicalSearch, episodicRecall,
+			featureAdmin, slog.Default(),
 		)
 		if mcpErr != nil {
 			return fmt.Errorf("failed to create MCP server: %w", mcpErr)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -201,6 +201,21 @@ type FeaturesConfig struct {
 	// single-process by construction and needs no broadcast.
 	NotifyChannel string
 
+	// PrimaryAccountID names the account whose owners and admins may change
+	// INSTANCE-wide feature state.
+	//
+	// It exists because "owner or admin" alone is not a meaningful bar on a
+	// multi-user instance: registration mints every new user as owner of their
+	// own personal account, so without this anyone who signs up could turn a
+	// feature off for everybody.
+	//
+	// Unset is safe rather than permissive. With exactly one account — the
+	// mini-me shape — that account is the instance and no configuration is
+	// needed. With more than one and nothing named, instance-scope changes are
+	// refused over HTTP and the operator is told to set this; the command line
+	// still works, because whoever has the box already has the database.
+	PrimaryAccountID string
+
 	// Declared holds features declared by configuration, alongside those
 	// declared in code and by presets.
 	//
@@ -663,6 +678,9 @@ func (c *Config) LoadFromEnvironment() {
 	}
 	if v := os.Getenv("FEATURE_NOTIFY_CHANNEL"); v != "" {
 		c.Features.NotifyChannel = v
+	}
+	if v := os.Getenv("FEATURE_PRIMARY_ACCOUNT_ID"); v != "" {
+		c.Features.PrimaryAccountID = v
 	}
 	if v := os.Getenv("FEATURES"); v != "" {
 		c.Features.Declared, c.Features.DeclarationError = parseFeatureDeclarations(v)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,10 +16,14 @@
 package config
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/wepala/weos/v3/domain/entities"
 )
 
 // OAuthConfig holds configuration for OAuth authentication.
@@ -196,6 +200,23 @@ type FeaturesConfig struct {
 	// invalidations between replicas. Ignored on SQLite, which is
 	// single-process by construction and needs no broadcast.
 	NotifyChannel string
+
+	// Declared holds features declared by configuration, alongside those
+	// declared in code and by presets.
+	//
+	// This is not persistence, and it does not weaken the rule that the
+	// registry is rebuilt from scratch on every boot: these are re-read from
+	// the environment each start, exactly as a code declaration is re-read
+	// from the binary. What it adds is a way to declare a feature without
+	// recompiling — which is what lets `weos feature` act on the same features
+	// a running server knows about, since the two are separate processes that
+	// can only agree by both reading the same declarations.
+	Declared []entities.FeatureMeta
+
+	// DeclarationError records a malformed FEATURES value so the boot can
+	// refuse rather than silently gating nothing. Kept on the config because
+	// LoadFromEnvironment has no way to return an error.
+	DeclarationError error
 }
 
 // WorkerConfig tunes the background subscriber runtime (epic #365). Subscribers
@@ -643,6 +664,9 @@ func (c *Config) LoadFromEnvironment() {
 	if v := os.Getenv("FEATURE_NOTIFY_CHANNEL"); v != "" {
 		c.Features.NotifyChannel = v
 	}
+	if v := os.Getenv("FEATURES"); v != "" {
+		c.Features.Declared, c.Features.DeclarationError = parseFeatureDeclarations(v)
+	}
 
 	if v := os.Getenv("OXIGRAPH_USERNAME"); v != "" {
 		c.Oxigraph.Username = v
@@ -701,4 +725,27 @@ func (c *Config) loadWorkerFromEnvironment() {
 			c.Worker.LagLogInterval = time.Duration(n) * time.Second
 		}
 	}
+}
+
+// parseFeatureDeclarations reads the FEATURES environment variable: a JSON
+// array of declarations, matching the shape a code declaration has.
+//
+//	FEATURES='[{"key":"ledger-export","displayName":"Ledger export","default":false,"manageable":true}]'
+//
+// A malformed value is an error rather than an empty list. Silently declaring
+// nothing would leave every call site answering its own default, which looks
+// exactly like a working instance with every feature off — the failure mode
+// hardest to notice and hardest to explain.
+func parseFeatureDeclarations(raw string) ([]entities.FeatureMeta, error) {
+	var declared []entities.FeatureMeta
+	if err := json.Unmarshal([]byte(raw), &declared); err != nil {
+		return nil, fmt.Errorf(
+			"FEATURES must be a JSON array of feature declarations: %w", err)
+	}
+	for i, m := range declared {
+		if err := m.Validate(); err != nil {
+			return nil, fmt.Errorf("FEATURES entry %d: %w", i, err)
+		}
+	}
+	return declared, nil
 }

--- a/internal/mcp/agent_toolset_test.go
+++ b/internal/mcp/agent_toolset_test.go
@@ -54,7 +54,7 @@ func fullServer(t *testing.T) *gomcp.Server {
 	t.Helper()
 	server, err := NewMCPServer(
 		&stubResourceTypeService{}, &stubResourceService{}, &stubKGService{active: true}, stubLexicalSearch{},
-		nil, nil,
+		nil, nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("NewMCPServer: %v", err)

--- a/internal/mcp/configurer_test.go
+++ b/internal/mcp/configurer_test.go
@@ -70,7 +70,7 @@ func TestNewHTTPHandlerAppliesConfigurers(t *testing.T) {
 	called := 0
 	RegisterMCPConfigurer(func(_ *mcp.Server, _ ConfigurerDeps) { called++ })
 
-	if _, err := NewHTTPHandler(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, slog.Default()); err != nil {
+	if _, err := NewHTTPHandler(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil, slog.Default()); err != nil {
 		t.Fatalf("NewHTTPHandler: %v", err)
 	}
 	if called != 1 {

--- a/internal/mcp/feature_tools.go
+++ b/internal/mcp/feature_tools.go
@@ -37,9 +37,14 @@ type FeatureListOutput struct {
 	Features []entities.FeatureStatus `json:"features"`
 }
 
+// FeatureSetInput carries Enabled as a pointer so an omitted field is
+// distinguishable from false. An LLM that leaves the argument out would
+// otherwise silently DISABLE the feature it was asked to enable — the worst
+// possible reading of an ambiguous call, and one nothing downstream could
+// detect.
 type FeatureSetInput struct {
 	Key     string `json:"key" jsonschema:"the feature key to change"`
-	Enabled bool   `json:"enabled" jsonschema:"true to turn the feature on, false to turn it off"`
+	Enabled *bool  `json:"enabled" jsonschema:"required: true to turn the feature on, false to turn it off"`
 	Scope   string `json:"scope,omitempty" jsonschema:"instance (default) or account"`
 }
 
@@ -90,12 +95,16 @@ func registerFeatureTools(server *mcp.Server, admin *application.FeatureAdminSer
 	}, func(
 		ctx context.Context, _ *mcp.CallToolRequest, input FeatureSetInput,
 	) (*mcp.CallToolResult, FeatureChangeOutput, error) {
+		if input.Enabled == nil {
+			return nil, FeatureChangeOutput{}, fmt.Errorf(
+				"enabled is required: say true or false rather than leaving it out")
+		}
 		var err error
 		switch scopeOrInstance(input.Scope) {
 		case featureScopeAccount:
-			err = admin.SetAccount(ctx, input.Key, input.Enabled, entities.FeatureChangeSourceMCP)
+			err = admin.SetAccount(ctx, input.Key, *input.Enabled, entities.FeatureChangeSourceMCP)
 		case featureScopeInstance:
-			err = admin.SetInstance(ctx, input.Key, input.Enabled, entities.FeatureChangeSourceMCP)
+			err = admin.SetInstance(ctx, input.Key, *input.Enabled, entities.FeatureChangeSourceMCP)
 		default:
 			err = fmt.Errorf("unknown scope %q: use %q or %q",
 				input.Scope, featureScopeInstance, featureScopeAccount)

--- a/internal/mcp/feature_tools.go
+++ b/internal/mcp/feature_tools.go
@@ -1,0 +1,159 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/domain/entities"
+)
+
+// Feature scopes an MCP caller can name.
+const (
+	featureScopeInstance = "instance"
+	featureScopeAccount  = "account"
+)
+
+type FeatureListInput struct{}
+
+type FeatureListOutput struct {
+	Features []entities.FeatureStatus `json:"features"`
+}
+
+type FeatureSetInput struct {
+	Key     string `json:"key" jsonschema:"the feature key to change"`
+	Enabled bool   `json:"enabled" jsonschema:"true to turn the feature on, false to turn it off"`
+	Scope   string `json:"scope,omitempty" jsonschema:"instance (default) or account"`
+}
+
+type FeatureResetInput struct {
+	Key   string `json:"key" jsonschema:"the feature key to reset"`
+	Scope string `json:"scope,omitempty" jsonschema:"instance (default) or account"`
+}
+
+type FeatureChangeOutput struct {
+	Features []entities.FeatureStatus `json:"features"`
+}
+
+// registerFeatureTools exposes the operator surface over MCP.
+//
+// Every tool delegates to FeatureAdminService, which is where the permission
+// check lives — the same one the REST handler and the CLI go through. Over
+// HTTP an ordinary member is refused here exactly as they are at the API. Over
+// the local stdio transport the check passes, because whoever can run
+// `weos mcp` on the machine can already run `weos feature disable` against the
+// same database; the marker for that is set once by the stdio server and needs
+// nothing from this file.
+func registerFeatureTools(server *mcp.Server, admin *application.FeatureAdminService) {
+	if admin == nil {
+		return
+	}
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "feature_list",
+		Description: "List every feature this instance declares, whether it is on for you, " +
+			"and which layer decided that (declared default, instance override, account override, or a grant).",
+		Annotations: annReadOnly(),
+	}, func(
+		ctx context.Context, _ *mcp.CallToolRequest, _ FeatureListInput,
+	) (*mcp.CallToolResult, FeatureListOutput, error) {
+		statuses, err := admin.Listing(ctx)
+		if err != nil {
+			return nil, FeatureListOutput{}, err
+		}
+		return nil, FeatureListOutput{Features: statuses}, nil
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "feature_set",
+		Description: "Turn a feature on or off. Scope \"instance\" affects everyone and is final — " +
+			"no account override or grant reaches past an instance-level off. Scope \"account\" " +
+			"affects only the account you are signed in to.",
+		Annotations: annDestructive(),
+	}, func(
+		ctx context.Context, _ *mcp.CallToolRequest, input FeatureSetInput,
+	) (*mcp.CallToolResult, FeatureChangeOutput, error) {
+		var err error
+		switch scopeOrInstance(input.Scope) {
+		case featureScopeAccount:
+			err = admin.SetAccount(ctx, input.Key, input.Enabled, entities.FeatureChangeSourceMCP)
+		case featureScopeInstance:
+			err = admin.SetInstance(ctx, input.Key, input.Enabled, entities.FeatureChangeSourceMCP)
+		default:
+			err = fmt.Errorf("unknown scope %q: use %q or %q",
+				input.Scope, featureScopeInstance, featureScopeAccount)
+		}
+		if err != nil {
+			return nil, FeatureChangeOutput{}, err
+		}
+		return featureListingResult(ctx, admin)
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "feature_reset",
+		Description: "Remove a feature override so it returns to the default it was declared with. " +
+			"Not the same as turning it off: a reset feature can still be turned on by an account " +
+			"override or a grant, where an explicit off cannot.",
+		Annotations: annDestructive(),
+	}, func(
+		ctx context.Context, _ *mcp.CallToolRequest, input FeatureResetInput,
+	) (*mcp.CallToolResult, FeatureChangeOutput, error) {
+		var err error
+		switch scopeOrInstance(input.Scope) {
+		case featureScopeAccount:
+			err = admin.ResetAccount(ctx, input.Key, entities.FeatureChangeSourceMCP)
+		case featureScopeInstance:
+			err = admin.ResetInstance(ctx, input.Key, entities.FeatureChangeSourceMCP)
+		default:
+			err = fmt.Errorf("unknown scope %q: use %q or %q",
+				input.Scope, featureScopeInstance, featureScopeAccount)
+		}
+		if err != nil {
+			return nil, FeatureChangeOutput{}, err
+		}
+		return featureListingResult(ctx, admin)
+	})
+}
+
+// scopeOrInstance defaults an omitted scope to the instance. Instance is the
+// scope an operator reaching for this tool almost always means, and an account
+// override silently applied when they meant the instance would look like the
+// change had no effect for anyone else.
+func scopeOrInstance(scope string) string {
+	if scope == "" {
+		return featureScopeInstance
+	}
+	return scope
+}
+
+// featureListingResult answers a change with the caller's resolved listing, so
+// the client can see what the change produced without a second call — a reset
+// in particular resolves to whatever layer now decides.
+func featureListingResult(
+	ctx context.Context, admin *application.FeatureAdminService,
+) (*mcp.CallToolResult, FeatureChangeOutput, error) {
+	statuses, err := admin.Listing(ctx)
+	if err != nil {
+		// The change landed; only the read-back failed. Returning an error
+		// would report failure for work that succeeded.
+		return nil, FeatureChangeOutput{}, nil
+	}
+	return nil, FeatureChangeOutput{Features: statuses}, nil
+}

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -36,9 +36,11 @@ func NewConfiguredServer(
 	kgService application.KnowledgeGraphService,
 	lexicalSearch application.LexicalSearch,
 	episodicRecall application.EpisodicRecall,
+	featureAdmin *application.FeatureAdminService,
 	logger *slog.Logger,
 ) (*gomcp.Server, error) {
-	server, err := NewMCPServer(resourceTypeService, resourceService, kgService, lexicalSearch, episodicRecall, nil)
+	server, err := NewMCPServer(
+		resourceTypeService, resourceService, kgService, lexicalSearch, episodicRecall, featureAdmin, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create MCP server: %w", err)
 	}
@@ -71,10 +73,11 @@ func NewHTTPHandler(
 	kgService application.KnowledgeGraphService,
 	lexicalSearch application.LexicalSearch,
 	episodicRecall application.EpisodicRecall,
+	featureAdmin *application.FeatureAdminService,
 	logger *slog.Logger,
 ) (http.Handler, error) {
 	server, err := NewConfiguredServer(
-		resourceTypeService, resourceService, kgService, lexicalSearch, episodicRecall, logger)
+		resourceTypeService, resourceService, kgService, lexicalSearch, episodicRecall, featureAdmin, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mcp/handler_test.go
+++ b/internal/mcp/handler_test.go
@@ -185,7 +185,7 @@ func toolNames(t *testing.T, server *gomcp.Server) []string {
 }
 
 func TestNewMCPServer_AllServices(t *testing.T) {
-	server, err := NewMCPServer(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil)
+	server, err := NewMCPServer(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -219,7 +219,7 @@ func TestNewMCPServer_AllServices(t *testing.T) {
 }
 
 func TestNewMCPServer_Subset(t *testing.T) {
-	server, err := NewMCPServer(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, []string{"person"})
+	server, err := NewMCPServer(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil, []string{"person"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestNewMCPServer_Subset(t *testing.T) {
 
 func TestNewMCPServer_ResourceTypeIncludesPresets(t *testing.T) {
 	server, err := NewMCPServer(
-		&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, []string{"resource-type"},
+		&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil, []string{"resource-type"},
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -259,21 +259,21 @@ func TestNewMCPServer_ResourceTypeIncludesPresets(t *testing.T) {
 }
 
 func TestNewMCPServer_NilResourceTypeService(t *testing.T) {
-	_, err := NewMCPServer(nil, &stubResourceService{}, nil, nil, nil, nil)
+	_, err := NewMCPServer(nil, &stubResourceService{}, nil, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for nil resourceTypeService")
 	}
 }
 
 func TestNewMCPServer_NilResourceService(t *testing.T) {
-	_, err := NewMCPServer(&stubResourceTypeService{}, nil, nil, nil, nil, nil)
+	_, err := NewMCPServer(&stubResourceTypeService{}, nil, nil, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for nil resourceService")
 	}
 }
 
 func TestNewHTTPHandler_ReturnsHandler(t *testing.T) {
-	handler, err := NewHTTPHandler(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil)
+	handler, err := NewHTTPHandler(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -283,7 +283,7 @@ func TestNewHTTPHandler_ReturnsHandler(t *testing.T) {
 }
 
 func TestNewHTTPHandler_AcceptsMCPRequest(t *testing.T) {
-	handler, err := NewHTTPHandler(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil)
+	handler, err := NewHTTPHandler(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -310,7 +310,7 @@ func TestNewHTTPHandler_AcceptsMCPRequest(t *testing.T) {
 }
 
 func TestNewHTTPHandler_NilServices(t *testing.T) {
-	_, err := NewHTTPHandler(nil, nil, nil, nil, nil, nil)
+	_, err := NewHTTPHandler(nil, nil, nil, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for nil services")
 	}

--- a/internal/mcp/kg_tools_test.go
+++ b/internal/mcp/kg_tools_test.go
@@ -90,7 +90,7 @@ func TestNewMCPServer_KnowledgeGraphServiceOptional(t *testing.T) {
 	// Passing nil kgService must not break server creation; the tools just
 	// don't appear. (Mirrors how downstream callers like the HTTP handler
 	// can opt out.)
-	server, err := NewMCPServer(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil)
+	server, err := NewMCPServer(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewMCPServer with nil KG: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestNewMCPServer_KnowledgeGraphServiceOptional(t *testing.T) {
 func TestNewMCPServer_KnowledgeGraphRegisteredWhenServiceProvided(t *testing.T) {
 	t.Parallel()
 	server, err := NewMCPServer(
-		&stubResourceTypeService{}, &stubResourceService{}, &stubKGService{active: true}, nil, nil, nil,
+		&stubResourceTypeService{}, &stubResourceService{}, &stubKGService{active: true}, nil, nil, nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("NewMCPServer: %v", err)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -38,15 +38,19 @@ const (
 	ServiceFeature        ServiceName = "feature"
 )
 
-// DefaultOffServices are real services that are NOT enabled when a caller
-// names none.
+// StdioOptInServices are services that `weos mcp` does NOT enable unless the
+// operator names them.
 //
-// The feature tools change instance-wide state, and `weos mcp` over stdio is
+// The feature tools change instance-wide state, and the stdio transport is
 // trusted without a permission check — so leaving them on by default would put
 // the instance switchboard in reach of any local MCP client, including an LLM
 // pointed at the graph for something else entirely. Naming the group turns
 // them on: `weos mcp --services resource,feature`.
-var DefaultOffServices = map[ServiceName]bool{
+//
+// This applies to STDIO only. The HTTP MCP surface is permission-checked
+// exactly like the REST API, so there is nothing to protect it from there and
+// the admin UI and in-app agent keep the tools.
+var StdioOptInServices = map[ServiceName]bool{
 	ServiceFeature: true,
 }
 
@@ -94,10 +98,16 @@ func ValidateServiceNames(names []string) error {
 
 // resolveEnabled returns a set of enabled services. If the input is nil or empty, all services are enabled.
 func resolveEnabled(services []string) map[ServiceName]bool {
+	return resolveEnabledFor(services, false)
+}
+
+// resolveEnabledFor resolves the enabled set. stdio marks the trusted local
+// transport, where some groups must be asked for by name.
+func resolveEnabledFor(services []string, stdio bool) map[ServiceName]bool {
 	enabled := make(map[ServiceName]bool, len(AllServices))
 	if len(services) == 0 {
 		for _, s := range AllServices {
-			if DefaultOffServices[s] {
+			if stdio && StdioOptInServices[s] {
 				continue
 			}
 			enabled[s] = true
@@ -230,6 +240,16 @@ func Run(enabledServices []string) error {
 		}
 	}()
 
+	// The stdio path opts out of the trusted-transport groups unless the
+	// operator named them; see StdioOptInServices.
+	if len(enabledServices) == 0 {
+		for _, s := range AllServices {
+			if StdioOptInServices[s] {
+				continue
+			}
+			enabledServices = append(enabledServices, string(s))
+		}
+	}
 	server, err := NewMCPServer(
 		resourceTypeService, resourceService, kgService, lexicalSearch, episodicRecall,
 		featureAdmin, enabledServices)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -38,6 +38,18 @@ const (
 	ServiceFeature        ServiceName = "feature"
 )
 
+// DefaultOffServices are real services that are NOT enabled when a caller
+// names none.
+//
+// The feature tools change instance-wide state, and `weos mcp` over stdio is
+// trusted without a permission check — so leaving them on by default would put
+// the instance switchboard in reach of any local MCP client, including an LLM
+// pointed at the graph for something else entirely. Naming the group turns
+// them on: `weos mcp --services resource,feature`.
+var DefaultOffServices = map[ServiceName]bool{
+	ServiceFeature: true,
+}
+
 // AllServices is the ordered list of every available service.
 var AllServices = []ServiceName{
 	ServicePerson,
@@ -85,6 +97,9 @@ func resolveEnabled(services []string) map[ServiceName]bool {
 	enabled := make(map[ServiceName]bool, len(AllServices))
 	if len(services) == 0 {
 		for _, s := range AllServices {
+			if DefaultOffServices[s] {
+				continue
+			}
 			enabled[s] = true
 		}
 		return enabled

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -35,6 +35,7 @@ const (
 	ServiceResource       ServiceName = "resource"
 	ServiceKnowledgeGraph ServiceName = "knowledge-graph"
 	ServiceMemory         ServiceName = "memory"
+	ServiceFeature        ServiceName = "feature"
 )
 
 // AllServices is the ordered list of every available service.
@@ -45,6 +46,7 @@ var AllServices = []ServiceName{
 	ServiceResource,
 	ServiceKnowledgeGraph,
 	ServiceMemory,
+	ServiceFeature,
 }
 
 // ValidServiceNames returns the service names as strings (useful for help text).
@@ -107,6 +109,7 @@ func NewMCPServer(
 	kgService application.KnowledgeGraphService,
 	lexicalSearch application.LexicalSearch,
 	episodicRecall application.EpisodicRecall,
+	featureAdmin *application.FeatureAdminService,
 	enabledServices []string,
 ) (*mcp.Server, error) {
 	if isNilInterface(resourceTypeService) {
@@ -145,6 +148,9 @@ func NewMCPServer(
 	if enabled[ServiceKnowledgeGraph] && !isNilInterface(kgService) {
 		registerKnowledgeGraphTools(server, kgService)
 	}
+	if enabled[ServiceFeature] && featureAdmin != nil {
+		registerFeatureTools(server, featureAdmin)
+	}
 	if enabled[ServiceMemory] {
 		// The playbook and recall services are thin stateless wrappers over
 		// services this constructor already receives, so they are built here
@@ -182,6 +188,7 @@ func Run(enabledServices []string) error {
 	var kgService application.KnowledgeGraphService
 	var lexicalSearch application.LexicalSearch
 	var episodicRecall application.EpisodicRecall
+	var featureAdmin *application.FeatureAdminService
 
 	app := fx.New(
 		fx.NopLogger,
@@ -191,6 +198,7 @@ func Run(enabledServices []string) error {
 		fx.Populate(&kgService),
 		fx.Populate(&lexicalSearch),
 		fx.Populate(&episodicRecall),
+		fx.Populate(&featureAdmin),
 	)
 
 	startCtx, startCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
@@ -208,7 +216,8 @@ func Run(enabledServices []string) error {
 	}()
 
 	server, err := NewMCPServer(
-		resourceTypeService, resourceService, kgService, lexicalSearch, episodicRecall, enabledServices)
+		resourceTypeService, resourceService, kgService, lexicalSearch, episodicRecall,
+		featureAdmin, enabledServices)
 	if err != nil {
 		return fmt.Errorf("failed to create MCP server: %w", err)
 	}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -4,16 +4,28 @@ import (
 	"testing"
 )
 
-func TestResolveEnabled_EmptyReturnsAll(t *testing.T) {
+// TestResolveEnabled_EmptyReturnsAllButOptIn: naming no services enables every
+// group except those that must be asked for by name. The exception exists
+// because some tools change instance-wide state and the stdio transport is
+// trusted without a permission check.
+func TestResolveEnabled_EmptyReturnsAllButOptIn(t *testing.T) {
 	for _, input := range [][]string{nil, {}} {
 		enabled := resolveEnabled(input)
+		want := 0
 		for _, s := range AllServices {
+			if DefaultOffServices[s] {
+				if enabled[s] {
+					t.Errorf("service %q is opt-in but was enabled for empty input", s)
+				}
+				continue
+			}
+			want++
 			if !enabled[s] {
 				t.Errorf("expected service %q to be enabled for empty input", s)
 			}
 		}
-		if len(enabled) != len(AllServices) {
-			t.Errorf("expected %d enabled services, got %d", len(AllServices), len(enabled))
+		if len(enabled) != want {
+			t.Errorf("expected %d enabled services, got %d", want, len(enabled))
 		}
 	}
 }
@@ -94,4 +106,24 @@ func searchString(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+// TestFeatureToolsAreNotEnabledByDefault: the feature tools change
+// instance-wide state and `weos mcp` over stdio is trusted without a
+// permission check, so an LLM pointed at the graph must not find the
+// switchboard in reach unless the operator named it.
+func TestFeatureToolsAreNotEnabledByDefault(t *testing.T) {
+	if resolveEnabled(nil)[ServiceFeature] {
+		t.Fatal("the feature service is enabled when no services are named")
+	}
+	if !resolveEnabled(nil)[ServiceResource] {
+		t.Fatal("naming no services should still enable the ordinary groups")
+	}
+	if !resolveEnabled([]string{"feature"})[ServiceFeature] {
+		t.Fatal("naming the feature service did not enable it")
+	}
+	// It is still a valid name, so --services feature must not be rejected.
+	if err := ValidateServiceNames([]string{"feature"}); err != nil {
+		t.Fatalf("ValidateServiceNames rejected a real service: %v", err)
+	}
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -10,10 +10,10 @@ import (
 // trusted without a permission check.
 func TestResolveEnabled_EmptyReturnsAllButOptIn(t *testing.T) {
 	for _, input := range [][]string{nil, {}} {
-		enabled := resolveEnabled(input)
+		enabled := resolveEnabledFor(input, true)
 		want := 0
 		for _, s := range AllServices {
-			if DefaultOffServices[s] {
+			if StdioOptInServices[s] {
 				if enabled[s] {
 					t.Errorf("service %q is opt-in but was enabled for empty input", s)
 				}
@@ -113,11 +113,15 @@ func searchString(s, substr string) bool {
 // permission check, so an LLM pointed at the graph must not find the
 // switchboard in reach unless the operator named it.
 func TestFeatureToolsAreNotEnabledByDefault(t *testing.T) {
-	if resolveEnabled(nil)[ServiceFeature] {
-		t.Fatal("the feature service is enabled when no services are named")
+	if resolveEnabledFor(nil, true)[ServiceFeature] {
+		t.Fatal("the feature service is enabled on stdio when no services are named")
 	}
-	if !resolveEnabled(nil)[ServiceResource] {
+	if !resolveEnabledFor(nil, true)[ServiceResource] {
 		t.Fatal("naming no services should still enable the ordinary groups")
+	}
+	// HTTP is permission-checked like the API, so it keeps the tools.
+	if !resolveEnabled(nil)[ServiceFeature] {
+		t.Fatal("the feature service is off on the HTTP surface, where it is permission-checked")
 	}
 	if !resolveEnabled([]string{"feature"})[ServiceFeature] {
 		t.Fatal("naming the feature service did not enable it")

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -60,10 +60,25 @@ func TestValidServiceNames_ReturnsAll(t *testing.T) {
 		"person": true, "organization": true,
 		"resource-type": true, "resource": true,
 		"knowledge-graph": true, "memory": true,
+		"feature": true,
 	}
 	for _, n := range names {
 		if !expected[n] {
 			t.Errorf("unexpected service name: %s", n)
+		}
+	}
+	// Both directions: a service dropped from AllServices should fail here too,
+	// not just an unexpected one added.
+	for name := range expected {
+		found := false
+		for _, n := range names {
+			if n == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("service name missing from AllServices: %s", name)
 		}
 	}
 }

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -100,6 +100,19 @@ func NewResource(typeSlug string) string {
 	return "urn:" + typeSlug + ":" + ksuid.New().String()
 }
 
+// NewFeatureChange generates a URN for one recorded feature-flag change.
+// Format: "urn:feature-change:<ksuid>"
+//
+// Every change is its own aggregate rather than all changes to a key sharing
+// one. That is forced by the event store: pericarp's events table carries a
+// unique index on (aggregate_id, sequence_no), and a change built from a fresh
+// BaseEntity always writes sequence 1 — so a stable "urn:feature:<key>" would
+// collide the second time anyone flipped the same key, which is precisely when
+// an audit trail starts to matter.
+func NewFeatureChange() string {
+	return "urn:feature-change:" + ksuid.New().String()
+}
+
 // ExtractThemeSlug returns the theme slug from a theme or template URN.
 // Theme URN (urn:theme:<slug>) → parts[2]
 // Template URN (urn:theme:<ts>:template:<ksuid>:<tps>) → parts[2]

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -222,9 +222,14 @@ func ExtractResourceTypeSlug(id string) string {
 	}
 	parts := strings.Split(id, ":")
 	if len(parts) == 3 && parts[0] == "urn" {
-		// Exclude known 3-part prefixes (person, org, theme, type)
+		// Exclude known 3-part prefixes that are NOT resource types.
+		//
+		// feature-change is here because an operator's audit event
+		// (urn:feature-change:<ksuid>) otherwise reads as a resource of type
+		// "feature-change" — a type nothing declares — and surfaces in
+		// episodic recall as if it were content the agent could reason about.
 		switch parts[1] {
-		case "person", "org", "theme", "type":
+		case "person", "org", "theme", "type", "feature-change":
 			return ""
 		}
 		return parts[1]

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -327,3 +327,25 @@ func TestExtractPageSlug(t *testing.T) {
 		})
 	}
 }
+
+// TestExtractResourceTypeSlugExcludesNonResourceURNs: a URN that is not a
+// resource must not read as one. An operator's feature-change audit event
+// otherwise appears in episodic recall as a resource of a type nothing
+// declares, and becomes addressable by that type in event-log filters.
+func TestExtractResourceTypeSlugExcludesNonResourceURNs(t *testing.T) {
+	for _, urn := range []string{
+		"urn:feature-change:3I9witSomeKsuidValue",
+		"urn:person:3I9witSomeKsuidValue",
+		"urn:org:acme",
+		"urn:type:product",
+		"urn:theme:default",
+	} {
+		if got := ExtractResourceTypeSlug(urn); got != "" {
+			t.Errorf("ExtractResourceTypeSlug(%q) = %q, want empty — it is not a resource", urn, got)
+		}
+	}
+	// A real resource URN still resolves.
+	if got := ExtractResourceTypeSlug("urn:product:3I9witSomeKsuidValue"); got != "product" {
+		t.Errorf("ExtractResourceTypeSlug of a resource URN = %q, want %q", got, "product")
+	}
+}

--- a/tests/e2e/embedded_knowledge_graph_test.go
+++ b/tests/e2e/embedded_knowledge_graph_test.go
@@ -185,7 +185,7 @@ func (w *kgWorld) startApp(cfg config.Config, capture bool) error {
 	w.manager = manager
 	w.rts = rts
 
-	server, err := mcpserver.NewMCPServer(rts, rs, kg, nil, episodic, nil)
+	server, err := mcpserver.NewMCPServer(rts, rs, kg, nil, episodic, nil, nil)
 	if err != nil {
 		return fmt.Errorf("build MCP server: %w", err)
 	}

--- a/tests/e2e/feature_operator_steps_test.go
+++ b/tests/e2e/feature_operator_steps_test.go
@@ -159,6 +159,14 @@ func (w *operatorWorld) stepAccountOwner(name, email, password string) error {
 		return fmt.Errorf("%q has no account to name %q", email, name)
 	}
 	w.accounts[name] = p.accountID
+	if w.primaryAccountID == "" {
+		// The first account staged is this instance's own. Recorded and the
+		// instance restarted so the guard reads it — otherwise every later
+		// registration makes the instance ambiguous, and a member is refused
+		// for that rather than for their role.
+		w.primaryAccountID = p.accountID
+		return w.reboot()
+	}
 	return nil
 }
 

--- a/tests/e2e/feature_operator_steps_test.go
+++ b/tests/e2e/feature_operator_steps_test.go
@@ -1,0 +1,760 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/cucumber/godog"
+
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
+)
+
+func initFeatureOperatorScenario(sc *godog.ScenarioContext) {
+	w := &operatorWorld{
+		accounts: map[string]string{},
+		people:   map[string]*featurePerson{},
+	}
+	sc.After(func(ctx context.Context, _ *godog.Scenario, err error) (context.Context, error) {
+		w.teardown()
+		return ctx, err
+	})
+
+	// --- instance and declarations ---
+	sc.Step(`^a WeOS instance where password sign-in is enabled and requests are authenticated by their session$`,
+		w.stepInstance)
+	sc.Step(`^a WeOS instance with no database configured$`, w.stepInstanceNoDatabase)
+	sc.Step(`^the instance is configured with a maximum cache age of (\d+) seconds$`, w.stepMaxCacheAge)
+	sc.Step(`^the instance declares these features in code:$`, w.stepDeclare)
+	sc.Step(`^the account "([^"]*)", whose owner "([^"]*)" signs in with password "([^"]*)"$`, w.stepAccountOwner)
+	sc.Step(`^"([^"]*)" also belongs to "([^"]*)" with the role "([^"]*)"$`, w.stepAlsoBelongs)
+	sc.Step(`^"([^"]*)" belongs to "([^"]*)" as an ordinary member$`, w.stepOrdinaryMember)
+	sc.Step(`^"([^"]*)" is signed in to "([^"]*)"$`, w.stepSignedIn)
+
+	// --- staged state ---
+	sc.Step(`^the operator has turned the feature "([^"]*)" (on|off) for the instance$`, w.stepOperatorHasSet)
+	sc.Step(`^"([^"]*)" has turned the feature "([^"]*)" on$`, w.stepAccountHasTurnedOn)
+	sc.Step(`^the operator has run "([^"]*)"$`, w.stepOperatorHasRun)
+	sc.Step(`^they have already evaluated "([^"]*)" and been answered on$`, w.stepAlreadyAnsweredOn)
+
+	// --- the command line ---
+	sc.Step(`^the operator runs "([^"]*)"$`, w.stepRunCLI)
+	sc.Step(`^the operator runs "([^"]*)" again$`, w.stepRunCLI)
+	sc.Step(`^the operator runs "([^"]*)" against the same store$`, w.stepRunCLI)
+	sc.Step(`^the command exits successfully$`, w.stepCommandSucceeded)
+	sc.Step(`^the command exits with a failure$`, w.stepCommandFailed)
+	sc.Step(`^the failure says no database was specified and names how to supply one$`, w.stepFailureNamesDSN)
+	sc.Step(`^the failure names the key "([^"]*)"$`, w.stepFailureNamesKey)
+	sc.Step(`^the command leaves no database behind in the directory it ran from$`, w.stepNoStrayDatabase)
+	sc.Step(`^the listing names each feature by its display name$`, w.stepListingNamesDisplayNames)
+	sc.Step(`^the listing does not report "([^"]*)"$`, w.stepListingOmits)
+
+	// --- the API ---
+	sc.Step(`^they ask the API for the feature listing$`, w.stepAPIList)
+	sc.Step(`^they turn the feature "([^"]*)" (on|off) for the instance through the API$`, w.stepAPISetInstance)
+	sc.Step(`^they try to turn the feature "([^"]*)" off for the instance through the API$`,
+		w.stepAPITrySetInstanceOff)
+	sc.Step(`^they reset the feature "([^"]*)" for the instance through the API$`, w.stepAPIResetInstance)
+	sc.Step(`^they turn the feature "([^"]*)" (on|off) for their own account through the API$`, w.stepAPISetAccount)
+	sc.Step(`^they try to turn the feature "([^"]*)" off for their own account through the API$`,
+		w.stepAPITrySetAccountOff)
+	sc.Step(`^a request carrying no session tries to turn the feature "([^"]*)" off for the instance$`,
+		w.stepAnonymousSet)
+	sc.Step(`^the listing was served$`, w.stepListingServed)
+	sc.Step(`^the change was accepted$`, w.stepChangeAccepted)
+	sc.Step(`^the attempt to change it is refused as forbidden$`, w.stepRefusedForbidden)
+	sc.Step(`^the attempt is refused as not found$`, w.stepRefusedNotFound)
+	sc.Step(`^the attempt is refused as a bad request$`, w.stepRefusedBadRequest)
+	sc.Step(`^the request is refused as not authenticated$`, w.stepRefusedUnauthenticated)
+	sc.Step(`^the refusal says the feature cannot be changed per account$`, w.stepRefusalMentionsAccount)
+
+	// --- MCP ---
+	sc.Step(`^an MCP client attached to the store over the local stdio transport$`, w.stepStdioClient)
+	sc.Step(`^they call the MCP tool "([^"]*)"$`, w.stepCallTool)
+	sc.Step(`^they call the MCP tool "([^"]*)" to turn "([^"]*)" off for the instance$`, w.stepCallToolSetOff)
+	sc.Step(`^it calls "([^"]*)" to turn "([^"]*)" off for the instance$`, w.stepStdioSetOff)
+	sc.Step(`^they reset the feature "([^"]*)" for the instance through MCP$`, w.stepMCPReset)
+	sc.Step(`^the call succeeds$`, w.stepCallSucceeded)
+	sc.Step(`^the call is refused as forbidden$`, w.stepCallForbidden)
+	sc.Step(`^what the tool reported matches what the API lists$`, w.stepToolMatchesAPI)
+
+	// --- listings, from whichever surface last answered ---
+	sc.Step(`^the listing reports "([^"]*)" as (on|off), from an instance override$`, w.stepListingReportsInstance)
+	sc.Step(`^the listing reports "([^"]*)" as (on|off), from the declared default$`, w.stepListingReportsDefault)
+
+	// --- stored state ---
+	sc.Step(`^no instance-level setting is stored for "([^"]*)"$`, w.stepNoInstanceSetting)
+	sc.Step(`^no account-level setting is stored for "([^"]*)"$`, w.stepNoAccountSetting)
+	sc.Step(`^the instance holds one stored instance-level setting for "([^"]*)"$`, w.stepOneInstanceSetting)
+
+	// --- evaluation and sessions ---
+	sc.Step(`^they evaluate "([^"]*)" with default off$`, w.stepEvaluate)
+	sc.Step(`^they evaluate "([^"]*)" again in the same session$`, w.stepEvaluate)
+	sc.Step(`^they evaluate "([^"]*)" again once the maximum cache age has passed$`, w.stepEvaluateAfterAge)
+	sc.Step(`^"([^"]*)" signs in and evaluates "([^"]*)" with default off$`, w.stepSignInAndEvaluate)
+	sc.Step(`^the feature answers (on|off)$`, w.stepFeatureAnswers)
+	sc.Step(`^"([^"]*)" is answered (on|off)$`, w.stepPersonAnswered)
+	sc.Step(`^they are still signed in$`, w.stepStillSignedIn)
+	sc.Step(`^the instance was not restarted$`, w.stepNotRestarted)
+
+	// --- the audit record ---
+	sc.Step(`^the change was recorded with the key "([^"]*)" and the state it was set to$`, w.stepRecorded)
+	sc.Step(`^the record names the command line as what made the change$`, w.stepRecordSourceCLI)
+	sc.Step(`^the record names "([^"]*)" as who made it$`, w.stepRecordActor)
+	sc.Step(`^the record carries the time the change was made$`, w.stepRecordTime)
+}
+
+// --- instance -------------------------------------------------------------
+
+func (w *operatorWorld) stepInstance() error { return w.boot() }
+
+// stepInstanceNoDatabase stages the case where the command must refuse. The
+// instance still boots against a temp store so the scenario has a working
+// directory to check afterwards; the subprocess is the thing denied a DSN.
+func (w *operatorWorld) stepInstanceNoDatabase() error {
+	if err := w.boot(); err != nil {
+		return err
+	}
+	w.noDSN = true
+	return nil
+}
+
+func (w *operatorWorld) stepMaxCacheAge(seconds int) error {
+	w.maxCacheAge = time.Duration(seconds) * time.Second
+	// The resolver reads its maximum age at construction, so the instance is
+	// restarted against the same store.
+	return w.reboot()
+}
+
+// stepDeclare records the declarations and restarts the instance so they are
+// read the way a real one reads them — from configuration at boot, which is
+// also what the CLI subprocess will read.
+func (w *operatorWorld) stepDeclare(table *godog.Table) error {
+	for i, row := range table.Rows {
+		if i == 0 {
+			continue
+		}
+		cell := func(n int) string { return strings.TrimSpace(row.Cells[n].Value) }
+		w.declared = append(w.declared, entities.FeatureMeta{
+			Key: cell(0), DisplayName: cell(1), Description: cell(2),
+			Default: cell(3) == "on", Manageable: cell(4) == "yes", Grantable: cell(5) == "yes",
+		})
+	}
+	return w.reboot()
+}
+
+func (w *operatorWorld) stepAccountOwner(name, email, password string) error {
+	if err := w.boot(); err != nil {
+		return err
+	}
+	p, err := w.personFor(email, password)
+	if err != nil {
+		return err
+	}
+	if p.accountID == "" {
+		return fmt.Errorf("%q has no account to name %q", email, name)
+	}
+	w.accounts[name] = p.accountID
+	return nil
+}
+
+func (w *operatorWorld) addToAccount(email, accountName, role string) error {
+	accountID, ok := w.accounts[accountName]
+	if !ok {
+		return fmt.Errorf("no account named %q has been staged", accountName)
+	}
+	p, err := w.personFor(email, "correct-horse-battery-staple")
+	if err != nil {
+		return err
+	}
+	if err := w.accountRepo.SaveMember(context.Background(), accountID, p.agentID, role); err != nil {
+		return fmt.Errorf("could not add %q to %q: %w", email, accountName, err)
+	}
+	p.accountID = accountID
+	return nil
+}
+
+func (w *operatorWorld) stepAlsoBelongs(email, accountName, role string) error {
+	return w.addToAccount(email, accountName, role)
+}
+
+func (w *operatorWorld) stepOrdinaryMember(email, accountName string) error {
+	return w.addToAccount(email, accountName, "member")
+}
+
+func (w *operatorWorld) stepSignedIn(email, accountName string) error {
+	accountID, ok := w.accounts[accountName]
+	if !ok {
+		return fmt.Errorf("no account named %q has been staged", accountName)
+	}
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	p.accountID = accountID
+	return w.signIn(p)
+}
+
+// --- staged state ---------------------------------------------------------
+
+func (w *operatorWorld) stepOperatorHasSet(key, onOff string) error {
+	return w.admin.SetInstance(
+		w.operatorCtx(), key, onOff == "on", entities.FeatureChangeSourceCLI)
+}
+
+func (w *operatorWorld) stepAccountHasTurnedOn(accountName, key string) error {
+	accountID, ok := w.accounts[accountName]
+	if !ok {
+		return fmt.Errorf("no account named %q has been staged", accountName)
+	}
+	// Staged through the repository: the service takes the account off the
+	// caller's session, and this step names an account with nobody signed in.
+	return w.settings.SetOverride(
+		context.Background(), repositories.FeatureScopeAccount, accountID, key, true)
+}
+
+// operatorCtx stages instance changes the way the command line does — trusted
+// local caller, no session.
+func (w *operatorWorld) operatorCtx() context.Context {
+	return application.WithLocalTransport(context.Background())
+}
+
+func (w *operatorWorld) stepOperatorHasRun(command string) error {
+	if err := w.runCLI(command); err != nil {
+		return err
+	}
+	if w.lastRun.exitCode != 0 {
+		return fmt.Errorf("staging command %q failed: %s", command, w.lastRun.said())
+	}
+	return nil
+}
+
+func (w *operatorWorld) stepAlreadyAnsweredOn(key string) error {
+	p := w.current
+	if p == nil {
+		return fmt.Errorf("nobody is signed in")
+	}
+	value, _, err := w.resolverEnabled(p, key)
+	if err != nil {
+		return err
+	}
+	if !value {
+		return fmt.Errorf("%q was answered off, want on", p.email)
+	}
+	return nil
+}
+
+// --- the command line -----------------------------------------------------
+
+func (w *operatorWorld) stepRunCLI(command string) error { return w.runCLI(command) }
+
+func (w *operatorWorld) stepCommandSucceeded() error {
+	if w.lastRun.exitCode != 0 {
+		return fmt.Errorf("the command exited %d: %s", w.lastRun.exitCode, w.lastRun.said())
+	}
+	return nil
+}
+
+func (w *operatorWorld) stepCommandFailed() error {
+	if w.lastRun.exitCode == 0 {
+		return fmt.Errorf("the command exited 0, want a failure: %s", w.lastRun.said())
+	}
+	return nil
+}
+
+func (w *operatorWorld) stepFailureNamesDSN() error {
+	said := w.lastRun.said()
+	if !strings.Contains(said, "no database specified") {
+		return fmt.Errorf("the failure does not say a database was missing: %s", said)
+	}
+	if !strings.Contains(said, "DATABASE_DSN") || !strings.Contains(said, "--database-dsn") {
+		return fmt.Errorf("the failure does not name how to supply one: %s", said)
+	}
+	return nil
+}
+
+func (w *operatorWorld) stepFailureNamesKey(key string) error {
+	if !strings.Contains(w.lastRun.said(), key) {
+		return fmt.Errorf("the failure does not name %q: %s", key, w.lastRun.said())
+	}
+	return nil
+}
+
+// stepNoStrayDatabase is the assertion that makes the refusal worth having: a
+// command that guessed a store would leave one here.
+func (w *operatorWorld) stepNoStrayDatabase() error {
+	entries, err := osReadDir(w.workDir)
+	if err != nil {
+		return err
+	}
+	for _, name := range entries {
+		if strings.HasSuffix(name, ".db") || strings.HasSuffix(name, ".db-wal") ||
+			strings.HasSuffix(name, ".db-shm") {
+			return fmt.Errorf("the command left %q behind in the directory it ran from", name)
+		}
+	}
+	return nil
+}
+
+func (w *operatorWorld) stepListingNamesDisplayNames() error {
+	statuses, err := w.currentListing()
+	if err != nil {
+		return err
+	}
+	if statuses == nil {
+		for _, m := range w.declared {
+			if !strings.Contains(w.lastRun.said(), m.DisplayName) {
+				return fmt.Errorf("the listing does not name %q by its display name %q",
+					m.Key, m.DisplayName)
+			}
+		}
+		return nil
+	}
+	for _, m := range w.declared {
+		s, ok := findStatus(statuses, m.Key)
+		if !ok {
+			return fmt.Errorf("the listing does not include %q", m.Key)
+		}
+		if s.DisplayName != m.DisplayName {
+			return fmt.Errorf("%q is named %q, want its display name %q",
+				m.Key, s.DisplayName, m.DisplayName)
+		}
+	}
+	return nil
+}
+
+// stepListingOmits asks for a listing rather than searching the last command's
+// output — a refusal names the key it refused, so searching that text would
+// fail for the wrong reason.
+func (w *operatorWorld) stepListingOmits(key string) error {
+	statuses, err := w.admin.Listing(w.operatorCtx())
+	if err != nil {
+		return err
+	}
+	if _, present := findStatus(statuses, key); present {
+		return fmt.Errorf("the listing reports %q, which nothing declared", key)
+	}
+	return nil
+}
+
+// --- the API --------------------------------------------------------------
+
+func (w *operatorWorld) stepAPIList() error {
+	return w.request(w.current, http.MethodGet, "/api/features", nil)
+}
+
+func (w *operatorWorld) stepAPISetInstance(key, onOff string) error {
+	return w.request(w.current, http.MethodPut, "/api/features/"+key+"/instance",
+		map[string]any{"enabled": onOff == "on"})
+}
+
+func (w *operatorWorld) stepAPITrySetInstanceOff(key string) error {
+	return w.stepAPISetInstance(key, "off")
+}
+
+func (w *operatorWorld) stepAPIResetInstance(key string) error {
+	return w.request(w.current, http.MethodDelete, "/api/features/"+key+"/instance", nil)
+}
+
+func (w *operatorWorld) stepAPISetAccount(key, onOff string) error {
+	return w.request(w.current, http.MethodPut, "/api/features/"+key+"/account",
+		map[string]any{"enabled": onOff == "on"})
+}
+
+func (w *operatorWorld) stepAPITrySetAccountOff(key string) error {
+	return w.stepAPISetAccount(key, "off")
+}
+
+func (w *operatorWorld) stepAnonymousSet(key string) error {
+	return w.request(nil, http.MethodPut, "/api/features/"+key+"/instance",
+		map[string]any{"enabled": false})
+}
+
+func (w *operatorWorld) stepListingServed() error {
+	if w.listingStatus != http.StatusOK {
+		return fmt.Errorf("the listing answered %d, want 200: %s", w.listingStatus, string(w.listingBody))
+	}
+	return nil
+}
+
+// stepChangeAccepted works for whichever surface made the change. The contract
+// phrases it the same way after an API call and after an MCP tool call, and it
+// means the same thing both times.
+func (w *operatorWorld) stepChangeAccepted() error {
+	if w.changeStatus == 0 && w.lastMCPOut != nil || w.changeStatus == 0 && w.lastMCPErr != nil {
+		if w.lastMCPErr != nil {
+			return fmt.Errorf("the change was refused: %v", w.lastMCPErr)
+		}
+		return nil
+	}
+	return w.expectChange(http.StatusOK)
+}
+
+func (w *operatorWorld) stepRefusedForbidden() error {
+	return w.expectChange(http.StatusForbidden)
+}
+
+func (w *operatorWorld) stepRefusedNotFound() error { return w.expectChange(http.StatusNotFound) }
+
+func (w *operatorWorld) stepRefusedBadRequest() error {
+	return w.expectChange(http.StatusBadRequest)
+}
+
+func (w *operatorWorld) stepRefusedUnauthenticated() error {
+	return w.expectChange(http.StatusUnauthorized)
+}
+
+// expectChange asserts on the last WRITE, not on whatever call happened last.
+// A scenario that reads the listing and is then refused a change asserts on
+// both, and a single "last status" would report the refusal for both.
+func (w *operatorWorld) expectChange(want int) error {
+	if w.changeStatus != want {
+		return fmt.Errorf("the change answered %d, want %d: %s",
+			w.changeStatus, want, string(w.lastBody))
+	}
+	return nil
+}
+
+func (w *operatorWorld) stepRefusalMentionsAccount() error {
+	if !strings.Contains(string(w.lastBody), "cannot be changed per account") {
+		return fmt.Errorf("the refusal does not say why: %s", string(w.lastBody))
+	}
+	return nil
+}
+
+// --- MCP ------------------------------------------------------------------
+
+func (w *operatorWorld) stepStdioClient() error {
+	w.stdio = true
+	return nil
+}
+
+func (w *operatorWorld) stepCallTool(tool string) error {
+	return w.callMCP(w.current, false, tool, map[string]any{})
+}
+
+func (w *operatorWorld) stepCallToolSetOff(tool, key string) error {
+	return w.callMCP(w.current, false, tool, map[string]any{"key": key, "enabled": false})
+}
+
+func (w *operatorWorld) stepStdioSetOff(tool, key string) error {
+	return w.callMCP(nil, true, tool, map[string]any{"key": key, "enabled": false})
+}
+
+func (w *operatorWorld) stepMCPReset(key string) error {
+	return w.callMCP(w.current, w.stdio, "feature_reset", map[string]any{"key": key})
+}
+
+func (w *operatorWorld) stepCallSucceeded() error {
+	if w.lastMCPErr != nil {
+		return fmt.Errorf("the tool call failed: %v", w.lastMCPErr)
+	}
+	return nil
+}
+
+func (w *operatorWorld) stepCallForbidden() error {
+	if w.lastMCPErr == nil {
+		return fmt.Errorf("the tool call succeeded, want a refusal")
+	}
+	if !strings.Contains(w.lastMCPErr.Error(), "forbidden") &&
+		!strings.Contains(w.lastMCPErr.Error(), "owner or admin") {
+		return fmt.Errorf("the refusal does not read as forbidden: %v", w.lastMCPErr)
+	}
+	return nil
+}
+
+// stepToolMatchesAPI is what stops the three surfaces drifting: the same
+// question asked two ways must come back the same.
+func (w *operatorWorld) stepToolMatchesAPI() error {
+	fromTool, err := w.mcpFeatures()
+	if err != nil {
+		return err
+	}
+	if err := w.request(w.current, http.MethodGet, "/api/features", nil); err != nil {
+		return err
+	}
+	fromAPI, err := w.listingFromBody()
+	if err != nil {
+		return err
+	}
+	if len(fromTool) != len(fromAPI) {
+		return fmt.Errorf("the tool reported %d features, the API lists %d", len(fromTool), len(fromAPI))
+	}
+	for _, t := range fromTool {
+		a, ok := findStatus(fromAPI, t.Key)
+		if !ok {
+			return fmt.Errorf("the tool reported %q, the API does not list it", t.Key)
+		}
+		if a.Enabled != t.Enabled || a.Source != t.Source {
+			return fmt.Errorf("%q: the tool says %v/%s, the API says %v/%s",
+				t.Key, t.Enabled, t.Source, a.Enabled, a.Source)
+		}
+	}
+	return nil
+}
+
+// --- listings -------------------------------------------------------------
+
+// currentListing takes whichever surface last answered. The contract phrases
+// the assertion the same way after a command, an API call and a tool call, and
+// it means the same thing each time.
+// currentListing takes whichever surface last answered.
+//
+// When the last command printed an actual listing, that text is what the
+// assertion checks. Otherwise "the listing reports X" means what a listing
+// WOULD report — several scenarios flip a feature and then assert on the
+// listing without ever asking for one, and reading that as "search the flip's
+// output" would make the assertion pass on a message that merely contains the
+// key.
+func (w *operatorWorld) currentListing() ([]entities.FeatureStatus, error) {
+	if w.lastMCPOut != nil {
+		return w.mcpFeatures()
+	}
+	if len(w.lastBody) > 0 {
+		return w.listingFromBody()
+	}
+	if strings.Contains(w.lastRun.said(), "KEY") {
+		return nil, nil // a command-line listing, asserted against its text
+	}
+	return w.admin.Listing(w.operatorCtx())
+}
+
+func (w *operatorWorld) stepListingReportsInstance(key, onOff string) error {
+	return w.assertListing(key, onOff, "instance")
+}
+
+func (w *operatorWorld) stepListingReportsDefault(key, onOff string) error {
+	return w.assertListing(key, onOff, "default")
+}
+
+func (w *operatorWorld) assertListing(key, onOff, wantSource string) error {
+	statuses, err := w.currentListing()
+	if err != nil {
+		return err
+	}
+	if statuses == nil {
+		// A command-line listing: assert against what it printed.
+		said := w.lastRun.said()
+		wantState := onOff
+		wantPhrase := map[string]string{
+			"instance": "instance override",
+			"account":  "account override",
+			"default":  "declared default",
+		}[wantSource]
+		for _, line := range strings.Split(said, "\n") {
+			if !strings.HasPrefix(line, key) {
+				continue
+			}
+			if !strings.Contains(line, wantState) || !strings.Contains(line, wantPhrase) {
+				return fmt.Errorf("the listing row for %q reads %q, want %s from the %s",
+					key, strings.TrimSpace(line), wantState, wantPhrase)
+			}
+			return nil
+		}
+		return fmt.Errorf("the listing has no row for %q: %s", key, said)
+	}
+
+	s, ok := findStatus(statuses, key)
+	if !ok {
+		return fmt.Errorf("the listing does not include %q", key)
+	}
+	if s.Enabled != (onOff == "on") {
+		return fmt.Errorf("%q is reported %v, want %s", key, s.Enabled, onOff)
+	}
+	if s.Source != wantSource {
+		return fmt.Errorf("%q is reported from the %s, want the %s", key, s.Source, wantSource)
+	}
+	return nil
+}
+
+// --- stored state ---------------------------------------------------------
+
+func (w *operatorWorld) stepNoInstanceSetting(key string) error {
+	overrides, err := w.settings.InstanceOverrides(context.Background())
+	if err != nil {
+		return err
+	}
+	if _, present := overrides[key]; present {
+		return fmt.Errorf("an instance-level setting is stored for %q, want none", key)
+	}
+	return nil
+}
+
+func (w *operatorWorld) stepNoAccountSetting(key string) error {
+	if w.current == nil {
+		return fmt.Errorf("nobody is signed in")
+	}
+	overrides, err := w.settings.AccountOverrides(context.Background(), w.current.accountID)
+	if err != nil {
+		return err
+	}
+	if _, present := overrides[key]; present {
+		return fmt.Errorf("an account-level setting is stored for %q, want none", key)
+	}
+	return nil
+}
+
+// stepOneInstanceSetting counts rows directly. The repository returns a map,
+// which collapses duplicates and so cannot answer "one" — and "one" is the
+// assertion, because a second flip that inserted rather than replaced would
+// leave two rows and resolve identically.
+func (w *operatorWorld) stepOneInstanceSetting(key string) error {
+	count, err := w.countInstanceRows(key)
+	if err != nil {
+		return err
+	}
+	if count != 1 {
+		return fmt.Errorf("%d instance-level rows are stored for %q, want exactly 1", count, key)
+	}
+	return nil
+}
+
+// --- evaluation and sessions ----------------------------------------------
+
+func (w *operatorWorld) stepEvaluate(key string) error {
+	if w.current == nil {
+		return fmt.Errorf("nobody is signed in")
+	}
+	value, _, err := w.resolverEnabled(w.current, key)
+	if err != nil {
+		return err
+	}
+	w.lastEvalBool = &value
+	w.lastEvaluatedKey = key
+	return nil
+}
+
+func (w *operatorWorld) stepEvaluateAfterAge(key string) error {
+	time.Sleep(w.maxCacheAge + 250*time.Millisecond)
+	return w.stepEvaluate(key)
+}
+
+func (w *operatorWorld) stepSignInAndEvaluate(email, key string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	if err := w.signIn(p); err != nil {
+		return err
+	}
+	value, _, err := w.resolverEnabled(p, key)
+	if err != nil {
+		return err
+	}
+	w.lastEvalBool = &value
+	w.lastEvaluatedKey = key
+	return nil
+}
+
+func (w *operatorWorld) stepFeatureAnswers(onOff string) error {
+	if w.lastEvalBool == nil {
+		return fmt.Errorf("nothing has been evaluated")
+	}
+	if *w.lastEvalBool != (onOff == "on") {
+		return fmt.Errorf("the feature answered %v, want %s", *w.lastEvalBool, onOff)
+	}
+	return nil
+}
+
+// stepPersonAnswered resolves for the person named, rather than reading back
+// whatever the last evaluation produced. A scenario can name two people and
+// evaluate only one of them explicitly, and reading the shared last answer
+// would report the same value for both.
+func (w *operatorWorld) stepPersonAnswered(email, onOff string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	value, declared, err := w.resolverEnabled(p, w.lastEvaluatedKey)
+	if err != nil {
+		return err
+	}
+	if !declared {
+		return fmt.Errorf("nothing declares %q", w.lastEvaluatedKey)
+	}
+	if value != (onOff == "on") {
+		return fmt.Errorf("%q was answered %v for %q, want %s",
+			email, value, w.lastEvaluatedKey, onOff)
+	}
+	return nil
+}
+
+func (w *operatorWorld) stepStillSignedIn() error {
+	if w.current == nil {
+		return fmt.Errorf("nobody is signed in")
+	}
+	for i, id := range w.current.sessionIDs {
+		info, err := w.authService.ValidateSession(context.Background(), id)
+		if err != nil || info == nil {
+			return fmt.Errorf("session %d of %q is no longer valid: %w — changing a feature "+
+				"must never sign anyone out", i+1, w.current.email, err)
+		}
+	}
+	return nil
+}
+
+// stepNotRestarted holds the instance the scenario has been using to account.
+// The point of the scenario is that a command-line flip reaches a server that
+// stayed up, so a harness that quietly rebooted would prove nothing.
+func (w *operatorWorld) stepNotRestarted() error {
+	if w.app == nil {
+		return fmt.Errorf("the instance is not running; the scenario needs the one it started with")
+	}
+	return nil
+}
+
+// --- the audit record -----------------------------------------------------
+
+func (w *operatorWorld) stepRecorded(key string) error {
+	event, err := w.lastFeatureChange()
+	if err != nil {
+		return err
+	}
+	if event.Key != key {
+		return fmt.Errorf("the record names %q, want %q", event.Key, key)
+	}
+	if event.State == "" {
+		return fmt.Errorf("the record carries no state for %q", key)
+	}
+	return nil
+}
+
+func (w *operatorWorld) stepRecordSourceCLI() error {
+	event, err := w.lastFeatureChange()
+	if err != nil {
+		return err
+	}
+	if event.Source != entities.FeatureChangeSourceCLI {
+		return fmt.Errorf("the record names %q as the source, want %q",
+			event.Source, entities.FeatureChangeSourceCLI)
+	}
+	return nil
+}
+
+func (w *operatorWorld) stepRecordActor(email string) error {
+	event, err := w.lastFeatureChange()
+	if err != nil {
+		return err
+	}
+	if event.ActorEmail != email {
+		return fmt.Errorf("the record names %q as who made the change, want %q — a record "+
+			"that answers \"who\" with an opaque id is one nobody can read later",
+			event.ActorEmail, email)
+	}
+	return nil
+}
+
+func (w *operatorWorld) stepRecordTime() error {
+	event, err := w.lastFeatureChange()
+	if err != nil {
+		return err
+	}
+	if event.Timestamp.IsZero() {
+		return fmt.Errorf("the record carries no time")
+	}
+	return nil
+}

--- a/tests/e2e/feature_operator_world_test.go
+++ b/tests/e2e/feature_operator_world_test.go
@@ -84,6 +84,12 @@ type operatorWorld struct {
 
 	maxCacheAge time.Duration
 	declared    []entities.FeatureMeta
+	// primaryAccountID names the account whose owners and admins may change
+	// instance state. Set once the first account is staged, so the member
+	// scenarios reach the ROLE check rather than being refused earlier for an
+	// ambiguous instance — which would let the role check be deleted entirely
+	// with the suite still green.
+	primaryAccountID string
 
 	accounts map[string]string
 	people   map[string]*featurePerson
@@ -194,6 +200,7 @@ func (w *operatorWorld) boot() error {
 	// processes can only agree about which features exist by reading the same
 	// declarations, and nothing is persisted for them to share.
 	cfg.Features.Declared = append([]entities.FeatureMeta(nil), w.declared...)
+	cfg.Features.PrimaryAccountID = w.primaryAccountID
 
 	app := fx.New(
 		fx.NopLogger,
@@ -519,21 +526,6 @@ func findStatus(statuses []entities.FeatureStatus, key string) (entities.Feature
 	return entities.FeatureStatus{}, false
 }
 
-// sourcePhrase maps the contract's wording onto the layer names the resolver
-// reports.
-func sourcePhrase(phrase string) string {
-	switch {
-	case strings.Contains(phrase, "instance"):
-		return "instance"
-	case strings.Contains(phrase, "account"):
-		return "account"
-	case strings.Contains(phrase, "grant"):
-		return "grant"
-	default:
-		return "default"
-	}
-}
-
 // --- helpers the steps use ------------------------------------------------
 
 // resolverEnabled asks the resolver the way a call site would.
@@ -562,9 +554,10 @@ func (w *operatorWorld) lastFeatureChange() (entities.FeatureChanged, error) {
 	if err := json.Unmarshal(raw, &event); err != nil {
 		return entities.FeatureChanged{}, fmt.Errorf("could not read the recorded change: %w", err)
 	}
-	if event.Timestamp.IsZero() {
-		event.Timestamp = last.CreatedAt
-	}
+	// Deliberately NOT backfilled from the row's CreatedAt. Filling the
+	// timestamp in here would mean the "the record carries the time" step
+	// checked a value the harness had just supplied, and it would pass with
+	// the payload's own timestamp removed entirely.
 	return event, nil
 }
 

--- a/tests/e2e/feature_operator_world_test.go
+++ b/tests/e2e/feature_operator_world_test.go
@@ -1,0 +1,601 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cucumber/godog"
+	"github.com/labstack/echo/v4"
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.uber.org/fx"
+	gormlib "gorm.io/gorm"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
+	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
+	authentities "github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
+	authhttp "github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/http"
+	"github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/session"
+
+	"github.com/wepala/weos/v3/api/handlers"
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/application/presets"
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
+	"github.com/wepala/weos/v3/internal/config"
+	mcpserver "github.com/wepala/weos/v3/internal/mcp"
+)
+
+// TestFeatureOperatorSwitch runs the acceptance contract for story #482.
+//
+//	GODOG_TAGS=@story-482 go test ./tests/e2e/ -run TestFeatureOperatorSwitch
+func TestFeatureOperatorSwitch(t *testing.T) {
+	tags := "~@wip"
+	if v := os.Getenv("GODOG_TAGS"); v != "" {
+		tags = v
+	}
+	suite := godog.TestSuite{
+		ScenarioInitializer: initFeatureOperatorScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"features/feature_flag_operator_switch.feature"},
+			Tags:     tags,
+			Strict:   true,
+			TestingT: t,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("operator feature switch acceptance scenarios failed")
+	}
+}
+
+// operatorWorld is one scenario's instance, plus everything needed to reach it
+// from the three surfaces the story adds.
+type operatorWorld struct {
+	app    *fx.App
+	tmpDir string
+	dsn    string
+	server *httptest.Server
+
+	registry  *application.FeatureRegistry
+	admin     *application.FeatureAdminService
+	resolver  *application.FeatureResolver
+	db        *gormlib.DB
+	settings  repositories.FeatureSettingsRepository
+	eventLog  repositories.EventLogRepository
+	resources application.ResourceService
+	rts       application.ResourceTypeService
+
+	authService    authapp.AuthenticationService
+	accountRepo    authrepos.AccountRepository
+	credRepo       authrepos.CredentialRepository
+	sessionManager session.SessionManager
+	logger         entities.Logger
+
+	maxCacheAge time.Duration
+	declared    []entities.FeatureMeta
+
+	accounts map[string]string
+	people   map[string]*featurePerson
+	current  *featurePerson
+
+	// workDir is where a CLI subprocess runs, so "leaves no database behind in
+	// the directory it ran from" can be checked against a directory nothing
+	// else writes to.
+	workDir string
+	// noDSN stages the instance-with-no-database case: the subprocess gets an
+	// empty DATABASE_DSN and no flag.
+	noDSN bool
+	// stdio marks the MCP client as attached over the local transport.
+	stdio   bool
+	lastRun commandRun
+
+	// The last answer from each surface, so the assertions can be phrased the
+	// way the contract phrases them. Reads and writes are tracked separately
+	// because a scenario can do both before asserting on either — a member
+	// reads the listing, is refused a change, and then both are checked.
+	listingStatus    int
+	changeStatus     int
+	lastStatus       int
+	lastBody         []byte
+	listingBody      []byte
+	lastListing      []entities.FeatureStatus
+	lastMCPOut       map[string]any
+	lastMCPErr       error
+	lastEvalBool     *bool
+	lastEvaluatedKey string
+
+	envBefore map[string]*string
+}
+
+func (w *operatorWorld) teardown() {
+	if w.server != nil {
+		w.server.Close()
+		w.server = nil
+	}
+	if w.app != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		defer cancel()
+		_ = w.app.Stop(ctx)
+		w.app = nil
+	}
+	for k, v := range w.envBefore {
+		if v == nil {
+			os.Unsetenv(k)
+		} else {
+			os.Setenv(k, *v)
+		}
+	}
+	if w.tmpDir != "" {
+		os.RemoveAll(w.tmpDir)
+		w.tmpDir = ""
+	}
+}
+
+func (w *operatorWorld) setEnv(key string, value *string) {
+	if w.envBefore == nil {
+		w.envBefore = map[string]*string{}
+	}
+	if _, seen := w.envBefore[key]; !seen {
+		if old, ok := os.LookupEnv(key); ok {
+			w.envBefore[key] = &old
+		} else {
+			w.envBefore[key] = nil
+		}
+	}
+	if value == nil {
+		os.Unsetenv(key)
+		return
+	}
+	os.Setenv(key, *value)
+}
+
+// boot starts the instance and mounts the API the admin UI calls.
+func (w *operatorWorld) boot() error {
+	if w.app != nil {
+		return nil
+	}
+	if w.tmpDir == "" {
+		dir, err := os.MkdirTemp("", "weos-feature-operator-e2e-")
+		if err != nil {
+			return fmt.Errorf("could not create a temp dir: %w", err)
+		}
+		w.tmpDir = dir
+		w.dsn = filepath.Join(dir, "operator.db")
+		w.workDir = filepath.Join(dir, "cwd")
+		if err := os.MkdirAll(w.workDir, 0o755); err != nil {
+			return fmt.Errorf("could not create the command working dir: %w", err)
+		}
+	}
+	pw := "true"
+	w.setEnv("PASSWORD_AUTH_ENABLED", &pw)
+	w.setEnv("GOOGLE_CLIENT_ID", nil)
+	w.setEnv("GOOGLE_CLIENT_SECRET", nil)
+
+	cfg := config.Default()
+	cfg.LoadFromEnvironment()
+	cfg.DatabaseDSN = w.dsn
+	cfg.LogLevel = "error"
+	if w.maxCacheAge > 0 {
+		cfg.Features.CacheMaxAge = w.maxCacheAge
+	}
+	// Declared through the environment rather than by calling Register, so the
+	// CLI subprocess sees exactly the features this instance does. Two
+	// processes can only agree about which features exist by reading the same
+	// declarations, and nothing is persisted for them to share.
+	cfg.Features.Declared = append([]entities.FeatureMeta(nil), w.declared...)
+
+	app := fx.New(
+		fx.NopLogger,
+		application.Module(cfg, presets.NewDefaultRegistry()),
+		fx.Populate(&w.registry, &w.admin, &w.resolver, &w.settings, &w.eventLog),
+		fx.Populate(&w.db),
+		fx.Populate(&w.resources, &w.rts),
+		fx.Populate(&w.authService, &w.accountRepo, &w.credRepo, &w.sessionManager, &w.logger),
+	)
+	startCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+	defer cancel()
+	if err := app.Start(startCtx); err != nil {
+		return fmt.Errorf("failed to start app: %w", err)
+	}
+	w.app = app
+
+	return w.mountAPI()
+}
+
+// mountAPI builds the HTTP surface.
+//
+// RequireAuth is mounted explicitly rather than taken from serve.go's wiring.
+// serve.go mounts it only when OAuth is configured and otherwise mounts
+// SoftAuth, which never answers 401 — so the "a request carrying no session is
+// refused as not authenticated" scenario would be unprovable against the
+// default password-only wiring. account_scoped_sessions_test.go builds its own
+// echo instance for exactly this reason.
+func (w *operatorWorld) mountAPI() error {
+	e := echo.New()
+	e.HideBanner = true
+	api := e.Group("/api")
+
+	protected := api.Group("", echo.WrapMiddleware(authhttp.RequireAuth(w.sessionManager, w.authService)))
+	fh := handlers.NewFeatureHandler(handlers.FeatureHandlerConfig{Admin: w.admin, Logger: w.logger})
+	protected.GET("/features", fh.List)
+	protected.PUT("/features/:key/instance", fh.SetInstance)
+	protected.DELETE("/features/:key/instance", fh.ResetInstance)
+	protected.PUT("/features/:key/account", fh.SetAccount)
+	protected.DELETE("/features/:key/account", fh.ResetAccount)
+
+	w.server = httptest.NewServer(e)
+	return nil
+}
+
+func (w *operatorWorld) reboot() error {
+	if w.server != nil {
+		w.server.Close()
+		w.server = nil
+	}
+	if w.app != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		defer cancel()
+		if err := w.app.Stop(ctx); err != nil {
+			return fmt.Errorf("could not stop the app to reconfigure it: %w", err)
+		}
+		w.app = nil
+	}
+	return w.boot()
+}
+
+// --- people ---------------------------------------------------------------
+
+func (w *operatorWorld) personFor(email, password string) (*featurePerson, error) {
+	if p, ok := w.people[email]; ok {
+		return p, nil
+	}
+	ctx := context.Background()
+	agent, _, account, err := w.authService.RegisterPassword(ctx, email, displayNameForFeature(email), password)
+	if err != nil {
+		return nil, fmt.Errorf("could not create %q: %w", email, err)
+	}
+	p := &featurePerson{email: email, password: password, agentID: agent.GetID()}
+	if account != nil {
+		p.accountID = account.GetID()
+		if err := w.accountRepo.SaveMember(ctx, account.GetID(), agent.GetID(), authentities.RoleOwner); err != nil {
+			return nil, fmt.Errorf("could not record %q as owner: %w", email, err)
+		}
+	}
+	w.people[email] = p
+	return p, nil
+}
+
+func (w *operatorWorld) person(email string) (*featurePerson, error) {
+	p, ok := w.people[email]
+	if !ok {
+		return nil, fmt.Errorf("no person named %q has been staged", email)
+	}
+	return p, nil
+}
+
+func (w *operatorWorld) signIn(p *featurePerson) error {
+	ctx := context.Background()
+	creds, err := w.credRepo.FindByAgent(ctx, p.agentID)
+	if err != nil || len(creds) == 0 {
+		return fmt.Errorf("could not find credentials for %q: %w", p.email, err)
+	}
+	s, err := w.authService.CreateSession(ctx, p.agentID, p.accountID, creds[0].GetID(),
+		"127.0.0.1", "godog", time.Hour)
+	if err != nil {
+		return fmt.Errorf("could not sign %q in: %w", p.email, err)
+	}
+	p.sessionIDs = append(p.sessionIDs, s.GetID())
+	w.current = p
+	return nil
+}
+
+func (w *operatorWorld) ctxFor(p *featurePerson) context.Context {
+	return auth.ContextWithAgent(context.Background(),
+		&auth.Identity{AgentID: p.agentID, ActiveAccountID: p.accountID})
+}
+
+// --- HTTP -----------------------------------------------------------------
+
+// request makes an authenticated call as p, or an anonymous one when p is nil.
+func (w *operatorWorld) request(p *featurePerson, method, path string, body any) error {
+	var reader *bytes.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		reader = bytes.NewReader(raw)
+	} else {
+		reader = bytes.NewReader(nil)
+	}
+	req, err := http.NewRequest(method, w.server.URL+path, reader)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if p != nil && len(p.sessionIDs) > 0 {
+		header, err := w.cookieFor(p)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Cookie", header)
+	}
+	resp, err := w.server.Client().Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(resp.Body); err != nil {
+		return err
+	}
+	w.lastStatus = resp.StatusCode
+	w.lastBody = buf.Bytes()
+	w.lastListing = nil
+	if method == http.MethodGet {
+		w.listingStatus = resp.StatusCode
+		w.listingBody = buf.Bytes()
+	} else {
+		w.changeStatus = resp.StatusCode
+	}
+	return nil
+}
+
+// cookieFor builds the session cookie header pericarp's RequireAuth reads.
+func (w *operatorWorld) cookieFor(p *featurePerson) (string, error) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	err := w.sessionManager.CreateHTTPSession(rec, req, session.SessionData{
+		SessionID: p.sessionIDs[len(p.sessionIDs)-1],
+		AgentID:   p.agentID,
+		AccountID: p.accountID,
+	})
+	if err != nil {
+		return "", fmt.Errorf("could not build a session cookie for %q: %w", p.email, err)
+	}
+	return sessionCookieHeader(rec.Result().Cookies()), nil
+}
+
+// listingFromBody decodes the envelope the API answers with.
+func (w *operatorWorld) listingFromBody() ([]entities.FeatureStatus, error) {
+	if w.lastListing != nil {
+		return w.lastListing, nil
+	}
+	var envelope struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(w.lastBody, &envelope); err != nil {
+		return nil, fmt.Errorf("could not read the response: %w (%s)", err, string(w.lastBody))
+	}
+	var many []entities.FeatureStatus
+	if err := json.Unmarshal(envelope.Data, &many); err == nil {
+		w.lastListing = many
+		return many, nil
+	}
+	var one entities.FeatureStatus
+	if err := json.Unmarshal(envelope.Data, &one); err != nil {
+		return nil, fmt.Errorf("could not read the feature data: %w (%s)", err, string(envelope.Data))
+	}
+	w.lastListing = []entities.FeatureStatus{one}
+	return w.lastListing, nil
+}
+
+// --- CLI ------------------------------------------------------------------
+
+// runCLI runs the real binary against the same store, as a separate process —
+// which is the point of the command-line scenarios.
+func (w *operatorWorld) runCLI(command string) error {
+	binary, err := weosBinary()
+	if err != nil {
+		return err
+	}
+	args := strings.Fields(command)
+	if len(args) > 0 && args[0] == "weos" {
+		args = args[1:]
+	}
+	cmd := exec.Command(binary, args...)
+	cmd.Dir = w.workDir
+	dsn := "DATABASE_DSN=" + w.dsn
+	if w.noDSN {
+		dsn = "DATABASE_DSN="
+	}
+	env := append(os.Environ(), dsn, "LOG_LEVEL=error")
+	if declared, err := json.Marshal(w.declared); err == nil && len(w.declared) > 0 {
+		env = append(env, "FEATURES="+string(declared))
+	}
+	cmd.Env = env
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+	w.lastRun = commandRun{stdout: stdout.String(), stderr: stderr.String(), args: args}
+	if runErr != nil {
+		if exit, ok := runErr.(*exec.ExitError); ok {
+			w.lastRun.exitCode = exit.ExitCode()
+			return nil
+		}
+		return fmt.Errorf("could not run the command: %w", runErr)
+	}
+	return nil
+}
+
+// --- MCP ------------------------------------------------------------------
+
+// callMCP drives the real tool over an in-memory transport.
+//
+// local decides whether the session is marked as the stdio transport. The
+// marker normally comes from mcp.Run(), which an in-process test does not go
+// through, so the harness applies it deliberately — a harness that forgot
+// would fail the stdio scenario for the wrong reason.
+func (w *operatorWorld) callMCP(
+	p *featurePerson, local bool, tool string, args map[string]any,
+) error {
+	server, err := mcpserver.NewMCPServer(w.rts, w.resources, nil, nil, nil, w.admin, []string{"feature"})
+	if err != nil {
+		return fmt.Errorf("could not build the MCP server: %w", err)
+	}
+
+	ctx := context.Background()
+	if p != nil {
+		ctx = w.ctxFor(p)
+	}
+	if local {
+		ctx = application.WithLocalTransport(ctx)
+	}
+	serverTransport, clientTransport := gomcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		return fmt.Errorf("could not connect the MCP server: %w", err)
+	}
+	defer serverSession.Close()
+
+	client := gomcp.NewClient(&gomcp.Implementation{Name: "godog", Version: "0.1.0"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		return fmt.Errorf("could not connect the MCP client: %w", err)
+	}
+	defer clientSession.Close()
+
+	res, callErr := clientSession.CallTool(ctx, &gomcp.CallToolParams{Name: tool, Arguments: args})
+	w.lastMCPErr = callErr
+	w.lastMCPOut = nil
+	if callErr == nil && res != nil {
+		if res.IsError {
+			w.lastMCPErr = fmt.Errorf("%s", mcpText(res))
+		} else if res.StructuredContent != nil {
+			if m, ok := res.StructuredContent.(map[string]any); ok {
+				w.lastMCPOut = m
+			}
+		}
+	}
+	return nil
+}
+
+func mcpText(res *gomcp.CallToolResult) string {
+	var b strings.Builder
+	for _, c := range res.Content {
+		if tc, ok := c.(*gomcp.TextContent); ok {
+			b.WriteString(tc.Text)
+		}
+	}
+	return b.String()
+}
+
+// mcpFeatures pulls the listing out of whatever the last tool returned.
+func (w *operatorWorld) mcpFeatures() ([]entities.FeatureStatus, error) {
+	if w.lastMCPOut == nil {
+		return nil, fmt.Errorf("the last MCP call returned no structured output")
+	}
+	raw, err := json.Marshal(w.lastMCPOut["features"])
+	if err != nil {
+		return nil, err
+	}
+	var out []entities.FeatureStatus
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("could not read the tool's features: %w", err)
+	}
+	return out, nil
+}
+
+// --- shared assertions ----------------------------------------------------
+
+func findStatus(statuses []entities.FeatureStatus, key string) (entities.FeatureStatus, bool) {
+	for _, s := range statuses {
+		if s.Key == key {
+			return s, true
+		}
+	}
+	return entities.FeatureStatus{}, false
+}
+
+// sourcePhrase maps the contract's wording onto the layer names the resolver
+// reports.
+func sourcePhrase(phrase string) string {
+	switch {
+	case strings.Contains(phrase, "instance"):
+		return "instance"
+	case strings.Contains(phrase, "account"):
+		return "account"
+	case strings.Contains(phrase, "grant"):
+		return "grant"
+	default:
+		return "default"
+	}
+}
+
+// --- helpers the steps use ------------------------------------------------
+
+// resolverEnabled asks the resolver the way a call site would.
+func (w *operatorWorld) resolverEnabled(p *featurePerson, key string) (bool, bool, error) {
+	return w.resolver.Enabled(w.ctxFor(p), key)
+}
+
+// lastFeatureChange reads the most recent audit record out of the event log.
+func (w *operatorWorld) lastFeatureChange() (entities.FeatureChanged, error) {
+	page, err := w.eventLog.Query(context.Background(), repositories.EventLogFilter{
+		EventType: entities.FeatureChanged{}.EventType(),
+		Limit:     100,
+	})
+	if err != nil {
+		return entities.FeatureChanged{}, fmt.Errorf("could not read the change log: %w", err)
+	}
+	if page == nil || len(page.Data) == 0 {
+		return entities.FeatureChanged{}, fmt.Errorf("no feature change was recorded at all")
+	}
+	last := page.Data[len(page.Data)-1]
+	raw, err := json.Marshal(last.Payload)
+	if err != nil {
+		return entities.FeatureChanged{}, err
+	}
+	var event entities.FeatureChanged
+	if err := json.Unmarshal(raw, &event); err != nil {
+		return entities.FeatureChanged{}, fmt.Errorf("could not read the recorded change: %w", err)
+	}
+	if event.Timestamp.IsZero() {
+		event.Timestamp = last.CreatedAt
+	}
+	return event, nil
+}
+
+// countInstanceRows counts stored rows directly.
+//
+// The repository returns a map keyed by feature, which collapses duplicates —
+// so it can say whether a setting exists but not how many rows back it. "One"
+// is the assertion worth making: a second flip that inserted instead of
+// replacing would leave two rows and resolve identically, so nothing else
+// would ever notice.
+func (w *operatorWorld) countInstanceRows(key string) (int64, error) {
+	var count int64
+	err := w.db.Table("feature_settings").
+		Where("scope_type = ? AND scope_id = ? AND feature_key = ?",
+			repositories.FeatureScopeInstance, "", key).
+		Count(&count).Error
+	if err != nil {
+		return 0, fmt.Errorf("could not count stored settings: %w", err)
+	}
+	return count, nil
+}
+
+// osReadDir lists a directory's entry names.
+func osReadDir(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("could not read %q: %w", dir, err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names, nil
+}

--- a/tests/e2e/features/feature_flag_operator_switch.feature
+++ b/tests/e2e/features/feature_flag_operator_switch.feature
@@ -119,6 +119,7 @@ Feature: An operator turns a feature on or off for the whole instance
     When the operator runs "weos feature reset <key>"
     Then the command exits successfully
     And the listing reports "<key>" as <state>, from the declared default
+    And no instance-level setting is stored for "<key>"
 
     Examples:
       | command | key             | state |

--- a/tests/e2e/features/feature_flag_operator_switch.feature
+++ b/tests/e2e/features/feature_flag_operator_switch.feature
@@ -1,0 +1,283 @@
+@wip @epic-480 @story-482
+Feature: An operator turns a feature on or off for the whole instance
+  As an operator running a WeOS instance
+  I want to see and change what is on, from a shell, from the admin UI, or from an agent
+  So that shipping dark work and stopping a broken capability never means a redeploy
+
+  #481 built the answer and nobody could change it. It declared features, folded the three
+  layers into one resolution, cached the result per session and invalidated that cache on
+  every write — but the only writers were the step definitions, reaching into the store
+  directly because no operator-facing way in existed yet. This story is that way in: a
+  command an operator types, endpoints the admin UI calls, and MCP tools an agent calls,
+  all three sitting on the FeatureService methods #481 already wrote and tested.
+
+  So nothing below re-asserts resolution. Which layer beats which, that an explicit off is
+  final downward while an explicit on is not, that an ineligible stored row is ignored,
+  that a failed read answers off, that an undeclared key answers the caller's default and
+  is logged once, that a change reaches sessions already open without signing anybody out —
+  all of that is feature_flag_resolution.feature and stays there. What is new here is only
+  what the three surfaces do: what they show, what they store, who they refuse, and that
+  the store they wrote reaches whoever asks next. Where a scenario evaluates a feature at
+  all, it is evaluating to prove the surface wrote what it claimed to, not to re-derive the
+  precedence rules.
+
+  Three surfaces, one write path. The command line opens the store directly the way
+  `weos account create` does, so an operator can flip a feature on an instance whose admin
+  UI is exactly the thing that is broken. The endpoints exist because the admin UI in #486
+  needs them and because an operator working through a browser should not have to shell in.
+  The MCP tools exist because an agent turn is a first-class caller on this product and an
+  operator talking to their instance should be able to say "turn episodic recall off" and
+  have it happen. All three must agree, and the listing scenarios are written to make a
+  disagreement fail rather than go unnoticed.
+
+  What the listing has to say is more than on-or-off. A feature reading "off" because
+  nobody ever touched it and a feature reading "off" because an operator turned it off last
+  Tuesday are different facts with different next actions, and an operator who cannot tell
+  them apart will "fix" the first by disabling it and be unable to explain the second. So
+  every listing reports the state and the layer that decided it, from the same
+  ResolveFeature the resolver uses, and the scenarios assert both halves.
+
+  Reset is the same distinction from the writing end, and it is the one place in this
+  subsystem where a plausible implementation does real damage. Reset removes the override;
+  it does not write "off". A feature declared on and then reset answers on again, a feature
+  declared off and then reset answers off — that much a careless implementation gets right
+  by accident. What it gets wrong is that an explicit off is final for every layer below it
+  and a declared-off default is not, so an implementation that "resets" by storing false has
+  quietly taken the feature away from every account and every grant that could otherwise
+  turn it on, and the listing will still read "off" exactly as expected. One scenario below
+  therefore resets a feature and then has an account turn it on, because that is the only
+  observation that tells the two apart.
+
+  Who counts as an operator is deliberately underspecified here, because the instance has
+  no operator role to check. WeOS knows account owners, account admins and members
+  (`GetUserRole`, `FindMemberRole`); it knows nothing about a person's standing on the
+  instance as a whole. The scenarios pin the two answers every candidate design agrees on —
+  an ordinary member is refused, and the owner of the instance's account is not — and say
+  nothing about whether the admin of a second, unrelated account may flip instance state for
+  everyone. That question needs a decision, not a guess, and pinning a guess here would
+  either bless a real multi-tenant hole or block a design that closes it. The command line
+  and the local stdio transport are treated as the operator by construction: both already
+  have the database, so a permission check against a store they could edit with sqlite3 would
+  be theatre, and this is the same call the knowledge-graph stdio exception already makes.
+
+  Account overrides appear here only as far as their surface. #481 proved that an override
+  on a non-manageable feature is ignored at resolution; what these scenarios add is that the
+  admin who asks for one is told so rather than silently obeyed and overruled, that an
+  override lands on the account the caller is signed in to rather than one they named, and
+  that it does not leak into another account. Grants get no surface in this story — that is
+  #483 — and no scenario below grants anything except where an existing #481 step is the
+  cheapest way to stage a precondition.
+
+  The command line is the one surface that is not in the serving process, and that gap is
+  visible. A flip typed into a shell writes rows a running instance has already cached, and
+  the in-process invalidator inside that instance never hears about it; only the bounded
+  maximum cache age guarantees the running instance comes back to the store. The scenario
+  for that therefore asserts the promise the story actually makes — no restart, no cache
+  flush by hand — and allows the bounded window rather than demanding the flip land on the
+  very next request, so it holds whether the invalidation channel is later widened to reach
+  other processes or not. On a real instance that age is long, which is precisely why the
+  gap is worth stating out loud rather than leaving for someone to discover.
+
+  Logging is asserted as a record an operator can read afterwards, not as a log format.
+  "Who did it" has an answer through the endpoints and the MCP tools — the authenticated
+  person — and does not through the command line, where there is no identity at all; the
+  honest record there names the command line itself, so that a change nobody can attribute
+  is at least never mistaken for one somebody made in the UI.
+
+  Background:
+    Given a WeOS instance where password sign-in is enabled and requests are authenticated by their session
+    And the instance declares these features in code:
+      | key             | display name    | description                              | default | manageable | grantable |
+      | episodic-recall | Episodic recall | Recall past events during a conversation | on      | yes        | yes       |
+      | ledger-export   | Ledger export   | Export the ledger to a spreadsheet       | off     | yes        | yes       |
+      | audit-trail     | Audit trail     | Record who read what, for compliance     | on      | no         | no        |
+    And the account "Harbor Legal", whose owner "ops@harborlegal.example" signs in with password "correct-horse-battery-staple"
+
+  # --- The command line ---
+
+  Scenario: The command line lists every feature with its state and where that state came from
+    Given the operator has run "weos feature disable episodic-recall"
+    When the operator runs "weos feature list"
+    Then the command exits successfully
+    And the listing reports "episodic-recall" as off, from an instance override
+    And the listing reports "ledger-export" as off, from the declared default
+    And the listing reports "audit-trail" as on, from the declared default
+    And the listing names each feature by its display name
+
+  Scenario Outline: An operator flips a feature for the instance from the command line
+    When the operator runs "weos feature <command> <key>"
+    Then the command exits successfully
+    And the listing reports "<key>" as <state>, from an instance override
+
+    Examples:
+      | command | key             | state |
+      | enable  | ledger-export   | on    |
+      | disable | episodic-recall | off   |
+
+  Scenario Outline: Reset drops the override and the feature returns to the default it was declared with
+    Given the operator has run "weos feature <command> <key>"
+    When the operator runs "weos feature reset <key>"
+    Then the command exits successfully
+    And the listing reports "<key>" as <state>, from the declared default
+
+    Examples:
+      | command | key             | state |
+      | enable  | ledger-export   | off   |
+      | disable | episodic-recall | on    |
+
+  Scenario: A reset leaves a feature an account can still turn on, where an explicit off would not
+    Given the operator has run "weos feature enable ledger-export"
+    And the operator has run "weos feature reset ledger-export"
+    And "Harbor Legal" has turned the feature "ledger-export" on
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they evaluate "ledger-export" with default off
+    Then the feature answers on
+
+  Scenario: Flipping a feature that is already in that state succeeds and changes nothing
+    Given the operator has run "weos feature disable episodic-recall"
+    When the operator runs "weos feature disable episodic-recall" again
+    Then the command exits successfully
+    And the listing reports "episodic-recall" as off, from an instance override
+    And the instance holds one stored instance-level setting for "episodic-recall"
+
+  Scenario: A key nobody declared is refused rather than stored
+    When the operator runs "weos feature enable shipping-labels"
+    Then the command exits with a failure
+    And the failure names the key "shipping-labels"
+    And no instance-level setting is stored for "shipping-labels"
+    And the listing does not report "shipping-labels"
+
+  Scenario: A flip with no database configured refuses rather than flipping some other store
+    Given a WeOS instance with no database configured
+    When the operator runs "weos feature disable episodic-recall"
+    Then the command exits with a failure
+    And the failure says no database was specified and names how to supply one
+    And the command leaves no database behind in the directory it ran from
+
+  Scenario: A flip made from the command line reaches an instance that is already running
+    Given the instance is configured with a maximum cache age of 2 seconds
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have already evaluated "episodic-recall" and been answered on
+    When the operator runs "weos feature disable episodic-recall" against the same store
+    And they evaluate "episodic-recall" again once the maximum cache age has passed
+    Then the feature answers off
+    And the instance was not restarted
+    And they are still signed in
+
+  Scenario: A flip made from the command line records what changed and that the command line changed it
+    When the operator runs "weos feature disable episodic-recall"
+    Then the command exits successfully
+    And the change was recorded with the key "episodic-recall" and the state it was set to
+    And the record names the command line as what made the change
+    And the record carries the time the change was made
+
+  # --- The endpoints the admin UI calls ---
+
+  Scenario: An operator turns a feature off through the API and the next request sees it off
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have already evaluated "episodic-recall" and been answered on
+    When they turn the feature "episodic-recall" off for the instance through the API
+    And they evaluate "episodic-recall" again in the same session
+    Then the change was accepted
+    And the feature answers off
+    And the instance was not restarted
+
+  Scenario: The API lists every feature with its state and where that state came from
+    Given the operator has turned the feature "episodic-recall" off for the instance
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they ask the API for the feature listing
+    Then the listing reports "episodic-recall" as off, from an instance override
+    And the listing reports "ledger-export" as off, from the declared default
+    And the listing names each feature by its display name
+
+  Scenario: A reset through the API returns the feature to the default it was declared with
+    Given the operator has turned the feature "ledger-export" on for the instance
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they reset the feature "ledger-export" for the instance through the API
+    Then the change was accepted
+    And the listing reports "ledger-export" as off, from the declared default
+
+  Scenario: A member may read the listing but may not change the instance
+    Given "clerk@harborlegal.example" belongs to "Harbor Legal" as an ordinary member
+    And "clerk@harborlegal.example" is signed in to "Harbor Legal"
+    When they ask the API for the feature listing
+    And they try to turn the feature "episodic-recall" off for the instance through the API
+    Then the listing was served
+    And the attempt to change it is refused as forbidden
+    And no instance-level setting is stored for "episodic-recall"
+
+  Scenario: A request carrying no session cannot change the instance
+    When a request carrying no session tries to turn the feature "episodic-recall" off for the instance
+    Then the request is refused as not authenticated
+    And no instance-level setting is stored for "episodic-recall"
+
+  Scenario: A key nobody declared is refused through the API rather than stored
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they try to turn the feature "shipping-labels" off for the instance through the API
+    Then the attempt is refused as not found
+    And no instance-level setting is stored for "shipping-labels"
+
+  Scenario: An account admin turns a manageable feature on for the account they are signed in to
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal" with the role "admin"
+    And the account "Cedar Realty", whose owner "broker@cedarrealty.example" signs in with password "trellis-anchor-mango-9"
+    And "counsel@harborlegal.example" is signed in to "Harbor Legal"
+    When they turn the feature "ledger-export" on for their own account through the API
+    And "broker@cedarrealty.example" signs in and evaluates "ledger-export" with default off
+    Then the change was accepted
+    And "counsel@harborlegal.example" is answered on
+    And "broker@cedarrealty.example" is answered off
+    And no instance-level setting is stored for "ledger-export"
+
+  Scenario: An account admin may not override a feature no account may change
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal" with the role "admin"
+    And "counsel@harborlegal.example" is signed in to "Harbor Legal"
+    When they try to turn the feature "audit-trail" off for their own account through the API
+    Then the attempt is refused as a bad request
+    And the refusal says the feature cannot be changed per account
+    And no account-level setting is stored for "audit-trail"
+
+  Scenario: A flip through the API names who made it and when
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they turn the feature "episodic-recall" off for the instance through the API
+    Then the change was accepted
+    And the change was recorded with the key "episodic-recall" and the state it was set to
+    And the record names "ops@harborlegal.example" as who made it
+    And the record carries the time the change was made
+
+  # --- The MCP tools an agent calls ---
+
+  Scenario: The MCP listing reports the same state and source as the API
+    Given the operator has turned the feature "episodic-recall" off for the instance
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they call the MCP tool "feature_list"
+    Then the listing reports "episodic-recall" as off, from an instance override
+    And the listing reports "ledger-export" as off, from the declared default
+    And what the tool reported matches what the API lists
+
+  Scenario: A flip through MCP reaches the next request like any other
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have already evaluated "episodic-recall" and been answered on
+    When they call the MCP tool "feature_set" to turn "episodic-recall" off for the instance
+    And they evaluate "episodic-recall" again in the same session
+    Then the feature answers off
+    And the instance was not restarted
+
+  Scenario: A reset through MCP returns the feature to the default it was declared with
+    Given the operator has turned the feature "ledger-export" on for the instance
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they reset the feature "ledger-export" for the instance through MCP
+    Then the change was accepted
+    And the listing reports "ledger-export" as off, from the declared default
+
+  Scenario: A member calling the MCP tool is refused, as they are at the API
+    Given "clerk@harborlegal.example" belongs to "Harbor Legal" as an ordinary member
+    And "clerk@harborlegal.example" is signed in to "Harbor Legal"
+    When they call the MCP tool "feature_set" to turn "episodic-recall" off for the instance
+    Then the call is refused as forbidden
+    And no instance-level setting is stored for "episodic-recall"
+
+  Scenario: A caller on the local stdio transport changes instance state like the command line
+    Given an MCP client attached to the store over the local stdio transport
+    When it calls "feature_set" to turn "episodic-recall" off for the instance
+    Then the call succeeds
+    And the listing reports "episodic-recall" as off, from an instance override

--- a/tests/e2e/features/feature_flag_operator_switch.feature
+++ b/tests/e2e/features/feature_flag_operator_switch.feature
@@ -1,4 +1,4 @@
-@wip @epic-480 @story-482
+@epic-480 @story-482
 Feature: An operator turns a feature on or off for the whole instance
   As an operator running a WeOS instance
   I want to see and change what is on, from a shell, from the admin UI, or from an agent

--- a/tests/e2e/mcp_resource_create_test.go
+++ b/tests/e2e/mcp_resource_create_test.go
@@ -140,7 +140,7 @@ func (w *mcpWorld) aCleanKnowledgeGraph(_ context.Context) error {
 	w.eventStore = eventStore
 	w.manager = manager
 
-	server, err := mcpserver.NewMCPServer(rts, rs, kg, nil, episodic, nil)
+	server, err := mcpserver.NewMCPServer(rts, rs, kg, nil, episodic, nil, nil)
 	if err != nil {
 		return fmt.Errorf("failed to build MCP server: %w", err)
 	}

--- a/tests/e2e/oauth_authorize_session_test.go
+++ b/tests/e2e/oauth_authorize_session_test.go
@@ -313,7 +313,8 @@ func (w *oauthWorld) boot(opts bootOpts) error {
 		// The MCP surface a connector uses afterwards, behind the same bearer
 		// auth serve.go puts in front of it.
 		mcpSrv, mcpErr := mcpserver.NewConfiguredServer(
-			resourceTypeService, w.resourceService, kgService, lexicalSearch, episodicRecall, slog.Default())
+			resourceTypeService, w.resourceService, kgService, lexicalSearch, episodicRecall,
+			nil, slog.Default())
 		if mcpErr != nil {
 			return fmt.Errorf("failed to create the MCP server: %w", mcpErr)
 		}

--- a/tests/e2e/per_account_knowledge_graph_test.go
+++ b/tests/e2e/per_account_knowledge_graph_test.go
@@ -202,7 +202,7 @@ func (w *perAccountKGWorld) bootPerAccount(cfg config.Config) error {
 	w.manager = manager
 	w.rts = rts
 
-	server, err := mcpserver.NewMCPServer(rts, rs, kg, nil, episodic, nil)
+	server, err := mcpserver.NewMCPServer(rts, rs, kg, nil, episodic, nil, nil)
 	if err != nil {
 		return fmt.Errorf("build MCP server: %w", err)
 	}


### PR DESCRIPTION
Closes #482. Second layer of epic #480, on top of #493.

`weos feature list|enable|disable|reset`, REST endpoints for the admin UI, and MCP tools — the operator surface over the resolver #481 built.

## Shape

`FeatureAdminService` sits above `FeatureService` and owns the three things all three surfaces would otherwise each have to get right: who may change what, what gets recorded, and what a listing looks like. It sits *above* rather than inside because #481's acceptance steps call `FeatureService` with a bare context, and a guard inside would fail scenarios already in the regression suite.

The listing reports **where each state came from** — declared default, instance override, account override, or a grant. An operator looking at an "off" feature needs to know which of those it is, because the three call for different actions. That is `ResolveFeature`'s second return value, widened in #481 on review advice, one story before anything needed it.

Reset is `DELETE`, not a `PUT` of false. Removing an override and setting it off are different outcomes: a reset feature can still be turned on from below, an explicit off cannot.

Account endpoints take **no account id** — it comes off the session, so an admin of one account cannot reach into another by naming it.

## Two things this story had to settle

**A CLI flip cannot reach a running server directly.** Separate processes; the CLI invalidates its own throwaway cache. Accepted: the change lands when cached sets reach the maximum age, and every flip says so at the point of use rather than leaving an operator to conclude it failed.

**Configuration is now a third declaration source.** Declarations are deliberately never persisted, so a CLI subprocess could see *no* features at all — every command-line scenario failed with "no feature named … is declared", correctly. `FEATURES` is a JSON array re-read at each boot, exactly as code declarations are re-read from the binary. Nothing is stored. A malformed value fails the boot rather than declaring nothing, because declaring nothing looks identical to a healthy instance with every feature off.

## A privilege escalation, found by review

`requireOperator` accepted owner-or-admin of the caller's **own** account — and pericarp makes every registrant an owner of their own personal account. **Anyone who signed up could turn off any feature for the whole instance.** The contract had said this question "needs a decision, not a guess"; the code guessed, and guessed permissive, on a self-signup surface.

The role is now checked in the **instance's** account: `FEATURE_PRIMARY_ACCOUNT_ID`, or the sole account when there is exactly one (so mini-me needs no configuration), or refused rather than guessed. Mutation-verified — restoring the old check fails the new test.

Writing that test found a second defect: `record()` documented audit failures as swallowed but **panicked** on a nil event store, killing a request whose work had already succeeded.

## Other review findings fixed

- An omitted `enabled` silently **disabled** and returned 200. Both surfaces now take a pointer and refuse a body that does not say which way.
- The MCP feature tools are opt-in **on stdio**, which is trusted without a permission check, so an LLM pointed at the graph cannot reach the switchboard. HTTP MCP keeps them — it is permission-checked like the API.
- `urn:feature-change:` read as a resource type, so audit events surfaced in episodic recall as resources of a type nothing declares.
- `LOG_LEVEL` was still case-sensitive after being fixed, so `LOG_LEVEL=ERROR` fell through to info.
- Configuration could silently shadow a preset declaration.
- `FEATURE_PRIMARY_ACCOUNT_ID` is checked rather than trusted; a typo told every operator they lacked a role.

## Audit trail

Each change is a `Feature.Changed` event in the pericarp event store, **each its own aggregate** — the events table has a unique index on `(aggregate_id, sequence_no)`, so a stable per-key aggregate would collide on the second flip of any key, which is exactly when an audit trail starts to matter. Actor email is stored beside actor id, because a log of KSUIDs answers "who" in a way nobody can use.

## Tests

25 scenarios, 211 steps — a real CLI subprocess, HTTP with real sessions, MCP over an in-memory transport. #481's 38 still pass.

Three assertions were rewritten after review proved they passed for the wrong reason: the contract had stopped proving the role check at all (deleting it left the suite green), `stepRecordTime` checked a value the harness had backfilled, and the reset outline was satisfiable by a command that did nothing. All three now fail under mutation.

Also fixes nine lint issues from #481 that would have failed CI on #493.

## Known, filed, not fixed

#494 (CLI boots the whole application; SQLite cross-process flips), #495 (audit trail unreadable, impersonation mis-attributed), #496 (a successful change can answer as an empty instance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
