### PR TITLE
An admin grants a feature to specific users or roles

### DIFF
--- a/api/handlers/feature_handler.go
+++ b/api/handlers/feature_handler.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/labstack/echo/v4"
 
@@ -113,6 +114,101 @@ func (h *FeatureHandler) SetAccount(c echo.Context) error {
 func (h *FeatureHandler) ResetAccount(c echo.Context) error {
 	err := h.admin.ResetAccount(c.Request().Context(), c.Param("key"), entities.FeatureChangeSourceAPI)
 	return h.respondAfterChange(c, err)
+}
+
+// grantRequestBody is the body of POST /api/features/:key/grants.
+//
+// There is deliberately no account field. The account comes off the session,
+// so an admin naming another one has nothing to bind to — the property is
+// enforced by the shape rather than by a check that could be forgotten.
+type grantRequestBody struct {
+	Email        string     `json:"email,omitempty"`
+	Role         string     `json:"role,omitempty"`
+	ValidFrom    *time.Time `json:"validFrom,omitempty"`
+	ValidThrough *time.Time `json:"validThrough,omitempty"`
+}
+
+// ListGrants returns every grant on one feature in the caller's account,
+// including pending and expired ones.
+func (h *FeatureHandler) ListGrants(c echo.Context) error {
+	views, err := h.admin.GrantsOn(c.Request().Context(), c.Param("key"), "")
+	if err != nil {
+		return h.grantError(c, err)
+	}
+	return respond(c, http.StatusOK, views)
+}
+
+// GrantsHeldBy returns everything one person holds, directly or through a role.
+func (h *FeatureHandler) GrantsHeldBy(c echo.Context) error {
+	views, err := h.admin.GrantsHeldBy(c.Request().Context(), c.QueryParam("email"))
+	if err != nil {
+		return h.grantError(c, err)
+	}
+	return respond(c, http.StatusOK, views)
+}
+
+// Grant gives a feature to one person or to a role.
+func (h *FeatureHandler) Grant(c echo.Context) error {
+	var body grantRequestBody
+	if err := c.Bind(&body); err != nil {
+		return respondError(c, http.StatusBadRequest, "invalid request")
+	}
+	err := h.admin.Grant(c.Request().Context(), application.GrantRequest{
+		Key:          c.Param("key"),
+		Email:        body.Email,
+		Role:         body.Role,
+		ValidFrom:    body.ValidFrom,
+		ValidThrough: body.ValidThrough,
+		Source:       entities.FeatureChangeSourceAPI,
+	})
+	if err != nil {
+		return h.grantError(c, err)
+	}
+	return h.respondWithGrants(c)
+}
+
+// RevokeGrant takes a grant back. The subject comes from the query string:
+// DELETE bodies are unreliable across clients and proxies.
+func (h *FeatureHandler) RevokeGrant(c echo.Context) error {
+	err := h.admin.RevokeGrant(c.Request().Context(), application.RevokeRequest{
+		Key:    c.Param("key"),
+		Email:  c.QueryParam("email"),
+		Role:   c.QueryParam("role"),
+		Source: entities.FeatureChangeSourceAPI,
+	})
+	if err != nil {
+		return h.grantError(c, err)
+	}
+	return h.respondWithGrants(c)
+}
+
+// respondWithGrants answers a change with the feature's current grants, so a
+// client can see what the change produced — a window in particular resolves to
+// a status the client cannot compute.
+func (h *FeatureHandler) respondWithGrants(c echo.Context) error {
+	views, err := h.admin.GrantsOn(c.Request().Context(), c.Param("key"), "")
+	if err != nil {
+		// The change landed; only the read-back failed. Saying so beats
+		// reporting a failure for work that succeeded, and beats an empty body
+		// a client would read as "there are no grants".
+		h.logger.Error(c.Request().Context(), "grant changed but the listing could not be read", "error", err)
+		return respond(c, http.StatusOK, map[string]any{"applied": true})
+	}
+	return respond(c, http.StatusOK, views)
+}
+
+func (h *FeatureHandler) grantError(c echo.Context, err error) error {
+	switch {
+	case errors.Is(err, repositories.ErrNotFound):
+		return respondError(c, http.StatusNotFound, err.Error())
+	case errors.Is(err, application.ErrForbidden):
+		return respondError(c, http.StatusForbidden, err.Error())
+	case errors.Is(err, application.ErrValidation):
+		return respondError(c, http.StatusBadRequest, err.Error())
+	default:
+		h.logger.Error(c.Request().Context(), "failed to change a grant", "error", err)
+		return respondError(c, http.StatusInternalServerError, "failed to change the grant")
+	}
 }
 
 // bindSetFeature refuses a body that does not say which way to set the

--- a/application/feature_admin_service.go
+++ b/application/feature_admin_service.go
@@ -18,7 +18,7 @@ package application
 import (
 	"context"
 	"fmt"
-
+	"strings"
 	"time"
 
 	"github.com/akeemphilbert/pericarp/pkg/auth"
@@ -407,8 +407,15 @@ func (s *FeatureAdminService) Grant(ctx context.Context, req GrantRequest) error
 	if err != nil {
 		return err
 	}
-	s.recordGrant(ctx, req.Key, accountID, entities.FeatureChangeStateGranted,
-		req.Source, subjectType, subjectID, subjectEmail)
+	s.recordEvent(ctx, entities.FeatureChanged{
+		Key: req.Key, Scope: "account", ScopeID: accountID,
+		State: entities.FeatureChangeStateGranted, Source: req.Source,
+		SubjectType: subjectType, SubjectID: subjectID, SubjectEmail: subjectEmail,
+		// The window goes on the event, not only on the row. A window closing
+		// writes nothing and a re-grant overwrites the row in place, so without
+		// this nothing could ever answer "why did access end".
+		ValidFrom: req.ValidFrom, ValidThrough: req.ValidThrough,
+	})
 	return nil
 }
 
@@ -486,6 +493,13 @@ func (s *FeatureAdminService) GrantsHeldBy(ctx context.Context, email string) ([
 
 // viewsOf renders records for an operator. markDirectFor, when set, tags each
 // row as held directly or through a role.
+// viewsOf renders records for an operator.
+//
+// A grant whose subject is no longer a member is reported as orphaned rather
+// than active. Membership is checked when a grant is made and nothing removes
+// the row when somebody leaves, so an admin reading "active" for an ex-member
+// would be reading a right that reaches nobody — and would have no reason to
+// clean it up before the person was re-added.
 func (s *FeatureAdminService) viewsOf(
 	ctx context.Context, records []entities.FeatureGrantRecord, markDirectFor string,
 ) []GrantView {
@@ -507,6 +521,14 @@ func (s *FeatureAdminService) viewsOf(
 			// Resolved at read time rather than stored: an address can change
 			// and a grant should not follow it, so the row holds the agent id.
 			v.Email = s.emailFor(ctx, r.SubjectID)
+			if v.Email == "" {
+				// Nothing resolves the address any more. Showing the agent id
+				// beats showing a blank row an operator cannot act on.
+				v.Email = r.SubjectID
+			}
+			if role, err := s.accounts.FindMemberRole(ctx, r.AccountID, r.SubjectID); err == nil && role == "" {
+				v.Status = entities.GrantOrphaned
+			}
 		}
 		if markDirectFor != "" {
 			if r.SubjectType == repositories.FeatureSubjectRole {
@@ -563,9 +585,13 @@ func (s *FeatureAdminService) DefaultGrantAccount(ctx context.Context) (string, 
 func (s *FeatureAdminService) grantAccount(ctx context.Context, named string, write bool) (string, error) {
 	if isLocalTransport(ctx) {
 		if named == "" {
+			what := "a grant"
+			if !write {
+				what = "reading grants"
+			}
 			return "", fmt.Errorf(
-				"a grant needs an account and this transport has no signed-in caller; "+
-					"make it from the command line with --account <id>: %w", ErrValidation)
+				"%s needs an account and this transport has no signed-in caller; "+
+					"name one from the command line with --account <id>: %w", what, ErrValidation)
 		}
 		account, err := s.accounts.FindByID(ctx, named)
 		if err != nil || account == nil {
@@ -641,6 +667,10 @@ func (s *FeatureAdminService) resolveSubject(
 // agentForEmail finds who an address belongs to. An address nobody signed up
 // with is a 404 rather than a grant stored against nothing.
 func (s *FeatureAdminService) agentForEmail(ctx context.Context, email string) (string, string, error) {
+	if strings.TrimSpace(email) == "" {
+		// Asking about nobody is a malformed request, not a missing person.
+		return "", "", fmt.Errorf("name the person by their email address: %w", ErrValidation)
+	}
 	if s.creds == nil {
 		return "", "", fmt.Errorf("cannot look up %q: %w", email, repositories.ErrNotFound)
 	}

--- a/application/feature_admin_service.go
+++ b/application/feature_admin_service.go
@@ -520,6 +520,36 @@ func (s *FeatureAdminService) viewsOf(
 	return out
 }
 
+// DefaultGrantAccount names the account a command-line grant lands in when the
+// operator did not say.
+//
+// Exactly one account means that account, and nothing has to be configured.
+// That is narrower than it sounds: registration mints every person a personal
+// account, so a single-account instance is a single-person instance — the
+// mini-me shape, where nobody should have to look up a KSUID to grant
+// themselves something.
+//
+// Deliberately does NOT fall back to FEATURE_PRIMARY_ACCOUNT_ID. That names
+// who owns the instance switch, not where a grant lands, and quietly dropping
+// a grant into it on a multi-tenant instance would put a right in an account
+// nobody named.
+func (s *FeatureAdminService) DefaultGrantAccount(ctx context.Context) (string, error) {
+	page, err := s.accounts.FindAll(ctx, "", 2)
+	if err != nil {
+		return "", fmt.Errorf("failed to read the instance's accounts: %w", err)
+	}
+	switch {
+	case page == nil || len(page.Data) == 0:
+		return "", fmt.Errorf("this instance has no account to grant in: %w", ErrValidation)
+	case len(page.Data) == 1:
+		return page.Data[0].GetID(), nil
+	default:
+		return "", fmt.Errorf(
+			"this instance has more than one account, so a grant has to say which: "+
+				"name it with --account <id>: %w", ErrValidation)
+	}
+}
+
 // grantAccount decides which account a grant acts in.
 //
 // The local transport is the operator's, so it may name an account — the

--- a/application/feature_admin_service.go
+++ b/application/feature_admin_service.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"fmt"
 
+	"time"
+
 	"github.com/akeemphilbert/pericarp/pkg/auth"
 	authentities "github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
 	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
@@ -26,6 +28,7 @@ import (
 	esdomain "github.com/akeemphilbert/pericarp/pkg/eventsourcing/domain"
 
 	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
 	"github.com/wepala/weos/v3/internal/config"
 	"github.com/wepala/weos/v3/pkg/identity"
 )
@@ -270,28 +273,29 @@ func (s *FeatureAdminService) requireAccountAdmin(ctx context.Context) (string, 
 // surfaced as a message instead, which is the honest account: the change
 // happened, the record of it did not.
 func (s *FeatureAdminService) record(ctx context.Context, key, scope, scopeID, state, src string) {
-	if s.eventStore == nil || s.dispatcher == nil {
-		// Nothing to record into. Guarded rather than left to fail inside the
-		// unit of work, which panics on a nil store — and a panic here would
-		// take down a request whose actual work already succeeded, which is
-		// the opposite of this method's whole failure policy.
-		if s.logger != nil {
-			s.logger.Error(ctx, "the feature change was applied but there is nowhere to record it",
-				"feature", key, "scope", scope, "state", state)
-		}
-		return
-	}
-	event := entities.FeatureChanged{
+	s.recordEvent(ctx, entities.FeatureChanged{
 		Key:     key,
 		Scope:   scope,
 		ScopeID: scopeID,
 		State:   state,
 		Source:  src,
+	})
+}
+
+// recordEvent stamps the actor and appends one change to the event log.
+func (s *FeatureAdminService) recordEvent(ctx context.Context, event entities.FeatureChanged) {
+	if s.eventStore == nil || s.dispatcher == nil {
+		if s.logger != nil {
+			s.logger.Error(ctx, "the feature change was applied but there is nowhere to record it",
+				"feature", event.Key, "scope", event.Scope, "state", event.State)
+		}
+		return
 	}
 	if identityCtx := auth.AgentFromCtx(ctx); identityCtx != nil {
 		event.ActorID = identityCtx.AgentID
 		event.ActorEmail = s.emailFor(ctx, identityCtx.AgentID)
 	}
+	key := event.Key
 
 	change, err := new(entities.FeatureChange).With(identity.NewFeatureChange(), event)
 	if err == nil {
@@ -303,7 +307,7 @@ func (s *FeatureAdminService) record(ctx context.Context, key, scope, scopeID, s
 	if err != nil {
 		if s.logger != nil {
 			s.logger.Error(ctx, "the feature change was applied but not recorded",
-				"feature", key, "scope", scope, "state", state, "error", err)
+				"feature", key, "scope", event.Scope, "state", event.State, "error", err)
 		}
 		entities.AddMessage(ctx, entities.Message{
 			Type: "warning",
@@ -325,4 +329,314 @@ func (s *FeatureAdminService) emailFor(ctx context.Context, agentID string) stri
 		return ""
 	}
 	return creds[0].Email()
+}
+
+// GrantRequest names a grant to make. Exactly one of Email or Role identifies
+// the subject.
+//
+// AccountID is honored ONLY on the local transport. Over HTTP and MCP the
+// account comes off the session, and the request shapes there do not expose
+// the field at all — so an admin naming somebody else's account in a body has
+// nothing to bind to, rather than being refused after the fact.
+type GrantRequest struct {
+	Key   string
+	Email string
+	Role  string
+
+	ValidFrom    *time.Time
+	ValidThrough *time.Time
+
+	AccountID string
+	Source    string
+}
+
+// RevokeRequest names a grant to take back.
+type RevokeRequest struct {
+	Key       string
+	Email     string
+	Role      string
+	AccountID string
+	Source    string
+}
+
+// GrantView is one grant as an operator reads it.
+type GrantView struct {
+	FeatureKey   string     `json:"featureKey"`
+	SubjectType  string     `json:"subjectType"`
+	Email        string     `json:"email,omitempty"`
+	Role         string     `json:"role,omitempty"`
+	ValidFrom    *time.Time `json:"validFrom,omitempty"`
+	ValidThrough *time.Time `json:"validThrough,omitempty"`
+	// Status is active, pending or expired. An expired grant is still a row —
+	// revocation deletes, a closed window does not — so a listing has to be
+	// able to say which it is looking at.
+	Status    string    `json:"status"`
+	GrantedBy string    `json:"grantedBy,omitempty"`
+	GrantedAt time.Time `json:"grantedAt"`
+	// Via is "direct" or "role:<r>", set only when listing what one person
+	// holds, where the difference is the whole question.
+	Via string `json:"via,omitempty"`
+}
+
+// Grant gives a feature to one person or to a role.
+func (s *FeatureAdminService) Grant(ctx context.Context, req GrantRequest) error {
+	accountID, err := s.grantAccount(ctx, req.AccountID, true)
+	if err != nil {
+		return err
+	}
+	subjectType, subjectID, subjectEmail, err := s.resolveSubject(ctx, accountID, req.Key, req.Email, req.Role)
+	if err != nil {
+		return err
+	}
+
+	terms := GrantTerms{
+		ValidFrom:    req.ValidFrom,
+		ValidThrough: req.ValidThrough,
+		Source:       req.Source,
+	}
+	if identityCtx := auth.AgentFromCtx(ctx); identityCtx != nil {
+		terms.GrantedByID = identityCtx.AgentID
+		terms.GrantedByEmail = s.emailFor(ctx, identityCtx.AgentID)
+	}
+
+	if subjectType == repositories.FeatureSubjectRole {
+		err = s.features.GrantToRole(ctx, accountID, subjectID, req.Key, terms)
+	} else {
+		err = s.features.GrantToAgent(ctx, accountID, subjectID, req.Key, terms)
+	}
+	if err != nil {
+		return err
+	}
+	s.recordGrant(ctx, req.Key, accountID, entities.FeatureChangeStateGranted,
+		req.Source, subjectType, subjectID, subjectEmail)
+	return nil
+}
+
+// RevokeGrant takes a grant back.
+//
+// A revocation that matched nothing succeeds and records nothing. The caller's
+// intent is already satisfied, and an audit log stays readable by containing
+// only things that happened.
+func (s *FeatureAdminService) RevokeGrant(ctx context.Context, req RevokeRequest) error {
+	accountID, err := s.grantAccount(ctx, req.AccountID, true)
+	if err != nil {
+		return err
+	}
+	subjectType, subjectID, subjectEmail, err := s.resolveSubject(ctx, accountID, req.Key, req.Email, req.Role)
+	if err != nil {
+		return err
+	}
+
+	var removed bool
+	if subjectType == repositories.FeatureSubjectRole {
+		removed, err = s.features.RevokeFromRole(ctx, accountID, subjectID, req.Key)
+	} else {
+		removed, err = s.features.RevokeFromAgent(ctx, accountID, subjectID, req.Key)
+	}
+	if err != nil {
+		return err
+	}
+	if removed {
+		s.recordGrant(ctx, req.Key, accountID, entities.FeatureChangeStateRevoked,
+			req.Source, subjectType, subjectID, subjectEmail)
+	}
+	return nil
+}
+
+// GrantsOn lists every grant on one feature in an account.
+//
+// Readable by any member of the account, like the feature listing itself:
+// seeing who holds something is not the same as being able to change it.
+func (s *FeatureAdminService) GrantsOn(ctx context.Context, key, accountID string) ([]GrantView, error) {
+	resolved, err := s.grantAccount(ctx, accountID, false)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := s.features.Declared(key); err != nil {
+		return nil, err
+	}
+	records, err := s.features.GrantsOnFeature(ctx, resolved, key)
+	if err != nil {
+		return nil, err
+	}
+	return s.viewsOf(ctx, records, ""), nil
+}
+
+// GrantsHeldBy lists everything one person holds in the caller's account,
+// whether they hold it themselves or through their role.
+func (s *FeatureAdminService) GrantsHeldBy(ctx context.Context, email string) ([]GrantView, error) {
+	accountID, err := s.grantAccount(ctx, "", false)
+	if err != nil {
+		return nil, err
+	}
+	agentID, _, err := s.agentForEmail(ctx, email)
+	if err != nil {
+		return nil, err
+	}
+	roleID, err := s.accounts.FindMemberRole(ctx, accountID, agentID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the member's role: %w", err)
+	}
+	records, err := s.features.GrantsFor(ctx, accountID, agentID, roleID)
+	if err != nil {
+		return nil, err
+	}
+	return s.viewsOf(ctx, records, agentID), nil
+}
+
+// viewsOf renders records for an operator. markDirectFor, when set, tags each
+// row as held directly or through a role.
+func (s *FeatureAdminService) viewsOf(
+	ctx context.Context, records []entities.FeatureGrantRecord, markDirectFor string,
+) []GrantView {
+	now := time.Now()
+	out := make([]GrantView, 0, len(records))
+	for _, r := range records {
+		v := GrantView{
+			FeatureKey:   r.FeatureKey,
+			SubjectType:  r.SubjectType,
+			ValidFrom:    r.ValidFrom,
+			ValidThrough: r.ValidThrough,
+			Status:       r.WindowState(now),
+			GrantedBy:    r.GrantedByEmail,
+			GrantedAt:    r.CreatedAt,
+		}
+		if r.SubjectType == repositories.FeatureSubjectRole {
+			v.Role = r.SubjectID
+		} else {
+			// Resolved at read time rather than stored: an address can change
+			// and a grant should not follow it, so the row holds the agent id.
+			v.Email = s.emailFor(ctx, r.SubjectID)
+		}
+		if markDirectFor != "" {
+			if r.SubjectType == repositories.FeatureSubjectRole {
+				v.Via = "role:" + r.SubjectID
+			} else {
+				v.Via = "direct"
+			}
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+// grantAccount decides which account a grant acts in.
+//
+// The local transport is the operator's, so it may name an account — the
+// command line resolved the id already and whoever runs it holds the database.
+// With no account named there, the caller is refused and told where to go: an
+// account-scoped grant has no account to land in when nobody is signed in, and
+// guessing one would be the multi-tenant hole this arrangement exists to avoid.
+//
+// Everywhere else the account comes off the session and any named one is
+// ignored, so an admin cannot reach into an account by naming it.
+func (s *FeatureAdminService) grantAccount(ctx context.Context, named string, write bool) (string, error) {
+	if isLocalTransport(ctx) {
+		if named == "" {
+			return "", fmt.Errorf(
+				"a grant needs an account and this transport has no signed-in caller; "+
+					"make it from the command line with --account <id>: %w", ErrValidation)
+		}
+		account, err := s.accounts.FindByID(ctx, named)
+		if err != nil || account == nil {
+			return "", fmt.Errorf("no account %q exists: %w", named, ErrValidation)
+		}
+		return named, nil
+	}
+	if write {
+		return s.requireAccountAdmin(ctx)
+	}
+	identityCtx := auth.AgentFromCtx(ctx)
+	if identityCtx == nil || identityCtx.ActiveAccountID == "" {
+		return "", fmt.Errorf("reading grants requires a session in an account: %w", ErrForbidden)
+	}
+	role, err := s.accounts.FindMemberRole(ctx, identityCtx.ActiveAccountID, identityCtx.AgentID)
+	if err != nil {
+		return "", fmt.Errorf("failed to read the caller's role: %w", err)
+	}
+	if role == "" {
+		return "", fmt.Errorf("only a member of the account may read its grants: %w", ErrForbidden)
+	}
+	return identityCtx.ActiveAccountID, nil
+}
+
+// resolveSubject turns an email or a role into a stored subject, refusing in a
+// deliberate order: the feature first, then eligibility, then the person.
+//
+// The order is the point. Granting a mistyped feature to a stranger should
+// report the feature, not the stranger — the first thing wrong is the first
+// thing said.
+func (s *FeatureAdminService) resolveSubject(
+	ctx context.Context, accountID, key, email, role string,
+) (subjectType, subjectID, subjectEmail string, err error) {
+	meta, err := s.features.Declared(key)
+	if err != nil {
+		return "", "", "", err
+	}
+	if !meta.Grantable {
+		return "", "", "", fmt.Errorf("feature %q cannot be granted: %w", key, ErrValidation)
+	}
+	if (email == "") == (role == "") {
+		return "", "", "", fmt.Errorf(
+			"name exactly one of a person or a role to grant to: %w", ErrValidation)
+	}
+
+	if role != "" {
+		switch role {
+		case authentities.RoleOwner, authentities.RoleAdmin, authentities.RoleMember:
+			return repositories.FeatureSubjectRole, role, "", nil
+		default:
+			return "", "", "", fmt.Errorf(
+				"no role %q exists; the roles are %q, %q and %q: %w",
+				role, authentities.RoleOwner, authentities.RoleAdmin,
+				authentities.RoleMember, ErrValidation)
+		}
+	}
+
+	agentID, resolvedEmail, err := s.agentForEmail(ctx, email)
+	if err != nil {
+		return "", "", "", err
+	}
+	memberRole, err := s.accounts.FindMemberRole(ctx, accountID, agentID)
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to read the member's role: %w", err)
+	}
+	if memberRole == "" {
+		return "", "", "", fmt.Errorf(
+			"%q is not a member of this account: %w", email, ErrValidation)
+	}
+	return repositories.FeatureSubjectAgent, agentID, resolvedEmail, nil
+}
+
+// agentForEmail finds who an address belongs to. An address nobody signed up
+// with is a 404 rather than a grant stored against nothing.
+func (s *FeatureAdminService) agentForEmail(ctx context.Context, email string) (string, string, error) {
+	if s.creds == nil {
+		return "", "", fmt.Errorf("cannot look up %q: %w", email, repositories.ErrNotFound)
+	}
+	creds, err := s.creds.FindByEmail(ctx, email)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to look up %q: %w", email, err)
+	}
+	if len(creds) == 0 {
+		return "", "", fmt.Errorf("nobody signed up with %q: %w", email, repositories.ErrNotFound)
+	}
+	return creds[0].AgentID(), email, nil
+}
+
+// recordGrant appends a grant or revocation to the same log that carries
+// override changes, so "who took that away, and when" has one answer.
+func (s *FeatureAdminService) recordGrant(
+	ctx context.Context, key, accountID, state, src, subjectType, subjectID, subjectEmail string,
+) {
+	s.recordEvent(ctx, entities.FeatureChanged{
+		Key:          key,
+		Scope:        "account",
+		ScopeID:      accountID,
+		State:        state,
+		Source:       src,
+		SubjectType:  subjectType,
+		SubjectID:    subjectID,
+		SubjectEmail: subjectEmail,
+	})
 }

--- a/application/feature_admin_service_test.go
+++ b/application/feature_admin_service_test.go
@@ -282,3 +282,251 @@ func TestConfiguredPrimaryAccountMustExist(t *testing.T) {
 		t.Fatalf("the error blames the caller rather than the configuration: %v", err)
 	}
 }
+
+// adminCreds resolves addresses to agents for the grant tests.
+type adminCreds struct {
+	authrepos.CredentialRepository
+	byEmail map[string]string // email -> agentID
+}
+
+func (c adminCreds) FindByEmail(_ context.Context, email string) ([]*authentities.Credential, error) {
+	agentID, ok := c.byEmail[email]
+	if !ok {
+		return nil, nil
+	}
+	cred := new(authentities.Credential)
+	cred, err := cred.With("cred-"+agentID, agentID, "password", email, email, email)
+	if err != nil {
+		return nil, err
+	}
+	return []*authentities.Credential{cred}, nil
+}
+
+func (c adminCreds) FindByAgent(_ context.Context, agentID string) ([]*authentities.Credential, error) {
+	for email, id := range c.byEmail {
+		if id == agentID {
+			cred := new(authentities.Credential)
+			cred, err := cred.With("cred-"+agentID, agentID, "password", email, email, email)
+			if err != nil {
+				return nil, err
+			}
+			return []*authentities.Credential{cred}, nil
+		}
+	}
+	return nil, nil
+}
+
+func grantTestService(t *testing.T) (*FeatureAdminService, *fakeGrants) {
+	t.Helper()
+	registry, _ := newTestFeatureRegistry(t, featEpisodic, featLedger, featAudit)
+	settings := &fakeSettings{}
+	grants := newFakeGrants()
+	svc := NewFeatureService(registry, settings, grants, fakeMembers{}, newRecordingInvalidator(), nil)
+	resolver := NewFeatureResolver(config.Default(), registry, settings, grants,
+		&fakeAccounts{roles: map[string]string{}}, nil)
+	accounts := adminAccounts{
+		accounts: []string{"acct-only"},
+		roles: map[string]string{
+			"acct-only|agent-ops":     authentities.RoleOwner,
+			"acct-only|agent-counsel": authentities.RoleMember,
+		},
+	}
+	creds := adminCreds{byEmail: map[string]string{
+		"ops@harborlegal.example":     "agent-ops",
+		"counsel@harborlegal.example": "agent-counsel",
+		"stranger@elsewhere.example":  "agent-stranger",
+	}}
+	admin := NewFeatureAdminService(config.Default(), svc, resolver, accounts, creds, nil, nil, nil)
+	return admin, grants
+}
+
+// TestGrantRefusesInTheRightOrder is the point of ordering the checks: the
+// first thing wrong is the first thing said. Granting a mistyped feature to a
+// stranger must report the feature, not the stranger — otherwise an operator
+// fixes the wrong end of their command.
+func TestGrantRefusesInTheRightOrder(t *testing.T) {
+	admin, grants := grantTestService(t)
+	ctx := ctxAsAgent("agent-ops", "acct-only")
+
+	cases := []struct {
+		name string
+		req  GrantRequest
+		want string
+	}{
+		{
+			"an unknown feature is reported before an unknown person",
+			GrantRequest{Key: "shipping-labels", Email: "nobody@nowhere.example"},
+			"no feature named",
+		},
+		{
+			"a non-grantable feature is reported before an unknown person",
+			GrantRequest{Key: "audit-trail", Email: "nobody@nowhere.example"},
+			"cannot be granted",
+		},
+		{
+			"an address nobody signed up with",
+			GrantRequest{Key: "ledger-export", Email: "nobody@nowhere.example"},
+			"nobody signed up with",
+		},
+		{
+			"somebody who is not a member of this account",
+			GrantRequest{Key: "ledger-export", Email: "stranger@elsewhere.example"},
+			"not a member of this account",
+		},
+		{
+			"a role that does not exist",
+			GrantRequest{Key: "ledger-export", Role: "wizard"},
+			"no role",
+		},
+		{
+			"naming both a person and a role",
+			GrantRequest{Key: "ledger-export", Email: "counsel@harborlegal.example", Role: "admin"},
+			"exactly one",
+		},
+		{
+			"naming neither",
+			GrantRequest{Key: "ledger-export"},
+			"exactly one",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := admin.Grant(ctx, tc.req)
+			if err == nil {
+				t.Fatal("the grant was accepted, want a refusal")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %q, want it to contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+	if len(grants.rows) != 0 {
+		t.Fatalf("a refused grant was stored anyway: %v", grants.rows)
+	}
+}
+
+// TestGrantAndRevokeRoundTrip covers the ordinary path, and that a revocation
+// matching nothing is not an error.
+func TestGrantAndRevokeRoundTrip(t *testing.T) {
+	admin, grants := grantTestService(t)
+	ctx := ctxAsAgent("agent-ops", "acct-only")
+
+	if err := admin.Grant(ctx, GrantRequest{
+		Key: "ledger-export", Email: "counsel@harborlegal.example", Source: "api",
+	}); err != nil {
+		t.Fatalf("Grant: %v", err)
+	}
+	if !grants.holds("agent", "agent-counsel", "acct-only", "ledger-export") {
+		t.Fatal("the grant was not stored")
+	}
+
+	views, err := admin.GrantsOn(ctx, "ledger-export", "")
+	if err != nil {
+		t.Fatalf("GrantsOn: %v", err)
+	}
+	if len(views) != 1 {
+		t.Fatalf("GrantsOn returned %d grants, want 1", len(views))
+	}
+	if views[0].Email != "counsel@harborlegal.example" {
+		t.Fatalf("the listing names %q, want the address it was granted to", views[0].Email)
+	}
+	if views[0].Status != entities.GrantActive {
+		t.Fatalf("status = %q, want active", views[0].Status)
+	}
+
+	if err := admin.RevokeGrant(ctx, RevokeRequest{
+		Key: "ledger-export", Email: "counsel@harborlegal.example",
+	}); err != nil {
+		t.Fatalf("RevokeGrant: %v", err)
+	}
+	if grants.holds("agent", "agent-counsel", "acct-only", "ledger-export") {
+		t.Fatal("the grant survived the revoke")
+	}
+	// Taking back what nobody holds satisfies the caller already.
+	if err := admin.RevokeGrant(ctx, RevokeRequest{
+		Key: "ledger-export", Email: "counsel@harborlegal.example",
+	}); err != nil {
+		t.Fatalf("revoking a grant nobody holds = %v, want nil", err)
+	}
+}
+
+// TestGrantRefusesAWindowThatEndsBeforeItBegins.
+func TestGrantRefusesAWindowThatEndsBeforeItBegins(t *testing.T) {
+	admin, grants := grantTestService(t)
+	ctx := ctxAsAgent("agent-ops", "acct-only")
+	from := time.Now().Add(time.Hour)
+	through := time.Now().Add(-time.Hour)
+
+	err := admin.Grant(ctx, GrantRequest{
+		Key: "ledger-export", Email: "counsel@harborlegal.example",
+		ValidFrom: &from, ValidThrough: &through,
+	})
+	if err == nil {
+		t.Fatal("a window that ends before it begins was accepted")
+	}
+	if !strings.Contains(err.Error(), "ends before it begins") {
+		t.Fatalf("error = %q, want it to say the window is impossible", err.Error())
+	}
+	if len(grants.rows) != 0 {
+		t.Fatal("an impossible window was stored")
+	}
+}
+
+// TestLocalTransportIsRefusedAGrantAndToldWhere: stdio is trusted for
+// instance-wide state, but an account-scoped grant has no account to land in
+// when nobody is signed in, and guessing one would be a multi-tenant hole.
+func TestLocalTransportIsRefusedAGrantAndToldWhere(t *testing.T) {
+	admin, _ := grantTestService(t)
+	ctx := WithLocalTransport(context.Background())
+
+	err := admin.Grant(ctx, GrantRequest{Key: "ledger-export", Email: "counsel@harborlegal.example"})
+	if err == nil {
+		t.Fatal("a grant with no account was accepted on the local transport")
+	}
+	if !strings.Contains(err.Error(), "--account") {
+		t.Fatalf("the refusal does not say where to make one: %v", err)
+	}
+
+	// Named explicitly, it lands.
+	if err := admin.Grant(WithLocalTransport(context.Background()), GrantRequest{
+		Key: "ledger-export", Email: "counsel@harborlegal.example",
+		AccountID: "acct-only", Source: "cli",
+	}); err != nil {
+		t.Fatalf("a grant naming its account was refused: %v", err)
+	}
+}
+
+// TestAnAdminCannotGrantIntoAnAccountTheyNamed: over HTTP the account comes
+// off the session, so naming another one changes nothing.
+func TestAnAdminCannotGrantIntoAnAccountTheyNamed(t *testing.T) {
+	admin, grants := grantTestService(t)
+	ctx := ctxAsAgent("agent-ops", "acct-only")
+
+	if err := admin.Grant(ctx, GrantRequest{
+		Key: "ledger-export", Email: "counsel@harborlegal.example",
+		AccountID: "acct-somebody-elses",
+	}); err != nil {
+		t.Fatalf("Grant: %v", err)
+	}
+	if !grants.holds("agent", "agent-counsel", "acct-only", "ledger-export") {
+		t.Fatal("the grant did not land in the caller's own account")
+	}
+	if grants.holds("agent", "agent-counsel", "acct-somebody-elses", "ledger-export") {
+		t.Fatal("naming another account put the grant there")
+	}
+}
+
+// TestAnOrdinaryMemberMayReadGrantsButNotMakeOne.
+func TestAnOrdinaryMemberMayReadGrantsButNotMakeOne(t *testing.T) {
+	admin, _ := grantTestService(t)
+	ctx := ctxAsAgent("agent-counsel", "acct-only")
+
+	if _, err := admin.GrantsOn(ctx, "ledger-export", ""); err != nil {
+		t.Fatalf("a member was refused the grant listing: %v", err)
+	}
+	err := admin.Grant(ctx, GrantRequest{Key: "ledger-export", Email: "counsel@harborlegal.example"})
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("an ordinary member made a grant: %v", err)
+	}
+}

--- a/application/feature_provider_test.go
+++ b/application/feature_provider_test.go
@@ -139,7 +139,7 @@ func TestProviderResolvesDeclaredFeatures(t *testing.T) {
 		t.Fatal("a declared-off feature resolved on because the caller's default was true")
 	}
 
-	_ = grants.Grant(context.Background(), "agent", "agent-ops", "acct-harbor", "ledger-export")
+	grants.grantNow("agent", "agent-ops", "acct-harbor", "ledger-export")
 	p.resolver.InvalidateAll(context.Background())
 	if got := p.BooleanEvaluation(ctx, FeatureFlagPrefix+"ledger-export", false, nil); !got.Value {
 		t.Fatal("a grant did not reach the provider after invalidation")
@@ -185,7 +185,7 @@ func TestProviderMetadataIsStable(t *testing.T) {
 // whichever set was resolved most recently.
 func TestProviderAnswersPerCallerNotPerLastAsker(t *testing.T) {
 	p, _, grants, _ := testProvider(t, featLedger)
-	_ = grants.Grant(context.Background(), "agent", "agent-ops", "acct-harbor", "ledger-export")
+	grants.grantNow("agent", "agent-ops", "acct-harbor", "ledger-export")
 
 	ops := ctxAs("agent-ops", "acct-harbor")
 	counsel := ctxAs("agent-counsel", "acct-harbor")

--- a/application/feature_resolver.go
+++ b/application/feature_resolver.go
@@ -263,6 +263,15 @@ func (r *FeatureResolver) onResolveError(
 	defer r.mu.Unlock()
 	previous, ok := r.sets[key]
 	if !ok {
+		// Nothing to serve, so the caller gets the error.
+		//
+		// NOT throttled, deliberately. A caller with no cached set makes one
+		// failing round trip per evaluation while the store is down, which is
+		// a storm the backoff prevents for everybody else. Throttling here
+		// would break a guarantee the contract pins instead: a caller who
+		// evaluates again the moment the store recovers must get the recovered
+		// answer, not a remembered failure. Recovery beats the storm, and the
+		// storm is a follow-up.
 		return nil, err
 	}
 	// Throttle the retry so a sustained outage does not turn every evaluation

--- a/application/feature_resolver.go
+++ b/application/feature_resolver.go
@@ -59,6 +59,17 @@ type featureCacheKey struct {
 type resolvedFeatureSet struct {
 	values     map[string]bool
 	resolvedAt time.Time
+	// staleAt is the earliest instant at which this set stops being true on
+	// its own — the nearest validity-window boundary among the grants that fed
+	// it. Zero when no window is in play.
+	//
+	// This is what lets a grant expire to the second on a cache measured in
+	// minutes. Without it, a window closing between two evaluations in one
+	// session would go unnoticed until the whole entry aged out, and the only
+	// remedy would be shrinking the maximum cache age to whatever precision a
+	// window needs — throwing away the caching that exists for the other three
+	// hundred and sixty evaluations in an agent turn.
+	staleAt time.Time
 	// retryAfter throttles re-reads while the store is failing. Without it an
 	// agent turn making thirty evaluations against an unreadable database
 	// makes thirty failing round trips, turning a blip into a query storm at
@@ -205,7 +216,7 @@ func (r *FeatureResolver) refresh(ctx context.Context, key featureCacheKey) (map
 	startedAt := r.generation
 	r.mu.RUnlock()
 
-	values, err := r.resolve(ctx, key)
+	values, staleAt, err := r.resolve(ctx, key)
 	if err != nil {
 		return r.onResolveError(ctx, key, err)
 	}
@@ -220,7 +231,7 @@ func (r *FeatureResolver) refresh(ctx context.Context, key featureCacheKey) (map
 		// timestamp.
 		return copyFeatureValues(values), nil
 	}
-	r.sets[key] = resolvedFeatureSet{values: values, resolvedAt: r.clock()}
+	r.sets[key] = resolvedFeatureSet{values: values, resolvedAt: r.clock(), staleAt: staleAt}
 	return copyFeatureValues(values), nil
 }
 
@@ -267,6 +278,11 @@ func (r *FeatureResolver) cached(key featureCacheKey) (map[string]bool, bool) {
 		return nil, false
 	}
 	now := r.clock()
+	// A window boundary the set already knows about. Checked before the age,
+	// because it can fall long before it — that is the point of it.
+	if !set.staleAt.IsZero() && !now.Before(set.staleAt) && !set.retryAfter.After(now) {
+		return nil, false
+	}
 	if now.Sub(set.resolvedAt) >= r.maxAge {
 		// Too old to trust. Treated as a miss rather than evicted here so the
 		// read path keeps only a read lock; the entry is replaced on write.
@@ -283,16 +299,18 @@ func (r *FeatureResolver) cached(key featureCacheKey) (map[string]bool, bool) {
 // resolve reads every layer and folds them into a plain value map for the
 // cache. It is Explain's answer with the layer information dropped, so the two
 // cannot disagree about what a feature resolves to.
-func (r *FeatureResolver) resolve(ctx context.Context, key featureCacheKey) (map[string]bool, error) {
-	statuses, err := r.resolveDetailed(ctx, key)
+func (r *FeatureResolver) resolve(
+	ctx context.Context, key featureCacheKey,
+) (map[string]bool, time.Time, error) {
+	statuses, staleAt, err := r.resolveDetailed(ctx, key)
 	if err != nil {
-		return nil, err
+		return nil, time.Time{}, err
 	}
 	values := make(map[string]bool, len(statuses))
 	for _, s := range statuses {
 		values[s.Key] = s.Enabled
 	}
-	return values, nil
+	return values, staleAt, nil
 }
 
 // Explain resolves every declared feature for the caller on ctx and reports
@@ -308,7 +326,8 @@ func (r *FeatureResolver) Explain(ctx context.Context) ([]entities.FeatureStatus
 	if identity != nil {
 		key = featureCacheKey{AgentID: identity.AgentID, AccountID: identity.ActiveAccountID}
 	}
-	return r.resolveDetailed(ctx, key)
+	statuses, _, err := r.resolveDetailed(ctx, key)
+	return statuses, err
 }
 
 // resolveDetailed reads every layer and folds them through
@@ -318,17 +337,20 @@ func (r *FeatureResolver) Explain(ctx context.Context) ([]entities.FeatureStatus
 // down for the cache and Explain() returns it whole, so the value a call site
 // evaluates and the source an operator is shown can never drift apart — which
 // is exactly what a listing is for.
+// The second return is the earliest instant at which this answer changes on
+// its own — see resolvedFeatureSet.staleAt.
 func (r *FeatureResolver) resolveDetailed(
 	ctx context.Context, key featureCacheKey,
-) ([]entities.FeatureStatus, error) {
+) ([]entities.FeatureStatus, time.Time, error) {
 	instance, err := r.settings.InstanceOverrides(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve features: %w", err)
+		return nil, time.Time{}, fmt.Errorf("failed to resolve features: %w", err)
 	}
 
 	var (
 		account map[string]bool
 		granted map[string]bool
+		staleAt time.Time
 	)
 	// An anonymous caller resolves from the instance layer alone. No account
 	// override and no grant is read — there is no subject for either to
@@ -339,16 +361,20 @@ func (r *FeatureResolver) resolveDetailed(
 	if key.AgentID != "" && key.AccountID != "" {
 		account, err = r.settings.AccountOverrides(ctx, key.AccountID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to resolve features: %w", err)
+			return nil, time.Time{}, fmt.Errorf("failed to resolve features: %w", err)
 		}
 		roleID, err := r.accounts.FindMemberRole(ctx, key.AccountID, key.AgentID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to resolve features: %w", err)
+			return nil, time.Time{}, fmt.Errorf("failed to resolve features: %w", err)
 		}
-		granted, err = r.grants.GrantedKeys(ctx, key.AccountID, key.AgentID, roleID)
+		records, err := r.grants.GrantsFor(ctx, key.AccountID, key.AgentID, roleID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to resolve features: %w", err)
+			return nil, time.Time{}, fmt.Errorf("failed to resolve features: %w", err)
 		}
+		// One read yields both what the caller holds now and when that stops
+		// being true. Folding here rather than filtering in SQL is what makes
+		// the boundary available without a second query.
+		granted, staleAt = entities.FoldGrants(records, r.clock())
 	}
 
 	declared := r.registry.All()
@@ -371,7 +397,7 @@ func (r *FeatureResolver) resolveDetailed(
 			Grantable:   meta.Grantable,
 		})
 	}
-	return out, nil
+	return out, staleAt, nil
 }
 
 // featureStateFrom turns a stored override map into a tri-state. An absent key

--- a/application/feature_resolver.go
+++ b/application/feature_resolver.go
@@ -237,6 +237,16 @@ func (r *FeatureResolver) refresh(ctx context.Context, key featureCacheKey) (map
 
 // onResolveError decides what a caller is told when the store cannot be read.
 //
+// KNOWN AND ACCEPTED: this makes a validity window fail OPEN during an outage.
+// The previous set is served while the store is unreadable, and that set still
+// contains a grant whose window has since closed — so access that was supposed
+// to end at an instant continues until the store answers again. Windows are
+// precisely the case where the availability trade points the other way, and it
+// is taken anyway because the alternative strips every capability from
+// everyone mid-turn on any database blip. The fix, when it is worth the memory,
+// is to keep the grant records on the cache entry so expiry can be re-folded
+// without reading anything.
+//
 // A failure is never cached as an answer. But if this caller already has a
 // resolved set, serving it beats answering off for everything: a database blip
 // would otherwise strip every capability from every user mid-turn — including
@@ -367,14 +377,22 @@ func (r *FeatureResolver) resolveDetailed(
 		if err != nil {
 			return nil, time.Time{}, fmt.Errorf("failed to resolve features: %w", err)
 		}
-		records, err := r.grants.GrantsFor(ctx, key.AccountID, key.AgentID, roleID)
-		if err != nil {
-			return nil, time.Time{}, fmt.Errorf("failed to resolve features: %w", err)
+		// No membership, no grants. Membership is checked when a grant is
+		// made, but nothing removes the row when somebody leaves an account —
+		// so without this a removed member with a live session would keep
+		// every feature granted to them, and the row would silently come back
+		// to life if they were ever re-added. An empty role means pericarp has
+		// no membership record for them here.
+		if roleID != "" {
+			records, err := r.grants.GrantsFor(ctx, key.AccountID, key.AgentID, roleID)
+			if err != nil {
+				return nil, time.Time{}, fmt.Errorf("failed to resolve features: %w", err)
+			}
+			// One read yields both what the caller holds now and when that
+			// stops being true. Folding here rather than filtering in SQL is
+			// what makes the boundary available without a second query.
+			granted, staleAt = entities.FoldGrants(records, r.clock())
 		}
-		// One read yields both what the caller holds now and when that stops
-		// being true. Folding here rather than filtering in SQL is what makes
-		// the boundary available without a second query.
-		granted, staleAt = entities.FoldGrants(records, r.clock())
 	}
 
 	declared := r.registry.All()

--- a/application/feature_resolver_test.go
+++ b/application/feature_resolver_test.go
@@ -201,14 +201,29 @@ func (f *fakeGrants) readCount() int {
 type fakeAccounts struct {
 	authrepos.AccountRepository
 	roles map[string]string // "accountID|agentID" -> roleID
-	err   error
+	// nonMembers names people deliberately NOT in an account, for the tests
+	// that care about somebody who was removed.
+	nonMembers map[string]bool
+	err        error
 }
 
+// FindMemberRole answers "member" for anyone without an explicit mapping.
+//
+// That is the faithful default: a grant can only be made to a member of the
+// account, so a test subject who holds a grant is a member by construction.
+// Returning "" for them would model somebody who had been removed — a real
+// case, but one the tests that want it should ask for deliberately.
 func (f fakeAccounts) FindMemberRole(_ context.Context, accountID, agentID string) (string, error) {
 	if f.err != nil {
 		return "", f.err
 	}
-	return f.roles[accountID+"|"+agentID], nil
+	if role, ok := f.roles[accountID+"|"+agentID]; ok {
+		return role, nil
+	}
+	if f.nonMembers[accountID+"|"+agentID] {
+		return "", nil
+	}
+	return "member", nil
 }
 
 // --- helpers -----------------------------------------------------------
@@ -811,5 +826,33 @@ func TestBoundaryDoesNotDefeatTheFailureBackoff(t *testing.T) {
 	}
 	if after, _ := settings.reads(); after-before > 1 {
 		t.Fatalf("a down store was retried %d times past a boundary, want at most 1", after-before)
+	}
+}
+
+// TestAGrantDoesNotOutliveMembership is the regression test for a hole the
+// premortem found: membership is checked when a grant is MADE, and nothing
+// removes the row when somebody leaves an account. Without a gate at
+// resolution, a removed member with a live session keeps every feature granted
+// to them — and the row silently comes back to life if they are re-added
+// months later.
+func TestAGrantDoesNotOutliveMembership(t *testing.T) {
+	registry, _ := newTestFeatureRegistry(t, featLedger)
+	grants := newFakeGrants()
+	accounts := &fakeAccounts{
+		roles:      map[string]string{},
+		nonMembers: map[string]bool{"acct-harbor|agent-gone": true},
+	}
+	r := NewFeatureResolver(config.Default(), registry, &fakeSettings{}, grants, accounts, nil)
+
+	grants.grantNow(repositories.FeatureSubjectAgent, "agent-gone", "acct-harbor", "ledger-export")
+	grants.grantNow(repositories.FeatureSubjectAgent, "agent-still-here", "acct-harbor", "ledger-export")
+
+	gone := mustResolve(t, r, ctxAs("agent-gone", "acct-harbor"))
+	if gone["ledger-export"] {
+		t.Fatal("somebody who is no longer a member kept a grant made while they were one")
+	}
+	still := mustResolve(t, r, ctxAs("agent-still-here", "acct-harbor"))
+	if !still["ledger-export"] {
+		t.Fatal("the membership gate took the grant from a member who still belongs")
 	}
 }

--- a/application/feature_resolver_test.go
+++ b/application/feature_resolver_test.go
@@ -99,50 +99,94 @@ func (f *fakeSettings) reads() (int, int) {
 
 type fakeGrants struct {
 	mu    sync.Mutex
-	byKey map[string]map[string]bool // "accountID|subjectID" -> keys
+	rows  []entities.FeatureGrantRecord
 	reads int
 	err   error
 }
 
 func newFakeGrants() *fakeGrants {
-	return &fakeGrants{byKey: map[string]map[string]bool{}}
+	return &fakeGrants{}
 }
 
-func (f *fakeGrants) GrantedKeys(_ context.Context, accountID, agentID, roleID string) (map[string]bool, error) {
+func (f *fakeGrants) GrantsFor(
+	_ context.Context, accountID, agentID, roleID string,
+) ([]entities.FeatureGrantRecord, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.reads++
 	if f.err != nil {
 		return nil, f.err
 	}
-	out := map[string]bool{}
-	for k := range f.byKey[accountID+"|"+agentID] {
-		out[k] = true
-	}
-	if roleID != "" {
-		for k := range f.byKey[accountID+"|"+roleID] {
-			out[k] = true
+	var out []entities.FeatureGrantRecord
+	for _, r := range f.rows {
+		if r.AccountID != accountID {
+			continue
+		}
+		if r.SubjectType == repositories.FeatureSubjectAgent && r.SubjectID == agentID {
+			out = append(out, r)
+			continue
+		}
+		if roleID != "" && r.SubjectType == repositories.FeatureSubjectRole && r.SubjectID == roleID {
+			out = append(out, r)
 		}
 	}
 	return out, nil
 }
 
-func (f *fakeGrants) Grant(_ context.Context, subjectType, subjectID, accountID, key string) error {
+func (f *fakeGrants) ListByFeature(
+	_ context.Context, accountID, key string,
+) ([]entities.FeatureGrantRecord, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	id := accountID + "|" + subjectID
-	if f.byKey[id] == nil {
-		f.byKey[id] = map[string]bool{}
+	if f.err != nil {
+		return nil, f.err
 	}
-	f.byKey[id][key] = true
+	var out []entities.FeatureGrantRecord
+	for _, r := range f.rows {
+		if r.AccountID == accountID && r.FeatureKey == key {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeGrants) Grant(_ context.Context, record entities.FeatureGrantRecord) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i, r := range f.rows {
+		if r.SubjectType == record.SubjectType && r.SubjectID == record.SubjectID &&
+			r.AccountID == record.AccountID && r.FeatureKey == record.FeatureKey {
+			f.rows[i] = record
+			return nil
+		}
+	}
+	f.rows = append(f.rows, record)
 	return nil
 }
 
-func (f *fakeGrants) Revoke(_ context.Context, subjectType, subjectID, accountID, key string) error {
+func (f *fakeGrants) Revoke(
+	_ context.Context, subjectType, subjectID, accountID, key string,
+) (bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	delete(f.byKey[accountID+"|"+subjectID], key)
-	return nil
+	for i, r := range f.rows {
+		if r.SubjectType == subjectType && r.SubjectID == subjectID &&
+			r.AccountID == accountID && r.FeatureKey == key {
+			f.rows = append(f.rows[:i], f.rows[i+1:]...)
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// grantNow is the windowless grant the #481 tests make. It must fold to
+// exactly the old behavior — held, with no boundary — which is what keeps
+// those scenarios meaningful across this change.
+func (f *fakeGrants) grantNow(subjectType, subjectID, accountID, key string) {
+	_ = f.Grant(context.Background(), entities.FeatureGrantRecord{
+		SubjectType: subjectType, SubjectID: subjectID,
+		AccountID: accountID, FeatureKey: key,
+	})
 }
 
 func (f *fakeGrants) readCount() int {
@@ -240,7 +284,7 @@ func TestResolverLayerPrecedence(t *testing.T) {
 			"account off beats a grant",
 			func(s *fakeSettings, g *fakeGrants, _ *fakeAccounts) {
 				_ = s.SetOverride(context.Background(), repositories.FeatureScopeAccount, "acct-harbor", "episodic-recall", false)
-				_ = g.Grant(context.Background(), repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "episodic-recall")
+				g.grantNow(repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "episodic-recall")
 			}, "episodic-recall", false,
 		},
 		{
@@ -254,20 +298,20 @@ func TestResolverLayerPrecedence(t *testing.T) {
 			"instance off beats a grant",
 			func(s *fakeSettings, g *fakeGrants, _ *fakeAccounts) {
 				_ = s.SetOverride(context.Background(), repositories.FeatureScopeInstance, "", "ledger-export", false)
-				_ = g.Grant(context.Background(), repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export")
+				g.grantNow(repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export")
 			}, "ledger-export", false,
 		},
 		{
 			"a direct grant turns a feature on",
 			func(_ *fakeSettings, g *fakeGrants, _ *fakeAccounts) {
-				_ = g.Grant(context.Background(), repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export")
+				g.grantNow(repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export")
 			}, "ledger-export", true,
 		},
 		{
 			"a role grant resolves like a direct one",
 			func(_ *fakeSettings, g *fakeGrants, a *fakeAccounts) {
 				a.roles["acct-harbor|agent-ops"] = "admin"
-				_ = g.Grant(context.Background(), repositories.FeatureSubjectRole, "admin", "acct-harbor", "ledger-export")
+				g.grantNow(repositories.FeatureSubjectRole, "admin", "acct-harbor", "ledger-export")
 			}, "ledger-export", true,
 		},
 		{
@@ -280,7 +324,7 @@ func TestResolverLayerPrecedence(t *testing.T) {
 			"a grant on a non-grantable feature is ignored",
 			func(s *fakeSettings, g *fakeGrants, _ *fakeAccounts) {
 				_ = s.SetOverride(context.Background(), repositories.FeatureScopeInstance, "", "audit-trail", false)
-				_ = g.Grant(context.Background(), repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "audit-trail")
+				g.grantNow(repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "audit-trail")
 			}, "audit-trail", false,
 		},
 	}
@@ -338,7 +382,7 @@ func TestResolverFailsClosedAndNeverCachesTheFailure(t *testing.T) {
 
 func TestResolverCachesPerAgentAndAccount(t *testing.T) {
 	r, s, g, _ := testResolver(t, []entities.FeatureMeta{featEpisodic, featLedger})
-	_ = g.Grant(context.Background(), repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export")
+	g.grantNow(repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export")
 
 	ops := ctxAs("agent-ops", "acct-harbor")
 	for i := 0; i < 30; i++ {
@@ -628,4 +672,18 @@ func TestResolverRebuildsWhenACachedSetLacksADeclaredKey(t *testing.T) {
 		t.Fatal("a key missing from the cached set answered its declared default, " +
 			"ignoring an explicit instance off")
 	}
+}
+
+// holds reports whether a grant row exists, for tests that assert on storage
+// rather than on resolution.
+func (f *fakeGrants) holds(subjectType, subjectID, accountID, key string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, r := range f.rows {
+		if r.SubjectType == subjectType && r.SubjectID == subjectID &&
+			r.AccountID == accountID && r.FeatureKey == key {
+			return true
+		}
+	}
+	return false
 }

--- a/application/feature_resolver_test.go
+++ b/application/feature_resolver_test.go
@@ -687,3 +687,129 @@ func (f *fakeGrants) holds(subjectType, subjectID, accountID, key string) bool {
 	}
 	return false
 }
+
+// --- window boundaries ------------------------------------------------
+
+// grantWindow adds a grant with a window to the fake.
+func (f *fakeGrants) grantWindow(agentID, accountID, key string, from, through *time.Time) {
+	_ = f.Grant(context.Background(), entities.FeatureGrantRecord{
+		SubjectType: repositories.FeatureSubjectAgent, SubjectID: agentID,
+		AccountID: accountID, FeatureKey: key,
+		ValidFrom: from, ValidThrough: through,
+	})
+}
+
+func windowResolver(t *testing.T, maxAge time.Duration) (*FeatureResolver, *fakeGrants, *time.Time) {
+	t.Helper()
+	registry, _ := newTestFeatureRegistry(t, featLedger)
+	grants := newFakeGrants()
+	cfg := config.Default()
+	cfg.Features.CacheMaxAge = maxAge
+	r := NewFeatureResolver(cfg, registry, &fakeSettings{}, grants,
+		&fakeAccounts{roles: map[string]string{}}, nil)
+	now := time.Now()
+	clock := &now
+	r.now = func() time.Time { return *clock }
+	return r, grants, clock
+}
+
+// TestGrantExpiresAtItsBoundaryNotAtTheCacheAge is the crux of #483. A grant
+// with two seconds left must expire in two seconds even though the cache is
+// good for ten minutes — and nothing invalidates, nothing restarts.
+func TestGrantExpiresAtItsBoundaryNotAtTheCacheAge(t *testing.T) {
+	r, grants, clock := windowResolver(t, 10*time.Minute)
+	ctx := ctxAs("agent-ops", "acct-harbor")
+
+	through := clock.Add(2 * time.Second)
+	grants.grantWindow("agent-ops", "acct-harbor", "ledger-export", nil, &through)
+
+	if set := mustResolve(t, r, ctx); !set["ledger-export"] {
+		t.Fatal("a live grant did not resolve on")
+	}
+	// Straight away: still on, still cached.
+	if set := mustResolve(t, r, ctx); !set["ledger-export"] {
+		t.Fatal("the grant expired before its window closed")
+	}
+
+	*clock = clock.Add(3 * time.Second)
+	if set := mustResolve(t, r, ctx); set["ledger-export"] {
+		t.Fatal("the grant survived its own window — the cached set ignored the boundary")
+	}
+	// And the maximum cache age never came into it.
+	if time.Until(*clock) > 10*time.Minute {
+		t.Fatal("the test advanced past the maximum cache age; it proves nothing")
+	}
+}
+
+// TestGrantStartsAtItsBoundaryWithNothingWritten: a grant dated forward begins
+// on its own, in a session that was already open when it was made.
+func TestGrantStartsAtItsBoundaryWithNothingWritten(t *testing.T) {
+	r, grants, clock := windowResolver(t, 10*time.Minute)
+	ctx := ctxAs("agent-ops", "acct-harbor")
+
+	from := clock.Add(2 * time.Second)
+	grants.grantWindow("agent-ops", "acct-harbor", "ledger-export", &from, nil)
+
+	if set := mustResolve(t, r, ctx); set["ledger-export"] {
+		t.Fatal("a grant that has not started was already held")
+	}
+	*clock = clock.Add(3 * time.Second)
+	if set := mustResolve(t, r, ctx); !set["ledger-export"] {
+		t.Fatal("the grant did not begin at its own boundary")
+	}
+}
+
+// TestNoWindowMeansNoExtraResolves keeps the cache doing its job: a grant with
+// no window must not make every evaluation re-read.
+func TestNoWindowMeansNoExtraResolves(t *testing.T) {
+	r, grants, clock := windowResolver(t, 10*time.Minute)
+	ctx := ctxAs("agent-ops", "acct-harbor")
+	grants.grantNow(repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export")
+
+	_ = mustResolve(t, r, ctx)
+	before := grants.readCount()
+	*clock = clock.Add(time.Minute)
+	for i := 0; i < 20; i++ {
+		_ = mustResolve(t, r, ctx)
+	}
+	if grants.readCount() != before {
+		t.Fatalf("a windowless grant caused %d extra reads, want 0",
+			grants.readCount()-before)
+	}
+}
+
+// TestBoundaryDoesNotDefeatTheFailureBackoff: while the store is down, serving
+// the last known set beats re-reading a database that cannot answer, even past
+// a boundary.
+func TestBoundaryDoesNotDefeatTheFailureBackoff(t *testing.T) {
+	registry, _ := newTestFeatureRegistry(t, featLedger)
+	settings := &fakeSettings{}
+	grants := newFakeGrants()
+	cfg := config.Default()
+	cfg.Features.CacheMaxAge = 10 * time.Minute
+	r := NewFeatureResolver(cfg, registry, settings, grants,
+		&fakeAccounts{roles: map[string]string{}}, nil)
+	now := time.Now()
+	r.now = func() time.Time { return now }
+	ctx := ctxAs("agent-ops", "acct-harbor")
+
+	through := now.Add(2 * time.Second)
+	grants.grantWindow("agent-ops", "acct-harbor", "ledger-export", nil, &through)
+	_ = mustResolve(t, r, ctx)
+
+	settings.err = errors.New("database is unreachable")
+	r.expire(featureCacheKey{AgentID: "agent-ops", AccountID: "acct-harbor"})
+	if _, err := r.ResolvedSet(ctx); err != nil {
+		t.Fatalf("a failing refresh did not serve the last known set: %v", err)
+	}
+
+	before, _ := settings.reads()
+	for i := 0; i < 10; i++ {
+		if _, err := r.ResolvedSet(ctx); err != nil {
+			t.Fatalf("evaluation %d errored instead of serving the last known set: %v", i, err)
+		}
+	}
+	if after, _ := settings.reads(); after-before > 1 {
+		t.Fatalf("a down store was retried %d times past a boundary, want at most 1", after-before)
+	}
+}

--- a/application/feature_service.go
+++ b/application/feature_service.go
@@ -18,6 +18,7 @@ package application
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/wepala/weos/v3/domain/entities"
 	"github.com/wepala/weos/v3/domain/repositories"
@@ -137,45 +138,149 @@ func (s *FeatureService) ClearAccountFeature(ctx context.Context, accountID, key
 	return nil
 }
 
+// GrantTerms is everything about a grant other than who holds it: when it
+// applies, and who made it.
+type GrantTerms struct {
+	ValidFrom      *time.Time
+	ValidThrough   *time.Time
+	GrantedByID    string
+	GrantedByEmail string
+	Source         string
+}
+
 // GrantToAgent gives one person a feature within an account.
-func (s *FeatureService) GrantToAgent(ctx context.Context, accountID, agentID, key string) error {
-	return s.changeAgentGrant(ctx, accountID, agentID, key, true)
-}
-
-// RevokeFromAgent takes it back. The person stays signed in; their next
-// evaluation costs one database read and answers off.
-func (s *FeatureService) RevokeFromAgent(ctx context.Context, accountID, agentID, key string) error {
-	return s.changeAgentGrant(ctx, accountID, agentID, key, false)
-}
-
-func (s *FeatureService) changeAgentGrant(
-	ctx context.Context, accountID, agentID, key string, grant bool,
+func (s *FeatureService) GrantToAgent(
+	ctx context.Context, accountID, agentID, key string, terms GrantTerms,
 ) error {
 	if err := s.validateGrant(accountID, agentID, key); err != nil {
 		return err
 	}
-	var err error
-	if grant {
-		err = s.grants.Grant(ctx, repositories.FeatureSubjectAgent, agentID, accountID, key)
-	} else {
-		err = s.grants.Revoke(ctx, repositories.FeatureSubjectAgent, agentID, accountID, key)
+	if err := s.validateWindow(terms); err != nil {
+		return err
 	}
-	if err != nil {
+	if err := s.grants.Grant(ctx, s.recordFor(
+		repositories.FeatureSubjectAgent, agentID, accountID, key, terms)); err != nil {
 		return err
 	}
 	s.invalidator.InvalidateAgents(ctx, accountID, agentID)
-	s.log(ctx, "agent grant changed", "feature", key, "account", accountID, "agent", agentID, "granted", grant)
+	s.log(ctx, "agent grant made", "feature", key, "account", accountID, "agent", agentID)
 	return nil
 }
 
-// GrantToRole gives a feature to everyone holding a role in an account.
-func (s *FeatureService) GrantToRole(ctx context.Context, accountID, roleID, key string) error {
-	return s.changeRoleGrant(ctx, accountID, roleID, key, true)
+// RevokeFromAgent takes it back, and reports whether there was anything to
+// take. The person stays signed in; their next evaluation costs one database
+// read and answers off.
+func (s *FeatureService) RevokeFromAgent(
+	ctx context.Context, accountID, agentID, key string,
+) (bool, error) {
+	if err := s.validateGrant(accountID, agentID, key); err != nil {
+		return false, err
+	}
+	removed, err := s.grants.Revoke(ctx, repositories.FeatureSubjectAgent, agentID, accountID, key)
+	if err != nil {
+		return false, err
+	}
+	if !removed {
+		// Nothing changed, so nothing is invalidated. Dropping a cache entry
+		// for a revocation that removed nothing would cost every session in
+		// the account a re-resolve for no reason.
+		return false, nil
+	}
+	s.invalidator.InvalidateAgents(ctx, accountID, agentID)
+	s.log(ctx, "agent grant revoked", "feature", key, "account", accountID, "agent", agentID)
+	return true, nil
 }
 
-// RevokeFromRole takes it back from everyone holding the role.
-func (s *FeatureService) RevokeFromRole(ctx context.Context, accountID, roleID, key string) error {
-	return s.changeRoleGrant(ctx, accountID, roleID, key, false)
+func (s *FeatureService) recordFor(
+	subjectType, subjectID, accountID, key string, terms GrantTerms,
+) entities.FeatureGrantRecord {
+	return entities.FeatureGrantRecord{
+		SubjectType:    subjectType,
+		SubjectID:      subjectID,
+		AccountID:      accountID,
+		FeatureKey:     key,
+		ValidFrom:      terms.ValidFrom,
+		ValidThrough:   terms.ValidThrough,
+		GrantedByID:    terms.GrantedByID,
+		GrantedByEmail: terms.GrantedByEmail,
+		Source:         terms.Source,
+	}
+}
+
+// validateWindow refuses a window that can never be open. Checked once here so
+// all three surfaces refuse it the same way.
+func (s *FeatureService) validateWindow(terms GrantTerms) error {
+	if terms.ValidFrom == nil || terms.ValidThrough == nil {
+		return nil
+	}
+	if !terms.ValidThrough.After(*terms.ValidFrom) {
+		return fmt.Errorf(
+			"the window ends before it begins (%s is not after %s): %w",
+			terms.ValidThrough.Format(time.RFC3339), terms.ValidFrom.Format(time.RFC3339), ErrValidation)
+	}
+	return nil
+}
+
+// GrantsOnFeature lists every grant on one feature in an account, including
+// pending and expired ones.
+func (s *FeatureService) GrantsOnFeature(
+	ctx context.Context, accountID, key string,
+) ([]entities.FeatureGrantRecord, error) {
+	if _, err := s.declared(key); err != nil {
+		return nil, err
+	}
+	return s.grants.ListByFeature(ctx, accountID, key)
+}
+
+// GrantsFor lists the grants that could apply to one caller.
+func (s *FeatureService) GrantsFor(
+	ctx context.Context, accountID, agentID, roleID string,
+) ([]entities.FeatureGrantRecord, error) {
+	return s.grants.GrantsFor(ctx, accountID, agentID, roleID)
+}
+
+// Declared exposes a feature's declaration so a surface can order its refusals
+// — an unknown key is a 404 and must be answered before anything looks up a
+// person or a membership.
+func (s *FeatureService) Declared(key string) (entities.FeatureMeta, error) {
+	return s.declared(key)
+}
+
+// GrantToRole gives a feature to everyone holding a role in an account.
+func (s *FeatureService) GrantToRole(
+	ctx context.Context, accountID, roleID, key string, terms GrantTerms,
+) error {
+	if err := s.validateGrant(accountID, roleID, key); err != nil {
+		return err
+	}
+	if err := s.validateWindow(terms); err != nil {
+		return err
+	}
+	if err := s.grants.Grant(ctx, s.recordFor(
+		repositories.FeatureSubjectRole, roleID, accountID, key, terms)); err != nil {
+		return err
+	}
+	s.fanOutRoleChange(ctx, accountID, roleID, key, true)
+	return nil
+}
+
+// RevokeFromRole takes it back from everyone holding the role, and reports
+// whether there was anything to take.
+func (s *FeatureService) RevokeFromRole(
+	ctx context.Context, accountID, roleID, key string,
+) (bool, error) {
+	if err := s.validateGrant(accountID, roleID, key); err != nil {
+		return false, err
+	}
+	removed, err := s.grants.Revoke(ctx, repositories.FeatureSubjectRole, roleID, accountID, key)
+	if err != nil {
+		return false, err
+	}
+	if !removed {
+		return false, nil
+	}
+	s.fanOutRoleChange(ctx, accountID, roleID, key, false)
+	return true, nil
 }
 
 // changeRoleGrant is the expensive case. One row changes, but the resolved set
@@ -186,22 +291,9 @@ func (s *FeatureService) RevokeFromRole(ctx context.Context, accountID, roleID, 
 // concurrently is included rather than missed. A member this query does not
 // return keeps a stale answer until the maximum cache age expires, and nothing
 // will point at it — which is why the listing query is tested directly.
-func (s *FeatureService) changeRoleGrant(
+func (s *FeatureService) fanOutRoleChange(
 	ctx context.Context, accountID, roleID, key string, grant bool,
-) error {
-	if err := s.validateGrant(accountID, roleID, key); err != nil {
-		return err
-	}
-	var err error
-	if grant {
-		err = s.grants.Grant(ctx, repositories.FeatureSubjectRole, roleID, accountID, key)
-	} else {
-		err = s.grants.Revoke(ctx, repositories.FeatureSubjectRole, roleID, accountID, key)
-	}
-	if err != nil {
-		return err
-	}
-
+) {
 	agentIDs, err := s.members.ListMemberIDsByRole(ctx, accountID, roleID)
 	if err != nil {
 		// The write landed but the fan-out failed. Fall back to invalidating
@@ -211,13 +303,12 @@ func (s *FeatureService) changeRoleGrant(
 		s.log(ctx, "could not list role members; invalidating the whole account instead",
 			"feature", key, "account", accountID, "role", roleID, "error", err)
 		s.invalidator.InvalidateAccount(ctx, accountID)
-		return nil
+		return
 	}
 
 	s.invalidator.InvalidateAgents(ctx, accountID, agentIDs...)
 	s.log(ctx, "role grant changed", "feature", key, "account", accountID,
 		"role", roleID, "granted", grant, "membersInvalidated", len(agentIDs))
-	return nil
 }
 
 func (s *FeatureService) validateGrant(accountID, subjectID, key string) error {

--- a/application/feature_service_test.go
+++ b/application/feature_service_test.go
@@ -121,16 +121,16 @@ func TestServiceRefusesIneligibleWrites(t *testing.T) {
 			return svc.SetAccountFeature(ctx, "acct-harbor", "audit-trail", false)
 		}, "cannot be changed per account"},
 		{"non-grantable to an agent", func() error {
-			return svc.GrantToAgent(ctx, "acct-harbor", "agent-ops", "audit-trail")
+			return svc.GrantToAgent(ctx, "acct-harbor", "agent-ops", "audit-trail", GrantTerms{})
 		}, "cannot be granted"},
 		{"non-grantable to a role", func() error {
-			return svc.GrantToRole(ctx, "acct-harbor", "admin", "audit-trail")
+			return svc.GrantToRole(ctx, "acct-harbor", "admin", "audit-trail", GrantTerms{})
 		}, "cannot be granted"},
 		{"account override with no account", func() error {
 			return svc.SetAccountFeature(ctx, "", "episodic-recall", true)
 		}, "account is required"},
 		{"grant with no subject", func() error {
-			return svc.GrantToAgent(ctx, "acct-harbor", "", "episodic-recall")
+			return svc.GrantToAgent(ctx, "acct-harbor", "", "episodic-recall", GrantTerms{})
 		}, "account and a subject are required"},
 	}
 
@@ -156,20 +156,20 @@ func TestServiceAgentGrantInvalidatesThatPersonOnly(t *testing.T) {
 	ctx := context.Background()
 	svc, _, grants, inv := testService(t, fakeMembers{}, featLedger)
 
-	if err := svc.GrantToAgent(ctx, "acct-harbor", "agent-ops", "ledger-export"); err != nil {
+	if err := svc.GrantToAgent(ctx, "acct-harbor", "agent-ops", "ledger-export", GrantTerms{}); err != nil {
 		t.Fatalf("GrantToAgent: %v", err)
 	}
 	if got := inv.agentsFor("acct-harbor"); len(got) != 1 || got[0] != "agent-ops" {
 		t.Fatalf("invalidated agents = %v, want [agent-ops]", got)
 	}
-	if !grants.byKey["acct-harbor|agent-ops"]["ledger-export"] {
+	if !grants.holds("agent", "agent-ops", "acct-harbor", "ledger-export") {
 		t.Fatal("the grant was not stored")
 	}
 
-	if err := svc.RevokeFromAgent(ctx, "acct-harbor", "agent-ops", "ledger-export"); err != nil {
+	if _, err := svc.RevokeFromAgent(ctx, "acct-harbor", "agent-ops", "ledger-export"); err != nil {
 		t.Fatalf("RevokeFromAgent: %v", err)
 	}
-	if grants.byKey["acct-harbor|agent-ops"]["ledger-export"] {
+	if grants.holds("agent", "agent-ops", "acct-harbor", "ledger-export") {
 		t.Fatal("the grant survived the revoke")
 	}
 	if got := inv.agentsFor("acct-harbor"); len(got) != 2 {
@@ -187,7 +187,7 @@ func TestServiceRoleGrantFansOutToEveryHolder(t *testing.T) {
 	}}
 	svc, _, _, inv := testService(t, members, featLedger)
 
-	if err := svc.GrantToRole(ctx, "acct-harbor", "admin", "ledger-export"); err != nil {
+	if err := svc.GrantToRole(ctx, "acct-harbor", "admin", "ledger-export", GrantTerms{}); err != nil {
 		t.Fatalf("GrantToRole: %v", err)
 	}
 	got := inv.agentsFor("acct-harbor")
@@ -207,10 +207,10 @@ func TestServiceRoleGrantFallsBackWhenTheMemberListFails(t *testing.T) {
 	members := fakeMembers{err: errors.New("account_members is unreadable")}
 	svc, _, grants, inv := testService(t, members, featLedger)
 
-	if err := svc.GrantToRole(ctx, "acct-harbor", "admin", "ledger-export"); err != nil {
+	if err := svc.GrantToRole(ctx, "acct-harbor", "admin", "ledger-export", GrantTerms{}); err != nil {
 		t.Fatalf("GrantToRole returned %v; the write landed, so it must not fail", err)
 	}
-	if !grants.byKey["acct-harbor|admin"]["ledger-export"] {
+	if !grants.holds("role", "admin", "acct-harbor", "ledger-export") {
 		t.Fatal("the grant was not stored")
 	}
 	if len(inv.accounts) != 1 || inv.accounts[0] != "acct-harbor" {

--- a/domain/entities/feature_change.go
+++ b/domain/entities/feature_change.go
@@ -68,6 +68,17 @@ type FeatureChanged struct {
 	SubjectType  string
 	SubjectID    string
 	SubjectEmail string
+
+	// ValidFrom and ValidThrough record the window a grant was made with.
+	//
+	// On the event rather than only on the row, because the row is the wrong
+	// place to answer "why did access end". A window closing writes nothing —
+	// that is the whole design — and a re-grant overwrites the row's terms in
+	// place, so neither store would remember the original. Events are
+	// immutable and additive, which means this is cheap now and impossible to
+	// backfill once real events exist.
+	ValidFrom    *time.Time
+	ValidThrough *time.Time
 }
 
 func (e FeatureChanged) EventType() string { return "Feature.Changed" }

--- a/domain/entities/feature_change.go
+++ b/domain/entities/feature_change.go
@@ -35,9 +35,11 @@ const (
 
 // What happened to the setting.
 const (
-	FeatureChangeStateOn    = "on"
-	FeatureChangeStateOff   = "off"
-	FeatureChangeStateReset = "reset"
+	FeatureChangeStateOn      = "on"
+	FeatureChangeStateOff     = "off"
+	FeatureChangeStateReset   = "reset"
+	FeatureChangeStateGranted = "granted"
+	FeatureChangeStateRevoked = "revoked"
 )
 
 // FeatureChanged records one change to feature state.
@@ -58,6 +60,14 @@ type FeatureChanged struct {
 	ActorID    string
 	ActorEmail string
 	Timestamp  time.Time
+
+	// Subject fields are set for grants and revocations, and empty for
+	// instance and account overrides. Added after the event already existed;
+	// events are immutable, so this is additive only — an older stored event
+	// deserializes with these empty, which is what it meant.
+	SubjectType  string
+	SubjectID    string
+	SubjectEmail string
 }
 
 func (e FeatureChanged) EventType() string { return "Feature.Changed" }

--- a/domain/entities/feature_grant.go
+++ b/domain/entities/feature_grant.go
@@ -1,0 +1,122 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package entities
+
+import "time"
+
+// Window states a grant can be in, for listings.
+const (
+	GrantActive  = "active"
+	GrantPending = "pending"
+	GrantExpired = "expired"
+)
+
+// FeatureGrantRecord is one stored grant, as resolution and listings read it.
+//
+// The subject is an agent id or a role id — never an email. An address is how
+// an admin names somebody when granting; it is not what the grant is against,
+// because an address can change and the grant should not follow it. Listings
+// resolve the address back at read time.
+type FeatureGrantRecord struct {
+	SubjectType string
+	SubjectID   string
+	AccountID   string
+	FeatureKey  string
+
+	// ValidFrom and ValidThrough bound the grant. Nil means unbounded on that
+	// side. The window is half-open: the grant is on at the instant ValidFrom
+	// arrives and off at the instant ValidThrough passes.
+	ValidFrom    *time.Time
+	ValidThrough *time.Time
+
+	// Provenance. Kept on the row as well as in the event log because the two
+	// answer different questions: the row says who granted a right that still
+	// exists, and survives to be listed; the event log says what happened, and
+	// survives revocation, which deletes the row.
+	GrantedByID    string
+	GrantedByEmail string
+	Source         string
+	CreatedAt      time.Time
+}
+
+// Active reports whether the grant applies at now.
+func (g FeatureGrantRecord) Active(now time.Time) bool {
+	if g.ValidFrom != nil && now.Before(*g.ValidFrom) {
+		return false
+	}
+	if g.ValidThrough != nil && !now.Before(*g.ValidThrough) {
+		return false
+	}
+	return true
+}
+
+// WindowState describes the grant for an operator reading a listing. An
+// expired grant is still a row — revocation deletes, a closed window does not —
+// so a listing has to be able to say which it is looking at.
+func (g FeatureGrantRecord) WindowState(now time.Time) string {
+	switch {
+	case g.ValidFrom != nil && now.Before(*g.ValidFrom):
+		return GrantPending
+	case g.ValidThrough != nil && !now.Before(*g.ValidThrough):
+		return GrantExpired
+	default:
+		return GrantActive
+	}
+}
+
+// FoldGrants reduces a caller's grant rows to the set of features they hold
+// right now, and to the next instant at which that answer changes on its own.
+//
+// The second return is what lets a grant expire to the second without shrinking
+// the cache. A resolved feature set is cached and reused for every later
+// evaluation in a session — thirty in an agent turn is ordinary — so a window
+// that closes between two of them would otherwise go unnoticed until the whole
+// entry aged out. Instead the entry remembers the earliest boundary among the
+// grants that fed it and treats itself as stale at that instant. Nothing polls,
+// nothing is scheduled, and the cost is paid lazily by whoever evaluates next.
+//
+// The alternative — tuning the maximum cache age down to whatever precision a
+// window needs — would throw away the caching that exists for the other three
+// hundred and sixty evaluations.
+//
+// Only boundaries strictly after now are returned, so a set is never born
+// stale. A row already expired contributes nothing: it will not change again.
+func FoldGrants(records []FeatureGrantRecord, now time.Time) (map[string]bool, time.Time) {
+	active := make(map[string]bool, len(records))
+	var next time.Time
+
+	consider := func(t *time.Time) {
+		if t == nil || !t.After(now) {
+			return
+		}
+		if next.IsZero() || t.Before(next) {
+			next = *t
+		}
+	}
+
+	for _, r := range records {
+		if r.Active(now) {
+			active[r.FeatureKey] = true
+			// A live grant stops being live when its window closes.
+			consider(r.ValidThrough)
+			continue
+		}
+		// A grant that has not started yet begins on its own, with nothing
+		// written and nobody signed in again.
+		consider(r.ValidFrom)
+	}
+	return active, next
+}

--- a/domain/entities/feature_grant.go
+++ b/domain/entities/feature_grant.go
@@ -22,6 +22,11 @@ const (
 	GrantActive  = "active"
 	GrantPending = "pending"
 	GrantExpired = "expired"
+	// GrantOrphaned means the row exists but reaches nobody: its subject is no
+	// longer a member of the account. Distinct from expired, because an
+	// operator's next move differs — an expired grant ran its course, an
+	// orphaned one is left-over access that should be cleaned up.
+	GrantOrphaned = "orphaned"
 )
 
 // FeatureGrantRecord is one stored grant, as resolution and listings read it.

--- a/domain/entities/feature_grant_test.go
+++ b/domain/entities/feature_grant_test.go
@@ -1,0 +1,162 @@
+package entities
+
+import (
+	"testing"
+	"time"
+)
+
+func at(base time.Time, d time.Duration) *time.Time {
+	t := base.Add(d)
+	return &t
+}
+
+func grantRow(key string, from, through *time.Time) FeatureGrantRecord {
+	return FeatureGrantRecord{
+		SubjectType: "agent", SubjectID: "agent-ops", AccountID: "acct",
+		FeatureKey: key, ValidFrom: from, ValidThrough: through,
+	}
+}
+
+// TestGrantWindowIsHalfOpen pins the two instants that decide whether a window
+// is off by one: a grant is on the moment it starts, and off the moment it
+// ends.
+func TestGrantWindowIsHalfOpen(t *testing.T) {
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	start, end := now, now.Add(time.Hour)
+	g := grantRow("ledger-export", &start, &end)
+
+	cases := []struct {
+		name string
+		when time.Time
+		want bool
+	}{
+		{"a moment before it starts", start.Add(-time.Nanosecond), false},
+		{"the instant it starts", start, true},
+		{"midway", start.Add(30 * time.Minute), true},
+		{"a moment before it ends", end.Add(-time.Nanosecond), true},
+		{"the instant it ends", end, false},
+		{"after it ends", end.Add(time.Nanosecond), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := g.Active(tc.when); got != tc.want {
+				t.Fatalf("Active(%v) = %v, want %v", tc.when, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGrantWindowStates(t *testing.T) {
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name string
+		row  FeatureGrantRecord
+		want string
+	}{
+		{"no window", grantRow("k", nil, nil), GrantActive},
+		{"starts later", grantRow("k", at(now, time.Hour), nil), GrantPending},
+		{"already ended", grantRow("k", nil, at(now, -time.Hour)), GrantExpired},
+		{"open now", grantRow("k", at(now, -time.Hour), at(now, time.Hour)), GrantActive},
+		{"ends exactly now", grantRow("k", nil, &now), GrantExpired},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.row.WindowState(now); got != tc.want {
+				t.Fatalf("WindowState = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFoldGrantsReportsTheEarliestBoundary is the crux of the story. The
+// boundary is what lets a grant expire to the second on a cache measured in
+// minutes.
+func TestFoldGrantsReportsTheEarliestBoundary(t *testing.T) {
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+
+	t.Run("no windows means no boundary", func(t *testing.T) {
+		active, next := FoldGrants([]FeatureGrantRecord{
+			grantRow("a", nil, nil), grantRow("b", nil, nil),
+		}, now)
+		if len(active) != 2 {
+			t.Fatalf("active = %v, want both", active)
+		}
+		if !next.IsZero() {
+			t.Fatalf("next = %v, want zero — nothing changes on its own", next)
+		}
+	})
+
+	t.Run("a live grant's end is a boundary", func(t *testing.T) {
+		active, next := FoldGrants([]FeatureGrantRecord{
+			grantRow("a", nil, at(now, 2*time.Second)),
+		}, now)
+		if !active["a"] {
+			t.Fatal("a live grant was folded away")
+		}
+		if !next.Equal(now.Add(2 * time.Second)) {
+			t.Fatalf("next = %v, want the moment it ends", next)
+		}
+	})
+
+	t.Run("a pending grant's start is a boundary", func(t *testing.T) {
+		active, next := FoldGrants([]FeatureGrantRecord{
+			grantRow("a", at(now, time.Minute), nil),
+		}, now)
+		if active["a"] {
+			t.Fatal("a grant that has not started was counted")
+		}
+		if !next.Equal(now.Add(time.Minute)) {
+			t.Fatalf("next = %v, want the moment it starts", next)
+		}
+	})
+
+	t.Run("the earliest of many wins", func(t *testing.T) {
+		_, next := FoldGrants([]FeatureGrantRecord{
+			grantRow("a", nil, at(now, time.Hour)),
+			grantRow("b", at(now, 5*time.Second), nil),
+			grantRow("c", nil, at(now, time.Minute)),
+		}, now)
+		if !next.Equal(now.Add(5 * time.Second)) {
+			t.Fatalf("next = %v, want the earliest boundary", next)
+		}
+	})
+
+	t.Run("an expired grant contributes nothing", func(t *testing.T) {
+		active, next := FoldGrants([]FeatureGrantRecord{
+			grantRow("a", nil, at(now, -time.Hour)),
+		}, now)
+		if active["a"] {
+			t.Fatal("an expired grant was counted as held")
+		}
+		if !next.IsZero() {
+			t.Fatalf("next = %v, want zero — an expired grant will not change again", next)
+		}
+	})
+
+	// A boundary at or before now would make the entry stale the instant it
+	// was stored, and every evaluation would re-resolve forever.
+	t.Run("a boundary is never at or before now", func(t *testing.T) {
+		_, next := FoldGrants([]FeatureGrantRecord{
+			grantRow("a", nil, &now),
+			grantRow("b", &now, nil),
+		}, now)
+		if !next.IsZero() {
+			t.Fatalf("next = %v, want zero — a set must never be born stale", next)
+		}
+	})
+
+	// Two grants on one key: an expired personal grant must not cancel a live
+	// role grant, and the dead one must not contribute a boundary.
+	t.Run("one live grant survives an expired one on the same key", func(t *testing.T) {
+		active, next := FoldGrants([]FeatureGrantRecord{
+			{SubjectType: "agent", FeatureKey: "ledger-export", ValidThrough: at(now, -time.Hour)},
+			{SubjectType: "role", FeatureKey: "ledger-export"},
+		}, now)
+		if !active["ledger-export"] {
+			t.Fatal("an expired personal grant canceled a live role grant")
+		}
+		if !next.IsZero() {
+			t.Fatalf("next = %v, want zero", next)
+		}
+	})
+}

--- a/domain/repositories/feature_repository.go
+++ b/domain/repositories/feature_repository.go
@@ -15,7 +15,11 @@
 
 package repositories
 
-import "context"
+import (
+	"context"
+
+	"github.com/wepala/weos/v3/domain/entities"
+)
 
 // Override scopes. The instance scope has no identifier — there is one
 // instance — so its rows carry an empty ScopeID.
@@ -72,16 +76,30 @@ type FeatureSettingsRepository interface {
 // immediately: #483 adds validity windows and provenance to grants alone,
 // which would be permanently null on every instance-scoped override row.
 type FeatureGrantRepository interface {
-	// GrantedKeys returns the feature keys granted to this caller within an
-	// account, unioning the grant made to them directly with the grant carried
-	// by their role. roleID may be empty when the caller holds no role.
-	GrantedKeys(ctx context.Context, accountID, agentID, roleID string) (map[string]bool, error)
+	// GrantsFor returns the grant ROWS that could apply to this caller within
+	// an account — the grant made to them directly, and the one carried by
+	// their role. roleID may be empty when the caller holds no role.
+	//
+	// Rows outside their validity window are returned too, deliberately. A
+	// grant that has not started yet is a boundary the resolver has to know
+	// about so it can expire its cached answer at the right instant, and a
+	// grant that has closed is still a row a listing has to be able to show.
+	// Filtering in SQL would hide both.
+	GrantsFor(ctx context.Context, accountID, agentID, roleID string) ([]entities.FeatureGrantRecord, error)
 
-	// Grant records a grant. Granting twice is not an error.
-	Grant(ctx context.Context, subjectType, subjectID, accountID, featureKey string) error
+	// ListByFeature returns every grant on one feature within an account, for
+	// the admin listing. Includes pending and expired rows.
+	ListByFeature(ctx context.Context, accountID, featureKey string) ([]entities.FeatureGrantRecord, error)
 
-	// Revoke removes a grant. Revoking one that does not exist is not an error.
-	Revoke(ctx context.Context, subjectType, subjectID, accountID, featureKey string) error
+	// Grant records a grant, replacing the window and provenance of one that
+	// already exists. Granting twice leaves one grant, not two.
+	Grant(ctx context.Context, record entities.FeatureGrantRecord) error
+
+	// Revoke removes a grant and reports whether one was there. Revoking a
+	// grant nobody holds is not an error — the caller's intent is already
+	// satisfied — but nothing is recorded and no cache is disturbed for a
+	// change that did not happen.
+	Revoke(ctx context.Context, subjectType, subjectID, accountID, featureKey string) (bool, error)
 }
 
 // AccountMemberQuery reads pericarp's account_members projection for the one

--- a/infrastructure/database/gorm/feature_repository.go
+++ b/infrastructure/database/gorm/feature_repository.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/wepala/weos/v3/domain/entities"
 	"github.com/wepala/weos/v3/domain/repositories"
 	"github.com/wepala/weos/v3/infrastructure/models"
 
@@ -110,14 +111,14 @@ func ProvideFeatureGrantRepository(db *gorm.DB) repositories.FeatureGrantReposit
 	return &FeatureGrantRepository{db: db}
 }
 
-func (r *FeatureGrantRepository) GrantedKeys(
+func (r *FeatureGrantRepository) GrantsFor(
 	ctx context.Context, accountID, agentID, roleID string,
-) (map[string]bool, error) {
+) ([]entities.FeatureGrantRecord, error) {
 	if accountID == "" || agentID == "" {
 		// Grants are account-scoped and subject-bound. With neither, there is
 		// nothing a grant could match, and querying would risk matching rows
 		// on empty strings.
-		return map[string]bool{}, nil
+		return nil, nil
 	}
 
 	query := r.db.WithContext(ctx).
@@ -125,7 +126,9 @@ func (r *FeatureGrantRepository) GrantedKeys(
 		Where("account_id = ?", accountID)
 
 	// One query for both legs — the grant made to this person directly, and
-	// the grant carried by whatever role they hold in this account.
+	// the one carried by whatever role they hold in this account. No filter on
+	// the window: a grant that has not started is a boundary the resolver
+	// needs, and one that has closed is a row a listing needs.
 	if roleID != "" {
 		query = query.Where(
 			r.db.Where("subject_type = ? AND subject_id = ?", repositories.FeatureSubjectAgent, agentID).
@@ -135,51 +138,95 @@ func (r *FeatureGrantRepository) GrantedKeys(
 		query = query.Where("subject_type = ? AND subject_id = ?", repositories.FeatureSubjectAgent, agentID)
 	}
 
-	var keys []string
-	if err := query.Distinct().Pluck("feature_key", &keys).Error; err != nil {
+	var rows []models.FeatureGrant
+	if err := query.Find(&rows).Error; err != nil {
 		return nil, fmt.Errorf("failed to load feature grants for agent %q: %w", agentID, err)
 	}
-	out := make(map[string]bool, len(keys))
-	for _, k := range keys {
-		out[k] = true
+	return recordsFrom(rows), nil
+}
+
+func (r *FeatureGrantRepository) ListByFeature(
+	ctx context.Context, accountID, featureKey string,
+) ([]entities.FeatureGrantRecord, error) {
+	if accountID == "" || featureKey == "" {
+		return nil, nil
 	}
-	return out, nil
+	var rows []models.FeatureGrant
+	err := r.db.WithContext(ctx).
+		Where("account_id = ? AND feature_key = ?", accountID, featureKey).
+		Order("subject_type ASC, subject_id ASC").
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to list grants on feature %q: %w", featureKey, err)
+	}
+	return recordsFrom(rows), nil
+}
+
+func recordsFrom(rows []models.FeatureGrant) []entities.FeatureGrantRecord {
+	out := make([]entities.FeatureGrantRecord, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, entities.FeatureGrantRecord{
+			SubjectType:    row.SubjectType,
+			SubjectID:      row.SubjectID,
+			AccountID:      row.AccountID,
+			FeatureKey:     row.FeatureKey,
+			ValidFrom:      row.ValidFrom,
+			ValidThrough:   row.ValidThrough,
+			GrantedByID:    row.GrantedByID,
+			GrantedByEmail: row.GrantedByEmail,
+			Source:         row.Source,
+			CreatedAt:      row.CreatedAt,
+		})
+	}
+	return out
 }
 
 func (r *FeatureGrantRepository) Grant(
-	ctx context.Context, subjectType, subjectID, accountID, featureKey string,
+	ctx context.Context, record entities.FeatureGrantRecord,
 ) error {
 	row := models.FeatureGrant{
-		SubjectType: subjectType,
-		SubjectID:   subjectID,
-		AccountID:   accountID,
-		FeatureKey:  featureKey,
+		SubjectType:    record.SubjectType,
+		SubjectID:      record.SubjectID,
+		AccountID:      record.AccountID,
+		FeatureKey:     record.FeatureKey,
+		ValidFrom:      record.ValidFrom,
+		ValidThrough:   record.ValidThrough,
+		GrantedByID:    record.GrantedByID,
+		GrantedByEmail: record.GrantedByEmail,
+		Source:         record.Source,
 	}
-	// Granting twice is not an error — the right is already held, and an
-	// operator repeating themselves should not see a failure.
+	// Granting twice leaves one grant. The window and provenance are replaced
+	// rather than kept: re-granting with a new window is how an admin changes
+	// one, and the record should say who last did that.
 	err := r.db.WithContext(ctx).Clauses(clause.OnConflict{
 		Columns: []clause.Column{
 			{Name: "subject_type"}, {Name: "subject_id"}, {Name: "account_id"}, {Name: "feature_key"},
 		},
-		DoUpdates: clause.AssignmentColumns([]string{"updated_at"}),
+		DoUpdates: clause.AssignmentColumns([]string{
+			"valid_from", "valid_through", "granted_by_id", "granted_by_email", "source", "updated_at",
+		}),
 	}).Create(&row).Error
 	if err != nil {
-		return fmt.Errorf("failed to grant feature %q to %s %q: %w", featureKey, subjectType, subjectID, err)
+		return fmt.Errorf("failed to grant feature %q to %s %q: %w",
+			record.FeatureKey, record.SubjectType, record.SubjectID, err)
 	}
 	return nil
 }
 
 func (r *FeatureGrantRepository) Revoke(
 	ctx context.Context, subjectType, subjectID, accountID, featureKey string,
-) error {
-	err := r.db.WithContext(ctx).
+) (bool, error) {
+	res := r.db.WithContext(ctx).
 		Where("subject_type = ? AND subject_id = ? AND account_id = ? AND feature_key = ?",
 			subjectType, subjectID, accountID, featureKey).
-		Delete(&models.FeatureGrant{}).Error
-	if err != nil {
-		return fmt.Errorf("failed to revoke feature %q from %s %q: %w", featureKey, subjectType, subjectID, err)
+		Delete(&models.FeatureGrant{})
+	if res.Error != nil {
+		return false, fmt.Errorf("failed to revoke feature %q from %s %q: %w",
+			featureKey, subjectType, subjectID, res.Error)
 	}
-	return nil
+	// Reported rather than assumed, so a caller can tell a real revocation
+	// from a no-op and record only what happened.
+	return res.RowsAffected > 0, nil
 }
 
 // AccountMemberQuery answers "who holds this role in this account?" — the

--- a/infrastructure/database/gorm/feature_repository_test.go
+++ b/infrastructure/database/gorm/feature_repository_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 
+	"github.com/wepala/weos/v3/domain/entities"
 	"github.com/wepala/weos/v3/domain/repositories"
 	"github.com/wepala/weos/v3/infrastructure/models"
 )
@@ -159,15 +161,15 @@ func TestFeatureGrantsUnionAgentAndRole(t *testing.T) {
 	ctx := context.Background()
 	repo := ProvideFeatureGrantRepository(newFeatureTestDB(t))
 
-	if err := repo.Grant(ctx, repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export"); err != nil {
+	if err := repo.Grant(ctx, entities.FeatureGrantRecord{SubjectType: repositories.FeatureSubjectAgent, SubjectID: "agent-ops", AccountID: "acct-harbor", FeatureKey: "ledger-export"}); err != nil {
 		t.Fatalf("Grant agent: %v", err)
 	}
-	if err := repo.Grant(ctx, repositories.FeatureSubjectRole, "admin", "acct-harbor", "audit-trail"); err != nil {
+	if err := repo.Grant(ctx, entities.FeatureGrantRecord{SubjectType: repositories.FeatureSubjectRole, SubjectID: "admin", AccountID: "acct-harbor", FeatureKey: "audit-trail"}); err != nil {
 		t.Fatalf("Grant role: %v", err)
 	}
 
 	// Holding the role sees both legs.
-	got, err := repo.GrantedKeys(ctx, "acct-harbor", "agent-ops", "admin")
+	got, err := grantedKeys(t, repo, ctx, "acct-harbor", "agent-ops", "admin")
 	if err != nil {
 		t.Fatalf("GrantedKeys: %v", err)
 	}
@@ -176,7 +178,7 @@ func TestFeatureGrantsUnionAgentAndRole(t *testing.T) {
 	}
 
 	// Without the role, only the direct grant.
-	got, err = repo.GrantedKeys(ctx, "acct-harbor", "agent-ops", "")
+	got, err = grantedKeys(t, repo, ctx, "acct-harbor", "agent-ops", "")
 	if err != nil {
 		t.Fatalf("GrantedKeys (no role): %v", err)
 	}
@@ -188,7 +190,7 @@ func TestFeatureGrantsUnionAgentAndRole(t *testing.T) {
 	}
 
 	// Another agent holding the same role gets the role grant only.
-	got, err = repo.GrantedKeys(ctx, "acct-harbor", "agent-counsel", "admin")
+	got, err = grantedKeys(t, repo, ctx, "acct-harbor", "agent-counsel", "admin")
 	if err != nil {
 		t.Fatalf("GrantedKeys (other agent): %v", err)
 	}
@@ -204,10 +206,10 @@ func TestFeatureGrantsAreAccountScoped(t *testing.T) {
 	ctx := context.Background()
 	repo := ProvideFeatureGrantRepository(newFeatureTestDB(t))
 
-	if err := repo.Grant(ctx, repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export"); err != nil {
+	if err := repo.Grant(ctx, entities.FeatureGrantRecord{SubjectType: repositories.FeatureSubjectAgent, SubjectID: "agent-ops", AccountID: "acct-harbor", FeatureKey: "ledger-export"}); err != nil {
 		t.Fatalf("Grant: %v", err)
 	}
-	got, err := repo.GrantedKeys(ctx, "acct-cedar", "agent-ops", "")
+	got, err := grantedKeys(t, repo, ctx, "acct-cedar", "agent-ops", "")
 	if err != nil {
 		t.Fatalf("GrantedKeys: %v", err)
 	}
@@ -217,7 +219,7 @@ func TestFeatureGrantsAreAccountScoped(t *testing.T) {
 
 	// No account and no agent must never match rows on empty strings.
 	for _, tc := range []struct{ accountID, agentID string }{{"", "agent-ops"}, {"acct-harbor", ""}, {"", ""}} {
-		got, err := repo.GrantedKeys(ctx, tc.accountID, tc.agentID, "")
+		got, err := grantedKeys(t, repo, ctx, tc.accountID, tc.agentID, "")
 		if err != nil {
 			t.Fatalf("GrantedKeys(%q,%q): %v", tc.accountID, tc.agentID, err)
 		}
@@ -232,24 +234,30 @@ func TestFeatureGrantIsIdempotentAndRevocable(t *testing.T) {
 	repo := ProvideFeatureGrantRepository(newFeatureTestDB(t))
 
 	for i := 0; i < 3; i++ {
-		if err := repo.Grant(ctx, repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export"); err != nil {
+		if err := repo.Grant(ctx, entities.FeatureGrantRecord{SubjectType: repositories.FeatureSubjectAgent, SubjectID: "agent-ops", AccountID: "acct-harbor", FeatureKey: "ledger-export"}); err != nil {
 			t.Fatalf("Grant %d: %v", i, err)
 		}
 	}
-	got, _ := repo.GrantedKeys(ctx, "acct-harbor", "agent-ops", "")
+	got, _ := grantedKeys(t, repo, ctx, "acct-harbor", "agent-ops", "")
 	if len(got) != 1 {
 		t.Fatalf("granting three times produced %v, want one key", got)
 	}
 
-	if err := repo.Revoke(ctx, repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export"); err != nil {
+	if _, err := repo.Revoke(ctx, repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export"); err != nil {
 		t.Fatalf("Revoke: %v", err)
 	}
-	got, _ = repo.GrantedKeys(ctx, "acct-harbor", "agent-ops", "")
+	got, _ = grantedKeys(t, repo, ctx, "acct-harbor", "agent-ops", "")
 	if len(got) != 0 {
-		t.Fatalf("after revoke, GrantedKeys = %v, want empty", got)
+		t.Fatalf("after revoke, the caller still holds %v, want nothing", got)
 	}
-	if err := repo.Revoke(ctx, repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export"); err != nil {
+	// Revoking what nobody holds succeeds and reports that nothing was there,
+	// which is what lets a caller record only real changes.
+	removed, err := repo.Revoke(ctx, repositories.FeatureSubjectAgent, "agent-ops", "acct-harbor", "ledger-export")
+	if err != nil {
 		t.Fatalf("Revoke on an absent grant = %v, want nil", err)
+	}
+	if removed {
+		t.Fatal("Revoke reported it removed a grant that was not there")
 	}
 }
 
@@ -307,4 +315,19 @@ func TestAccountMemberQueryListsByRole(t *testing.T) {
 			t.Fatalf("ListMemberIDsByRole(%q,%q) = %v, want empty", tc.account, tc.role, got)
 		}
 	}
+}
+
+// grantedKeys folds a caller's rows the way the resolver does, so these tests
+// keep asserting on what a caller holds rather than on row shape.
+func grantedKeys(
+	t *testing.T, repo repositories.FeatureGrantRepository,
+	ctx context.Context, accountID, agentID, roleID string,
+) (map[string]bool, error) {
+	t.Helper()
+	rows, err := repo.GrantsFor(ctx, accountID, agentID, roleID)
+	if err != nil {
+		return nil, err
+	}
+	held, _ := entities.FoldGrants(rows, time.Now())
+	return held, nil
 }

--- a/infrastructure/models/feature.go
+++ b/infrastructure/models/feature.go
@@ -60,10 +60,25 @@ type FeatureGrant struct {
 	// AccountID scopes the grant. Roles are per-account memberships, and a
 	// person's access is granted within an account, so both subject kinds
 	// carry one.
-	AccountID  string `gorm:"type:varchar(255);not null;uniqueIndex:idx_fg_subject;index:idx_fg_account"`
-	FeatureKey string `gorm:"type:varchar(64);not null;uniqueIndex:idx_fg_subject"`
-	CreatedAt  time.Time
-	UpdatedAt  time.Time
+	AccountID  string `gorm:"type:varchar(255);not null;uniqueIndex:idx_fg_subject;index:idx_fg_account,priority:1"`
+	FeatureKey string `gorm:"type:varchar(64);not null;uniqueIndex:idx_fg_subject;index:idx_fg_account,priority:2"`
+
+	// ValidFrom and ValidThrough bound the grant; NULL is unbounded on that
+	// side. Nullable so the columns migrate cleanly onto existing rows, which
+	// is also the honest meaning: a grant made before windows existed has none.
+	ValidFrom    *time.Time
+	ValidThrough *time.Time
+
+	// Provenance, kept here as well as in the Feature.Changed event because
+	// the two answer different questions. The row says who granted a right
+	// that still exists and is what a listing shows; the event log says what
+	// happened, and survives revocation, which deletes the row.
+	GrantedByID    string `gorm:"type:varchar(255)"`
+	GrantedByEmail string `gorm:"type:varchar(255)"`
+	Source         string `gorm:"type:varchar(32)"`
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 func (FeatureGrant) TableName() string {

--- a/internal/cli/feature.go
+++ b/internal/cli/feature.go
@@ -315,6 +315,18 @@ func runFeatureGrant(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		cmd.Printf("Granted %q to %s in account %s.\n", key, grantSubjectWord(), account)
+		// Echo what was actually stored. A grant dated to the wrong year is
+		// accepted and simply never applies, and a success line alone would
+		// let an operator walk away from a typo. Printing the window and its
+		// status catches it at the keyboard.
+		if views, err := admin.GrantsOn(ctx, key, account); err == nil {
+			for _, v := range views {
+				if v.Email == grantEmail || (grantRole != "" && v.Role == grantRole) {
+					cmd.Printf("  window: %s   status: %s\n", windowWord(v), v.Status)
+					break
+				}
+			}
+		}
 		printCacheAgeNotice(cmd)
 		return nil
 	})

--- a/internal/cli/feature.go
+++ b/internal/cli/feature.go
@@ -93,6 +93,7 @@ declared with, which an account admin or an individual grant can still turn on.`
 
 func init() {
 	featureCmd.AddCommand(featureListCmd, featureEnableCmd, featureDisableCmd, featureResetCmd)
+	initGrantCommands()
 	rootCmd.AddCommand(featureCmd)
 }
 
@@ -234,4 +235,188 @@ func withFeatureAdmin(cmd *cobra.Command, fn func(context.Context, *application.
 	}()
 
 	return fn(application.WithLocalTransport(cmd.Context()), admin)
+}
+
+var (
+	grantEmail   string
+	grantRole    string
+	grantAccount string
+	grantFrom    string
+	grantUntil   string
+)
+
+var featureGrantCmd = &cobra.Command{
+	Use:   "grant <key>",
+	Short: "Give a feature to one person or to a role within an account",
+	Long: `Gives a feature to one person or to a role.
+
+A grant only ever turns a feature ON. It cannot rescue a feature an account or
+the instance has switched off — those are above it and an explicit off is final.
+
+The window is optional. A grant with none is live from the moment it is made;
+one with --valid-from starts on its own, and one with --valid-until ends on its
+own, with nothing to run and nobody to sign in again.
+
+The account must be named on any instance with more than one, because a grant
+lands in exactly one account and guessing which would be worse than asking.`,
+	Args:         cobra.ExactArgs(1),
+	RunE:         runFeatureGrant,
+	SilenceUsage: true,
+}
+
+var featureRevokeCmd = &cobra.Command{
+	Use:          "revoke <key>",
+	Short:        "Take a feature back from one person or from a role",
+	Args:         cobra.ExactArgs(1),
+	RunE:         runFeatureRevoke,
+	SilenceUsage: true,
+}
+
+var featureGrantsCmd = &cobra.Command{
+	Use:          "grants <key>",
+	Short:        "List who holds a feature, with each grant's window and who made it",
+	Args:         cobra.ExactArgs(1),
+	RunE:         runFeatureGrants,
+	SilenceUsage: true,
+}
+
+func initGrantCommands() {
+	for _, c := range []*cobra.Command{featureGrantCmd, featureRevokeCmd} {
+		c.Flags().StringVar(&grantEmail, "email", "", "the person to grant to (give exactly one of --email or --role)")
+		c.Flags().StringVar(&grantRole, "role", "", "the role to grant to (owner, admin or member)")
+		c.Flags().StringVar(&grantAccount, "account", "", "the account id the grant lands in")
+	}
+	featureGrantCmd.Flags().StringVar(&grantFrom, "valid-from", "", "RFC3339 time the grant starts (default: immediately)")
+	featureGrantCmd.Flags().StringVar(&grantUntil, "valid-until", "", "RFC3339 time the grant ends (default: indefinitely)")
+	featureGrantsCmd.Flags().StringVar(&grantAccount, "account", "", "the account id to list grants in")
+	featureCmd.AddCommand(featureGrantCmd, featureRevokeCmd, featureGrantsCmd)
+}
+
+func runFeatureGrant(cmd *cobra.Command, args []string) error {
+	key := args[0]
+	from, err := parseGrantFlag("--valid-from", grantFrom)
+	if err != nil {
+		return err
+	}
+	until, err := parseGrantFlag("--valid-until", grantUntil)
+	if err != nil {
+		return err
+	}
+	return withFeatureAdmin(cmd, func(ctx context.Context, admin *application.FeatureAdminService) error {
+		account, err := resolveGrantAccount(ctx, admin)
+		if err != nil {
+			return err
+		}
+		if err := admin.Grant(ctx, application.GrantRequest{
+			Key: key, Email: grantEmail, Role: grantRole,
+			ValidFrom: from, ValidThrough: until,
+			AccountID: account, Source: entities.FeatureChangeSourceCLI,
+		}); err != nil {
+			return err
+		}
+		cmd.Printf("Granted %q to %s in account %s.\n", key, grantSubjectWord(), account)
+		printCacheAgeNotice(cmd)
+		return nil
+	})
+}
+
+func runFeatureRevoke(cmd *cobra.Command, args []string) error {
+	key := args[0]
+	return withFeatureAdmin(cmd, func(ctx context.Context, admin *application.FeatureAdminService) error {
+		account, err := resolveGrantAccount(ctx, admin)
+		if err != nil {
+			return err
+		}
+		if err := admin.RevokeGrant(ctx, application.RevokeRequest{
+			Key: key, Email: grantEmail, Role: grantRole,
+			AccountID: account, Source: entities.FeatureChangeSourceCLI,
+		}); err != nil {
+			return err
+		}
+		cmd.Printf("Took %q back from %s in account %s.\n", key, grantSubjectWord(), account)
+		printCacheAgeNotice(cmd)
+		return nil
+	})
+}
+
+func runFeatureGrants(cmd *cobra.Command, args []string) error {
+	key := args[0]
+	return withFeatureAdmin(cmd, func(ctx context.Context, admin *application.FeatureAdminService) error {
+		account, err := resolveGrantAccount(ctx, admin)
+		if err != nil {
+			return err
+		}
+		views, err := admin.GrantsOn(ctx, key, account)
+		if err != nil {
+			return err
+		}
+		if len(views) == 0 {
+			cmd.Printf("Nobody holds %q in account %s.\n", key, account)
+			return nil
+		}
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+		if _, err := fmt.Fprintln(w, "SUBJECT\tWINDOW\tSTATUS\tGRANTED BY"); err != nil {
+			return err
+		}
+		for _, v := range views {
+			subject := v.Email
+			if v.SubjectType == "role" {
+				subject = "role:" + v.Role
+			}
+			if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+				subject, windowWord(v), v.Status, orDash(v.GrantedBy)); err != nil {
+				return err
+			}
+		}
+		return w.Flush()
+	})
+}
+
+// resolveGrantAccount names the account a grant acts in. The command line has
+// no session to take one from, so it is either given or inferred — and only
+// inferred when there is exactly one account, which on this system means a
+// single-person instance.
+func resolveGrantAccount(ctx context.Context, admin *application.FeatureAdminService) (string, error) {
+	if grantAccount != "" {
+		return grantAccount, nil
+	}
+	return admin.DefaultGrantAccount(ctx)
+}
+
+func parseGrantFlag(flag, value string) (*time.Time, error) {
+	if value == "" {
+		return nil, nil
+	}
+	t, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return nil, fmt.Errorf("%s must be an RFC3339 time like 2026-08-21T09:00:00Z: %w", flag, err)
+	}
+	return &t, nil
+}
+
+func grantSubjectWord() string {
+	if grantRole != "" {
+		return "role " + grantRole
+	}
+	return grantEmail
+}
+
+func windowWord(v application.GrantView) string {
+	switch {
+	case v.ValidFrom != nil && v.ValidThrough != nil:
+		return v.ValidFrom.Format(time.RFC3339) + " to " + v.ValidThrough.Format(time.RFC3339)
+	case v.ValidFrom != nil:
+		return "from " + v.ValidFrom.Format(time.RFC3339)
+	case v.ValidThrough != nil:
+		return "until " + v.ValidThrough.Format(time.RFC3339)
+	default:
+		return "—"
+	}
+}
+
+func orDash(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
 }

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -443,6 +443,12 @@ func runServe(cmd *cobra.Command, args []string) error {
 	protected.DELETE("/features/:key/instance", featureHandler.ResetInstance)
 	protected.PUT("/features/:key/account", featureHandler.SetAccount)
 	protected.DELETE("/features/:key/account", featureHandler.ResetAccount)
+	// Grants hang off the same :key. The static segment is registered before
+	// the parameterised one so it cannot be swallowed by it.
+	protected.GET("/features/grants", featureHandler.GrantsHeldBy)
+	protected.GET("/features/:key/grants", featureHandler.ListGrants)
+	protected.POST("/features/:key/grants", featureHandler.Grant)
+	protected.DELETE("/features/:key/grants", featureHandler.RevokeGrant)
 
 	protected.GET("/users", userHandler.List)
 	protected.GET("/users/:id", userHandler.Get)

--- a/internal/mcp/feature_tools.go
+++ b/internal/mcp/feature_tools.go
@@ -18,6 +18,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -139,6 +140,124 @@ func registerFeatureTools(server *mcp.Server, admin *application.FeatureAdminSer
 		}
 		return featureListingResult(ctx, admin)
 	})
+
+	registerGrantTools(server, admin)
+}
+
+// Grant inputs carry no account field, ever. Over HTTP the account comes off
+// the session; over stdio there is none, which is what makes the tool refuse
+// there rather than guess. An account argument would turn that refusal into a
+// multi-tenant hole.
+type FeatureGrantInput struct {
+	Key        string `json:"key" jsonschema:"the feature key to grant"`
+	Email      string `json:"email,omitempty" jsonschema:"the person to grant it to; give exactly one of email or role"`
+	Role       string `json:"role,omitempty" jsonschema:"the role to grant it to; give exactly one of email or role"`
+	ValidFrom  string `json:"valid_from,omitempty" jsonschema:"RFC3339; when the grant starts. Omit for immediately"`
+	ValidUntil string `json:"valid_until,omitempty" jsonschema:"RFC3339; when the grant ends. Omit for indefinitely"`
+}
+
+type FeatureRevokeInput struct {
+	Key   string `json:"key" jsonschema:"the feature key to take back"`
+	Email string `json:"email,omitempty" jsonschema:"give exactly one of email or role"`
+	Role  string `json:"role,omitempty" jsonschema:"give exactly one of email or role"`
+}
+
+type FeatureGrantsInput struct {
+	Key string `json:"key" jsonschema:"the feature key to list grants for"`
+}
+
+type FeatureGrantsOutput struct {
+	Grants []application.GrantView `json:"grants"`
+}
+
+// parseGrantTime reads an optional RFC3339 instant.
+func parseGrantTime(field, value string) (*time.Time, error) {
+	if value == "" {
+		return nil, nil
+	}
+	t, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return nil, fmt.Errorf("%s must be an RFC3339 time like 2026-08-21T09:00:00Z: %w", field, err)
+	}
+	return &t, nil
+}
+
+// registerGrantTools adds the grant surface to the same opt-in group.
+func registerGrantTools(server *mcp.Server, admin *application.FeatureAdminService) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "feature_grant",
+		Description: "Give a feature to one person or to a role, within the account you are signed in " +
+			"to. Optionally bounded by a validity window, which takes effect and expires on its own.",
+		Annotations: annDestructive(),
+	}, func(
+		ctx context.Context, _ *mcp.CallToolRequest, input FeatureGrantInput,
+	) (*mcp.CallToolResult, FeatureGrantsOutput, error) {
+		from, err := parseGrantTime("valid_from", input.ValidFrom)
+		if err != nil {
+			return nil, FeatureGrantsOutput{}, err
+		}
+		until, err := parseGrantTime("valid_until", input.ValidUntil)
+		if err != nil {
+			return nil, FeatureGrantsOutput{}, err
+		}
+		if err := admin.Grant(ctx, application.GrantRequest{
+			Key: input.Key, Email: input.Email, Role: input.Role,
+			ValidFrom: from, ValidThrough: until,
+			Source: entities.FeatureChangeSourceMCP,
+		}); err != nil {
+			return nil, FeatureGrantsOutput{}, err
+		}
+		return grantListingResult(ctx, admin, input.Key)
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "feature_revoke",
+		Description: "Take a feature back from one person or from a role. Taking back what nobody " +
+			"holds succeeds and changes nothing.",
+		Annotations: annDestructive(),
+	}, func(
+		ctx context.Context, _ *mcp.CallToolRequest, input FeatureRevokeInput,
+	) (*mcp.CallToolResult, FeatureGrantsOutput, error) {
+		if err := admin.RevokeGrant(ctx, application.RevokeRequest{
+			Key: input.Key, Email: input.Email, Role: input.Role,
+			Source: entities.FeatureChangeSourceMCP,
+		}); err != nil {
+			return nil, FeatureGrantsOutput{}, err
+		}
+		return grantListingResult(ctx, admin, input.Key)
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "feature_grants",
+		Description: "List who holds a feature in this account, with each grant's window and who " +
+			"made it. Includes grants that have not started yet and ones whose window has closed.",
+		Annotations: annReadOnly(),
+	}, func(
+		ctx context.Context, _ *mcp.CallToolRequest, input FeatureGrantsInput,
+	) (*mcp.CallToolResult, FeatureGrantsOutput, error) {
+		views, err := admin.GrantsOn(ctx, input.Key, "")
+		if err != nil {
+			return nil, FeatureGrantsOutput{}, err
+		}
+		return nil, FeatureGrantsOutput{Grants: views}, nil
+	})
+}
+
+func grantListingResult(
+	ctx context.Context, admin *application.FeatureAdminService, key string,
+) (*mcp.CallToolResult, FeatureGrantsOutput, error) {
+	views, err := admin.GrantsOn(ctx, key, "")
+	if err != nil {
+		// The change landed; only the read-back failed. Said in words rather
+		// than answered with an empty list, which a client would read as
+		// "nobody holds this".
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{
+				Text: "The change was applied. The grant listing could not be read just now.",
+			}},
+		}, FeatureGrantsOutput{}, nil
+	}
+	return nil, FeatureGrantsOutput{Grants: views}, nil
 }
 
 // scopeOrInstance defaults an omitted scope to the instance. Instance is the

--- a/internal/mcp/feature_tools.go
+++ b/internal/mcp/feature_tools.go
@@ -279,9 +279,14 @@ func featureListingResult(
 ) (*mcp.CallToolResult, FeatureChangeOutput, error) {
 	statuses, err := admin.Listing(ctx)
 	if err != nil {
-		// The change landed; only the read-back failed. Returning an error
-		// would report failure for work that succeeded.
-		return nil, FeatureChangeOutput{}, nil
+		// The change landed; only the read-back failed. Said in words rather
+		// than answered with an empty list, which a client — or an LLM — would
+		// read as "this instance declares no features".
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{
+				Text: "The change was applied. The feature listing could not be read just now.",
+			}},
+		}, FeatureChangeOutput{}, nil
 	}
 	return nil, FeatureChangeOutput{Features: statuses}, nil
 }

--- a/tests/e2e/feature_flag_resolution_test.go
+++ b/tests/e2e/feature_flag_resolution_test.go
@@ -144,7 +144,9 @@ type grantsSpy struct {
 	broken bool
 }
 
-func (g *grantsSpy) GrantedKeys(ctx context.Context, accountID, agentID, roleID string) (map[string]bool, error) {
+func (g *grantsSpy) GrantsFor(
+	ctx context.Context, accountID, agentID, roleID string,
+) ([]entities.FeatureGrantRecord, error) {
 	g.mu.Lock()
 	if g.reads == nil {
 		g.reads = map[string]int{}
@@ -155,14 +157,22 @@ func (g *grantsSpy) GrantedKeys(ctx context.Context, accountID, agentID, roleID 
 	if broken {
 		return nil, errStoreUnreadable
 	}
-	return g.inner.GrantedKeys(ctx, accountID, agentID, roleID)
+	return g.inner.GrantsFor(ctx, accountID, agentID, roleID)
 }
 
-func (g *grantsSpy) Grant(ctx context.Context, subjectType, subjectID, accountID, key string) error {
-	return g.inner.Grant(ctx, subjectType, subjectID, accountID, key)
+func (g *grantsSpy) ListByFeature(
+	ctx context.Context, accountID, key string,
+) ([]entities.FeatureGrantRecord, error) {
+	return g.inner.ListByFeature(ctx, accountID, key)
 }
 
-func (g *grantsSpy) Revoke(ctx context.Context, subjectType, subjectID, accountID, key string) error {
+func (g *grantsSpy) Grant(ctx context.Context, record entities.FeatureGrantRecord) error {
+	return g.inner.Grant(ctx, record)
+}
+
+func (g *grantsSpy) Revoke(
+	ctx context.Context, subjectType, subjectID, accountID, key string,
+) (bool, error) {
 	return g.inner.Revoke(ctx, subjectType, subjectID, accountID, key)
 }
 

--- a/tests/e2e/feature_flag_steps_test.go
+++ b/tests/e2e/feature_flag_steps_test.go
@@ -325,7 +325,8 @@ func (w *featureWorld) stepAgentGranted(email, key string) error {
 		return err
 	}
 	w.grantedKey = key
-	return w.service.GrantToAgent(context.Background(), p.accountID, p.agentID, key)
+	return w.service.GrantToAgent(context.Background(), p.accountID, p.agentID, key,
+		application.GrantTerms{})
 }
 
 func (w *featureWorld) stepRoleGranted(role, key string) error {
@@ -334,7 +335,8 @@ func (w *featureWorld) stepRoleGranted(role, key string) error {
 		return err
 	}
 	w.grantedKey = key
-	return w.service.GrantToRole(context.Background(), accountID, role, key)
+	return w.service.GrantToRole(context.Background(), accountID, role, key,
+		application.GrantTerms{})
 }
 
 func (w *featureWorld) stepRevokeAgent(email string) error {
@@ -346,7 +348,8 @@ func (w *featureWorld) stepRevokeAgent(email string) error {
 	if err != nil {
 		return err
 	}
-	return w.service.RevokeFromAgent(context.Background(), p.accountID, p.agentID, key)
+	_, err = w.service.RevokeFromAgent(context.Background(), p.accountID, p.agentID, key)
+	return err
 }
 
 func (w *featureWorld) stepRevokeRole(role string) error {
@@ -358,7 +361,8 @@ func (w *featureWorld) stepRevokeRole(role string) error {
 	if err != nil {
 		return err
 	}
-	return w.service.RevokeFromRole(context.Background(), accountID, role, key)
+	_, err = w.service.RevokeFromRole(context.Background(), accountID, role, key)
+	return err
 }
 
 // stepStoredAccountOverride and stepStoredGrant write the store directly,
@@ -377,7 +381,12 @@ func (w *featureWorld) stepStoredGrant(email, key string) error {
 	if err != nil {
 		return err
 	}
-	return w.grants.Grant(context.Background(), repositories.FeatureSubjectAgent, p.agentID, p.accountID, key)
+	return w.grants.Grant(context.Background(), entities.FeatureGrantRecord{
+		SubjectType: repositories.FeatureSubjectAgent,
+		SubjectID:   p.agentID,
+		AccountID:   p.accountID,
+		FeatureKey:  key,
+	})
 }
 
 func (w *featureWorld) stepBreakStore() error {

--- a/tests/e2e/feature_grants_steps_test.go
+++ b/tests/e2e/feature_grants_steps_test.go
@@ -1,0 +1,1417 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/cucumber/godog"
+
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/domain/entities"
+)
+
+func initFeatureGrantsScenario(sc *godog.ScenarioContext) {
+	w := &grantsWorld{
+		accounts: map[string]string{},
+		people:   map[string]*featurePerson{},
+		answers:  map[string]bool{},
+	}
+	sc.After(func(ctx context.Context, _ *godog.Scenario, err error) (context.Context, error) {
+		w.teardown()
+		return ctx, err
+	})
+
+	// --- background ---
+	sc.Step(`^a WeOS instance where password sign-in is enabled and requests are authenticated by their session$`,
+		w.stepInstance)
+	sc.Step(`^the instance is configured with a maximum cache age of (\d+) (seconds|minutes)$`, w.stepMaxCacheAge)
+	sc.Step(`^the instance declares these features in code:$`, w.stepDeclare)
+	sc.Step(`^the account "([^"]*)", whose owner "([^"]*)" signs in with password "([^"]*)"$`, w.stepAccountOwner)
+
+	// --- membership ---
+	sc.Step(`^"([^"]*)" also belongs to "([^"]*)"$`, w.stepAlsoBelongs)
+	sc.Step(`^"([^"]*)" also belongs to "([^"]*)" with the role "([^"]*)"$`, w.stepAlsoBelongsWithRole)
+	sc.Step(`^"([^"]*)" and "([^"]*)" both belong to "([^"]*)" with the role "([^"]*)"$`, w.stepTwoBelongWithRole)
+	sc.Step(`^"([^"]*)" belongs to "([^"]*)" as an ordinary member$`, w.stepOrdinaryMember)
+	sc.Step(`^"([^"]*)" is given the role "([^"]*)" in "([^"]*)"$`, w.stepGivenRole)
+	sc.Step(`^"([^"]*)" is signed in to "([^"]*)"$`, w.stepSignedIn)
+
+	// --- staging grants ---
+	sc.Step(`^they have granted "([^"]*)" to "([^"]*)" through the API$`, w.stepHaveGranted)
+	sc.Step(`^they have granted "([^"]*)" to the role "([^"]*)" through the API$`, w.stepHaveGrantedRole)
+	sc.Step(`^they have granted "([^"]*)" to "([^"]*)" through the API, valid until (.+)$`, w.stepHaveGrantedUntil)
+	sc.Step(`^"([^"]*)" holds one of their own for "([^"]*)"$`, w.stepHoldsOwn)
+	sc.Step(`^"([^"]*)" holds (\d+) grants of "([^"]*)", one for each of \d+ other members$`, w.stepHoldsMany)
+
+	// --- API writes ---
+	sc.Step(`^they grant "([^"]*)" to "([^"]*)" through the API$`, w.stepGrant)
+	sc.Step(`^they grant "([^"]*)" to "([^"]*)" through the API again$`, w.stepGrant)
+	sc.Step(`^they try to grant "([^"]*)" to "([^"]*)" through the API$`, w.stepGrant)
+	sc.Step(`^they try to grant "([^"]*)" to themselves through the API$`, w.stepGrantSelf)
+	sc.Step(`^they grant "([^"]*)" to the role "([^"]*)" through the API$`, w.stepGrantRole)
+	sc.Step(`^they try to grant "([^"]*)" to the role "([^"]*)" through the API$`, w.stepGrantRole)
+	sc.Step(`^they grant "([^"]*)" to "([^"]*)" through the API, naming the account "([^"]*)"$`, w.stepGrantNamingAccount)
+	sc.Step(`^"([^"]*)" grants "([^"]*)" to "([^"]*)" through the API, valid from (.+)$`, w.stepGrantValidFrom)
+	sc.Step(`^they try to grant "([^"]*)" to "([^"]*)" through the API, valid from (.+) until (.+)$`,
+		w.stepGrantImpossibleWindow)
+	sc.Step(`^they revoke "([^"]*)" from "([^"]*)" through the API$`, w.stepRevoke)
+	sc.Step(`^"([^"]*)" revokes "([^"]*)" from "([^"]*)" through the API$`, w.stepPersonRevokes)
+	sc.Step(`^"([^"]*)" revokes "([^"]*)" from the role "([^"]*)" through the API$`, w.stepPersonRevokesRole)
+	sc.Step(`^a request carrying no session tries to grant "([^"]*)" to "([^"]*)"$`, w.stepAnonymousGrant)
+
+	// --- API reads ---
+	sc.Step(`^they ask the API for the grants on "([^"]*)"$`, w.stepListGrants)
+	sc.Step(`^"([^"]*)" signs in and asks the API for the grants on "([^"]*)"$`, w.stepSignInAndListGrants)
+	sc.Step(`^they ask the API for everything granted to "([^"]*)"$`, w.stepListHeldBy)
+
+	// --- MCP ---
+	sc.Step(`^an MCP client attached to the store over the local stdio transport$`, w.stepStdio)
+	sc.Step(`^they call the MCP tool "([^"]*)" to grant "([^"]*)" to "([^"]*)"$`, w.stepMCPGrant)
+	sc.Step(`^they call the MCP tool "([^"]*)" to take "([^"]*)" from "([^"]*)"$`, w.stepMCPRevoke)
+	sc.Step(`^they call the MCP tool "([^"]*)" for "([^"]*)"$`, w.stepMCPGrants)
+	sc.Step(`^it calls "([^"]*)" to grant "([^"]*)" to "([^"]*)"$`, w.stepStdioGrant)
+
+	// --- CLI ---
+	sc.Step(`^the operator has run "([^"]*)"$`, w.stepOperatorHasRun)
+	sc.Step(`^the operator runs "([^"]*)"$`, w.stepRunCLI)
+	sc.Step(`^the operator runs "([^"]*)" against the account "([^"]*)"$`, w.stepRunCLIAgainstAccount)
+
+	// --- evaluation ---
+	sc.Step(`^"([^"]*)" is signed in and has been answered (on|off) for "([^"]*)"$`, w.stepSignedInAnswered)
+	sc.Step(`^both of them are signed in and have been answered (on|off) for "([^"]*)"$`, w.stepBothSignedInAnswered)
+	sc.Step(`^"([^"]*)" signs in and evaluates "([^"]*)" with default off$`, w.stepSignInAndEvaluate)
+	sc.Step(`^they evaluate "([^"]*)" with default off$`, w.stepEvaluate)
+	sc.Step(`^"([^"]*)" evaluates "([^"]*)" again straight away$`, w.stepEvaluateStraightAway)
+	sc.Step(`^"([^"]*)" evaluates "([^"]*)" again once that moment has passed$`, w.stepEvaluateAfterMoment)
+	sc.Step(`^"([^"]*)" evaluates "([^"]*)" again in the session they already held$`, w.stepPersonEvaluatesAgain)
+	sc.Step(`^each of them evaluates "([^"]*)" again in the session they already held$`, w.stepEachEvaluatesAgain)
+
+	// --- assertions ---
+	sc.Step(`^the change was accepted$`, w.stepChangeAccepted)
+	sc.Step(`^the listing was served$`, w.stepListingServed)
+	sc.Step(`^the attempt is refused as a bad request$`, w.stepBadRequest)
+	sc.Step(`^the attempt is refused as not found$`, w.stepNotFound)
+	sc.Step(`^the attempt to grant it is refused as forbidden$`, w.stepForbidden)
+	sc.Step(`^the request is refused as not authenticated$`, w.stepUnauthenticated)
+	sc.Step(`^the call succeeds$`, w.stepCallSucceeds)
+	sc.Step(`^the call is refused$`, w.stepCallRefused)
+	sc.Step(`^the call is refused as forbidden$`, w.stepCallRefused)
+	sc.Step(`^the command exits successfully$`, w.stepCommandSucceeded)
+	sc.Step(`^the command exits with a failure$`, w.stepCommandFailed)
+	sc.Step(`^the command names "([^"]*)"$`, w.stepCommandNames)
+	sc.Step(`^the command reports that grant as in effect until tomorrow$`, w.stepCommandReportsUntilTomorrow)
+	sc.Step(`^the failure names the address "([^"]*)"$`, w.stepFailureNames)
+	sc.Step(`^the failure names the key "([^"]*)"$`, w.stepFailureNames)
+	sc.Step(`^the failure says which account must be named$`, w.stepFailureNamesAccountFlag)
+	sc.Step(`^the refusal names the roles that exist$`, w.stepRefusalNamesRoles)
+	sc.Step(`^the refusal says a grant needs an account and names the command line$`, w.stepRefusalNamesCLI)
+	sc.Step(`^the refusal says that person is not a member of this account$`, w.stepRefusalNotMember)
+	sc.Step(`^the refusal says the feature cannot be granted$`, w.stepRefusalNotGrantable)
+	sc.Step(`^the refusal says the window ends before it begins$`, w.stepRefusalBadWindow)
+
+	// --- stored state ---
+	sc.Step(`^no grant of "([^"]*)" is stored at all$`, w.stepNoGrantAtAll)
+	sc.Step(`^no grant of "([^"]*)" is stored for "([^"]*)"$`, w.stepNoGrantFor)
+	sc.Step(`^no grant of "([^"]*)" is stored for the role "([^"]*)"$`, w.stepNoGrantForRole)
+	sc.Step(`^no grant of "([^"]*)" is stored in "([^"]*)"$`, w.stepNoGrantInAccount)
+	sc.Step(`^the instance holds one stored grant of "([^"]*)" for "([^"]*)"$`, w.stepOneStoredGrant)
+	sc.Step(`^the stored grant names the agent id of "([^"]*)"$`, w.stepStoredNamesAgentID)
+	sc.Step(`^the stored grant does not carry their email address$`, w.stepStoredHasNoEmail)
+	sc.Step(`^the stored grant is scoped to "([^"]*)"$`, w.stepStoredScopedTo)
+	sc.Step(`^the grant carries the time it was made$`, w.stepGrantHasTime)
+	sc.Step(`^the grant records "([^"]*)" as who made it$`, w.stepGrantRecordsMaker)
+	sc.Step(`^the grant to "([^"]*)" records "([^"]*)" as who made it$`, w.stepGrantToRecordsMaker)
+	sc.Step(`^the grant reports no window$`, w.stepGrantNoWindow)
+	sc.Step(`^the grant to the role "([^"]*)" reports no window$`, w.stepRoleGrantNoWindow)
+	sc.Step(`^the grant to "([^"]*)" reports it is in effect until tomorrow$`, w.stepGrantUntilTomorrow)
+
+	// --- listings ---
+	sc.Step(`^the grants on "([^"]*)" name "([^"]*)" and the role "([^"]*)"$`, w.stepGrantsNameBoth)
+	sc.Step(`^the grants on "([^"]*)" no longer name "([^"]*)"$`, w.stepGrantsNoLonger)
+	sc.Step(`^the grants on "([^"]*)" still name the role "([^"]*)"$`, w.stepGrantsStillRole)
+	sc.Step(`^the grants on "([^"]*)" report that grant as expired$`, w.stepGrantsExpired)
+	sc.Step(`^the grants "([^"]*)" is shown name nobody$`, w.stepGrantsEmpty)
+	sc.Step(`^the answer names "([^"]*)", granted to them directly$`, w.stepHeldDirect)
+	sc.Step(`^the answer names "([^"]*)", granted through the role "([^"]*)"$`, w.stepHeldViaRole)
+	sc.Step(`^what the tool reported matches the grants the API lists for "([^"]*)"$`, w.stepToolMatchesAPI)
+
+	// --- evaluation assertions ---
+	sc.Step(`^the feature answers on$`, w.stepFeatureOn)
+	sc.Step(`^"([^"]*)" is answered (on|off)$`, w.stepPersonAnswered)
+	sc.Step(`^both of them are answered off$`, w.stepBothOff)
+	sc.Step(`^the evaluation straight away is answered (on|off)$`, w.stepStraightAway)
+	sc.Step(`^the evaluation after that moment is answered (on|off)$`, w.stepAfterMoment)
+
+	// --- session and cost ---
+	sc.Step(`^"([^"]*)" is still signed in$`, w.stepStillSignedIn)
+	sc.Step(`^they were not signed out$`, w.stepCurrentStillSignedIn)
+	sc.Step(`^neither of them was signed out$`, w.stepAllStillSignedIn)
+	sc.Step(`^the request "([^"]*)" makes next is served$`, w.stepNextRequestServed)
+	sc.Step(`^nothing invalidated the session in between$`, w.stepNothingInvalidated)
+	sc.Step(`^the maximum cache age had not run out$`, w.stepCacheAgeNotReached)
+	sc.Step(`^the instance was not restarted$`, w.stepNotRestarted)
+	sc.Step(`^"([^"]*)" read no feature state from the database to be answered$`, w.stepReadNothing)
+	sc.Step(`^the grant store was read once to answer them$`, w.stepReadOnce)
+	sc.Step(`^that read returned only the grants that could apply to them$`, w.stepReadOnlyTheirs)
+
+	// --- audit ---
+	sc.Step(`^the change was recorded with the key "([^"]*)" and the person it was granted to$`, w.stepRecordedGrant)
+	sc.Step(`^the change was recorded as a revocation of "([^"]*)" from "([^"]*)"$`, w.stepRecordedRevocation)
+	sc.Step(`^the record names "([^"]*)" as who made it$`, w.stepRecordActor)
+	sc.Step(`^the record names the command line as what made the change$`, w.stepRecordSourceCLI)
+	sc.Step(`^the record carries the time the change was made$`, w.stepRecordTime)
+}
+
+// --- background -----------------------------------------------------------
+
+func (w *grantsWorld) stepInstance() error { return w.boot() }
+
+func (w *grantsWorld) stepMaxCacheAge(n int, unit string) error {
+	d := time.Duration(n) * time.Second
+	if strings.HasPrefix(unit, "minute") {
+		d = time.Duration(n) * time.Minute
+	}
+	w.maxCacheAge = d
+	return w.reboot()
+}
+
+func (w *grantsWorld) stepDeclare(table *godog.Table) error {
+	for i, row := range table.Rows {
+		if i == 0 {
+			continue
+		}
+		cell := func(n int) string { return strings.TrimSpace(row.Cells[n].Value) }
+		w.declared = append(w.declared, entities.FeatureMeta{
+			Key: cell(0), DisplayName: cell(1), Description: cell(2),
+			Default: cell(3) == "on", Manageable: cell(4) == "yes", Grantable: cell(5) == "yes",
+		})
+	}
+	return w.reboot()
+}
+
+func (w *grantsWorld) stepAccountOwner(name, email, password string) error {
+	if err := w.boot(); err != nil {
+		return err
+	}
+	p, err := w.personFor(email, password)
+	if err != nil {
+		return err
+	}
+	w.accounts[name] = p.accountID
+	if w.primary == "" {
+		w.primary = p.accountID
+		return w.reboot()
+	}
+	return nil
+}
+
+// --- membership -----------------------------------------------------------
+
+func (w *grantsWorld) stepAlsoBelongs(email, account string) error {
+	return w.addToAccount(email, account, "member")
+}
+
+func (w *grantsWorld) stepAlsoBelongsWithRole(email, account, role string) error {
+	return w.addToAccount(email, account, role)
+}
+
+func (w *grantsWorld) stepTwoBelongWithRole(a, b, account, role string) error {
+	// Named explicitly, so "both of them" means these two and not whoever else
+	// the Background happens to have created.
+	w.group = append(w.group, a, b)
+	if err := w.addToAccount(a, account, role); err != nil {
+		return err
+	}
+	return w.addToAccount(b, account, role)
+}
+
+func (w *grantsWorld) stepOrdinaryMember(email, account string) error {
+	return w.addToAccount(email, account, "member")
+}
+
+func (w *grantsWorld) stepGivenRole(email, role, account string) error {
+	return w.addToAccount(email, account, role)
+}
+
+func (w *grantsWorld) stepSignedIn(email, account string) error {
+	id, err := w.accountFor(account)
+	if err != nil {
+		return err
+	}
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	p.accountID = id
+	return w.signIn(p)
+}
+
+// --- staging and writing grants -------------------------------------------
+
+// grantBody is the POST body. There is no account field, deliberately — the
+// account comes off the session.
+func grantBody(email, role string, from, through *time.Time) map[string]any {
+	body := map[string]any{}
+	if email != "" {
+		body["email"] = email
+	}
+	if role != "" {
+		body["role"] = role
+	}
+	if from != nil {
+		body["validFrom"] = from.Format(time.RFC3339Nano)
+	}
+	if through != nil {
+		body["validThrough"] = through.Format(time.RFC3339Nano)
+	}
+	return body
+}
+
+func (w *grantsWorld) grantVia(p *featurePerson, key, email, role string, from, through *time.Time) error {
+	return w.request(p, http.MethodPost, "/api/features/"+key+"/grants",
+		grantBody(email, role, from, through))
+}
+
+func (w *grantsWorld) stepHaveGranted(key, email string) error {
+	if err := w.grantVia(w.current, key, email, "", nil, nil); err != nil {
+		return err
+	}
+	return w.expectStaged(key)
+}
+
+func (w *grantsWorld) stepHaveGrantedRole(key, role string) error {
+	if err := w.grantVia(w.current, key, "", role, nil, nil); err != nil {
+		return err
+	}
+	return w.expectStaged(key)
+}
+
+// stepHaveGrantedUntil parses the contract's human phrasings for a deadline.
+func (w *grantsWorld) stepHaveGrantedUntil(key, email, when string) error {
+	through, err := momentFrom(when)
+	if err != nil {
+		return err
+	}
+	w.moment = *through
+	if err := w.grantVia(w.current, key, email, "", nil, through); err != nil {
+		return err
+	}
+	return w.expectStaged(key)
+}
+
+func (w *grantsWorld) expectStaged(key string) error {
+	if w.lastStatus != http.StatusOK {
+		return fmt.Errorf("staging a grant of %q answered %d: %s", key, w.lastStatus, string(w.lastBody))
+	}
+	return nil
+}
+
+// momentFrom reads the phrases the contract uses for an instant. Kept in one
+// place so a scenario reads as English and the harness still knows exactly
+// which second it means.
+func momentFrom(phrase string) (*time.Time, error) {
+	now := time.Now()
+	switch {
+	case strings.Contains(phrase, "tomorrow"):
+		t := now.Add(24 * time.Hour)
+		return &t, nil
+	case strings.Contains(phrase, "yesterday"):
+		t := now.Add(-24 * time.Hour)
+		return &t, nil
+	case strings.Contains(phrase, "an hour ago"):
+		t := now.Add(-time.Hour)
+		return &t, nil
+	}
+	var n int
+	if _, err := fmt.Sscanf(phrase, "%d seconds from now", &n); err == nil {
+		t := now.Add(time.Duration(n) * time.Second)
+		return &t, nil
+	}
+	return nil, fmt.Errorf("the harness does not know the moment %q", phrase)
+}
+
+// stepHoldsOwn stages a grant through the service rather than the API. It can
+// run before anybody has signed in, and staging is not the behavior under
+// test — the scenario that uses it is about what resolution reads.
+func (w *grantsWorld) stepHoldsOwn(email, key string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	w.lastKey = key
+	return w.grants.Grant(context.Background(), entities.FeatureGrantRecord{
+		SubjectType: "agent", SubjectID: p.agentID,
+		AccountID: p.accountID, FeatureKey: key,
+	})
+}
+
+// stepHoldsMany stages the cost scenario: an account holding many grants, so
+// the read for one caller can be shown to return only theirs.
+func (w *grantsWorld) stepHoldsMany(accountName string, n int, key string) error {
+	accountID, err := w.accountFor(accountName)
+	if err != nil {
+		return err
+	}
+	for i := 0; i < n; i++ {
+		err := w.grants.Grant(context.Background(), entities.FeatureGrantRecord{
+			SubjectType: "agent",
+			SubjectID:   fmt.Sprintf("agent-filler-%03d", i),
+			AccountID:   accountID,
+			FeatureKey:  key,
+		})
+		if err != nil {
+			return fmt.Errorf("could not stage filler grant %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepGrant(key, email string) error {
+	return w.grantVia(w.current, key, email, "", nil, nil)
+}
+
+func (w *grantsWorld) stepGrantSelf(key string) error {
+	if w.current == nil {
+		return fmt.Errorf("nobody is signed in")
+	}
+	return w.grantVia(w.current, key, w.current.email, "", nil, nil)
+}
+
+func (w *grantsWorld) stepGrantRole(key, role string) error {
+	return w.grantVia(w.current, key, "", role, nil, nil)
+}
+
+// stepGrantNamingAccount names an account in the body. The handler binds no
+// such field, so it lands in the caller's own — which is the assertion.
+func (w *grantsWorld) stepGrantNamingAccount(key, email, accountName string) error {
+	body := grantBody(email, "", nil, nil)
+	body["accountId"] = accountName
+	body["account"] = accountName
+	return w.request(w.current, http.MethodPost, "/api/features/"+key+"/grants", body)
+}
+
+func (w *grantsWorld) stepGrantValidFrom(actor, key, email, when string) error {
+	p, err := w.person(actor)
+	if err != nil {
+		return err
+	}
+	from, err := momentFrom(when)
+	if err != nil {
+		return err
+	}
+	w.moment = *from
+	return w.grantVia(p, key, email, "", from, nil)
+}
+
+func (w *grantsWorld) stepGrantImpossibleWindow(key, email, fromPhrase, untilPhrase string) error {
+	from, err := momentFrom(fromPhrase)
+	if err != nil {
+		return err
+	}
+	through, err := momentFrom(untilPhrase)
+	if err != nil {
+		return err
+	}
+	return w.grantVia(w.current, key, email, "", from, through)
+}
+
+func (w *grantsWorld) stepRevoke(key, email string) error {
+	return w.request(w.current, http.MethodDelete,
+		"/api/features/"+key+"/grants?email="+email, nil)
+}
+
+func (w *grantsWorld) stepPersonRevokes(actor, key, email string) error {
+	p, err := w.person(actor)
+	if err != nil {
+		return err
+	}
+	return w.request(p, http.MethodDelete, "/api/features/"+key+"/grants?email="+email, nil)
+}
+
+func (w *grantsWorld) stepPersonRevokesRole(actor, key, role string) error {
+	p, err := w.person(actor)
+	if err != nil {
+		return err
+	}
+	return w.request(p, http.MethodDelete, "/api/features/"+key+"/grants?role="+role, nil)
+}
+
+func (w *grantsWorld) stepAnonymousGrant(key, email string) error {
+	return w.request(nil, http.MethodPost, "/api/features/"+key+"/grants",
+		grantBody(email, "", nil, nil))
+}
+
+// --- API reads ------------------------------------------------------------
+
+func (w *grantsWorld) stepListGrants(key string) error {
+	return w.request(w.current, http.MethodGet, "/api/features/"+key+"/grants", nil)
+}
+
+func (w *grantsWorld) stepSignInAndListGrants(email, key string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	if err := w.signIn(p); err != nil {
+		return err
+	}
+	return w.stepListGrants(key)
+}
+
+func (w *grantsWorld) stepListHeldBy(email string) error {
+	return w.request(w.current, http.MethodGet, "/api/features/grants?email="+email, nil)
+}
+
+// --- MCP ------------------------------------------------------------------
+
+func (w *grantsWorld) stepStdio() error {
+	w.stdio = true
+	return nil
+}
+
+func (w *grantsWorld) stepMCPGrant(tool, key, email string) error {
+	return w.callMCP(w.current, false, tool, map[string]any{"key": key, "email": email})
+}
+
+func (w *grantsWorld) stepMCPRevoke(tool, key, email string) error {
+	return w.callMCP(w.current, false, tool, map[string]any{"key": key, "email": email})
+}
+
+func (w *grantsWorld) stepMCPGrants(tool, key string) error {
+	return w.callMCP(w.current, false, tool, map[string]any{"key": key})
+}
+
+func (w *grantsWorld) stepStdioGrant(tool, key, email string) error {
+	return w.callMCP(nil, true, tool, map[string]any{"key": key, "email": email})
+}
+
+// --- CLI ------------------------------------------------------------------
+
+func (w *grantsWorld) stepRunCLI(command string) error { return w.runCLI(command) }
+
+// stepOperatorHasRun stages through the command line and insists it worked,
+// so a scenario never builds on a command that silently failed.
+func (w *grantsWorld) stepOperatorHasRun(command string) error {
+	if err := w.runCLI(command); err != nil {
+		return err
+	}
+	if w.lastRun.exitCode != 0 {
+		return fmt.Errorf("staging command %q failed: %s", command, w.lastRun.said())
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepRunCLIAgainstAccount(command, accountName string) error {
+	id, err := w.accountFor(accountName)
+	if err != nil {
+		return err
+	}
+	return w.runCLI(command + " --account " + id)
+}
+
+// --- evaluation -----------------------------------------------------------
+
+func (w *grantsWorld) evaluate(p *featurePerson, key string) (bool, error) {
+	value, _, err := w.resolver.Enabled(w.ctxFor(p), key)
+	if err != nil {
+		return false, err
+	}
+	w.answers[p.email] = value
+	w.lastKey = key
+	return value, nil
+}
+
+func (w *grantsWorld) stepSignedInAnswered(email, onOff, key string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	if err := w.signIn(p); err != nil {
+		return err
+	}
+	got, err := w.evaluate(p, key)
+	if err != nil {
+		return err
+	}
+	if got != (onOff == "on") {
+		return fmt.Errorf("%q was answered %v, want %s", email, got, onOff)
+	}
+	w.spy.reset()
+	return nil
+}
+
+// cohort is who "both of them" / "each of them" refers to: the people the
+// scenario named, or everyone signed in if it named nobody in particular.
+func (w *grantsWorld) cohort() []*featurePerson {
+	if len(w.group) > 0 {
+		out := make([]*featurePerson, 0, len(w.group))
+		for _, email := range w.group {
+			if p, ok := w.people[email]; ok {
+				out = append(out, p)
+			}
+		}
+		return out
+	}
+	out := make([]*featurePerson, 0, len(w.people))
+	for _, p := range w.people {
+		out = append(out, p)
+	}
+	return out
+}
+
+func (w *grantsWorld) stepBothSignedInAnswered(onOff, key string) error {
+	for _, p := range w.cohort() {
+		if len(p.sessionIDs) == 0 {
+			if err := w.signIn(p); err != nil {
+				return err
+			}
+		}
+		got, err := w.evaluate(p, key)
+		if err != nil {
+			return err
+		}
+		if got != (onOff == "on") {
+			return fmt.Errorf("%q was answered %v, want %s", p.email, got, onOff)
+		}
+	}
+	w.spy.reset()
+	return nil
+}
+
+func (w *grantsWorld) stepSignInAndEvaluate(email, key string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	if err := w.signIn(p); err != nil {
+		return err
+	}
+	_, err = w.evaluate(p, key)
+	return err
+}
+
+func (w *grantsWorld) stepEvaluate(key string) error {
+	if w.current == nil {
+		return fmt.Errorf("nobody is signed in")
+	}
+	_, err := w.evaluate(w.current, key)
+	return err
+}
+
+func (w *grantsWorld) stepEvaluateStraightAway(email, key string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	got, err := w.evaluate(p, key)
+	if err != nil {
+		return err
+	}
+	w.straightAway = got
+	return nil
+}
+
+// stepEvaluateAfterMoment waits out the window the scenario staged. Real time,
+// because the whole claim is that nothing scheduled has to run.
+func (w *grantsWorld) stepEvaluateAfterMoment(email, key string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	if w.moment.IsZero() {
+		return fmt.Errorf("no window was staged, so there is no moment to wait for")
+	}
+	if wait := time.Until(w.moment); wait > 0 {
+		time.Sleep(wait + 250*time.Millisecond)
+	}
+	got, err := w.evaluate(p, key)
+	if err != nil {
+		return err
+	}
+	w.afterMoment = got
+	return nil
+}
+
+func (w *grantsWorld) stepPersonEvaluatesAgain(email, key string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	_, err = w.evaluate(p, key)
+	return err
+}
+
+func (w *grantsWorld) stepEachEvaluatesAgain(key string) error {
+	for _, p := range w.cohort() {
+		if len(p.sessionIDs) == 0 {
+			continue
+		}
+		if _, err := w.evaluate(p, key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// --- status assertions ----------------------------------------------------
+
+func (w *grantsWorld) expect(status int) error {
+	if w.lastStatus != status {
+		return fmt.Errorf("the API answered %d, want %d: %s", w.lastStatus, status, string(w.lastBody))
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepChangeAccepted() error { return w.expect(http.StatusOK) }
+func (w *grantsWorld) stepBadRequest() error     { return w.expect(http.StatusBadRequest) }
+func (w *grantsWorld) stepNotFound() error       { return w.expect(http.StatusNotFound) }
+func (w *grantsWorld) stepForbidden() error      { return w.expect(http.StatusForbidden) }
+
+func (w *grantsWorld) stepUnauthenticated() error { return w.expect(http.StatusUnauthorized) }
+
+func (w *grantsWorld) stepListingServed() error {
+	if w.listingStat != http.StatusOK {
+		return fmt.Errorf("the listing answered %d, want 200: %s", w.listingStat, string(w.listingBody))
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepCallSucceeds() error {
+	if w.lastMCPErr != nil {
+		return fmt.Errorf("the tool call failed: %v", w.lastMCPErr)
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepCallRefused() error {
+	if w.lastMCPErr == nil {
+		return fmt.Errorf("the tool call succeeded, want a refusal")
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepCommandSucceeded() error {
+	if w.lastRun.exitCode != 0 {
+		return fmt.Errorf("the command exited %d: %s", w.lastRun.exitCode, w.lastRun.said())
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepCommandFailed() error {
+	if w.lastRun.exitCode == 0 {
+		return fmt.Errorf("the command exited 0, want a failure: %s", w.lastRun.said())
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepCommandNames(text string) error {
+	if !strings.Contains(w.lastRun.said(), text) {
+		return fmt.Errorf("the command does not name %q: %s", text, w.lastRun.said())
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepCommandReportsUntilTomorrow() error {
+	said := w.lastRun.said()
+	if !strings.Contains(said, "until") {
+		return fmt.Errorf("the command does not report the window: %s", said)
+	}
+	tomorrow := time.Now().Add(24 * time.Hour).Format("2006-01-02")
+	if !strings.Contains(said, tomorrow) {
+		return fmt.Errorf("the command does not report the window ending tomorrow (%s): %s", tomorrow, said)
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepFailureNames(text string) error {
+	if !strings.Contains(w.lastRun.said(), text) && !strings.Contains(string(w.lastBody), text) {
+		return fmt.Errorf("neither the command nor the API named %q: %s | %s",
+			text, w.lastRun.said(), string(w.lastBody))
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepFailureNamesAccountFlag() error {
+	if !strings.Contains(w.lastRun.said(), "--account") {
+		return fmt.Errorf("the failure does not say which account must be named: %s", w.lastRun.said())
+	}
+	return nil
+}
+
+func (w *grantsWorld) refusalSays(fragments ...string) error {
+	body := string(w.lastBody)
+	if w.lastMCPErr != nil {
+		body += " " + w.lastMCPErr.Error()
+	}
+	body += " " + w.lastRun.said()
+	for _, f := range fragments {
+		if strings.Contains(body, f) {
+			return nil
+		}
+	}
+	return fmt.Errorf("the refusal does not say %v: %s", fragments, body)
+}
+
+func (w *grantsWorld) stepRefusalNamesRoles() error {
+	return w.refusalSays("owner", "admin", "member")
+}
+
+func (w *grantsWorld) stepRefusalNamesCLI() error {
+	return w.refusalSays("--account", "command line")
+}
+
+func (w *grantsWorld) stepRefusalNotMember() error {
+	return w.refusalSays("not a member of this account")
+}
+
+func (w *grantsWorld) stepRefusalNotGrantable() error {
+	return w.refusalSays("cannot be granted")
+}
+
+func (w *grantsWorld) stepRefusalBadWindow() error {
+	return w.refusalSays("ends before it begins")
+}
+
+// --- stored state ---------------------------------------------------------
+
+func (w *grantsWorld) currentAccount() (string, error) {
+	if w.current != nil && w.current.accountID != "" {
+		return w.current.accountID, nil
+	}
+	for _, id := range w.accounts {
+		return id, nil
+	}
+	return "", fmt.Errorf("no account has been staged")
+}
+
+func (w *grantsWorld) stepNoGrantAtAll(key string) error {
+	account, err := w.currentAccount()
+	if err != nil {
+		return err
+	}
+	rows, err := w.storedGrants(account, key)
+	if err != nil {
+		return err
+	}
+	if len(rows) != 0 {
+		return fmt.Errorf("%d grants of %q are stored, want none", len(rows), key)
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepNoGrantFor(key, email string) error {
+	account, err := w.currentAccount()
+	if err != nil {
+		return err
+	}
+	p, ok := w.people[email]
+	if !ok {
+		// Nobody by that address exists, so nothing can be stored for them.
+		return nil
+	}
+	rows, err := w.storedGrants(account, key)
+	if err != nil {
+		return err
+	}
+	for _, r := range rows {
+		if r.SubjectType == "agent" && r.SubjectID == p.agentID {
+			return fmt.Errorf("a grant of %q is stored for %q", key, email)
+		}
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepNoGrantForRole(key, role string) error {
+	account, err := w.currentAccount()
+	if err != nil {
+		return err
+	}
+	rows, err := w.storedGrants(account, key)
+	if err != nil {
+		return err
+	}
+	for _, r := range rows {
+		if r.SubjectType == "role" && r.SubjectID == role {
+			return fmt.Errorf("a grant of %q is stored for the role %q", key, role)
+		}
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepNoGrantInAccount(key, accountName string) error {
+	id, err := w.accountFor(accountName)
+	if err != nil {
+		return err
+	}
+	rows, err := w.storedGrants(id, key)
+	if err != nil {
+		return err
+	}
+	if len(rows) != 0 {
+		return fmt.Errorf("%d grants of %q are stored in %q, want none", len(rows), key, accountName)
+	}
+	return nil
+}
+
+func (w *grantsWorld) storedFor(key, email string) (entities.FeatureGrantRecord, error) {
+	account, err := w.currentAccount()
+	if err != nil {
+		return entities.FeatureGrantRecord{}, err
+	}
+	p, err := w.person(email)
+	if err != nil {
+		return entities.FeatureGrantRecord{}, err
+	}
+	rows, err := w.storedGrants(account, key)
+	if err != nil {
+		return entities.FeatureGrantRecord{}, err
+	}
+	for _, r := range rows {
+		if r.SubjectType == "agent" && r.SubjectID == p.agentID {
+			return r, nil
+		}
+	}
+	return entities.FeatureGrantRecord{}, fmt.Errorf("no grant of %q is stored for %q", key, email)
+}
+
+// stepOneStoredGrant is the assertion that a re-grant replaces rather than
+// accumulates: two rows would resolve identically, so nothing else would tell.
+func (w *grantsWorld) stepOneStoredGrant(key, email string) error {
+	account, err := w.currentAccount()
+	if err != nil {
+		return err
+	}
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	rows, err := w.storedGrants(account, key)
+	if err != nil {
+		return err
+	}
+	count := 0
+	for _, r := range rows {
+		if r.SubjectType == "agent" && r.SubjectID == p.agentID {
+			count++
+		}
+	}
+	if count != 1 {
+		return fmt.Errorf("%d grants of %q are stored for %q, want exactly 1", count, key, email)
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepStoredNamesAgentID(email string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	row, err := w.storedFor(w.lastGrantKey(), email)
+	if err != nil {
+		return err
+	}
+	if row.SubjectID != p.agentID {
+		return fmt.Errorf("the stored grant names %q, want the agent id %q", row.SubjectID, p.agentID)
+	}
+	return nil
+}
+
+// stepStoredHasNoEmail: the row holds an agent id, because an address can
+// change and a grant should not follow it.
+func (w *grantsWorld) stepStoredHasNoEmail() error {
+	account, err := w.currentAccount()
+	if err != nil {
+		return err
+	}
+	rows, err := w.storedGrants(account, w.lastGrantKey())
+	if err != nil {
+		return err
+	}
+	for _, r := range rows {
+		if strings.Contains(r.SubjectID, "@") {
+			return fmt.Errorf("the stored grant carries an address (%q) rather than an agent id", r.SubjectID)
+		}
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepStoredScopedTo(accountName string) error {
+	id, err := w.accountFor(accountName)
+	if err != nil {
+		return err
+	}
+	rows, err := w.storedGrants(id, w.lastGrantKey())
+	if err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		return fmt.Errorf("no grant of %q is stored in %q", w.lastGrantKey(), accountName)
+	}
+	return nil
+}
+
+// lastGrantKey is whichever feature the scenario has been granting. The
+// contract's stored-state steps do not repeat the key, so it is remembered.
+func (w *grantsWorld) lastGrantKey() string {
+	if w.lastKey != "" {
+		return w.lastKey
+	}
+	return "ledger-export"
+}
+
+func (w *grantsWorld) stepGrantHasTime() error {
+	views, err := w.currentGrantViews()
+	if err != nil {
+		return err
+	}
+	if len(views) == 0 {
+		return fmt.Errorf("no grant is listed")
+	}
+	if views[0].GrantedAt.IsZero() {
+		return fmt.Errorf("the grant carries no time")
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepGrantRecordsMaker(email string) error {
+	views, err := w.currentGrantViews()
+	if err != nil {
+		return err
+	}
+	for _, v := range views {
+		if v.GrantedBy == email {
+			return nil
+		}
+	}
+	return fmt.Errorf("no grant records %q as who made it: %+v", email, views)
+}
+
+func (w *grantsWorld) stepGrantToRecordsMaker(subject, maker string) error {
+	views, err := w.currentGrantViews()
+	if err != nil {
+		return err
+	}
+	v, ok := findGrant(views, subject)
+	if !ok {
+		return fmt.Errorf("no grant is listed for %q", subject)
+	}
+	if v.GrantedBy != maker {
+		return fmt.Errorf("the grant to %q records %q as who made it, want %q", subject, v.GrantedBy, maker)
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepGrantNoWindow() error {
+	views, err := w.currentGrantViews()
+	if err != nil {
+		return err
+	}
+	if len(views) == 0 {
+		return fmt.Errorf("no grant is listed")
+	}
+	if views[0].ValidFrom != nil || views[0].ValidThrough != nil {
+		return fmt.Errorf("the grant reports a window it was not given: %+v", views[0])
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepRoleGrantNoWindow(role string) error {
+	views, err := w.currentGrantViews()
+	if err != nil {
+		return err
+	}
+	v, ok := findRoleGrant(views, role)
+	if !ok {
+		return fmt.Errorf("no grant is listed for the role %q", role)
+	}
+	if v.ValidFrom != nil || v.ValidThrough != nil {
+		return fmt.Errorf("the role grant reports a window it was not given: %+v", v)
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepGrantUntilTomorrow(email string) error {
+	views, err := w.currentGrantViews()
+	if err != nil {
+		return err
+	}
+	v, ok := findGrant(views, email)
+	if !ok {
+		return fmt.Errorf("no grant is listed for %q", email)
+	}
+	if v.ValidThrough == nil {
+		return fmt.Errorf("the grant to %q reports no end", email)
+	}
+	if v.ValidThrough.Before(time.Now().Add(12 * time.Hour)) {
+		return fmt.Errorf("the grant to %q ends at %v, want about tomorrow", email, v.ValidThrough)
+	}
+	return nil
+}
+
+// --- listings -------------------------------------------------------------
+
+// currentGrantViews takes whichever surface last answered, falling back to
+// asking the service — several scenarios grant and then assert on the listing
+// without requesting one.
+func (w *grantsWorld) currentGrantViews() ([]application.GrantView, error) {
+	if w.lastMCPOut != nil {
+		return w.mcpGrants()
+	}
+	if len(w.lastBody) > 0 {
+		if views, err := w.grantViews(w.lastBody); err == nil {
+			return views, nil
+		}
+	}
+	if w.current == nil {
+		return nil, fmt.Errorf("nobody is signed in to read grants as")
+	}
+	return w.admin.GrantsOn(w.ctxFor(w.current), w.lastGrantKey(), "")
+}
+
+func (w *grantsWorld) grantViewsOn(key string) ([]application.GrantView, error) {
+	if w.current == nil {
+		return nil, fmt.Errorf("nobody is signed in")
+	}
+	return w.admin.GrantsOn(w.ctxFor(w.current), key, "")
+}
+
+func (w *grantsWorld) stepGrantsNameBoth(key, email, role string) error {
+	views, err := w.grantViewsOn(key)
+	if err != nil {
+		return err
+	}
+	if _, ok := findGrant(views, email); !ok {
+		return fmt.Errorf("the grants on %q do not name %q", key, email)
+	}
+	if _, ok := findRoleGrant(views, role); !ok {
+		return fmt.Errorf("the grants on %q do not name the role %q", key, role)
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepGrantsNoLonger(key, email string) error {
+	views, err := w.grantViewsOn(key)
+	if err != nil {
+		return err
+	}
+	if _, ok := findGrant(views, email); ok {
+		return fmt.Errorf("the grants on %q still name %q", key, email)
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepGrantsStillRole(key, role string) error {
+	views, err := w.grantViewsOn(key)
+	if err != nil {
+		return err
+	}
+	if _, ok := findRoleGrant(views, role); !ok {
+		return fmt.Errorf("the grants on %q no longer name the role %q", key, role)
+	}
+	return nil
+}
+
+// stepGrantsExpired: a closed window leaves the row where revocation deletes
+// it, and an operator has to be able to tell those apart.
+func (w *grantsWorld) stepGrantsExpired(key string) error {
+	views, err := w.grantViewsOn(key)
+	if err != nil {
+		return err
+	}
+	for _, v := range views {
+		if v.Status == entities.GrantExpired {
+			return nil
+		}
+	}
+	return fmt.Errorf("no grant on %q is reported expired: %+v", key, views)
+}
+
+func (w *grantsWorld) stepGrantsEmpty(email string) error {
+	views, err := w.currentGrantViews()
+	if err != nil {
+		return err
+	}
+	if len(views) != 0 {
+		return fmt.Errorf("%q is shown %d grants, want none", email, len(views))
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepHeldDirect(key string) error {
+	views, err := w.currentGrantViews()
+	if err != nil {
+		return err
+	}
+	for _, v := range views {
+		if v.FeatureKey == key && v.Via == "direct" {
+			return nil
+		}
+	}
+	return fmt.Errorf("%q is not reported as held directly: %+v", key, views)
+}
+
+func (w *grantsWorld) stepHeldViaRole(key, role string) error {
+	views, err := w.currentGrantViews()
+	if err != nil {
+		return err
+	}
+	for _, v := range views {
+		if v.FeatureKey == key && v.Via == "role:"+role {
+			return nil
+		}
+	}
+	return fmt.Errorf("%q is not reported as held through the role %q: %+v", key, role, views)
+}
+
+// stepToolMatchesAPI is what stops the surfaces drifting.
+func (w *grantsWorld) stepToolMatchesAPI(key string) error {
+	fromTool, err := w.mcpGrants()
+	if err != nil {
+		return err
+	}
+	if err := w.request(w.current, http.MethodGet, "/api/features/"+key+"/grants", nil); err != nil {
+		return err
+	}
+	fromAPI, err := w.grantViews(w.lastBody)
+	if err != nil {
+		return err
+	}
+	if len(fromTool) != len(fromAPI) {
+		return fmt.Errorf("the tool reported %d grants, the API lists %d", len(fromTool), len(fromAPI))
+	}
+	for _, tv := range fromTool {
+		matched := false
+		for _, av := range fromAPI {
+			if av.Email == tv.Email && av.Role == tv.Role && av.Status == tv.Status {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return fmt.Errorf("the tool reported %+v, which the API does not list the same way", tv)
+		}
+	}
+	return nil
+}
+
+// --- evaluation assertions ------------------------------------------------
+
+func (w *grantsWorld) stepFeatureOn() error {
+	if w.current == nil {
+		return fmt.Errorf("nobody is signed in")
+	}
+	if !w.answers[w.current.email] {
+		return fmt.Errorf("the feature answered off, want on")
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepPersonAnswered(email, onOff string) error {
+	got, ok := w.answers[email]
+	if !ok {
+		return fmt.Errorf("%q has not evaluated anything", email)
+	}
+	if got != (onOff == "on") {
+		return fmt.Errorf("%q was answered %v, want %s", email, got, onOff)
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepBothOff() error {
+	for _, p := range w.cohort() {
+		if got, ok := w.answers[p.email]; ok && got {
+			return fmt.Errorf("%q was answered on, want off", p.email)
+		}
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepStraightAway(onOff string) error {
+	if w.straightAway != (onOff == "on") {
+		return fmt.Errorf("the evaluation straight away answered %v, want %s", w.straightAway, onOff)
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepAfterMoment(onOff string) error {
+	if w.afterMoment != (onOff == "on") {
+		return fmt.Errorf("the evaluation after that moment answered %v, want %s — "+
+			"a window has to take effect on its own", w.afterMoment, onOff)
+	}
+	return nil
+}
+
+// --- sessions and cost ----------------------------------------------------
+
+func (w *grantsWorld) assertSignedIn(p *featurePerson) error {
+	for i, id := range p.sessionIDs {
+		info, err := w.authService.ValidateSession(context.Background(), id)
+		if err != nil || info == nil {
+			return fmt.Errorf("session %d of %q is no longer valid: %w — a grant changing "+
+				"must never sign anyone out", i+1, p.email, err)
+		}
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepStillSignedIn(email string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	return w.assertSignedIn(p)
+}
+
+func (w *grantsWorld) stepCurrentStillSignedIn() error {
+	if w.current == nil {
+		return fmt.Errorf("nobody is signed in")
+	}
+	return w.assertSignedIn(w.current)
+}
+
+func (w *grantsWorld) stepAllStillSignedIn() error {
+	for _, p := range w.cohort() {
+		if len(p.sessionIDs) == 0 {
+			continue
+		}
+		if err := w.assertSignedIn(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepNextRequestServed(email string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	if err := w.assertSignedIn(p); err != nil {
+		return err
+	}
+	_, err = w.evaluate(p, w.lastGrantKey())
+	return err
+}
+
+// stepNothingInvalidated is a claim about the mechanism: the window took
+// effect without anything dropping the cache.
+func (w *grantsWorld) stepNothingInvalidated() error { return nil }
+
+func (w *grantsWorld) stepCacheAgeNotReached() error {
+	if w.maxCacheAge < time.Minute {
+		return fmt.Errorf("the configured cache age is %s, which is too short to prove "+
+			"the window did the work rather than the age", w.maxCacheAge)
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepNotRestarted() error {
+	if w.app == nil {
+		return fmt.Errorf("the instance is not running; the scenario needs the one it started with")
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepReadNothing(email string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	if n := w.spy.countFor(p.agentID); n != 0 {
+		return fmt.Errorf("%q read the grant store %d times, want none — their session was "+
+			"not invalidated, so the answer had to come from memory", email, n)
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepReadOnce() error {
+	if w.current == nil {
+		return fmt.Errorf("nobody is signed in")
+	}
+	if n := w.spy.countFor(w.current.agentID); n != 1 {
+		return fmt.Errorf("the grant store was read %d times, want exactly 1", n)
+	}
+	return nil
+}
+
+// stepReadOnlyTheirs is the cost assertion: a caller with a few grants must
+// not read the account's many.
+func (w *grantsWorld) stepReadOnlyTheirs() error {
+	if rows := w.spy.rowsLastRead(); rows > 5 {
+		return fmt.Errorf("the read returned %d rows — it fetched the account's grants "+
+			"rather than the caller's", rows)
+	}
+	return nil
+}
+
+// --- audit ----------------------------------------------------------------
+
+func (w *grantsWorld) stepRecordedGrant(key string) error {
+	event, err := w.lastFeatureChangeEvent()
+	if err != nil {
+		return err
+	}
+	if event.Key != key {
+		return fmt.Errorf("the record names %q, want %q", event.Key, key)
+	}
+	if event.State != entities.FeatureChangeStateGranted {
+		return fmt.Errorf("the record says %q, want %q", event.State, entities.FeatureChangeStateGranted)
+	}
+	if event.SubjectID == "" {
+		return fmt.Errorf("the record does not say who it was granted to")
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepRecordedRevocation(key, email string) error {
+	event, err := w.lastFeatureChangeEvent()
+	if err != nil {
+		return err
+	}
+	if event.Key != key || event.State != entities.FeatureChangeStateRevoked {
+		return fmt.Errorf("the last record is %q/%q, want a revocation of %q",
+			event.Key, event.State, key)
+	}
+	if email != "" && event.SubjectEmail != "" && event.SubjectEmail != email {
+		return fmt.Errorf("the record names %q, want %q", event.SubjectEmail, email)
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepRecordActor(email string) error {
+	event, err := w.lastFeatureChangeEvent()
+	if err != nil {
+		return err
+	}
+	if event.ActorEmail != email {
+		return fmt.Errorf("the record names %q as who made the change, want %q",
+			event.ActorEmail, email)
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepRecordSourceCLI() error {
+	event, err := w.lastFeatureChangeEvent()
+	if err != nil {
+		return err
+	}
+	if event.Source != entities.FeatureChangeSourceCLI {
+		return fmt.Errorf("the record names %q as the source, want %q",
+			event.Source, entities.FeatureChangeSourceCLI)
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepRecordTime() error {
+	event, err := w.lastFeatureChangeEvent()
+	if err != nil {
+		return err
+	}
+	if event.Timestamp.IsZero() {
+		return fmt.Errorf("the record carries no time")
+	}
+	return nil
+}

--- a/tests/e2e/feature_grants_steps_test.go
+++ b/tests/e2e/feature_grants_steps_test.go
@@ -151,6 +151,9 @@ func initFeatureGrantsScenario(sc *godog.ScenarioContext) {
 	sc.Step(`^neither of them was signed out$`, w.stepAllStillSignedIn)
 	sc.Step(`^the request "([^"]*)" makes next is served$`, w.stepNextRequestServed)
 	sc.Step(`^nothing invalidated the session in between$`, w.stepNothingInvalidated)
+	sc.Step(`^that answer came from memory, without reading the grant store$`, w.stepAnswerCameFromMemory)
+	sc.Step(`^the grant store was read once to answer that one$`, w.stepReadOnceForThatOne)
+	sc.Step(`^the grant store was read once for each of those two evaluations$`, w.stepReadOnceEach)
 	sc.Step(`^the maximum cache age had not run out$`, w.stepCacheAgeNotReached)
 	sc.Step(`^the instance was not restarted$`, w.stepNotRestarted)
 	sc.Step(`^"([^"]*)" read no feature state from the database to be answered$`, w.stepReadNothing)
@@ -210,11 +213,15 @@ func (w *grantsWorld) stepAccountOwner(name, email, password string) error {
 
 // --- membership -----------------------------------------------------------
 
+// Each of these names a person the scenario is about, so "both of them" and
+// "each of them" mean those people rather than whoever else exists.
 func (w *grantsWorld) stepAlsoBelongs(email, account string) error {
+	w.group = append(w.group, email)
 	return w.addToAccount(email, account, "member")
 }
 
 func (w *grantsWorld) stepAlsoBelongsWithRole(email, account, role string) error {
+	w.group = append(w.group, email)
 	return w.addToAccount(email, account, role)
 }
 
@@ -229,6 +236,7 @@ func (w *grantsWorld) stepTwoBelongWithRole(a, b, account, role string) error {
 }
 
 func (w *grantsWorld) stepOrdinaryMember(email, account string) error {
+	w.group = append(w.group, email)
 	return w.addToAccount(email, account, "member")
 }
 
@@ -555,15 +563,33 @@ func (w *grantsWorld) cohort() []*featurePerson {
 		}
 		return out
 	}
+	// Not "everyone staged". A scenario that says "both of them" and named
+	// nobody would otherwise sweep in the Background's owner, and pass or fail
+	// for reasons it never mentions.
 	out := make([]*featurePerson, 0, len(w.people))
 	for _, p := range w.people {
-		out = append(out, p)
+		if len(p.sessionIDs) > 0 {
+			out = append(out, p)
+		}
 	}
 	return out
 }
 
+// requireCohort refuses to let a "both of them" step assert nothing.
+func (w *grantsWorld) requireCohort() ([]*featurePerson, error) {
+	group := w.cohort()
+	if len(group) == 0 {
+		return nil, fmt.Errorf("this step is about several people and the scenario named none")
+	}
+	return group, nil
+}
+
 func (w *grantsWorld) stepBothSignedInAnswered(onOff, key string) error {
-	for _, p := range w.cohort() {
+	group, err := w.requireCohort()
+	if err != nil {
+		return err
+	}
+	for _, p := range group {
 		if len(p.sessionIDs) == 0 {
 			if err := w.signIn(p); err != nil {
 				return err
@@ -606,11 +632,14 @@ func (w *grantsWorld) stepEvaluateStraightAway(email, key string) error {
 	if err != nil {
 		return err
 	}
+	before := w.spy.countFor(p.agentID)
 	got, err := w.evaluate(p, key)
 	if err != nil {
 		return err
 	}
 	w.straightAway = got
+	w.readsStraightAway = w.spy.countFor(p.agentID) - before
+	w.invalidationsAtStraightAway = w.invSpy.count()
 	return nil
 }
 
@@ -627,11 +656,13 @@ func (w *grantsWorld) stepEvaluateAfterMoment(email, key string) error {
 	if wait := time.Until(w.moment); wait > 0 {
 		time.Sleep(wait + 250*time.Millisecond)
 	}
+	before := w.spy.countFor(p.agentID)
 	got, err := w.evaluate(p, key)
 	if err != nil {
 		return err
 	}
 	w.afterMoment = got
+	w.readsAfterMoment = w.spy.countFor(p.agentID) - before
 	return nil
 }
 
@@ -645,7 +676,11 @@ func (w *grantsWorld) stepPersonEvaluatesAgain(email, key string) error {
 }
 
 func (w *grantsWorld) stepEachEvaluatesAgain(key string) error {
-	for _, p := range w.cohort() {
+	group, err := w.requireCohort()
+	if err != nil {
+		return err
+	}
+	for _, p := range group {
 		if len(p.sessionIDs) == 0 {
 			continue
 		}
@@ -1061,9 +1096,14 @@ func (w *grantsWorld) currentGrantViews() ([]application.GrantView, error) {
 		return w.mcpGrants()
 	}
 	if len(w.lastBody) > 0 {
-		if views, err := w.grantViews(w.lastBody); err == nil {
-			return views, nil
+		// Fail loudly rather than falling through. Asking the service when the
+		// response did not parse would let a handler that stopped returning
+		// grants keep every one of these assertions green.
+		views, err := w.grantViews(w.lastBody)
+		if err != nil {
+			return nil, fmt.Errorf("the surface answered something that is not a grant listing: %w", err)
 		}
+		return views, nil
 	}
 	if w.current == nil {
 		return nil, fmt.Errorf("nobody is signed in to read grants as")
@@ -1221,8 +1261,16 @@ func (w *grantsWorld) stepPersonAnswered(email, onOff string) error {
 }
 
 func (w *grantsWorld) stepBothOff() error {
-	for _, p := range w.cohort() {
-		if got, ok := w.answers[p.email]; ok && got {
+	group, err := w.requireCohort()
+	if err != nil {
+		return err
+	}
+	for _, p := range group {
+		got, ok := w.answers[p.email]
+		if !ok {
+			return fmt.Errorf("%q never evaluated, so this asserts nothing about them", p.email)
+		}
+		if got {
 			return fmt.Errorf("%q was answered on, want off", p.email)
 		}
 	}
@@ -1296,9 +1344,45 @@ func (w *grantsWorld) stepNextRequestServed(email string) error {
 	return err
 }
 
-// stepNothingInvalidated is a claim about the mechanism: the window took
-// effect without anything dropping the cache.
-func (w *grantsWorld) stepNothingInvalidated() error { return nil }
+// stepNothingInvalidated is the claim the whole boundary mechanism rests on:
+// the window took effect without anything dropping the cache. Measured, not
+// asserted in prose — the count is snapshotted at the straight-away
+// evaluation and must not have moved by the time the window closed.
+func (w *grantsWorld) stepNothingInvalidated() error {
+	if now := w.invSpy.count(); now != w.invalidationsAtStraightAway {
+		return fmt.Errorf("%d invalidations happened between the two evaluations, want none — "+
+			"the window has to take effect on its own, not because something dropped the cache",
+			now-w.invalidationsAtStraightAway)
+	}
+	return nil
+}
+
+// stepAnswerCameFromMemory is what stops the window scenarios passing against
+// an implementation that never caches at all: with no cache, every evaluation
+// reads, and both a live and an expired grant would look correct.
+func (w *grantsWorld) stepAnswerCameFromMemory() error {
+	if w.readsStraightAway != 0 {
+		return fmt.Errorf("the straight-away answer cost %d grant reads, want none — "+
+			"it should have come from the cached set", w.readsStraightAway)
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepReadOnceForThatOne() error {
+	if w.readsAfterMoment != 1 {
+		return fmt.Errorf("the evaluation after the boundary cost %d grant reads, want exactly 1",
+			w.readsAfterMoment)
+	}
+	return nil
+}
+
+func (w *grantsWorld) stepReadOnceEach() error {
+	if w.readsStraightAway != 1 || w.readsAfterMoment != 1 {
+		return fmt.Errorf("the two evaluations cost %d and %d grant reads, want exactly 1 each",
+			w.readsStraightAway, w.readsAfterMoment)
+	}
+	return nil
+}
 
 func (w *grantsWorld) stepCacheAgeNotReached() error {
 	if w.maxCacheAge < time.Minute {

--- a/tests/e2e/feature_grants_world_test.go
+++ b/tests/e2e/feature_grants_world_test.go
@@ -123,6 +123,41 @@ func (g *grantsSpyRepo) rowsLastRead() int {
 	return g.lastRows
 }
 
+// invalidatorSpy counts invalidations, so a scenario claiming a window took
+// effect on its own can prove nothing dropped the cache for it.
+type invalidatorSpy struct {
+	inner repositories.FeatureCacheInvalidator
+	mu    sync.Mutex
+	calls int
+}
+
+func (i *invalidatorSpy) InvalidateAll(ctx context.Context) {
+	i.bump()
+	i.inner.InvalidateAll(ctx)
+}
+
+func (i *invalidatorSpy) InvalidateAccount(ctx context.Context, accountID string) {
+	i.bump()
+	i.inner.InvalidateAccount(ctx, accountID)
+}
+
+func (i *invalidatorSpy) InvalidateAgents(ctx context.Context, accountID string, agentIDs ...string) {
+	i.bump()
+	i.inner.InvalidateAgents(ctx, accountID, agentIDs...)
+}
+
+func (i *invalidatorSpy) bump() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.calls++
+}
+
+func (i *invalidatorSpy) count() int {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.calls
+}
+
 type grantsWorld struct {
 	app    *fx.App
 	tmpDir string
@@ -134,6 +169,7 @@ type grantsWorld struct {
 	resolver *application.FeatureResolver
 	grants   repositories.FeatureGrantRepository
 	spy      *grantsSpyRepo
+	invSpy   *invalidatorSpy
 	settings repositories.FeatureSettingsRepository
 	eventLog repositories.EventLogRepository
 	db       *gormlib.DB
@@ -170,6 +206,14 @@ type grantsWorld struct {
 	lastKey      string
 	straightAway bool
 	afterMoment  bool
+	// readsStraightAway and readsAfterMoment record what each of the two
+	// window evaluations cost, so the scenarios can tell the boundary
+	// mechanism from an implementation that simply never caches.
+	readsStraightAway int
+	readsAfterMoment  int
+	// invalidationsAtStraightAway snapshots the invalidation count, so
+	// "nothing invalidated the session in between" is a measurement.
+	invalidationsAtStraightAway int
 	// moment is the instant a window scenario waits for.
 	moment time.Time
 
@@ -250,12 +294,17 @@ func (w *grantsWorld) boot() error {
 	cfg.Features.PrimaryAccountID = w.primary
 
 	w.spy = &grantsSpyRepo{}
+	w.invSpy = &invalidatorSpy{}
 	app := fx.New(
 		fx.NopLogger,
 		application.Module(cfg, presets.NewDefaultRegistry()),
 		fx.Decorate(func(inner repositories.FeatureGrantRepository) repositories.FeatureGrantRepository {
 			w.spy.inner = inner
 			return w.spy
+		}),
+		fx.Decorate(func(inner repositories.FeatureCacheInvalidator) repositories.FeatureCacheInvalidator {
+			w.invSpy.inner = inner
+			return w.invSpy
 		}),
 		fx.Populate(&w.registry, &w.admin, &w.resolver, &w.grants, &w.settings, &w.eventLog),
 		fx.Populate(&w.db, &w.resources, &w.rts),
@@ -416,6 +465,9 @@ func (w *grantsWorld) request(p *featurePerson, method, path string, body any) e
 	}
 	w.lastStatus = resp.StatusCode
 	w.lastBody = buf.Bytes()
+	// An HTTP answer supersedes any earlier tool payload, so a later
+	// assertion cannot read a stale MCP result as if it were this response.
+	w.lastMCPOut = nil
 	if method == http.MethodGet {
 		w.listingStat = resp.StatusCode
 		w.listingBody = buf.Bytes()

--- a/tests/e2e/feature_grants_world_test.go
+++ b/tests/e2e/feature_grants_world_test.go
@@ -1,0 +1,604 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cucumber/godog"
+	"github.com/labstack/echo/v4"
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.uber.org/fx"
+	gormlib "gorm.io/gorm"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
+	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
+	authentities "github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
+	authhttp "github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/http"
+	"github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/session"
+
+	"github.com/wepala/weos/v3/api/handlers"
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/application/presets"
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
+	"github.com/wepala/weos/v3/internal/config"
+	mcpserver "github.com/wepala/weos/v3/internal/mcp"
+)
+
+// TestFeatureGrants runs the acceptance contract for story #483.
+//
+//	GODOG_TAGS=@story-483 go test ./tests/e2e/ -run TestFeatureGrants
+func TestFeatureGrants(t *testing.T) {
+	tags := "~@wip"
+	if v := os.Getenv("GODOG_TAGS"); v != "" {
+		tags = v
+	}
+	suite := godog.TestSuite{
+		ScenarioInitializer: initFeatureGrantsScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"features/feature_flag_grants.feature"},
+			Tags:     tags,
+			Strict:   true,
+			TestingT: t,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("feature grant acceptance scenarios failed")
+	}
+}
+
+// grantsSpyRepo counts reads per caller, so "read no feature state" and "the
+// grant store was read once" are measurements rather than intentions.
+type grantsSpyRepo struct {
+	inner repositories.FeatureGrantRepository
+
+	mu    sync.Mutex
+	reads map[string]int
+	// lastRows records how many rows the last read returned, which is what the
+	// cost scenario is actually about: a caller with three grants must not
+	// read the account's two hundred.
+	lastRows int
+}
+
+func (g *grantsSpyRepo) GrantsFor(
+	ctx context.Context, accountID, agentID, roleID string,
+) ([]entities.FeatureGrantRecord, error) {
+	g.mu.Lock()
+	if g.reads == nil {
+		g.reads = map[string]int{}
+	}
+	g.reads[agentOf(ctx)]++
+	g.mu.Unlock()
+	rows, err := g.inner.GrantsFor(ctx, accountID, agentID, roleID)
+	g.mu.Lock()
+	g.lastRows = len(rows)
+	g.mu.Unlock()
+	return rows, err
+}
+
+func (g *grantsSpyRepo) ListByFeature(
+	ctx context.Context, accountID, key string,
+) ([]entities.FeatureGrantRecord, error) {
+	return g.inner.ListByFeature(ctx, accountID, key)
+}
+
+func (g *grantsSpyRepo) Grant(ctx context.Context, record entities.FeatureGrantRecord) error {
+	return g.inner.Grant(ctx, record)
+}
+
+func (g *grantsSpyRepo) Revoke(
+	ctx context.Context, subjectType, subjectID, accountID, key string,
+) (bool, error) {
+	return g.inner.Revoke(ctx, subjectType, subjectID, accountID, key)
+}
+
+func (g *grantsSpyRepo) countFor(agentID string) int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.reads[agentID]
+}
+
+func (g *grantsSpyRepo) reset() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.reads = map[string]int{}
+}
+
+func (g *grantsSpyRepo) rowsLastRead() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.lastRows
+}
+
+type grantsWorld struct {
+	app    *fx.App
+	tmpDir string
+	dsn    string
+	server *httptest.Server
+
+	registry *application.FeatureRegistry
+	admin    *application.FeatureAdminService
+	resolver *application.FeatureResolver
+	grants   repositories.FeatureGrantRepository
+	spy      *grantsSpyRepo
+	settings repositories.FeatureSettingsRepository
+	eventLog repositories.EventLogRepository
+	db       *gormlib.DB
+
+	resources application.ResourceService
+	rts       application.ResourceTypeService
+
+	authService    authapp.AuthenticationService
+	accountRepo    authrepos.AccountRepository
+	credRepo       authrepos.CredentialRepository
+	sessionManager session.SessionManager
+	logger         entities.Logger
+
+	maxCacheAge time.Duration
+	declared    []entities.FeatureMeta
+	primary     string
+
+	accounts map[string]string
+	people   map[string]*featurePerson
+	current  *featurePerson
+	// group is who "both of them" means: the people a scenario named.
+	group   []string
+	workDir string
+	stdio   bool
+
+	lastRun      commandRun
+	lastStatus   int
+	lastBody     []byte
+	listingStat  int
+	listingBody  []byte
+	lastMCPOut   map[string]any
+	lastMCPErr   error
+	answers      map[string]bool
+	lastKey      string
+	straightAway bool
+	afterMoment  bool
+	// moment is the instant a window scenario waits for.
+	moment time.Time
+
+	envBefore map[string]*string
+}
+
+func (w *grantsWorld) teardown() {
+	if w.server != nil {
+		w.server.Close()
+		w.server = nil
+	}
+	if w.app != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		defer cancel()
+		_ = w.app.Stop(ctx)
+		w.app = nil
+	}
+	for k, v := range w.envBefore {
+		if v == nil {
+			os.Unsetenv(k)
+		} else {
+			os.Setenv(k, *v)
+		}
+	}
+	if w.tmpDir != "" {
+		os.RemoveAll(w.tmpDir)
+		w.tmpDir = ""
+	}
+}
+
+func (w *grantsWorld) setEnv(key string, value *string) {
+	if w.envBefore == nil {
+		w.envBefore = map[string]*string{}
+	}
+	if _, seen := w.envBefore[key]; !seen {
+		if old, ok := os.LookupEnv(key); ok {
+			w.envBefore[key] = &old
+		} else {
+			w.envBefore[key] = nil
+		}
+	}
+	if value == nil {
+		os.Unsetenv(key)
+		return
+	}
+	os.Setenv(key, *value)
+}
+
+func (w *grantsWorld) boot() error {
+	if w.app != nil {
+		return nil
+	}
+	if w.tmpDir == "" {
+		dir, err := os.MkdirTemp("", "weos-feature-grants-e2e-")
+		if err != nil {
+			return fmt.Errorf("could not create a temp dir: %w", err)
+		}
+		w.tmpDir = dir
+		w.dsn = filepath.Join(dir, "grants.db")
+		w.workDir = filepath.Join(dir, "cwd")
+		if err := os.MkdirAll(w.workDir, 0o755); err != nil {
+			return err
+		}
+	}
+	pw := "true"
+	w.setEnv("PASSWORD_AUTH_ENABLED", &pw)
+	w.setEnv("GOOGLE_CLIENT_ID", nil)
+	w.setEnv("GOOGLE_CLIENT_SECRET", nil)
+
+	cfg := config.Default()
+	cfg.LoadFromEnvironment()
+	cfg.DatabaseDSN = w.dsn
+	cfg.LogLevel = "error"
+	if w.maxCacheAge > 0 {
+		cfg.Features.CacheMaxAge = w.maxCacheAge
+	}
+	cfg.Features.Declared = append([]entities.FeatureMeta(nil), w.declared...)
+	cfg.Features.PrimaryAccountID = w.primary
+
+	w.spy = &grantsSpyRepo{}
+	app := fx.New(
+		fx.NopLogger,
+		application.Module(cfg, presets.NewDefaultRegistry()),
+		fx.Decorate(func(inner repositories.FeatureGrantRepository) repositories.FeatureGrantRepository {
+			w.spy.inner = inner
+			return w.spy
+		}),
+		fx.Populate(&w.registry, &w.admin, &w.resolver, &w.grants, &w.settings, &w.eventLog),
+		fx.Populate(&w.db, &w.resources, &w.rts),
+		fx.Populate(&w.authService, &w.accountRepo, &w.credRepo, &w.sessionManager, &w.logger),
+	)
+	startCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+	defer cancel()
+	if err := app.Start(startCtx); err != nil {
+		return fmt.Errorf("failed to start app: %w", err)
+	}
+	w.app = app
+	return w.mountAPI()
+}
+
+// mountAPI mounts RequireAuth explicitly, for the same reason #482's world
+// does: serve.go mounts SoftAuth under password-only auth, which never answers
+// 401, so the unauthenticated scenario would be unprovable against it.
+func (w *grantsWorld) mountAPI() error {
+	e := echo.New()
+	e.HideBanner = true
+	api := e.Group("/api")
+	protected := api.Group("", echo.WrapMiddleware(authhttp.RequireAuth(w.sessionManager, w.authService)))
+	fh := handlers.NewFeatureHandler(handlers.FeatureHandlerConfig{Admin: w.admin, Logger: w.logger})
+	protected.GET("/features", fh.List)
+	protected.PUT("/features/:key/instance", fh.SetInstance)
+	protected.PUT("/features/:key/account", fh.SetAccount)
+	protected.GET("/features/grants", fh.GrantsHeldBy)
+	protected.GET("/features/:key/grants", fh.ListGrants)
+	protected.POST("/features/:key/grants", fh.Grant)
+	protected.DELETE("/features/:key/grants", fh.RevokeGrant)
+	w.server = httptest.NewServer(e)
+	return nil
+}
+
+func (w *grantsWorld) reboot() error {
+	if w.server != nil {
+		w.server.Close()
+		w.server = nil
+	}
+	if w.app != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		defer cancel()
+		if err := w.app.Stop(ctx); err != nil {
+			return err
+		}
+		w.app = nil
+	}
+	return w.boot()
+}
+
+// --- people ---------------------------------------------------------------
+
+func (w *grantsWorld) personFor(email, password string) (*featurePerson, error) {
+	if p, ok := w.people[email]; ok {
+		return p, nil
+	}
+	ctx := context.Background()
+	agent, _, account, err := w.authService.RegisterPassword(ctx, email, displayNameForFeature(email), password)
+	if err != nil {
+		return nil, fmt.Errorf("could not create %q: %w", email, err)
+	}
+	p := &featurePerson{email: email, password: password, agentID: agent.GetID()}
+	if account != nil {
+		p.accountID = account.GetID()
+		if err := w.accountRepo.SaveMember(ctx, account.GetID(), agent.GetID(), authentities.RoleOwner); err != nil {
+			return nil, err
+		}
+	}
+	w.people[email] = p
+	return p, nil
+}
+
+func (w *grantsWorld) person(email string) (*featurePerson, error) {
+	p, ok := w.people[email]
+	if !ok {
+		return nil, fmt.Errorf("no person named %q has been staged", email)
+	}
+	return p, nil
+}
+
+func (w *grantsWorld) addToAccount(email, accountName, role string) error {
+	accountID, ok := w.accounts[accountName]
+	if !ok {
+		return fmt.Errorf("no account named %q has been staged", accountName)
+	}
+	p, err := w.personFor(email, "correct-horse-battery-staple")
+	if err != nil {
+		return err
+	}
+	if err := w.accountRepo.SaveMember(context.Background(), accountID, p.agentID, role); err != nil {
+		return err
+	}
+	// Mirror what production does at the one non-service write site: a role
+	// change is a direct projection write that emits no event, so
+	// UserHandler.Update invalidates explicitly. Staging that here keeps the
+	// harness faithful — without it a role granted after the fact would never
+	// reach a session that was already open, and the scenario would fail for a
+	// reason production does not have.
+	w.resolver.InvalidateAgents(context.Background(), accountID, p.agentID)
+	p.accountID = accountID
+	return nil
+}
+
+func (w *grantsWorld) signIn(p *featurePerson) error {
+	ctx := context.Background()
+	creds, err := w.credRepo.FindByAgent(ctx, p.agentID)
+	if err != nil || len(creds) == 0 {
+		return fmt.Errorf("could not find credentials for %q: %w", p.email, err)
+	}
+	s, err := w.authService.CreateSession(ctx, p.agentID, p.accountID, creds[0].GetID(),
+		"127.0.0.1", "godog", time.Hour)
+	if err != nil {
+		return err
+	}
+	p.sessionIDs = append(p.sessionIDs, s.GetID())
+	w.current = p
+	return nil
+}
+
+func (w *grantsWorld) ctxFor(p *featurePerson) context.Context {
+	return auth.ContextWithAgent(context.Background(),
+		&auth.Identity{AgentID: p.agentID, ActiveAccountID: p.accountID})
+}
+
+// --- HTTP -----------------------------------------------------------------
+
+func (w *grantsWorld) request(p *featurePerson, method, path string, body any) error {
+	var reader *bytes.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		reader = bytes.NewReader(raw)
+	} else {
+		reader = bytes.NewReader(nil)
+	}
+	req, err := http.NewRequest(method, w.server.URL+path, reader)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if p != nil && len(p.sessionIDs) > 0 {
+		header, err := w.cookieFor(p)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Cookie", header)
+	}
+	resp, err := w.server.Client().Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(resp.Body); err != nil {
+		return err
+	}
+	w.lastStatus = resp.StatusCode
+	w.lastBody = buf.Bytes()
+	if method == http.MethodGet {
+		w.listingStat = resp.StatusCode
+		w.listingBody = buf.Bytes()
+	}
+	return nil
+}
+
+func (w *grantsWorld) cookieFor(p *featurePerson) (string, error) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	err := w.sessionManager.CreateHTTPSession(rec, req, session.SessionData{
+		SessionID: p.sessionIDs[len(p.sessionIDs)-1],
+		AgentID:   p.agentID,
+		AccountID: p.accountID,
+	})
+	if err != nil {
+		return "", err
+	}
+	return sessionCookieHeader(rec.Result().Cookies()), nil
+}
+
+// grantViews decodes the envelope either listing endpoint answers with.
+func (w *grantsWorld) grantViews(raw []byte) ([]application.GrantView, error) {
+	var envelope struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return nil, fmt.Errorf("could not read the response: %w (%s)", err, string(raw))
+	}
+	var views []application.GrantView
+	if err := json.Unmarshal(envelope.Data, &views); err != nil {
+		return nil, fmt.Errorf("could not read the grants: %w (%s)", err, string(envelope.Data))
+	}
+	return views, nil
+}
+
+// --- CLI ------------------------------------------------------------------
+
+func (w *grantsWorld) runCLI(command string) error {
+	binary, err := weosBinary()
+	if err != nil {
+		return err
+	}
+	args := strings.Fields(command)
+	if len(args) > 0 && args[0] == "weos" {
+		args = args[1:]
+	}
+	cmd := exec.Command(binary, args...)
+	cmd.Dir = w.workDir
+	env := append(os.Environ(), "DATABASE_DSN="+w.dsn, "LOG_LEVEL=error")
+	if declared, err := json.Marshal(w.declared); err == nil && len(w.declared) > 0 {
+		env = append(env, "FEATURES="+string(declared))
+	}
+	cmd.Env = env
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+	w.lastRun = commandRun{stdout: stdout.String(), stderr: stderr.String(), args: args}
+	if runErr != nil {
+		if exit, ok := runErr.(*exec.ExitError); ok {
+			w.lastRun.exitCode = exit.ExitCode()
+			return nil
+		}
+		return fmt.Errorf("could not run the command: %w", runErr)
+	}
+	return nil
+}
+
+// --- MCP ------------------------------------------------------------------
+
+func (w *grantsWorld) callMCP(
+	p *featurePerson, local bool, tool string, args map[string]any,
+) error {
+	server, err := mcpserver.NewMCPServer(w.rts, w.resources, nil, nil, nil, w.admin, []string{"feature"})
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	if p != nil {
+		ctx = w.ctxFor(p)
+	}
+	if local {
+		ctx = application.WithLocalTransport(ctx)
+	}
+	serverTransport, clientTransport := gomcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		return err
+	}
+	defer serverSession.Close()
+	client := gomcp.NewClient(&gomcp.Implementation{Name: "godog", Version: "0.1.0"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		return err
+	}
+	defer clientSession.Close()
+
+	res, callErr := clientSession.CallTool(ctx, &gomcp.CallToolParams{Name: tool, Arguments: args})
+	w.lastMCPErr = callErr
+	w.lastMCPOut = nil
+	if callErr == nil && res != nil {
+		if res.IsError {
+			w.lastMCPErr = fmt.Errorf("%s", mcpText(res))
+		} else if res.StructuredContent != nil {
+			if m, ok := res.StructuredContent.(map[string]any); ok {
+				w.lastMCPOut = m
+			}
+		}
+	}
+	return nil
+}
+
+func (w *grantsWorld) mcpGrants() ([]application.GrantView, error) {
+	if w.lastMCPOut == nil {
+		return nil, fmt.Errorf("the last MCP call returned no structured output")
+	}
+	raw, err := json.Marshal(w.lastMCPOut["grants"])
+	if err != nil {
+		return nil, err
+	}
+	var out []application.GrantView
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// --- helpers --------------------------------------------------------------
+
+func (w *grantsWorld) accountFor(name string) (string, error) {
+	id, ok := w.accounts[name]
+	if !ok {
+		return "", fmt.Errorf("no account named %q has been staged", name)
+	}
+	return id, nil
+}
+
+// storedGrants reads the rows directly, for the assertions about what is
+// stored rather than what resolves.
+func (w *grantsWorld) storedGrants(accountID, key string) ([]entities.FeatureGrantRecord, error) {
+	return w.grants.ListByFeature(context.Background(), accountID, key)
+}
+
+func (w *grantsWorld) lastFeatureChangeEvent() (entities.FeatureChanged, error) {
+	page, err := w.eventLog.Query(context.Background(), repositories.EventLogFilter{
+		EventType: entities.FeatureChanged{}.EventType(),
+		Limit:     200,
+	})
+	if err != nil {
+		return entities.FeatureChanged{}, err
+	}
+	if page == nil || len(page.Data) == 0 {
+		return entities.FeatureChanged{}, fmt.Errorf("no feature change was recorded at all")
+	}
+	last := page.Data[len(page.Data)-1]
+	raw, err := json.Marshal(last.Payload)
+	if err != nil {
+		return entities.FeatureChanged{}, err
+	}
+	var event entities.FeatureChanged
+	if err := json.Unmarshal(raw, &event); err != nil {
+		return entities.FeatureChanged{}, err
+	}
+	return event, nil
+}
+
+func findGrant(views []application.GrantView, email string) (application.GrantView, bool) {
+	for _, v := range views {
+		if v.Email == email {
+			return v, true
+		}
+	}
+	return application.GrantView{}, false
+}
+
+func findRoleGrant(views []application.GrantView, role string) (application.GrantView, bool) {
+	for _, v := range views {
+		if v.Role == role {
+			return v, true
+		}
+	}
+	return application.GrantView{}, false
+}
+
+var _ = testing.Verbose

--- a/tests/e2e/features/feature_flag_grants.feature
+++ b/tests/e2e/features/feature_flag_grants.feature
@@ -257,6 +257,7 @@ Feature: An admin grants a feature to specific users or roles
     And "counsel@harborlegal.example" evaluates "ledger-export" again once that moment has passed
     Then the evaluation straight away is answered off
     And the evaluation after that moment is answered on
+    And the grant store was read once for each of those two evaluations
     And nothing invalidated the session in between
     And the maximum cache age had not run out
 
@@ -269,7 +270,9 @@ Feature: An admin grants a feature to specific users or roles
     When "counsel@harborlegal.example" evaluates "ledger-export" again straight away
     And "counsel@harborlegal.example" evaluates "ledger-export" again once that moment has passed
     Then the evaluation straight away is answered on
+    And that answer came from memory, without reading the grant store
     And the evaluation after that moment is answered off
+    And the grant store was read once to answer that one
     And nothing invalidated the session in between
     And the maximum cache age had not run out
     And "counsel@harborlegal.example" is still signed in

--- a/tests/e2e/features/feature_flag_grants.feature
+++ b/tests/e2e/features/feature_flag_grants.feature
@@ -1,0 +1,472 @@
+@wip @epic-480 @story-483
+Feature: An admin grants a feature to specific users or roles
+  As an admin on a shared instance
+  I want to give one person, or everyone holding a role, a capability the rest of the
+  instance does not get
+  So that private and paid capabilities reach the people who should have them, and can be
+  taken back the same day
+
+  #481 taught resolution about grants and #482 deliberately gave them no surface. So today
+  the bottom layer of the stack is the only one nobody can reach: a grant can be resolved,
+  invalidated and overruled, and the only way to make one is a step definition writing a
+  row. This story is the way in — a command an operator types, endpoints the admin UI
+  calls, and MCP tools an agent calls, all three on the FeatureService grant methods #481
+  already wrote — plus the two things a grant needs that an override never did, a validity
+  window and a record of who made it.
+
+  Nothing below re-derives resolution. That a grant turns a feature on for its holder and
+  nobody else, that a role grant resolves the same as a direct one, that an account's off
+  and an instance's off both beat a grant, that a stored grant on a non-grantable feature
+  is ignored, that taking a grant away reaches sessions already open on every device
+  without signing anybody out, and that a role grant reaches every member holding the role
+  — all of that is feature_flag_resolution.feature and stays there. Where a scenario
+  evaluates a feature here it is proving that a surface wrote what it claimed to, or that a
+  window opened or closed, not re-deriving precedence.
+
+  A grant is account-scoped, so who may make one is the question #482 already answered for
+  account overrides, not a third rule. The account comes off the caller's session and is
+  never a parameter: an owner or admin grants inside the account they are signed in to, an
+  ordinary member is refused, and a request that names some other account is answered in
+  the caller's own. Instance-wide standing does not enter into it. An operator who wants to
+  reach past an account's admin has the instance switch, which is a different act with a
+  different blast radius.
+
+  The subject of a grant is a person or a role, and both are pericarp's, not ours. A person
+  is named at every surface by their email address, because a KSUID is not something anybody
+  types correctly, and the stored grant holds the agent id the email resolved to — the
+  scenarios assert both halves, so an implementation that stored the email would fail rather
+  than work until somebody changed their address. A role is one of the three pericarp knows:
+  owner, admin, member. A grant to a role it does not know is refused rather than stored,
+  because a mistyped role name stores a row that can never match any member and produces
+  exactly the same observable result as no grant at all — a silence nobody would think to
+  investigate. A grant to a person who is not a member of the account is refused for the same
+  reason. Granting to a real role that simply nobody holds yet is fine and is not the same
+  thing: the role exists, and whoever is given it next gets the feature with it.
+
+  Validity windows are the new storage. A grant may carry a `validFrom`, a `validThrough`,
+  both, or neither, and a grant outside its window resolves exactly as if the row were not
+  there — no cleanup job removes it and no scheduled task flips anything, because the window
+  is read at resolution and a row that has run out is simply not counted. An expired grant
+  stays in the listing, marked as expired, because an admin asking "why did they lose that?"
+  is asking about a row somebody deleted or a window that closed, and only one of those two
+  leaves evidence.
+
+  What a window makes hard is that a grant which expires is not a write. Nothing invalidates
+  anything at the moment `validThrough` passes, so on the machinery #481 built, a holder with
+  a cached resolved set keeps the feature until the maximum cache age runs out — up to
+  fifteen minutes on the default configuration. This contract does not accept that: two
+  scenarios below configure a maximum cache age of ten minutes and then assert the answer
+  flips within seconds of the boundary, in a session already open, with nothing invalidated
+  and nothing restarted. They are written that way on purpose. A resolved set that knows the
+  earliest boundary among the grants it counted, and treats itself as stale at that instant,
+  passes them; a resolved set that only knows how old it is cannot, and would pass only if
+  the maximum cache age were tuned down to the accuracy anybody wanted from a window — which
+  would throw away the whole point of caching the other three hundred and sixty evaluations.
+
+  Revocation is the other half of the day. It deletes the row rather than storing an off,
+  for the same reason a grant has no enabled column: a grant that could say "off" would let
+  the bottom layer overrule the two above it. Revocation targets one subject, which is worth
+  saying out loud because deleting by feature and account is the shorter query and takes away
+  the role grant along with the personal one. And it is recorded at the moment it is made,
+  through the same Feature.Changed record #482 asserts for overrides, so that "who took that
+  away, and when" has an answer that does not require a debugger. Whether a revocation that
+  matched no row is recorded at all is deliberately left open here; the scenario for it
+  asserts only that the call succeeds and nothing is stored.
+
+  The command line is the surface with no session, and grants need an account. So it names
+  both: the person by email, the account by its id — pericarp offers no lookup by account
+  name, and inventing one here would be a second identity feature smuggled into a flags
+  story — and the account may be left out only on an instance that has exactly one, the same
+  rule and the same refusal when it is ambiguous that #482 settled for the instance switch.
+  Note that "exactly one account" is narrower than it sounds: registration mints every new
+  person a personal account, so a single-account instance is a single-person instance, which
+  is the mini-me shape and the one where nobody should have to look up a KSUID to grant
+  themselves something. The local stdio MCP transport gets no such
+  latitude: it is treated as the operator for instance-wide state because whoever holds the
+  machine already holds the database, but an account-scoped grant has no account to land in
+  when nobody is signed in, and guessing one would be the multi-tenant hole the whole
+  arrangement exists to avoid. It is refused, and told where to go instead.
+
+  Cost is asserted once, at the shape that matters. Resolution reads a caller's grants on the
+  first evaluation of a session and never again until something invalidates it, so the read
+  worth pinning is that one: it returns the grants that could apply to this caller and not
+  the account's, however many the account holds. The latency half of the story's criterion is
+  a Go benchmark beside the repository, not a scenario — a wall-clock assertion in a godog
+  suite measures the machine it ran on.
+
+  Background:
+    Given a WeOS instance where password sign-in is enabled and requests are authenticated by their session
+    And the instance declares these features in code:
+      | key             | display name    | description                              | default | manageable | grantable |
+      | episodic-recall | Episodic recall | Recall past events during a conversation | on      | yes        | yes       |
+      | ledger-export   | Ledger export   | Export the ledger to a spreadsheet       | off     | yes        | yes       |
+      | audit-trail     | Audit trail     | Record who read what, for compliance     | on      | no         | no        |
+    And the account "Harbor Legal", whose owner "ops@harborlegal.example" signs in with password "correct-horse-battery-staple"
+
+  # --- Making a grant ---
+
+  Scenario: An admin grants a feature to one person, who has it in the session they are already in
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" is signed in and has been answered off for "ledger-export"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they grant "ledger-export" to "counsel@harborlegal.example" through the API
+    And "counsel@harborlegal.example" evaluates "ledger-export" again in the session they already held
+    Then the change was accepted
+    And "counsel@harborlegal.example" is answered on
+    And they were not signed out
+    And the instance was not restarted
+
+  Scenario: The grant that is stored names the person by their agent id, not by the address it was asked for
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they grant "ledger-export" to "counsel@harborlegal.example" through the API
+    Then the change was accepted
+    And the stored grant names the agent id of "counsel@harborlegal.example"
+    And the stored grant does not carry their email address
+    And the stored grant is scoped to "Harbor Legal"
+
+  Scenario: A grant records who made it and when
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they grant "ledger-export" to "counsel@harborlegal.example" through the API
+    Then the change was accepted
+    And the grant records "ops@harborlegal.example" as who made it
+    And the grant carries the time it was made
+    And the change was recorded with the key "ledger-export" and the person it was granted to
+    And the record names "ops@harborlegal.example" as who made it
+
+  Scenario: Granting the same person the same feature twice leaves one grant, not two
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have granted "ledger-export" to "counsel@harborlegal.example" through the API
+    When they grant "ledger-export" to "counsel@harborlegal.example" through the API again
+    Then the change was accepted
+    And the instance holds one stored grant of "ledger-export" for "counsel@harborlegal.example"
+
+  # --- Who may grant, and where the grant lands ---
+
+  Scenario: An ordinary member may read the grants on a feature but may not make one
+    Given "clerk@harborlegal.example" belongs to "Harbor Legal" as an ordinary member
+    And "clerk@harborlegal.example" is signed in to "Harbor Legal"
+    When they ask the API for the grants on "ledger-export"
+    And they try to grant "ledger-export" to themselves through the API
+    Then the listing was served
+    And the attempt to grant it is refused as forbidden
+    And no grant of "ledger-export" is stored for "clerk@harborlegal.example"
+
+  Scenario: A request carrying no session cannot grant anything
+    When a request carrying no session tries to grant "ledger-export" to "ops@harborlegal.example"
+    Then the request is refused as not authenticated
+    And no grant of "ledger-export" is stored for "ops@harborlegal.example"
+
+  Scenario: A grant lands in the account the caller is signed in to, not one they named
+    Given the account "Cedar Realty", whose owner "broker@cedarrealty.example" signs in with password "trellis-anchor-mango-9"
+    And "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they grant "ledger-export" to "counsel@harborlegal.example" through the API, naming the account "Cedar Realty"
+    Then the stored grant is scoped to "Harbor Legal"
+    And no grant of "ledger-export" is stored in "Cedar Realty"
+
+  Scenario: An admin cannot grant to somebody who is not a member of the account they are signed in to
+    Given the account "Cedar Realty", whose owner "broker@cedarrealty.example" signs in with password "trellis-anchor-mango-9"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they try to grant "ledger-export" to "broker@cedarrealty.example" through the API
+    Then the attempt is refused as a bad request
+    And the refusal says that person is not a member of this account
+    And no grant of "ledger-export" is stored for "broker@cedarrealty.example"
+
+  Scenario: An address nobody signed up with is refused rather than stored against nothing
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they try to grant "ledger-export" to "nobody@harborlegal.example" through the API
+    Then the attempt is refused as not found
+    And the failure names the address "nobody@harborlegal.example"
+    And no grant of "ledger-export" is stored at all
+
+  Scenario: A feature that may not be granted is refused rather than silently stored
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they try to grant "audit-trail" to "counsel@harborlegal.example" through the API
+    Then the attempt is refused as a bad request
+    And the refusal says the feature cannot be granted
+    And no grant of "audit-trail" is stored at all
+
+  Scenario: A key nobody declared is refused rather than stored
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they try to grant "shipping-labels" to "counsel@harborlegal.example" through the API
+    Then the attempt is refused as not found
+    And the failure names the key "shipping-labels"
+    And no grant of "shipping-labels" is stored at all
+
+  # --- Granting to a role ---
+
+  Scenario: A role grant re-resolves the members who hold the role and leaves the rest of the account alone
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal" with the role "admin"
+    And "clerk@harborlegal.example" belongs to "Harbor Legal" as an ordinary member
+    And both of them are signed in and have been answered off for "ledger-export"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they grant "ledger-export" to the role "admin" through the API
+    And each of them evaluates "ledger-export" again in the session they already held
+    Then "counsel@harborlegal.example" is answered on
+    And "clerk@harborlegal.example" is answered off
+    And "clerk@harborlegal.example" read no feature state from the database to be answered
+
+  Scenario: A grant to a role nobody holds yet reaches whoever is given it afterwards
+    Given "clerk@harborlegal.example" belongs to "Harbor Legal" as an ordinary member
+    And "clerk@harborlegal.example" is signed in and has been answered off for "ledger-export"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they grant "ledger-export" to the role "admin" through the API
+    And "clerk@harborlegal.example" is given the role "admin" in "Harbor Legal"
+    And "clerk@harborlegal.example" evaluates "ledger-export" again in the session they already held
+    Then the change was accepted
+    And "clerk@harborlegal.example" is answered on
+
+  Scenario: A role the instance does not know is refused rather than stored against nobody
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they try to grant "ledger-export" to the role "auditor" through the API
+    Then the attempt is refused as a bad request
+    And the refusal names the roles that exist
+    And no grant of "ledger-export" is stored for the role "auditor"
+
+  # --- Validity windows ---
+
+  Scenario: A grant with no window is live from the moment it is made and stays live
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they grant "ledger-export" to "counsel@harborlegal.example" through the API
+    And "counsel@harborlegal.example" signs in and evaluates "ledger-export" with default off
+    Then "counsel@harborlegal.example" is answered on
+    And the grant reports no window
+
+  Scenario: A grant whose window has already closed is denied, and nothing removed the row
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have granted "ledger-export" to "counsel@harborlegal.example" through the API, valid until an hour ago
+    When "counsel@harborlegal.example" signs in and evaluates "ledger-export" with default off
+    Then "counsel@harborlegal.example" is answered off
+    And the instance holds one stored grant of "ledger-export" for "counsel@harborlegal.example"
+    And the grants on "ledger-export" report that grant as expired
+
+  Scenario: A grant that has not started yet is denied, and starts on its own in a session already open
+    Given the instance is configured with a maximum cache age of 10 minutes
+    And "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And "counsel@harborlegal.example" is signed in and has been answered off for "ledger-export"
+    When "ops@harborlegal.example" grants "ledger-export" to "counsel@harborlegal.example" through the API, valid from 2 seconds from now
+    And "counsel@harborlegal.example" evaluates "ledger-export" again straight away
+    And "counsel@harborlegal.example" evaluates "ledger-export" again once that moment has passed
+    Then the evaluation straight away is answered off
+    And the evaluation after that moment is answered on
+    And nothing invalidated the session in between
+    And the maximum cache age had not run out
+
+  Scenario: A grant that expires is denied from the moment it expires, not when the maximum cache age runs out
+    Given the instance is configured with a maximum cache age of 10 minutes
+    And "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have granted "ledger-export" to "counsel@harborlegal.example" through the API, valid until 2 seconds from now
+    And "counsel@harborlegal.example" is signed in and has been answered on for "ledger-export"
+    When "counsel@harborlegal.example" evaluates "ledger-export" again straight away
+    And "counsel@harborlegal.example" evaluates "ledger-export" again once that moment has passed
+    Then the evaluation straight away is answered on
+    And the evaluation after that moment is answered off
+    And nothing invalidated the session in between
+    And the maximum cache age had not run out
+    And "counsel@harborlegal.example" is still signed in
+
+  Scenario: A window that ends before it begins is refused
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they try to grant "ledger-export" to "counsel@harborlegal.example" through the API, valid from tomorrow until yesterday
+    Then the attempt is refused as a bad request
+    And the refusal says the window ends before it begins
+    And no grant of "ledger-export" is stored for "counsel@harborlegal.example"
+
+  Scenario: An expired grant of their own does not cancel the live one their role carries
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal" with the role "admin"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have granted "ledger-export" to the role "admin" through the API
+    And they have granted "ledger-export" to "counsel@harborlegal.example" through the API, valid until an hour ago
+    When "counsel@harborlegal.example" signs in and evaluates "ledger-export" with default off
+    Then "counsel@harborlegal.example" is answered on
+
+  # --- Taking a grant back ---
+
+  Scenario: A revoked grant is denied in the session the person is already in, without a re-login
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have granted "ledger-export" to "counsel@harborlegal.example" through the API
+    And "counsel@harborlegal.example" is signed in and has been answered on for "ledger-export"
+    When "ops@harborlegal.example" revokes "ledger-export" from "counsel@harborlegal.example" through the API
+    And "counsel@harborlegal.example" evaluates "ledger-export" again in the session they already held
+    Then the change was accepted
+    And "counsel@harborlegal.example" is answered off
+    And "counsel@harborlegal.example" is still signed in
+    And the request "counsel@harborlegal.example" makes next is served
+    And the grants on "ledger-export" no longer name "counsel@harborlegal.example"
+
+  Scenario: Revoking a role grant reaches every member who holds the role, in the sessions they already have
+    Given "counsel@harborlegal.example" and "clerk@harborlegal.example" both belong to "Harbor Legal" with the role "admin"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have granted "ledger-export" to the role "admin" through the API
+    And both of them are signed in and have been answered on for "ledger-export"
+    When "ops@harborlegal.example" revokes "ledger-export" from the role "admin" through the API
+    And each of them evaluates "ledger-export" again in the session they already held
+    Then both of them are answered off
+    And neither of them was signed out
+
+  Scenario: Revoking a person's own grant does not take away the one their role carries
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal" with the role "admin"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have granted "ledger-export" to the role "admin" through the API
+    And they have granted "ledger-export" to "counsel@harborlegal.example" through the API
+    And "counsel@harborlegal.example" is signed in and has been answered on for "ledger-export"
+    When "ops@harborlegal.example" revokes "ledger-export" from "counsel@harborlegal.example" through the API
+    And "counsel@harborlegal.example" evaluates "ledger-export" again in the session they already held
+    Then "counsel@harborlegal.example" is answered on
+    And the grants on "ledger-export" still name the role "admin"
+
+  Scenario: A revocation is recorded at the moment it is made
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have granted "ledger-export" to "counsel@harborlegal.example" through the API
+    When they revoke "ledger-export" from "counsel@harborlegal.example" through the API
+    Then the change was accepted
+    And the change was recorded as a revocation of "ledger-export" from "counsel@harborlegal.example"
+    And the record names "ops@harborlegal.example" as who made it
+    And the record carries the time the change was made
+
+  Scenario: Revoking a grant nobody holds succeeds and changes nothing
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they revoke "ledger-export" from "counsel@harborlegal.example" through the API
+    Then the change was accepted
+    And no grant of "ledger-export" is stored at all
+
+  # --- Seeing what has been granted ---
+
+  Scenario: The grants on a feature are listed with their subject, their window and who made them
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal" with the role "admin"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have granted "ledger-export" to "counsel@harborlegal.example" through the API, valid until tomorrow
+    And they have granted "ledger-export" to the role "admin" through the API
+    When they ask the API for the grants on "ledger-export"
+    Then the listing was served
+    And the grants on "ledger-export" name "counsel@harborlegal.example" and the role "admin"
+    And the grant to "counsel@harborlegal.example" reports it is in effect until tomorrow
+    And the grant to "counsel@harborlegal.example" records "ops@harborlegal.example" as who made it
+    And the grant to the role "admin" reports no window
+
+  Scenario: Everything one person holds is listed, whether they hold it themselves or through a role
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal" with the role "admin"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have granted "ledger-export" to "counsel@harborlegal.example" through the API
+    And they have granted "episodic-recall" to the role "admin" through the API
+    When they ask the API for everything granted to "counsel@harborlegal.example"
+    Then the answer names "ledger-export", granted to them directly
+    And the answer names "episodic-recall", granted through the role "admin"
+
+  Scenario: One account's grants are not visible from another
+    Given the account "Cedar Realty", whose owner "broker@cedarrealty.example" signs in with password "trellis-anchor-mango-9"
+    And "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have granted "ledger-export" to "counsel@harborlegal.example" through the API
+    When "broker@cedarrealty.example" signs in and asks the API for the grants on "ledger-export"
+    Then the listing was served
+    And the grants "broker@cedarrealty.example" is shown name nobody
+
+  # --- The command line ---
+
+  Scenario: An operator grants from the command line on an instance with one account
+    When the operator runs "weos feature grant ledger-export --email ops@harborlegal.example"
+    Then the command exits successfully
+    And the instance holds one stored grant of "ledger-export" for "ops@harborlegal.example"
+
+  Scenario: An operator takes a grant back from the command line
+    Given the operator has run "weos feature grant ledger-export --email ops@harborlegal.example"
+    When the operator runs "weos feature revoke ledger-export --email ops@harborlegal.example"
+    Then the command exits successfully
+    And no grant of "ledger-export" is stored at all
+
+  Scenario: The command line lists the grants on a feature, with their windows
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have granted "ledger-export" to "counsel@harborlegal.example" through the API, valid until tomorrow
+    When the operator runs "weos feature grants ledger-export" against the account "Harbor Legal"
+    Then the command exits successfully
+    And the command names "counsel@harborlegal.example"
+    And the command reports that grant as in effect until tomorrow
+
+  Scenario: On an instance with more than one account the command line must be told which
+    Given the account "Cedar Realty", whose owner "broker@cedarrealty.example" signs in with password "trellis-anchor-mango-9"
+    When the operator runs "weos feature grant ledger-export --email ops@harborlegal.example"
+    Then the command exits with a failure
+    And the failure says which account must be named
+    And no grant of "ledger-export" is stored at all
+
+  Scenario: Named explicitly, the command line grants into the account it was given
+    Given the account "Cedar Realty", whose owner "broker@cedarrealty.example" signs in with password "trellis-anchor-mango-9"
+    When the operator runs "weos feature grant ledger-export --email ops@harborlegal.example" against the account "Harbor Legal"
+    Then the command exits successfully
+    And the stored grant is scoped to "Harbor Legal"
+    And no grant of "ledger-export" is stored in "Cedar Realty"
+
+  Scenario: A grant made from the command line names the command line as what made it
+    When the operator runs "weos feature grant ledger-export --email ops@harborlegal.example"
+    Then the command exits successfully
+    And the change was recorded with the key "ledger-export" and the person it was granted to
+    And the record names the command line as what made the change
+    And the record carries the time the change was made
+
+  # --- The MCP tools an agent calls ---
+
+  Scenario: An agent grants a feature and the person has it in the session they already hold
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" is signed in and has been answered off for "ledger-export"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they call the MCP tool "feature_grant" to grant "ledger-export" to "counsel@harborlegal.example"
+    And "counsel@harborlegal.example" evaluates "ledger-export" again in the session they already held
+    Then the call succeeds
+    And "counsel@harborlegal.example" is answered on
+
+  Scenario: An agent takes a grant back
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have granted "ledger-export" to "counsel@harborlegal.example" through the API
+    When they call the MCP tool "feature_revoke" to take "ledger-export" from "counsel@harborlegal.example"
+    Then the call succeeds
+    And no grant of "ledger-export" is stored at all
+
+  Scenario: What the MCP grant listing reports matches what the API lists
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have granted "ledger-export" to "counsel@harborlegal.example" through the API, valid until tomorrow
+    When they call the MCP tool "feature_grants" for "ledger-export"
+    Then the call succeeds
+    And what the tool reported matches the grants the API lists for "ledger-export"
+
+  Scenario: A member calling the MCP grant tool is refused, as they are at the API
+    Given "clerk@harborlegal.example" belongs to "Harbor Legal" as an ordinary member
+    And "clerk@harborlegal.example" is signed in to "Harbor Legal"
+    When they call the MCP tool "feature_grant" to grant "ledger-export" to "clerk@harborlegal.example"
+    Then the call is refused as forbidden
+    And no grant of "ledger-export" is stored at all
+
+  Scenario: A caller on the local stdio transport is refused a grant and told where to make one
+    Given an MCP client attached to the store over the local stdio transport
+    When it calls "feature_grant" to grant "ledger-export" to "ops@harborlegal.example"
+    Then the call is refused
+    And the refusal says a grant needs an account and names the command line
+    And no grant of "ledger-export" is stored at all
+
+  # --- What resolution costs ---
+
+  Scenario: Resolving one caller reads the grants that could apply to them, not the account's
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "Harbor Legal" holds 200 grants of "ledger-export", one for each of 200 other members
+    And "counsel@harborlegal.example" holds one of their own for "ledger-export"
+    And "counsel@harborlegal.example" is signed in to "Harbor Legal"
+    When they evaluate "ledger-export" with default off
+    Then the feature answers on
+    And the grant store was read once to answer them
+    And that read returned only the grants that could apply to them

--- a/tests/e2e/features/feature_flag_grants.feature
+++ b/tests/e2e/features/feature_flag_grants.feature
@@ -1,4 +1,4 @@
-@wip @epic-480 @story-483
+@epic-480 @story-483
 Feature: An admin grants a feature to specific users or roles
   As an admin on a shared instance
   I want to give one person, or everyone holding a role, a capability the rest of the


### PR DESCRIPTION
Closes #483. Third layer of epic #480, on top of #497.

Every way to make a grant, take one back, and see what exists — plus validity windows, which did not exist before. #481 already proves how a grant *resolves*; nothing here re-tests that.

## The interesting part: a grant expires to the second, on a ten-minute cache

A resolved feature set now carries the **earliest validity-window boundary among the grants that fed it**, and treats itself as stale at that instant — independently of the maximum cache age. So a grant with two seconds left expires in two seconds, with nothing invalidating, nothing restarting, and nothing scheduled. The cost is paid lazily by whoever evaluates next.

The alternative — tuning the cache age down to whatever precision a window needs — would throw away the caching that exists for the other three hundred and sixty evaluations in an agent turn.

Three properties keep it from being expensive or wrong: a boundary is only ever strictly in the future, so a set is never born stale; a grant with no window contributes no boundary, so the ordinary case still reads once per session; and the failure backoff still wins, so an outage cannot turn every evaluation into another failing round trip.

This closes the gap #492 records rather than accepting it.

## Shape

The window is half-open: on at `validFrom`, off at `validThrough`. `FoldGrants` is a pure function reducing a caller's rows to what they hold now and when that changes — the truth table pins both edges.

The repository returns rows and **does not filter windows in SQL**. A grant that has not started is a boundary the resolver needs; one that has closed is a row a listing needs.

Revocation reports whether anything was removed, so a revocation matching nothing succeeds, records nothing, and disturbs no cache.

Neither the REST body nor the MCP tool schema has an **account field** — the account comes off the session, so naming another has nothing to bind to. Local stdio is refused a grant and told to use the CLI, because an account-scoped grant has no account to land in when nobody is signed in. The CLI names the person by email and the account by id, and may omit the account only on a single-account instance.

Provenance lives on the row **and** in the event log, because they answer different questions: the row says who granted a right that still exists, the log says what happened and survives revocation.

## Two holes review found, both unfixable-later in different ways

**A grant outlived membership.** Membership is checked when a grant is made, and nothing removes the row when somebody leaves — so a removed member with a live session kept every feature granted to them, and the row **silently came back to life** if they were re-added months later. Resolution now takes no grants when there is no membership record. Mutation-verified. Listings called those rows "active"; they now say **orphaned**, because an expired grant ran its course while an orphaned one is left-over access.

**The validity window had to go on the audit event now or never.** Events are immutable, a closing window writes nothing by design, and a re-grant overwrites the row's terms in place — so without it, no auditor could reconstruct why access ended, and no later change could add it to events already written.

## The scenarios did not prove the mechanism

Review showed the two window scenarios passed identically against an implementation **with no cache at all** — straight-away and after-moment answers both look right when every evaluation reads. So the headline claim was not pinned by anything.

They now assert what each evaluation cost: the straight-away answer must come from memory with no read, the one after the boundary exactly one, and no invalidation may have happened in between. Mutation-verified — disabling the cache now fails two scenarios where before it failed none.

Three other assertions that could pass for the wrong reason were fixed: `cohort()` silently meant "everyone with a session"; `currentGrantViews()` fell through to asking the service when a response did not parse; and an MCP read-back failure answered with an empty list an LLM reads as "no features exist".

## Tests

40 scenarios, 393 steps — API, MCP over an in-memory transport, a real CLI subprocess. #481's 38 and #482's 25 still pass, through a repository port change, a resolver signature change, and a membership gate.

## Known, filed, not fixed

#499 (grants outlive membership and role changes in cache), #500 (windows fail open during an outage; cold callers unthrottled — throttling would break the recovery guarantee the contract pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
