### PR TITLE
Gate MCP tools on a feature, at each tool's own call site

### DIFF
--- a/application/feature_declarations.go
+++ b/application/feature_declarations.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import "github.com/wepala/weos/v3/domain/entities"
+
+// CoreFeatureDeclarations are the features core itself declares. Presets and
+// downstream binaries declare their own through the same value group; see
+// FeatureDeclarations.
+//
+// Keep this list short. A feature belongs here only when core ships the call
+// site that reads it — a key declared with nothing gating on it is a switch
+// wired to nothing, and an operator who flips it learns that the hard way.
+func CoreFeatureDeclarations() []entities.FeatureMeta {
+	return []entities.FeatureMeta{
+		{
+			// Gates the episodic_recall MCP tool, at that tool's own
+			// mcp.AddTool call site.
+			//
+			// Declared ON. The tool ships today and instances rely on it, so
+			// an upgrade that introduced the gate with a default of off would
+			// take a working capability away from every instance until
+			// somebody noticed and turned it back on. An operator who wants it
+			// dark turns it off, and that is a decision with a name on it.
+			Key:         "episodic-recall",
+			DisplayName: "Episodic recall",
+			Description: "Let an assistant recall past events from the instance's event log.",
+			Default:     true,
+			Manageable:  true,
+			Grantable:   true,
+		},
+	}
+}

--- a/application/feature_registry.go
+++ b/application/feature_registry.go
@@ -16,6 +16,7 @@
 package application
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"sync"
@@ -114,11 +115,59 @@ func NewFeatureRegistry(
 					m.Key, existing.DisplayName)
 			}
 		}
+		if agrees, err := r.reconcileWithCode(m); err != nil {
+			return nil, err
+		} else if agrees {
+			continue
+		}
 		if err := r.Register(m); err != nil {
 			return nil, fmt.Errorf("FEATURES: %w", err)
 		}
 	}
 	return r, nil
+}
+
+// reconcileWithCode decides what a FEATURES entry means when code declares the
+// same key. The first result reports that the entry is redundant and should be
+// skipped.
+//
+// Core did not declare any feature until it shipped a call site that reads one,
+// so an operator who wanted a switch early could only get it by naming the key
+// in FEATURES. When core later declares that key itself, a plain duplicate-key
+// error stops the whole application at upgrade — not one feature, the instance:
+// serve, mcp and the CLI all refuse to start. That is a bad trade for a
+// disagreement that does not exist.
+//
+// So an entry that agrees with the code declaration about what the feature DOES
+// is a no-op with a warning naming the remedy. An entry that disagrees is still
+// an error, because that is the case where picking one would gate the wrong
+// thing — and the message names both sources and what to do about it.
+//
+// Only the behavior-deciding fields are compared. A description is prose an
+// operator reads; code's wins and the difference is worth a line, not a
+// failure to boot.
+func (r *FeatureRegistry) reconcileWithCode(m entities.FeatureMeta) (bool, error) {
+	r.mu.RLock()
+	code, declared := r.code[m.Key]
+	r.mu.RUnlock()
+	if !declared {
+		return false, nil
+	}
+	if code.Default != m.Default || code.Manageable != m.Manageable || code.Grantable != m.Grantable {
+		return false, fmt.Errorf(
+			"FEATURES declares feature %q as (default=%v manageable=%v grantable=%v), but this build "+
+				"declares it in code as (default=%v manageable=%v grantable=%v); "+
+				"remove %q from FEATURES to use the built-in declaration, or correct the entry to match it",
+			m.Key, m.Default, m.Manageable, m.Grantable,
+			code.Default, code.Manageable, code.Grantable, m.Key)
+	}
+	if r.logger != nil {
+		r.logger.Warn(context.Background(),
+			"FEATURES redeclares a feature this build already declares in code; the entry has no effect "+
+				"and can be removed",
+			"feature", m.Key)
+	}
+	return true, nil
 }
 
 // Register adds a code-declared feature. Duplicate keys are an error rather
@@ -169,6 +218,16 @@ func (r *FeatureRegistry) All() []entities.FeatureMeta {
 	}
 	r.mu.RLock()
 	for key, m := range r.code {
+		if existing, shadowed := merged[key]; shadowed && r.logger != nil && existing != m {
+			// Code wins, deliberately — a binary that declares a key a preset
+			// also uses is overriding it on purpose, and cannot edit the
+			// preset to say so. But an override nobody announced changes a
+			// feature's default, or whether it can be granted, with nothing to
+			// read afterwards.
+			r.logger.Warn(context.Background(),
+				"a code declaration overrides a preset's feature of the same key",
+				"feature", key, "preset_default", existing.Default, "code_default", m.Default)
+		}
 		merged[key] = m
 	}
 	r.mu.RUnlock()

--- a/application/feature_registry_test.go
+++ b/application/feature_registry_test.go
@@ -268,19 +268,59 @@ func TestFeatureRegistryRefusesMalformedConfigDeclarations(t *testing.T) {
 	}
 }
 
-// TestFeatureRegistryRefusesAConfigKeyCodeAlreadyOwns keeps configuration from
-// silently redefining something the binary declares — two owners of one key
-// means one of them is gating the wrong thing.
-func TestFeatureRegistryRefusesAConfigKeyCodeAlreadyOwns(t *testing.T) {
+// TestFeatureRegistryRefusesAConfigKeyThatDisagreesWithCode keeps
+// configuration from silently redefining something the binary declares — two
+// owners that disagree means one of them is gating the wrong thing.
+func TestFeatureRegistryRefusesAConfigKeyThatDisagreesWithCode(t *testing.T) {
 	cfg := config.Default()
-	cfg.Features.Declared = []entities.FeatureMeta{{Key: "ledger-export", DisplayName: "From config"}}
+	cfg.Features.Declared = []entities.FeatureMeta{
+		{Key: "ledger-export", DisplayName: "From config", Default: true},
+	}
 	_, err := NewFeatureRegistry(cfg, NewPresetRegistry(), nil,
-		[]entities.FeatureMeta{{Key: "ledger-export", DisplayName: "From code"}})
+		[]entities.FeatureMeta{{Key: "ledger-export", DisplayName: "From code", Default: false}})
 	if err == nil {
-		t.Fatal("configuration silently redeclared a key code already owns")
+		t.Fatal("configuration silently redeclared a key code already owns, with a different default")
 	}
 	if !strings.Contains(err.Error(), "FEATURES") {
 		t.Fatalf("the error does not say the clash came from configuration: %v", err)
+	}
+	// A person has to be able to act on it without reading the source.
+	if !strings.Contains(err.Error(), "remove") {
+		t.Fatalf("the error does not say what to do about it: %v", err)
+	}
+}
+
+// TestFeatureRegistryAcceptsAConfigKeyThatAgreesWithCode is the upgrade path.
+//
+// Core declared no features until it shipped a call site that read one, so an
+// operator who wanted a switch early could only get it by naming the key in
+// FEATURES. When core later declares that same key, a plain duplicate-key error
+// would stop the whole application — serve, mcp and the CLI — over a
+// disagreement that does not exist. An entry that agrees about what the feature
+// DOES is redundant, not wrong.
+func TestFeatureRegistryAcceptsAConfigKeyThatAgreesWithCode(t *testing.T) {
+	cfg := config.Default()
+	cfg.Features.Declared = []entities.FeatureMeta{{
+		Key: "episodic-recall", DisplayName: "Episodic recall",
+		Description: "an operator's own wording",
+		Default:     true, Manageable: true, Grantable: true,
+	}}
+	code := []entities.FeatureMeta{{
+		Key: "episodic-recall", DisplayName: "Episodic recall",
+		Description: "the built-in wording",
+		Default:     true, Manageable: true, Grantable: true,
+	}}
+	r, err := NewFeatureRegistry(cfg, NewPresetRegistry(), nil, code)
+	if err != nil {
+		t.Fatalf("a redundant FEATURES entry stopped the boot: %v", err)
+	}
+	got, ok := r.Lookup("episodic-recall")
+	if !ok {
+		t.Fatal("the feature is not declared at all")
+	}
+	// Code owns the key, so its wording is what an operator is shown.
+	if got.Description != "the built-in wording" {
+		t.Fatalf("configuration overwrote the code declaration: %+v", got)
 	}
 }
 

--- a/application/feature_tool_gate.go
+++ b/application/feature_tool_gate.go
@@ -18,6 +18,7 @@ package application
 import (
 	"context"
 
+	"github.com/akeemphilbert/pericarp/pkg/auth"
 	"github.com/open-feature/go-sdk/openfeature"
 )
 
@@ -50,4 +51,16 @@ func ToolFeatureGate(client *openfeature.Client) func(context.Context, string) b
 		}
 		return client.Boolean(ctx, FeatureFlagPrefix+featureKey, true, openfeature.EvaluationContext{})
 	}
+}
+
+// HasCallerIdentity reports whether ctx carries an authenticated caller.
+//
+// It is the exact condition under which resolution reaches the account layer
+// and the caller's grants at all: with no identity, ResolvedSet stops at the
+// instance layer. A refusal uses it to be truthful about whose answer it is —
+// telling a local stdio user that a capability is "not enabled for you" would
+// send them looking for a grant that cannot apply on a transport with no
+// caller.
+func HasCallerIdentity(ctx context.Context) bool {
+	return auth.AgentFromCtx(ctx) != nil
 }

--- a/application/feature_tool_gate.go
+++ b/application/feature_tool_gate.go
@@ -49,7 +49,26 @@ func ToolFeatureGate(client *openfeature.Client) func(context.Context, string) b
 		if featureKey == "" {
 			return true
 		}
-		return client.Boolean(ctx, FeatureFlagPrefix+featureKey, true, openfeature.EvaluationContext{})
+		details, err := client.BooleanValueDetails(
+			ctx, FeatureFlagPrefix+featureKey, true, openfeature.EvaluationContext{})
+		if err != nil {
+			// Closed. This is the one path the provider cannot answer for
+			// itself: the client short-circuits BEFORE calling the provider
+			// when the domain's provider is NOT_READY or FATAL, and returns
+			// the caller's default — which is `true` here. Client.Boolean
+			// discards that error, so using it would open every gate exactly
+			// when the flag source is unavailable.
+			//
+			// SetNamedProviderAndWait makes that unreachable today. It becomes
+			// reachable the moment anyone switches to the async setter, gives
+			// the provider a state handler, or re-registers on the domain at
+			// runtime — and nothing would fail to say so. Failing closed here
+			// stops the guarantee depending on a client internal.
+			return false
+		}
+		// ERROR already carries false from the provider; DEFAULT carries the
+		// caller's `true`, which is the undeclared-key case.
+		return details.Value
 	}
 }
 

--- a/application/feature_tool_gate.go
+++ b/application/feature_tool_gate.go
@@ -1,0 +1,53 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"context"
+
+	"github.com/open-feature/go-sdk/openfeature"
+)
+
+// ToolFeatureGate answers whether a gated capability is available to the
+// caller on ctx. The MCP tool surface is its first consumer (#484), and
+// nothing about it is MCP-specific — any call site gating on a feature can
+// use it.
+//
+// It evaluates through the OpenFeature client rather than reaching for the
+// resolver, so a call site gets the epic's whole contract for free: the
+// per-caller cache, the layer precedence, the fail-closed store error, and
+// the log-once on registry drift all live behind one boolean.
+//
+// The default passed to the client is `true`, and that is the load-bearing
+// detail. It is NOT a fail-open: a store that cannot be read resolves off
+// through the provider's ERROR reason, which the client does not overrule,
+// so a gated capability still disappears during an outage. The default is
+// reached only when nobody declared the key — registry drift, where a deploy's
+// call sites and declarations disagree — and there the answer must be to leave
+// the capability exactly as it was. The alternative, closing every gate whose
+// key does not resolve, turns one mistyped constant into a silent outage
+// across an instance. The provider logs the drift once so it is fixable.
+func ToolFeatureGate(client *openfeature.Client) func(context.Context, string) bool {
+	if client == nil {
+		return nil
+	}
+	return func(ctx context.Context, featureKey string) bool {
+		if featureKey == "" {
+			return true
+		}
+		return client.Boolean(ctx, FeatureFlagPrefix+featureKey, true, openfeature.EvaluationContext{})
+	}
+}

--- a/application/feature_tool_gate_test.go
+++ b/application/feature_tool_gate_test.go
@@ -1,0 +1,84 @@
+package application
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-feature/go-sdk/openfeature"
+)
+
+// erroringProvider answers every boolean evaluation with a ResolutionError,
+// which is what the OpenFeature client turns into a non-nil error from
+// BooleanValueDetails. It stands in for the provider states the client
+// short-circuits on — NOT_READY and FATAL — which are unreachable while
+// registration uses SetNamedProviderAndWait but are the same code path in the
+// gate.
+type erroringProvider struct {
+	openfeature.NoopProvider
+}
+
+func (erroringProvider) Metadata() openfeature.Metadata {
+	return openfeature.Metadata{Name: "erroring-test-provider"}
+}
+
+func (erroringProvider) BooleanEvaluation(
+	_ context.Context, _ string, defaultValue bool, _ openfeature.FlattenedContext,
+) openfeature.BoolResolutionDetail {
+	return openfeature.BoolResolutionDetail{
+		Value: defaultValue,
+		ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+			ResolutionError: openfeature.NewGeneralResolutionError("the flag source is unavailable"),
+			Reason:          openfeature.ErrorReason,
+		},
+	}
+}
+
+// TestToolFeatureGateClosesWhenTheClientCannotAnswer is the regression test for
+// the one real fail-open in this design.
+//
+// The gate passes `true` as the client default, because an undeclared key must
+// leave a capability exactly where it was. That default is also what the
+// OpenFeature client returns when it cannot reach the provider at all — and
+// Client.Boolean discards the error that says so, which would open every gate
+// at exactly the moment the flag source is unavailable. The gate reads the
+// error instead.
+func TestToolFeatureGateClosesWhenTheClientCannotAnswer(t *testing.T) {
+	const domain = "weos-tool-gate-test"
+	if err := openfeature.SetNamedProviderAndWait(domain, erroringProvider{}); err != nil {
+		t.Fatalf("could not register the test provider: %v", err)
+	}
+	gate := ToolFeatureGate(openfeature.NewClient(domain))
+	if gate == nil {
+		t.Fatal("ToolFeatureGate returned nil for a real client")
+	}
+
+	// The naive form — the one this fix replaced — returns the caller's
+	// default here, so this assertion is exactly the difference.
+	if openfeature.NewClient(domain).Boolean(
+		context.Background(), FeatureFlagPrefix+"ledger-export", true, openfeature.EvaluationContext{},
+	) != true {
+		t.Fatal("the test provider no longer reproduces the client's default-on-error behavior")
+	}
+
+	if gate(context.Background(), "ledger-export") {
+		t.Fatal("the gate opened while the client could not answer; a capability is handed out during an outage")
+	}
+}
+
+// TestToolFeatureGateIsNilWithoutAClient pins the signal the transports check:
+// no client means no gate, and a transport that would have gated tools must
+// refuse to start rather than serve them open.
+func TestToolFeatureGateIsNilWithoutAClient(t *testing.T) {
+	if ToolFeatureGate(nil) != nil {
+		t.Fatal("a nil client produced a gate, which would look wired while gating nothing")
+	}
+}
+
+// TestHasCallerIdentity pins the predicate the refusal wording branches on. It
+// is the same condition resolution uses to decide whether to read the account
+// layer and the caller's grants, so the two cannot drift.
+func TestHasCallerIdentity(t *testing.T) {
+	if HasCallerIdentity(context.Background()) {
+		t.Fatal("a context with nobody on it reported a caller")
+	}
+}

--- a/application/module.go
+++ b/application/module.go
@@ -129,6 +129,7 @@ func Module(cfg config.Config, registry *PresetRegistry) fx.Option {
 			NewFeatureRegistry,
 			fx.ParamTags(``, ``, ``, `group:"feature_declarations"`),
 		)),
+		fx.Provide(AsFeatureDeclarations(CoreFeatureDeclarations)),
 		fx.Provide(gorm.ProvideFeatureSettingsRepository),
 		fx.Provide(gorm.ProvideFeatureGrantRepository),
 		fx.Provide(gorm.ProvideAccountMemberQuery),

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -28,8 +28,10 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/wepala/weos/v3/api/handlers"
 	apimw "github.com/wepala/weos/v3/api/middleware"
+
 	"github.com/wepala/weos/v3/application"
 	appagents "github.com/wepala/weos/v3/application/agents"
 	"github.com/wepala/weos/v3/application/presets"
@@ -136,6 +138,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	var skillRegistry *application.SkillRegistry
 	var featureInvalidator repositories.FeatureCacheInvalidator
 	var featureAdmin *application.FeatureAdminService
+	var featureClient *openfeature.Client
 
 	registry := presets.NewDefaultRegistry()
 
@@ -147,6 +150,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		fx.Populate(&skillRegistry),
 		fx.Populate(&featureInvalidator),
 		fx.Populate(&featureAdmin),
+		fx.Populate(&featureClient),
 		fx.Populate(&resourceTypeService),
 		fx.Populate(&resourceService),
 		fx.Populate(&kgService),
@@ -545,7 +549,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	if serveViper.GetBool("enabled") {
 		mcpSrv, mcpErr := mcpserver.NewConfiguredServer(
 			resourceTypeService, resourceService, kgService, lexicalSearch, episodicRecall,
-			featureAdmin, slog.Default(),
+			featureAdmin, application.ToolFeatureGate(featureClient), slog.Default(),
 		)
 		if mcpErr != nil {
 			return fmt.Errorf("failed to create MCP server: %w", mcpErr)

--- a/internal/mcp/agent_toolset.go
+++ b/internal/mcp/agent_toolset.go
@@ -81,6 +81,15 @@ func AgentToolsetFactory(server *mcp.Server, cfg AgentToolsetConfig) func(contex
 // serverTools lists the server's registered tools over a short-lived
 // in-memory session.
 func serverTools(ctx context.Context, server *mcp.Server) ([]*mcp.Tool, error) {
+	// An inventory of the build's tools, not a caller's permissions. Its three
+	// consumers — skill-allowlist validation, the read-only classification
+	// behind call confirmation, and the coordinator's default tool names — run
+	// once at boot with no caller, and each result is later intersected with
+	// the per-turn gated toolset. Resolving them against the anonymous caller
+	// would freeze a feature's boot-time value into lists that outlive it, so
+	// a tool turned on afterwards would stay missing until a restart. See
+	// WithToolInventory: it is honored on the listing only, never on a call.
+	ctx = WithToolInventory(ctx)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/internal/mcp/agent_toolset_test.go
+++ b/internal/mcp/agent_toolset_test.go
@@ -54,7 +54,7 @@ func fullServer(t *testing.T) *gomcp.Server {
 	t.Helper()
 	server, err := NewMCPServer(
 		&stubResourceTypeService{}, &stubResourceService{}, &stubKGService{active: true}, stubLexicalSearch{},
-		nil, nil, nil,
+		nil, nil, nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("NewMCPServer: %v", err)

--- a/internal/mcp/configurer.go
+++ b/internal/mcp/configurer.go
@@ -48,6 +48,14 @@ type ConfigurerDeps struct {
 	// passes this, so the gate is written at the tool's own call site exactly
 	// as it is for a built-in tool. A tool added with plain mcp.AddTool is
 	// ungated and behaves as it always did. Never nil on either transport.
+	//
+	// This package is internal, so an out-of-tree binary reaches both the type
+	// and the helper through pkg/cli (MCPFeatureGates and AddGatedTool) rather
+	// than importing them here.
+	//
+	// The gate key must also be declared, or it is registry drift: the tool
+	// stays available and the instance logs it once. See
+	// application.AsFeatureDeclarations.
 	Gates *FeatureGates
 }
 

--- a/internal/mcp/configurer.go
+++ b/internal/mcp/configurer.go
@@ -43,6 +43,12 @@ type ConfigurerDeps struct {
 	ResourceService     application.ResourceService
 	ResourceTypeService application.ResourceTypeService
 	Logger              *slog.Logger
+	// Gates is the server's feature-gate index (#484). A configurer that
+	// wants its tool gated on a feature registers it with AddGatedTool and
+	// passes this, so the gate is written at the tool's own call site exactly
+	// as it is for a built-in tool. A tool added with plain mcp.AddTool is
+	// ungated and behaves as it always did. Never nil on either transport.
+	Gates *FeatureGates
 }
 
 // MCPConfigurer registers additional tools on the server after the

--- a/internal/mcp/configurer_test.go
+++ b/internal/mcp/configurer_test.go
@@ -70,7 +70,7 @@ func TestNewHTTPHandlerAppliesConfigurers(t *testing.T) {
 	called := 0
 	RegisterMCPConfigurer(func(_ *mcp.Server, _ ConfigurerDeps) { called++ })
 
-	if _, err := NewHTTPHandler(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil, slog.Default()); err != nil {
+	if _, err := NewHTTPHandler(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil, ungated, slog.Default()); err != nil {
 		t.Fatalf("NewHTTPHandler: %v", err)
 	}
 	if called != 1 {

--- a/internal/mcp/episodic_tools.go
+++ b/internal/mcp/episodic_tools.go
@@ -63,8 +63,18 @@ type EpisodicEventGetInput struct {
 }
 
 // registerEpisodicTools registers the episodic-memory tool group.
-func registerEpisodicTools(server *mcp.Server, episodic application.EpisodicRecall) {
-	mcp.AddTool(server, &mcp.Tool{
+func registerEpisodicTools(server *mcp.Server, gates *FeatureGates, episodic application.EpisodicRecall) {
+	// episodic_recall is gated on the "episodic-recall" feature, declared
+	// beside its name and annotations because that is the only place the two
+	// stay together. When the feature is off for the caller the tool is
+	// absent from their listing and a call to it is refused; when it is on,
+	// nothing about the tool differs from before it had a gate.
+	//
+	// Its two companions are deliberately ungated. The feature names the
+	// capability an operator thinks about — recalling past events during a
+	// conversation — and that capability is reached through this tool. The
+	// others drill into an event whose URN a caller already holds.
+	AddGatedTool(server, gates, "episodic-recall", &mcp.Tool{
 		Name: "episodic_recall",
 		Description: "Recall what happened from the event log: a time-ordered, paginated slice of " +
 			"events, filterable by time window (absolute or relative), anchor resource URNs " +

--- a/internal/mcp/episodic_tools.go
+++ b/internal/mcp/episodic_tools.go
@@ -64,16 +64,20 @@ type EpisodicEventGetInput struct {
 
 // registerEpisodicTools registers the episodic-memory tool group.
 func registerEpisodicTools(server *mcp.Server, gates *FeatureGates, episodic application.EpisodicRecall) {
-	// episodic_recall is gated on the "episodic-recall" feature, declared
-	// beside its name and annotations because that is the only place the two
-	// stay together. When the feature is off for the caller the tool is
-	// absent from their listing and a call to it is refused; when it is on,
-	// nothing about the tool differs from before it had a gate.
+	// All three tools are gated on the "episodic-recall" feature, declared
+	// beside each tool's name and annotations because that is the only place
+	// the two stay together. When the feature is off for the caller each tool
+	// is absent from their listing and a call to it is refused; when it is on,
+	// nothing about them differs from before they had a gate.
 	//
-	// Its two companions are deliberately ungated. The feature names the
-	// capability an operator thinks about — recalling past events during a
-	// conversation — and that capability is reached through this tool. The
-	// others drill into an event whose URN a caller already holds.
+	// The whole group, not just the entry point. It is tempting to gate only
+	// episodic_recall on the grounds that the other two need an event URN the
+	// caller already holds — but a model holds URNs from earlier turns, and
+	// episodic_similar ranks the most recent thousand events from any seed, so
+	// one retained URN re-opens broad recall. An operator who turns off a
+	// feature called "Episodic recall" means the assistant stops recalling
+	// past events, and a gate that left two doors open would be read as a
+	// privacy defect rather than a boundary.
 	AddGatedTool(server, gates, "episodic-recall", &mcp.Tool{
 		Name: "episodic_recall",
 		Description: "Recall what happened from the event log: a time-ordered, paginated slice of " +
@@ -103,7 +107,7 @@ func registerEpisodicTools(server *mcp.Server, gates *FeatureGates, episodic app
 			HasMore: res.HasMore,
 		}, nil
 	})
-	mcp.AddTool(server, &mcp.Tool{
+	AddGatedTool(server, gates, "episodic-recall", &mcp.Tool{
 		Name: "episodic_similar",
 		Description: "Find events structurally similar to a seed event, ranked by a fixed, " +
 			"deterministic score: +100 per shared referenced resource (dominant), +10 same " +
@@ -122,7 +126,7 @@ func registerEpisodicTools(server *mcp.Server, gates *FeatureGates, episodic app
 		}
 		return nil, EpisodicSimilarOutput{Results: res.Events}, nil
 	})
-	mcp.AddTool(server, &mcp.Tool{
+	AddGatedTool(server, gates, "episodic-recall", &mcp.Tool{
 		Name: "episodic_event_get",
 		Description: "Fetch one event's full stored payload by its URN. Recall results stay " +
 			"compact by default — use this to drill into a single event an episodic tool " +

--- a/internal/mcp/feature_gate.go
+++ b/internal/mcp/feature_gate.go
@@ -131,6 +131,22 @@ func (g *FeatureGates) empty() bool {
 	return len(g.byTool) == 0
 }
 
+// snapshot copies the index once, for a caller that is about to consult it for
+// every tool on a page. A listing of forty tools should take one lock, not
+// forty.
+func (g *FeatureGates) snapshot() map[string]string {
+	if g == nil {
+		return nil
+	}
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	out := make(map[string]string, len(g.byTool))
+	for tool, key := range g.byTool {
+		out[tool] = key
+	}
+	return out
+}
+
 // AddGatedTool declares a tool and the feature that gates it in one statement.
 // It is mcp.AddTool with the gate written beside the name and the annotations,
 // which is the only place the two stay together.
@@ -206,9 +222,10 @@ func filterListing(
 	if !ok || listing == nil {
 		return res, err
 	}
+	gated := gates.snapshot()
 	kept := make([]*mcp.Tool, 0, len(listing.Tools))
 	for _, t := range listing.Tools {
-		if key, gated := gates.Of(t.Name); gated && !gate(ctx, key) {
+		if key, ok := gated[t.Name]; ok && !gate(ctx, key) {
 			continue
 		}
 		kept = append(kept, t)

--- a/internal/mcp/feature_gate.go
+++ b/internal/mcp/feature_gate.go
@@ -1,0 +1,238 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// Gating an MCP tool on a feature (epic #480, story #484).
+//
+// Two gates, and they are not equally important. Filtering `tools/list` is a
+// convenience for the model: it cannot propose what it cannot see, so it
+// cannot hallucinate a call the instance will refuse, and the user is never
+// offered a capability that does not exist for them. Refusing `tools/call` is
+// the control. An implementation that filtered the listing and forgot the
+// handler would have built a UI affordance and called it authorization, and
+// the difference stays invisible right up until a client calls a tool by name
+// from a list it cached an hour ago.
+//
+// So a stale tool list is never authorization. Whether the answer changed a
+// second ago because an operator flipped a switch, or on its own because a
+// grant's validity window closed with nothing to announce it, the call is
+// resolved when it arrives.
+//
+// Deliberately NOT implemented here: a `tools/list_changed` notification. The
+// protocol has one and the SDK can send it, and it cannot be the mechanism.
+// Grant expiry is lazy by design (#483) — a window that closes fires nothing,
+// because a row that has run out is simply not counted at the next
+// resolution — so at the moment the resolved tool list changes there is no
+// event to hang a notification on, and there would not be one without a
+// scheduler the epic does not want. A notification may be added later for the
+// changes an implementation can see; nothing may be built on top of it.
+
+// SDK method names. The Go SDK keeps its own copies unexported, so they are
+// restated here rather than reached for.
+const (
+	methodListTools = "tools/list"
+	methodCallTool  = "tools/call"
+)
+
+// FeatureGate reports whether the feature a tool names is on for the caller on
+// ctx. It absorbs the three answers a call site cares about into the one it
+// can act on:
+//
+//   - the feature is declared and resolves on or off — that answer;
+//   - nobody declared the key — the tool stays where it was, because a typo in
+//     one gate must not turn into a silent capability outage across an
+//     instance, with a tool surface that looks deliberate;
+//   - the stored state cannot be read — off, because a gate that opens on the
+//     way to a database error hands out the capability at exactly the moment
+//     nobody can see why.
+//
+// application.ToolFeatureGate builds the real one over the OpenFeature client.
+// A nil gate means nothing is gated.
+type FeatureGate func(ctx context.Context, featureKey string) bool
+
+// FeatureGates indexes which feature gates each tool.
+//
+// This is an index of declarations, not a second place to declare. A tool's
+// gate is written at its own mcp.AddTool call site, beside its name, schema
+// and annotations, through AddGatedTool — a tool declared in one file and
+// gated in a registry somewhere else is two things that will drift.
+type FeatureGates struct {
+	mu     sync.RWMutex
+	byTool map[string]string
+}
+
+// NewFeatureGates builds an empty index.
+func NewFeatureGates() *FeatureGates {
+	return &FeatureGates{byTool: make(map[string]string)}
+}
+
+// Gate records that toolName is gated by featureKey. Prefer AddGatedTool,
+// which records the gate and adds the tool in one statement so the two cannot
+// be written apart.
+func (g *FeatureGates) Gate(toolName, featureKey string) {
+	if g == nil || toolName == "" || featureKey == "" {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.byTool[toolName] = featureKey
+}
+
+// Of returns the feature gating toolName. The second result is false for an
+// ungated tool, which is every tool that ships today bar one: nothing about
+// an ungated tool changes — no lookup, no resolver, no new failure mode.
+func (g *FeatureGates) Of(toolName string) (string, bool) {
+	if g == nil {
+		return "", false
+	}
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	key, ok := g.byTool[toolName]
+	return key, ok
+}
+
+func (g *FeatureGates) empty() bool {
+	if g == nil {
+		return true
+	}
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return len(g.byTool) == 0
+}
+
+// AddGatedTool declares a tool and the feature that gates it in one statement.
+// It is mcp.AddTool with the gate written beside the name and the annotations,
+// which is the only place the two stay together.
+func AddGatedTool[In, Out any](
+	server *mcp.Server, gates *FeatureGates, featureKey string, t *mcp.Tool, h mcp.ToolHandlerFor[In, Out],
+) {
+	gates.Gate(t.Name, featureKey)
+	mcp.AddTool(server, t, h)
+}
+
+// inventoryKey marks a context as an internal inventory of the build's tools
+// rather than a caller asking what it may use.
+type inventoryKey struct{}
+
+// WithToolInventory marks ctx as an internal enumeration of every registered
+// tool, which the gate does not filter.
+//
+// This is not a way to call a gated tool: it is honored on the listing only,
+// never on a call, so nothing reached through it can execute anything a caller
+// could not. It exists because three consumers at boot want the build's tool
+// inventory rather than one caller's permissions — the skill registry
+// validating allowlists, the read-only classification behind human-in-the-loop
+// confirmation, and the coordinator's default tool names. Resolving those
+// against the anonymous caller would freeze a feature's boot-time value into
+// lists that outlive it, so a tool turned on afterwards would stay missing
+// until a restart. Each of those lists is later intersected with the caller's
+// own gated toolset, so widening them cannot widen what anybody may run.
+func WithToolInventory(ctx context.Context) context.Context {
+	return context.WithValue(ctx, inventoryKey{}, true)
+}
+
+func isToolInventory(ctx context.Context) bool {
+	v, _ := ctx.Value(inventoryKey{}).(bool)
+	return v
+}
+
+// featureGateMiddleware filters the tool listing and refuses calls to tools
+// whose feature is off for the caller.
+func featureGateMiddleware(gates *FeatureGates, gate FeatureGate) mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			if gate == nil || gates.empty() {
+				return next(ctx, method, req)
+			}
+			switch method {
+			case methodListTools:
+				return filterListing(ctx, gates, gate, next, method, req)
+			case methodCallTool:
+				if refusal := refuseGatedCall(ctx, gates, gate, req); refusal != nil {
+					return refusal, nil
+				}
+			}
+			return next(ctx, method, req)
+		}
+	}
+}
+
+// filterListing removes the tools the caller's features do not reach.
+//
+// Filtering happens after the SDK paginated, so a page can come back shorter
+// than the page size. That is correct: the cursor walks the unfiltered list,
+// so every page is still visited and the caller ends up with exactly the tools
+// they may use.
+func filterListing(
+	ctx context.Context, gates *FeatureGates, gate FeatureGate,
+	next mcp.MethodHandler, method string, req mcp.Request,
+) (mcp.Result, error) {
+	res, err := next(ctx, method, req)
+	if err != nil || isToolInventory(ctx) {
+		return res, err
+	}
+	listing, ok := res.(*mcp.ListToolsResult)
+	if !ok || listing == nil {
+		return res, err
+	}
+	kept := make([]*mcp.Tool, 0, len(listing.Tools))
+	for _, t := range listing.Tools {
+		if key, gated := gates.Of(t.Name); gated && !gate(ctx, key) {
+			continue
+		}
+		kept = append(kept, t)
+	}
+	// The result is freshly allocated per request, so replacing its slice is
+	// safe. The tools themselves are the server's own pointers and are handed
+	// on untouched — a gated tool that IS shown is advertised with exactly the
+	// description, schema and annotations it declared.
+	listing.Tools = kept
+	return listing, nil
+}
+
+// refuseGatedCall returns the refusal for a call the caller's features do not
+// reach, or nil to let the call through.
+//
+// The refusal is a tool result with IsError set rather than a protocol error,
+// so the model sees it, can tell the user the capability is not enabled, and
+// stops proposing the call. It carries the refusal and nothing else — the
+// handler never ran, so there is no partial result to leak.
+func refuseGatedCall(
+	ctx context.Context, gates *FeatureGates, gate FeatureGate, req mcp.Request,
+) *mcp.CallToolResult {
+	call, ok := req.(*mcp.CallToolRequest)
+	if !ok || call.Params == nil {
+		return nil
+	}
+	key, gated := gates.Of(call.Params.Name)
+	if !gated || gate(ctx, key) {
+		return nil
+	}
+	return &mcp.CallToolResult{
+		IsError: true,
+		Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf(
+			"%s is not available: the %q capability is not enabled for you.",
+			call.Params.Name, key)}},
+	}
+}

--- a/internal/mcp/feature_gate.go
+++ b/internal/mcp/feature_gate.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/wepala/weos/v3/application"
 )
 
 // Gating an MCP tool on a feature (epic #480, story #484).
@@ -40,13 +42,21 @@ import (
 // resolved when it arrives.
 //
 // Deliberately NOT implemented here: a `tools/list_changed` notification. The
-// protocol has one and the SDK can send it, and it cannot be the mechanism.
+// protocol has one and the SDK can send it, and it cannot be THE mechanism.
 // Grant expiry is lazy by design (#483) — a window that closes fires nothing,
 // because a row that has run out is simply not counted at the next
-// resolution — so at the moment the resolved tool list changes there is no
-// event to hang a notification on, and there would not be one without a
-// scheduler the epic does not want. A notification may be added later for the
-// changes an implementation can see; nothing may be built on top of it.
+// resolution — so for that case there is no event to hang a notification on,
+// and there would not be one without a scheduler the epic does not want.
+//
+// Worth knowing before anyone revisits this: expiry is the ONLY unobservable
+// case. An operator's flip, an account override and a grant being made or
+// revoked are all writes that already invalidate caches, so a courtesy
+// notification could hang on them, and it would cover the direction the
+// refusal cannot help with — a capability being turned ON, where a client
+// holding a stale list never re-lists and the model cannot call what it
+// cannot see. Such a notification stays a courtesy: it must never become the
+// thing anything relies on, because the expiry case would silently not have
+// it.
 
 // SDK method names. The Go SDK keeps its own copies unexported, so they are
 // restated here rather than reached for.
@@ -232,7 +242,23 @@ func refuseGatedCall(
 	return &mcp.CallToolResult{
 		IsError: true,
 		Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf(
-			"%s is not available: the %q capability is not enabled for you.",
-			call.Params.Name, key)}},
+			"%s is not available: the %q capability is not enabled %s.",
+			call.Params.Name, key, refusalScope(ctx))}},
 	}
+}
+
+// refusalScope says whose answer the refusal is, because the two cases send a
+// reader somewhere different.
+//
+// With a caller, the answer came from their account and their grants, so "for
+// you" is exact and an admin can change it for them. With no caller —  the
+// local stdio transport, or an anonymous request — resolution stopped at the
+// instance layer, and no account override or personal grant could have
+// reached it. Saying "for you" there would send a mini-me user looking for a
+// grant that cannot apply on the transport they are using.
+func refusalScope(ctx context.Context) string {
+	if application.HasCallerIdentity(ctx) {
+		return "for you"
+	}
+	return "on this server"
 }

--- a/internal/mcp/feature_gate_test.go
+++ b/internal/mcp/feature_gate_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/akeemphilbert/pericarp/pkg/auth"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/wepala/weos/v3/application"
@@ -108,7 +109,7 @@ func TestGateHidesAndRefusesOnlyTheGatedTool(t *testing.T) {
 		t.Fatalf("the refusal carried a partial result: %v", res.StructuredContent)
 	}
 	text := textFromResult(res)
-	if !strings.Contains(text, "gated_tool") || !strings.Contains(text, "not enabled for you") {
+	if !strings.Contains(text, "gated_tool") || !strings.Contains(text, "not enabled") {
 		t.Fatalf("the refusal does not say what happened: %q", text)
 	}
 
@@ -202,8 +203,14 @@ func TestEpisodicRecallCarriesItsGate(t *testing.T) {
 	if has(names, "episodic_recall") {
 		t.Fatal("episodic_recall was offered while its feature was off")
 	}
-	if !has(names, "episodic_event_get") {
-		t.Fatalf("an ungated companion tool went missing: %v", names)
+	// The whole group goes, not only the entry point: a model holds event URNs
+	// from earlier turns, and episodic_similar ranks a thousand events from any
+	// seed, so leaving either open would re-open broad recall.
+	if has(names, "episodic_similar") || has(names, "episodic_event_get") {
+		t.Fatalf("a companion episodic tool stayed open while the feature was off: %v", names)
+	}
+	if !has(names, "resource_get") {
+		t.Fatalf("an ungated tool went missing: %v", names)
 	}
 	if asked["episodic-recall"] == 0 {
 		t.Fatalf("the gate was never asked about episodic-recall; it was asked about %v", asked)
@@ -249,4 +256,37 @@ func (stubEpisodicRecall) Similar(
 
 func (stubEpisodicRecall) EventByURN(context.Context, string) (*application.FetchedEvent, error) {
 	return &application.FetchedEvent{}, nil
+}
+
+// TestRefusalSaysWhoseAnswerItIs pins the wording split. With a caller the
+// refusal is about them and an admin can change it; with none — the local
+// stdio transport — resolution never reached an account or a grant, so
+// wording it "for you" would send the reader after a grant that cannot apply.
+func TestRefusalSaysWhoseAnswerItIs(t *testing.T) {
+	server, _, _ := gatedTestServer(t, func(context.Context, string) bool { return false })
+
+	withCaller := auth.ContextWithAgent(context.Background(),
+		&auth.Identity{AgentID: "agent-ops", ActiveAccountID: "acct-harbor"})
+	cs := connectForGate(t, withCaller, server)
+	res, err := cs.CallTool(withCaller, &mcp.CallToolParams{Name: "gated_tool"})
+	if err != nil {
+		t.Fatalf("unexpected protocol error: %v", err)
+	}
+	if text := textFromResult(res); !strings.Contains(text, "not enabled for you") {
+		t.Fatalf("a refusal to a known caller does not say it is about them: %q", text)
+	}
+
+	anonymous := context.Background()
+	cs2 := connectForGate(t, anonymous, server)
+	res2, err := cs2.CallTool(anonymous, &mcp.CallToolParams{Name: "gated_tool"})
+	if err != nil {
+		t.Fatalf("unexpected protocol error: %v", err)
+	}
+	text := textFromResult(res2)
+	if strings.Contains(text, "for you") {
+		t.Fatalf("a refusal on a transport with no caller blames the caller: %q", text)
+	}
+	if !strings.Contains(text, "on this server") {
+		t.Fatalf("a refusal with no caller does not say the answer is instance-wide: %q", text)
+	}
 }

--- a/internal/mcp/feature_gate_test.go
+++ b/internal/mcp/feature_gate_test.go
@@ -1,0 +1,252 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/wepala/weos/v3/application"
+)
+
+type gateProbeInput struct{}
+
+type gateProbeOutput struct {
+	Ran bool `json:"ran"`
+}
+
+// gatedTestServer builds a server holding one gated and one ungated tool, plus
+// a record of whether each handler ran — which is what separates a refusal
+// from a call that went through and merely reported an error.
+func gatedTestServer(t *testing.T, gate FeatureGate) (*mcp.Server, *bool, *bool) {
+	t.Helper()
+	server := mcp.NewServer(&mcp.Implementation{Name: "weos-test", Version: "0.1.0"}, nil)
+	gates := NewFeatureGates()
+	server.AddReceivingMiddleware(featureGateMiddleware(gates, gate))
+
+	gatedRan, plainRan := false, false
+	AddGatedTool(server, gates, "ledger-export", &mcp.Tool{Name: "gated_tool"}, func(
+		_ context.Context, _ *mcp.CallToolRequest, _ gateProbeInput,
+	) (*mcp.CallToolResult, gateProbeOutput, error) {
+		gatedRan = true
+		return nil, gateProbeOutput{Ran: true}, nil
+	})
+	mcp.AddTool(server, &mcp.Tool{Name: "plain_tool"}, func(
+		_ context.Context, _ *mcp.CallToolRequest, _ gateProbeInput,
+	) (*mcp.CallToolResult, gateProbeOutput, error) {
+		plainRan = true
+		return nil, gateProbeOutput{Ran: true}, nil
+	})
+	return server, &gatedRan, &plainRan
+}
+
+func connectForGate(t *testing.T, ctx context.Context, server *mcp.Server) *mcp.ClientSession {
+	t.Helper()
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("connect server: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "probe", Version: "0.1.0"}, nil)
+	cs, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("connect client: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	return cs
+}
+
+func listedNames(t *testing.T, cs *mcp.ClientSession, ctx context.Context) []string {
+	t.Helper()
+	res, err := cs.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("list tools: %v", err)
+	}
+	names := make([]string, 0, len(res.Tools))
+	for _, tool := range res.Tools {
+		names = append(names, tool.Name)
+	}
+	return names
+}
+
+func has(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestGateHidesAndRefusesOnlyTheGatedTool is the pair the story turns on: the
+// listing is a convenience, the refusal is the control, and an ungated tool is
+// touched by neither.
+func TestGateHidesAndRefusesOnlyTheGatedTool(t *testing.T) {
+	ctx := context.Background()
+	server, gatedRan, plainRan := gatedTestServer(t, func(context.Context, string) bool { return false })
+	cs := connectForGate(t, ctx, server)
+
+	names := listedNames(t, cs, ctx)
+	if has(names, "gated_tool") {
+		t.Fatal("a tool whose feature is off was offered to the caller")
+	}
+	if !has(names, "plain_tool") {
+		t.Fatalf("an ungated tool went missing: %v", names)
+	}
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "gated_tool"})
+	if err != nil {
+		t.Fatalf("the refusal came back as a protocol error, which a model cannot read: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("the call was not refused")
+	}
+	if *gatedRan {
+		t.Fatal("the handler ran despite the refusal")
+	}
+	if res.StructuredContent != nil {
+		t.Fatalf("the refusal carried a partial result: %v", res.StructuredContent)
+	}
+	text := textFromResult(res)
+	if !strings.Contains(text, "gated_tool") || !strings.Contains(text, "not enabled for you") {
+		t.Fatalf("the refusal does not say what happened: %q", text)
+	}
+
+	if _, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "plain_tool"}); err != nil {
+		t.Fatalf("an ungated tool was disturbed by the gate: %v", err)
+	}
+	if !*plainRan {
+		t.Fatal("the ungated tool's handler did not run")
+	}
+}
+
+// TestGateLetsAnEnabledToolThroughUnchanged pins that a gate costs a tool
+// nothing when its feature is on.
+func TestGateLetsAnEnabledToolThroughUnchanged(t *testing.T) {
+	ctx := context.Background()
+	server, gatedRan, _ := gatedTestServer(t, func(context.Context, string) bool { return true })
+	cs := connectForGate(t, ctx, server)
+
+	if names := listedNames(t, cs, ctx); !has(names, "gated_tool") {
+		t.Fatalf("a tool whose feature is on was withheld: %v", names)
+	}
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "gated_tool"})
+	if err != nil || res.IsError {
+		t.Fatalf("the call did not go through: %v %v", err, textFromResult(res))
+	}
+	if !*gatedRan {
+		t.Fatal("the handler did not run")
+	}
+}
+
+// TestToolInventoryWidensTheListingButNeverACall is the safety property of the
+// boot-time inventory: it can enumerate a tool the caller may not use, and it
+// still cannot run it.
+func TestToolInventoryWidensTheListingButNeverACall(t *testing.T) {
+	ctx := WithToolInventory(context.Background())
+	server, gatedRan, _ := gatedTestServer(t, func(context.Context, string) bool { return false })
+	cs := connectForGate(t, ctx, server)
+
+	if names := listedNames(t, cs, ctx); !has(names, "gated_tool") {
+		t.Fatalf("the inventory did not enumerate every registered tool: %v", names)
+	}
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "gated_tool"})
+	if err != nil {
+		t.Fatalf("unexpected protocol error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("the inventory marker let a gated call through; it must only widen a listing")
+	}
+	if *gatedRan {
+		t.Fatal("the handler ran under the inventory marker")
+	}
+}
+
+// TestNilGateGatesNothing covers the low-level constructor's contract: a build
+// with no feature wiring behaves exactly as it did before gates existed.
+func TestNilGateGatesNothing(t *testing.T) {
+	ctx := context.Background()
+	server, gatedRan, _ := gatedTestServer(t, nil)
+	cs := connectForGate(t, ctx, server)
+
+	if names := listedNames(t, cs, ctx); !has(names, "gated_tool") {
+		t.Fatalf("a nil gate hid a tool: %v", names)
+	}
+	if _, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "gated_tool"}); err != nil {
+		t.Fatalf("a nil gate refused a call: %v", err)
+	}
+	if !*gatedRan {
+		t.Fatal("the handler did not run under a nil gate")
+	}
+}
+
+// TestEpisodicRecallCarriesItsGate proves the shipped tool is wired to the
+// feature, at the surface a client actually reaches. Without it the mechanism
+// could be perfect and attached to nothing.
+func TestEpisodicRecallCarriesItsGate(t *testing.T) {
+	ctx := context.Background()
+	asked := map[string]int{}
+	server, err := NewMCPServer(
+		&stubResourceTypeService{}, &stubResourceService{}, nil, nil, stubEpisodicRecall{}, nil,
+		func(_ context.Context, key string) bool {
+			asked[key]++
+			return false
+		}, nil,
+	)
+	if err != nil {
+		t.Fatalf("NewMCPServer: %v", err)
+	}
+	cs := connectForGate(t, ctx, server)
+
+	names := listedNames(t, cs, ctx)
+	if has(names, "episodic_recall") {
+		t.Fatal("episodic_recall was offered while its feature was off")
+	}
+	if !has(names, "episodic_event_get") {
+		t.Fatalf("an ungated companion tool went missing: %v", names)
+	}
+	if asked["episodic-recall"] == 0 {
+		t.Fatalf("the gate was never asked about episodic-recall; it was asked about %v", asked)
+	}
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "episodic_recall"})
+	if err != nil {
+		t.Fatalf("unexpected protocol error: %v", err)
+	}
+	if !res.IsError || !strings.Contains(textFromResult(res), "episodic-recall") {
+		t.Fatalf("calling episodic_recall was not refused: %v", textFromResult(res))
+	}
+}
+
+func textFromResult(res *mcp.CallToolResult) string {
+	if res == nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, c := range res.Content {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			b.WriteString(tc.Text)
+		}
+	}
+	return b.String()
+}
+
+// stubEpisodicRecall satisfies application.EpisodicRecall so the episodic tool
+// group registers. Nothing calls through it: the gate refuses first, which is
+// the point.
+type stubEpisodicRecall struct{}
+
+func (stubEpisodicRecall) Recall(
+	context.Context, application.EpisodicQuery,
+) (*application.EpisodicRecallResult, error) {
+	return &application.EpisodicRecallResult{}, nil
+}
+
+func (stubEpisodicRecall) Similar(
+	context.Context, application.SimilarQuery,
+) (*application.SimilarResult, error) {
+	return &application.SimilarResult{}, nil
+}
+
+func (stubEpisodicRecall) EventByURN(context.Context, string) (*application.FetchedEvent, error) {
+	return &application.FetchedEvent{}, nil
+}

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -30,6 +30,13 @@ import (
 // every downstream configurer applied — the complete tool surface both
 // transports and the in-app agent toolset share. kgService may be nil — if
 // so the knowledge-graph tools are not registered (and not advertised).
+//
+// featureGate is required, and a nil one is an error rather than "nothing is
+// gated". This constructor builds the surface real callers reach, so a wiring
+// slip here would leave every gated tool open on every transport while every
+// test still passed — the way the feature provider itself once shipped inert
+// (#481). A build that genuinely wants no gating says so with a gate that
+// always answers true; the low-level NewMCPServer still accepts nil.
 func NewConfiguredServer(
 	resourceTypeService application.ResourceTypeService,
 	resourceService application.ResourceService,
@@ -37,10 +44,15 @@ func NewConfiguredServer(
 	lexicalSearch application.LexicalSearch,
 	episodicRecall application.EpisodicRecall,
 	featureAdmin *application.FeatureAdminService,
+	featureGate FeatureGate,
 	logger *slog.Logger,
 ) (*gomcp.Server, error) {
-	server, err := NewMCPServer(
-		resourceTypeService, resourceService, kgService, lexicalSearch, episodicRecall, featureAdmin, nil)
+	if featureGate == nil {
+		return nil, fmt.Errorf("featureGate must not be nil; gated tools would be open on every transport")
+	}
+	server, gates, err := newServerWithGates(
+		resourceTypeService, resourceService, kgService, lexicalSearch, episodicRecall,
+		featureAdmin, featureGate, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create MCP server: %w", err)
 	}
@@ -50,6 +62,7 @@ func NewConfiguredServer(
 		ResourceService:     resourceService,
 		ResourceTypeService: resourceTypeService,
 		Logger:              logger,
+		Gates:               gates,
 	})
 	return server, nil
 }
@@ -74,10 +87,12 @@ func NewHTTPHandler(
 	lexicalSearch application.LexicalSearch,
 	episodicRecall application.EpisodicRecall,
 	featureAdmin *application.FeatureAdminService,
+	featureGate FeatureGate,
 	logger *slog.Logger,
 ) (http.Handler, error) {
 	server, err := NewConfiguredServer(
-		resourceTypeService, resourceService, kgService, lexicalSearch, episodicRecall, featureAdmin, logger)
+		resourceTypeService, resourceService, kgService, lexicalSearch, episodicRecall,
+		featureAdmin, featureGate, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mcp/handler_test.go
+++ b/internal/mcp/handler_test.go
@@ -185,7 +185,7 @@ func toolNames(t *testing.T, server *gomcp.Server) []string {
 }
 
 func TestNewMCPServer_AllServices(t *testing.T) {
-	server, err := NewMCPServer(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil, nil)
+	server, err := NewMCPServer(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -219,7 +219,7 @@ func TestNewMCPServer_AllServices(t *testing.T) {
 }
 
 func TestNewMCPServer_Subset(t *testing.T) {
-	server, err := NewMCPServer(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil, []string{"person"})
+	server, err := NewMCPServer(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil, nil, []string{"person"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestNewMCPServer_Subset(t *testing.T) {
 
 func TestNewMCPServer_ResourceTypeIncludesPresets(t *testing.T) {
 	server, err := NewMCPServer(
-		&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil, []string{"resource-type"},
+		&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil, nil, []string{"resource-type"},
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -259,21 +259,21 @@ func TestNewMCPServer_ResourceTypeIncludesPresets(t *testing.T) {
 }
 
 func TestNewMCPServer_NilResourceTypeService(t *testing.T) {
-	_, err := NewMCPServer(nil, &stubResourceService{}, nil, nil, nil, nil, nil)
+	_, err := NewMCPServer(nil, &stubResourceService{}, nil, nil, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for nil resourceTypeService")
 	}
 }
 
 func TestNewMCPServer_NilResourceService(t *testing.T) {
-	_, err := NewMCPServer(&stubResourceTypeService{}, nil, nil, nil, nil, nil, nil)
+	_, err := NewMCPServer(&stubResourceTypeService{}, nil, nil, nil, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for nil resourceService")
 	}
 }
 
 func TestNewHTTPHandler_ReturnsHandler(t *testing.T) {
-	handler, err := NewHTTPHandler(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil, nil)
+	handler, err := NewHTTPHandler(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil, ungated, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -283,7 +283,7 @@ func TestNewHTTPHandler_ReturnsHandler(t *testing.T) {
 }
 
 func TestNewHTTPHandler_AcceptsMCPRequest(t *testing.T) {
-	handler, err := NewHTTPHandler(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil, nil)
+	handler, err := NewHTTPHandler(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil, ungated, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -310,8 +310,13 @@ func TestNewHTTPHandler_AcceptsMCPRequest(t *testing.T) {
 }
 
 func TestNewHTTPHandler_NilServices(t *testing.T) {
-	_, err := NewHTTPHandler(nil, nil, nil, nil, nil, nil, nil)
+	_, err := NewHTTPHandler(nil, nil, nil, nil, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for nil services")
 	}
 }
+
+// ungated is the gate a test uses when it is not about gating: every feature
+// is on, said out loud rather than left as a nil gate, which
+// NewConfiguredServer refuses on purpose.
+func ungated(context.Context, string) bool { return true }

--- a/internal/mcp/kg_tools_test.go
+++ b/internal/mcp/kg_tools_test.go
@@ -90,7 +90,7 @@ func TestNewMCPServer_KnowledgeGraphServiceOptional(t *testing.T) {
 	// Passing nil kgService must not break server creation; the tools just
 	// don't appear. (Mirrors how downstream callers like the HTTP handler
 	// can opt out.)
-	server, err := NewMCPServer(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil, nil)
+	server, err := NewMCPServer(&stubResourceTypeService{}, &stubResourceService{}, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewMCPServer with nil KG: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestNewMCPServer_KnowledgeGraphServiceOptional(t *testing.T) {
 func TestNewMCPServer_KnowledgeGraphRegisteredWhenServiceProvided(t *testing.T) {
 	t.Parallel()
 	server, err := NewMCPServer(
-		&stubResourceTypeService{}, &stubResourceService{}, &stubKGService{active: true}, nil, nil, nil, nil,
+		&stubResourceTypeService{}, &stubResourceService{}, &stubKGService{active: true}, nil, nil, nil, nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("NewMCPServer: %v", err)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -287,9 +287,20 @@ func Run(enabledServices []string) error {
 	// override and no personal grant can apply — gating on this transport is
 	// instance-wide and cannot be anything else until the local transport
 	// carries an identity.
+	//
+	// The gate is required here for the same reason NewConfiguredServer
+	// requires one: newServerWithGates reads a nil gate as "nothing is gated",
+	// so a build that ever yields a nil client would silently un-gate every
+	// tool on the surface mini-me actually uses, while `weos serve` refused to
+	// start. Checked rather than trusted, because the two paths must fail the
+	// same way.
+	gate := application.ToolFeatureGate(featureClient)
+	if gate == nil {
+		return fmt.Errorf("the feature gate is not wired; gated tools would be open on this transport")
+	}
 	server, gates, err := newServerWithGates(
 		resourceTypeService, resourceService, kgService, lexicalSearch, episodicRecall,
-		featureAdmin, application.ToolFeatureGate(featureClient), enabledServices)
+		featureAdmin, gate, enabledServices)
 	if err != nil {
 		return fmt.Errorf("failed to create MCP server: %w", err)
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/wepala/weos/v3/internal/config"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/open-feature/go-sdk/openfeature"
 	"go.uber.org/fx"
 )
 
@@ -135,17 +136,39 @@ func NewMCPServer(
 	lexicalSearch application.LexicalSearch,
 	episodicRecall application.EpisodicRecall,
 	featureAdmin *application.FeatureAdminService,
+	featureGate FeatureGate,
 	enabledServices []string,
 ) (*mcp.Server, error) {
+	server, _, err := newServerWithGates(
+		resourceTypeService, resourceService, kgService, lexicalSearch, episodicRecall,
+		featureAdmin, featureGate, enabledServices)
+	return server, err
+}
+
+// newServerWithGates is NewMCPServer plus the gate index it built. The index
+// is what a downstream configurer needs to gate a tool of its own, and the
+// two transports pass it on through ConfigurerDeps. It is not returned from
+// NewMCPServer because every caller would have to accept a value only this
+// package's two transports use.
+func newServerWithGates(
+	resourceTypeService application.ResourceTypeService,
+	resourceService application.ResourceService,
+	kgService application.KnowledgeGraphService,
+	lexicalSearch application.LexicalSearch,
+	episodicRecall application.EpisodicRecall,
+	featureAdmin *application.FeatureAdminService,
+	featureGate FeatureGate,
+	enabledServices []string,
+) (*mcp.Server, *FeatureGates, error) {
 	if isNilInterface(resourceTypeService) {
-		return nil, fmt.Errorf("resourceTypeService must not be nil")
+		return nil, nil, fmt.Errorf("resourceTypeService must not be nil")
 	}
 	if isNilInterface(resourceService) {
-		return nil, fmt.Errorf("resourceService must not be nil")
+		return nil, nil, fmt.Errorf("resourceService must not be nil")
 	}
 	if len(enabledServices) > 0 {
 		if err := ValidateServiceNames(enabledServices); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
@@ -154,6 +177,13 @@ func NewMCPServer(
 		Title:   "WeOS MCP Server",
 		Version: "0.1.0",
 	}, nil)
+
+	// The gate index is built here and shared with every registrar and with
+	// the downstream configurers, so a tool added anywhere can declare its
+	// feature at its own AddTool call site. The middleware reads the index at
+	// request time, so a configurer that runs after this still gates.
+	gates := NewFeatureGates()
+	server.AddReceivingMiddleware(featureGateMiddleware(gates, featureGate))
 
 	enabled := resolveEnabled(enabledServices)
 
@@ -196,11 +226,11 @@ func NewMCPServer(
 		// Episodic recall needs the event-log repository and IS threaded in;
 		// when nil (tests, minimal wiring) episodic_recall is not registered.
 		if !isNilInterface(episodicRecall) {
-			registerEpisodicTools(server, episodicRecall)
+			registerEpisodicTools(server, gates, episodicRecall)
 		}
 	}
 
-	return server, nil
+	return server, gates, nil
 }
 
 // Run starts the MCP server on stdio, registering only the tool groups listed in enabledServices.
@@ -214,6 +244,7 @@ func Run(enabledServices []string) error {
 	var lexicalSearch application.LexicalSearch
 	var episodicRecall application.EpisodicRecall
 	var featureAdmin *application.FeatureAdminService
+	var featureClient *openfeature.Client
 
 	app := fx.New(
 		fx.NopLogger,
@@ -224,6 +255,7 @@ func Run(enabledServices []string) error {
 		fx.Populate(&lexicalSearch),
 		fx.Populate(&episodicRecall),
 		fx.Populate(&featureAdmin),
+		fx.Populate(&featureClient),
 	)
 
 	startCtx, startCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
@@ -250,9 +282,14 @@ func Run(enabledServices []string) error {
 			enabledServices = append(enabledServices, string(s))
 		}
 	}
-	server, err := NewMCPServer(
+	// On stdio the gate reaches the instance layer and stops. There is no
+	// session, no bearer token and no active account here, so no account
+	// override and no personal grant can apply — gating on this transport is
+	// instance-wide and cannot be anything else until the local transport
+	// carries an identity.
+	server, gates, err := newServerWithGates(
 		resourceTypeService, resourceService, kgService, lexicalSearch, episodicRecall,
-		featureAdmin, enabledServices)
+		featureAdmin, application.ToolFeatureGate(featureClient), enabledServices)
 	if err != nil {
 		return fmt.Errorf("failed to create MCP server: %w", err)
 	}
@@ -265,6 +302,7 @@ func Run(enabledServices []string) error {
 		ResourceService:     resourceService,
 		ResourceTypeService: resourceTypeService,
 		Logger:              slog.New(slog.NewTextHandler(os.Stderr, nil)),
+		Gates:               gates,
 	})
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -69,3 +69,30 @@ type MCPConfigurerDeps = mcpserver.ConfigurerDeps
 func RegisterMCPConfigurer(c func(server *mcp.Server, deps MCPConfigurerDeps)) {
 	mcpserver.RegisterMCPConfigurer(c)
 }
+
+// MCPFeatureGates re-exports the server's feature-gate index, which a
+// configurer receives as MCPConfigurerDeps.Gates.
+type MCPFeatureGates = mcpserver.FeatureGates
+
+// AddGatedTool adds a custom MCP tool and the feature that gates it, in one
+// statement. It is the downstream equivalent of what a built-in tool does at
+// its own call site: when the feature is off for the caller the tool is absent
+// from their listing and a call to it is refused, and when it is on nothing
+// about the tool differs from an ungated one.
+//
+// Re-exported because the gate index and the helper both live in an internal
+// package, so an out-of-tree binary can receive deps.Gates but cannot name the
+// type or call the helper. Without this the seam looks open and is not.
+//
+//	cli.RegisterMCPConfigurer(func(s *mcp.Server, deps cli.MCPConfigurerDeps) {
+//	    cli.AddGatedTool(s, deps.Gates, "invoice-export", &mcp.Tool{…}, handler)
+//	})
+//
+// The feature key must also be declared, or it is registry drift: the tool
+// stays available and the instance logs it once. Declare it with
+// application.AsFeatureDeclarations.
+func AddGatedTool[In, Out any](
+	server *mcp.Server, gates *MCPFeatureGates, featureKey string, t *mcp.Tool, h mcp.ToolHandlerFor[In, Out],
+) {
+	mcpserver.AddGatedTool(server, gates, featureKey, t, h)
+}

--- a/tests/e2e/embedded_knowledge_graph_test.go
+++ b/tests/e2e/embedded_knowledge_graph_test.go
@@ -185,7 +185,7 @@ func (w *kgWorld) startApp(cfg config.Config, capture bool) error {
 	w.manager = manager
 	w.rts = rts
 
-	server, err := mcpserver.NewMCPServer(rts, rs, kg, nil, episodic, nil, nil)
+	server, err := mcpserver.NewMCPServer(rts, rs, kg, nil, episodic, nil, nil, nil)
 	if err != nil {
 		return fmt.Errorf("build MCP server: %w", err)
 	}

--- a/tests/e2e/feature_flag_resolution_test.go
+++ b/tests/e2e/feature_flag_resolution_test.go
@@ -481,8 +481,14 @@ func (w *featureWorld) declareFeatures(table *godog.Table) error {
 			Manageable:  cell(4) == "yes",
 			Grantable:   cell(5) == "yes",
 		}
-		if err := w.registry.Register(meta); err != nil {
-			return fmt.Errorf("could not declare %q: %w", meta.Key, err)
+		core, err := coreAlreadyDeclares(meta)
+		if err != nil {
+			return err
+		}
+		if !core {
+			if err := w.registry.Register(meta); err != nil {
+				return fmt.Errorf("could not declare %q: %w", meta.Key, err)
+			}
 		}
 		w.declared = append(w.declared, meta)
 	}

--- a/tests/e2e/feature_grants_world_test.go
+++ b/tests/e2e/feature_grants_world_test.go
@@ -290,7 +290,9 @@ func (w *grantsWorld) boot() error {
 	if w.maxCacheAge > 0 {
 		cfg.Features.CacheMaxAge = w.maxCacheAge
 	}
-	cfg.Features.Declared = append([]entities.FeatureMeta(nil), w.declared...)
+	// A key core declares in code is left out of FEATURES: declaring it twice
+	// is an error by design. See coreAlreadyDeclares.
+	cfg.Features.Declared = declarationsBeyondCore(w.declared)
 	cfg.Features.PrimaryAccountID = w.primary
 
 	w.spy = &grantsSpyRepo{}
@@ -518,7 +520,10 @@ func (w *grantsWorld) runCLI(command string) error {
 	cmd := exec.Command(binary, args...)
 	cmd.Dir = w.workDir
 	env := append(os.Environ(), "DATABASE_DSN="+w.dsn, "LOG_LEVEL=error")
-	if declared, err := json.Marshal(w.declared); err == nil && len(w.declared) > 0 {
+	// The CLI reads its declarations from the same env channel the server
+	// does, minus whatever core declares in code. See coreAlreadyDeclares.
+	beyondCore := declarationsBeyondCore(w.declared)
+	if declared, err := json.Marshal(beyondCore); err == nil && len(beyondCore) > 0 {
 		env = append(env, "FEATURES="+string(declared))
 	}
 	cmd.Env = env
@@ -542,7 +547,7 @@ func (w *grantsWorld) runCLI(command string) error {
 func (w *grantsWorld) callMCP(
 	p *featurePerson, local bool, tool string, args map[string]any,
 ) error {
-	server, err := mcpserver.NewMCPServer(w.rts, w.resources, nil, nil, nil, w.admin, []string{"feature"})
+	server, err := mcpserver.NewMCPServer(w.rts, w.resources, nil, nil, nil, w.admin, nil, []string{"feature"})
 	if err != nil {
 		return err
 	}

--- a/tests/e2e/feature_mcp_tools_steps_test.go
+++ b/tests/e2e/feature_mcp_tools_steps_test.go
@@ -1,0 +1,1071 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cucumber/godog"
+
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/domain/entities"
+)
+
+// gatedTools is what the contract's Background says gates what. The
+// declarations themselves live at each tool's AddTool call site; this is the
+// harness's copy of the same table, and a background step compares the two so
+// the contract cannot quietly drift from the code.
+var gatedTools = map[string]string{
+	"episodic_recall": "episodic-recall",
+	"ledger_export":   "ledger-export",
+}
+
+//nolint:funlen // a step table is one statement per contract sentence
+func initFeatureMCPToolsScenario(sc *godog.ScenarioContext) {
+	w := newToolsWorld()
+	sc.After(func(ctx context.Context, _ *godog.Scenario, err error) (context.Context, error) {
+		w.teardown()
+		return ctx, err
+	})
+
+	// --- background -------------------------------------------------------
+	sc.Given(`^a WeOS instance where password sign-in is enabled and requests are `+
+		`authenticated by their session$`, func() error { return nil })
+	sc.Given(`^the instance declares these features in code:$`, w.stepDeclareFeatures)
+	sc.Given(`^these tools declare the feature that gates them:$`, w.stepToolsDeclareGates)
+	sc.Given(`^the account "([^"]*)", whose owner "([^"]*)" signs in with password "([^"]*)"$`,
+		w.stepAccountWithOwner)
+
+	// --- staging ----------------------------------------------------------
+	sc.Given(`^nothing has been overridden or granted on this instance$`, func() error { return nil })
+	sc.Given(`^the operator has turned the feature "([^"]*)" (on|off) for the instance$`, w.stepInstanceFlag)
+	sc.When(`^the operator turns the feature "([^"]*)" (on|off) for the instance$`, w.stepInstanceFlag)
+	sc.Given(`^the instance booted with the feature "([^"]*)" (on|off) for the instance$`, w.stepBootedWith)
+	sc.Given(`^"([^"]*)" has turned the feature "([^"]*)" (on|off)$`, w.stepAccountFlag)
+	sc.Given(`^"([^"]*)" also belongs to "([^"]*)"$`, w.stepAlsoBelongs)
+	sc.Given(`^"([^"]*)" has been granted the feature "([^"]*)"$`, w.stepGranted)
+	sc.Given(`^"([^"]*)" holds a grant of "([^"]*)" valid until (\d+) seconds from now$`, w.stepGrantUntil)
+	sc.Given(`^the tool "([^"]*)" is gated by the undeclared feature "([^"]*)"$`, w.stepGatedByUndeclared)
+	sc.Given(`^the instance is configured with a maximum cache age of (\d+) minutes$`, w.stepCacheAge)
+	sc.Given(`^the store holding account overrides and grants cannot be read$`, w.stepStoreDown)
+	sc.When(`^the store can be read again$`, w.stepStoreUp)
+
+	// --- connecting -------------------------------------------------------
+	sc.Given(`^"([^"]*)" is connected over MCP$`, w.stepConnected)
+	sc.Given(`^"([^"]*)" is connected over MCP acting in "([^"]*)"$`, w.stepConnectedActingIn)
+	sc.Given(`^both of them are connected over MCP, each in their own session$`, w.stepBothConnected)
+	sc.Given(`^an MCP client attached to the store over the local stdio transport$`, w.stepStdioConnected)
+	sc.Given(`^"([^"]*)" is signed in to "([^"]*)"$`, w.stepSignedIn)
+	sc.Given(`^both of them are signed in to "([^"]*)"$`, w.stepBothSignedIn)
+
+	// --- listing ----------------------------------------------------------
+	sc.When(`^they list the server's tools$`, w.stepListTools)
+	sc.When(`^it lists the server's tools$`, w.stepListTools)
+	sc.When(`^they list the server's tools (\d+) times$`, w.stepListToolsTimes)
+	sc.When(`^each of them lists the server's tools$`, w.stepEachLists)
+	sc.Given(`^they have listed the server's tools and been shown "([^"]*)"$`, w.stepListedAndShown)
+	sc.Given(`^they have listed the server's tools and not been shown "([^"]*)"$`, w.stepListedAndNotShown)
+	sc.When(`^"([^"]*)" lists the server's tools again in the session they already held$`,
+		w.stepListAgainNamed)
+	sc.When(`^they list the server's tools again in the session they already held$`, w.stepListAgain)
+	sc.When(`^they list the server's tools again$`, w.stepListAgain)
+	sc.When(`^they act in "([^"]*)" and list the server's tools again$`, w.stepActInAndList)
+	sc.When(`^they list the server's tools over MCP in the same session$`, w.stepListOverMCPSameSession)
+
+	// --- calling ----------------------------------------------------------
+	sc.When(`^they call "([^"]*)"$`, w.stepCall)
+	sc.When(`^they call every gated tool the instance declares$`, w.stepCallEveryGatedTool)
+	sc.When(`^"([^"]*)" calls "([^"]*)" from the list they already hold$`, w.stepCallFromHeldList)
+	sc.When(`^they call "([^"]*)" straight away$`, w.stepCallStraightAway)
+	sc.When(`^they call "([^"]*)" again once that moment has passed$`, w.stepCallAfterMoment)
+	sc.When(`^they make (\d+) tool calls in that session$`, w.stepMakeCalls)
+	sc.When(`^"([^"]*)" revokes "([^"]*)" from "([^"]*)"$`, w.stepRevoke)
+
+	// --- the in-app agent -------------------------------------------------
+	sc.When(`^their in-app agent opens a toolset for a turn$`, w.stepAgentOpensToolset)
+	sc.When(`^each of them takes a turn with the in-app agent$`, w.stepEachTakesATurn)
+	sc.When(`^"([^"]*)" takes a turn with the in-app agent$`, w.stepNamedTakesATurn)
+
+	// --- outcomes ---------------------------------------------------------
+	sc.Then(`^the listing (includes|omits) "([^"]*)"$`, w.stepListingHas)
+	sc.Then(`^the listing now omits "([^"]*)"$`, func(tool string) error {
+		return w.stepListingHas("omits", tool)
+	})
+	sc.Then(`^"([^"]*)" is (shown|not shown) "([^"]*)"$`, w.stepPersonShown)
+	sc.Then(`^both of them are shown "([^"]*)"$`, w.stepBothShown)
+	sc.Then(`^"([^"]*)" is advertised with the annotation it declares$`, w.stepAdvertisedAnnotation)
+	sc.Then(`^"([^"]*)" is advertised with the input schema it declares$`, w.stepAdvertisedSchema)
+	sc.Then(`^calling "([^"]*)" (succeeds|is refused)$`, w.stepCallingOutcome)
+	sc.Then(`^every tool the listing showed them was callable$`, w.stepShownWereCallable)
+	sc.Then(`^every gated tool the listing withheld was refused$`, w.stepWithheldWereRefused)
+	sc.Then(`^the call is refused with an error the client can read$`, w.stepCallRefusedReadable)
+	sc.Then(`^the call is refused$`, w.stepCallRefused)
+	sc.Then(`^the refusal names the tool "([^"]*)"$`, w.stepRefusalNamesTool)
+	sc.Then(`^the refusal says the capability is not enabled for them$`, w.stepRefusalSaysNotEnabled)
+	sc.Then(`^the refusal is not a partial result$`, w.stepRefusalNotPartial)
+	sc.Then(`^no ledger export was recorded$`, w.stepNoExportRecorded)
+	sc.Then(`^the call straight away succeeded$`, w.stepStraightAwaySucceeded)
+	sc.Then(`^the call after that moment is refused$`, w.stepAfterMomentRefused)
+	sc.Then(`^every call was answered$`, w.stepEveryCallAnswered)
+	sc.Then(`^feature state was read from the database only while the listing was answered$`,
+		w.stepReadOnlyDuringListing)
+	sc.Then(`^the instance logged the undeclared feature key once$`, w.stepLoggedUndeclaredOnce)
+	sc.Then(`^the log names the key "([^"]*)"$`, w.stepLogNamesKey)
+	sc.Then(`^the instance logged the failure$`, w.stepLoggedFailure)
+	sc.Then(`^"([^"]*)" is still connected$`, w.stepStillConnected)
+	sc.Then(`^they were not signed out$`, w.stepNotSignedOut)
+	sc.Then(`^the MCP session was not reconnected$`, w.stepNotReconnected)
+	sc.Then(`^the instance was not restarted$`, w.stepNotRestarted)
+	sc.Then(`^nothing invalidated the session in between$`, w.stepNothingInvalidated)
+	sc.Then(`^the maximum cache age had not run out$`, w.stepCacheAgeHadNotRunOut)
+	sc.Then(`^the toolset holds exactly the tools the MCP listing showed$`, w.stepToolsetMatchesListing)
+	sc.Then(`^the toolset (holds|does not hold) "([^"]*)"$`, w.stepToolsetHas)
+	sc.Then(`^"([^"]*)" was (offered|not offered) "([^"]*)"$`, w.stepWasOffered)
+	sc.Then(`^the agent's call to "([^"]*)" succeeds$`, w.stepAgentCallSucceeds)
+	sc.Then(`^no account override or grant was read to answer either$`, w.stepNoAccountLayerRead)
+}
+
+// --- background -----------------------------------------------------------
+
+func (w *toolsWorld) stepDeclareFeatures(table *godog.Table) error {
+	metas, err := featureMetasFrom(table)
+	if err != nil {
+		return err
+	}
+	w.declared = metas
+	for _, m := range metas {
+		if _, err := coreAlreadyDeclares(m); err != nil {
+			return err
+		}
+	}
+	return w.boot()
+}
+
+func featureMetasFrom(table *godog.Table) ([]entities.FeatureMeta, error) {
+	if len(table.Rows) < 2 {
+		return nil, fmt.Errorf("the feature table has no rows")
+	}
+	index := map[string]int{}
+	for i, cell := range table.Rows[0].Cells {
+		index[cell.Value] = i
+	}
+	var out []entities.FeatureMeta
+	for _, row := range table.Rows[1:] {
+		cell := func(name string) string { return row.Cells[index[name]].Value }
+		out = append(out, entities.FeatureMeta{
+			Key:         cell("key"),
+			DisplayName: cell("display name"),
+			Description: cell("description"),
+			Default:     cell("default") == "on",
+			Manageable:  cell("manageable") == "yes",
+			Grantable:   cell("grantable") == "yes",
+		})
+	}
+	return out, nil
+}
+
+// stepToolsDeclareGates checks the contract's table against the gates the code
+// actually declares, by listing the tools with each feature on and then off.
+// It is the one step that would catch a gate quietly moved or deleted.
+func (w *toolsWorld) stepToolsDeclareGates(table *godog.Table) error {
+	if err := w.boot(); err != nil {
+		return err
+	}
+	for _, row := range table.Rows[1:] {
+		tool, key := row.Cells[0].Value, row.Cells[1].Value
+		if gatedTools[tool] != key {
+			return fmt.Errorf("the contract says %q is gated by %q; the harness knows it as %q",
+				tool, key, gatedTools[tool])
+		}
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepAccountWithOwner(name, email, password string) error {
+	if err := w.boot(); err != nil {
+		return err
+	}
+	p, err := w.personFor(email, password)
+	if err != nil {
+		return err
+	}
+	if p.accountID == "" {
+		return fmt.Errorf("registering %q created no account", email)
+	}
+	w.accounts[name] = p.accountID
+	return nil
+}
+
+// --- staging --------------------------------------------------------------
+
+func (w *toolsWorld) stepInstanceFlag(key, state string) error {
+	if err := w.boot(); err != nil {
+		return err
+	}
+	return w.features.SetInstanceFeature(context.Background(), key, state == "on")
+}
+
+// stepBootedWith puts the instance in a state and then restarts, so the
+// scenario's "without a restart" claim is about what happens afterwards.
+func (w *toolsWorld) stepBootedWith(key, state string) error {
+	if err := w.stepInstanceFlag(key, state); err != nil {
+		return err
+	}
+	return w.reboot()
+}
+
+func (w *toolsWorld) stepAccountFlag(accountName, key, state string) error {
+	accountID, err := w.accountFor(accountName)
+	if err != nil {
+		return err
+	}
+	return w.features.SetAccountFeature(context.Background(), accountID, key, state == "on")
+}
+
+func (w *toolsWorld) stepAlsoBelongs(email, accountName string) error {
+	return w.addToAccount(email, accountName)
+}
+
+func (w *toolsWorld) stepGranted(email, key string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	return w.features.GrantToAgent(context.Background(), p.accountID, p.agentID, key, application.GrantTerms{
+		GrantedByEmail: "ops@harborlegal.example", Source: "test",
+	})
+}
+
+func (w *toolsWorld) stepGrantUntil(email, key string, seconds int) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	w.moment = time.Now().Add(time.Duration(seconds) * time.Second)
+	w.windowStart = time.Now()
+	through := w.moment
+	return w.features.GrantToAgent(context.Background(), p.accountID, p.agentID, key, application.GrantTerms{
+		ValidThrough: &through, GrantedByEmail: "ops@harborlegal.example", Source: "test",
+	})
+}
+
+func (w *toolsWorld) stepGatedByUndeclared(tool, key string) error {
+	if tool != "ledger_export" {
+		return fmt.Errorf("only the harness's own tool can have its gate rewritten, not %q", tool)
+	}
+	w.ledgerGateKey = key
+	// The gate is read when the tool is registered, so the surface has to be
+	// built again — which is what a deploy carrying the typo would do.
+	w.server = nil
+	return nil
+}
+
+func (w *toolsWorld) stepCacheAge(minutes int) error {
+	w.maxCacheAge = time.Duration(minutes) * time.Minute
+	return w.reboot()
+}
+
+func (w *toolsWorld) stepStoreDown() error {
+	if err := w.boot(); err != nil {
+		return err
+	}
+	w.settings.setDown(true)
+	w.grants.setDown(true)
+	return nil
+}
+
+func (w *toolsWorld) stepStoreUp() error {
+	w.settings.setDown(false)
+	w.grants.setDown(false)
+	return nil
+}
+
+// --- connecting -----------------------------------------------------------
+
+func (w *toolsWorld) stepConnected(email string) error {
+	p, err := w.personFor(email, "correct-horse-battery-staple")
+	if err != nil {
+		return err
+	}
+	_, err = w.connect(p, false)
+	return err
+}
+
+func (w *toolsWorld) stepConnectedActingIn(email, accountName string) error {
+	if err := w.actIn(email, accountName); err != nil {
+		return err
+	}
+	return w.stepConnected(email)
+}
+
+// actIn points a person's identity at one of their accounts, which is what the
+// active account on a session does over HTTP.
+func (w *toolsWorld) actIn(email, accountName string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	accountID, err := w.accountFor(accountName)
+	if err != nil {
+		return err
+	}
+	p.accountID = accountID
+	return nil
+}
+
+func (w *toolsWorld) stepBothConnected() error {
+	for _, email := range w.staged() {
+		if err := w.stepConnected(email); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepStdioConnected() error {
+	if err := w.boot(); err != nil {
+		return err
+	}
+	_, err := w.connect(nil, true)
+	return err
+}
+
+func (w *toolsWorld) stepSignedIn(email, accountName string) error {
+	if _, err := w.personFor(email, "correct-horse-battery-staple"); err != nil {
+		return err
+	}
+	if err := w.actIn(email, accountName); err != nil {
+		return err
+	}
+	if !contains(w.signedInOrder, email) {
+		w.signedInOrder = append(w.signedInOrder, email)
+	}
+	w.restartBaseline = w.boots
+	return nil
+}
+
+func (w *toolsWorld) stepBothSignedIn(accountName string) error {
+	for _, email := range w.staged() {
+		if err := w.stepSignedIn(email, accountName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// staged returns the two people a "both of them" step means, in a stable
+// order.
+func (w *toolsWorld) staged() []string {
+	emails := make([]string, 0, len(w.people))
+	for email := range w.people {
+		emails = append(emails, email)
+	}
+	sort.Strings(emails)
+	return emails
+}
+
+// --- listing --------------------------------------------------------------
+
+func (w *toolsWorld) stepListTools() error {
+	conn, err := w.theOne()
+	if err != nil {
+		return err
+	}
+	w.readsBefore = w.settings.count()
+	_, err = w.list(conn)
+	if err != nil {
+		return err
+	}
+	w.readsAfterListing = w.settings.count()
+	return nil
+}
+
+func (w *toolsWorld) stepListToolsTimes(times int) error {
+	for i := 0; i < times; i++ {
+		if err := w.stepListTools(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepEachLists() error {
+	for _, email := range w.staged() {
+		conn, err := w.connectionFor(email)
+		if err != nil {
+			return err
+		}
+		if _, err := w.list(conn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepListedAndShown(tool string) error {
+	if err := w.stepListTools(); err != nil {
+		return err
+	}
+	return w.stepListingHas("includes", tool)
+}
+
+func (w *toolsWorld) stepListedAndNotShown(tool string) error {
+	if err := w.stepListTools(); err != nil {
+		return err
+	}
+	return w.stepListingHas("omits", tool)
+}
+
+func (w *toolsWorld) stepListAgain() error { return w.stepListTools() }
+
+func (w *toolsWorld) stepListAgainNamed(email string) error {
+	conn, err := w.connectionFor(email)
+	if err != nil {
+		return err
+	}
+	_, err = w.list(conn)
+	return err
+}
+
+func (w *toolsWorld) stepActInAndList(accountName string) error {
+	conn, err := w.theOne()
+	if err != nil || conn.person == nil {
+		return fmt.Errorf("nobody is connected who could act in %q", accountName)
+	}
+	email := conn.person.email
+	if err := w.actIn(email, accountName); err != nil {
+		return err
+	}
+	// Acting in another account is another identity, which over HTTP is
+	// another request. The session that carried the first account cannot carry
+	// the second, so the client connects again.
+	conn.close()
+	delete(w.connections, email)
+	if err := w.stepConnected(email); err != nil {
+		return err
+	}
+	return w.stepListTools()
+}
+
+func (w *toolsWorld) stepListOverMCPSameSession() error {
+	email := w.lastAgentEmail
+	if email == "" {
+		return fmt.Errorf("no in-app agent turn has been taken")
+	}
+	if _, ok := w.connections[email]; !ok {
+		if err := w.stepConnected(email); err != nil {
+			return err
+		}
+	}
+	conn, err := w.connectionFor(email)
+	if err != nil {
+		return err
+	}
+	_, err = w.list(conn)
+	return err
+}
+
+// --- calling --------------------------------------------------------------
+
+func (w *toolsWorld) stepCall(tool string) error {
+	conn, err := w.theOne()
+	if err != nil {
+		return err
+	}
+	_, callErr := w.call(conn, tool)
+	w.lastCallTool = tool
+	return callErr
+}
+
+func (w *toolsWorld) stepCallEveryGatedTool() error {
+	conn, err := w.theOne()
+	if err != nil {
+		return err
+	}
+	for tool := range gatedTools {
+		if _, callErr := w.call(conn, tool); callErr != nil {
+			return callErr
+		}
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepCallFromHeldList(email, tool string) error {
+	conn, err := w.connectionFor(email)
+	if err != nil {
+		return err
+	}
+	if !contains(conn.listed, tool) {
+		return fmt.Errorf("%q does not hold %q in the list they already fetched", email, tool)
+	}
+	_, callErr := w.call(conn, tool)
+	w.lastCallTool = tool
+	w.lastCallEmail = email
+	return callErr
+}
+
+func (w *toolsWorld) stepCallStraightAway(tool string) error {
+	conn, err := w.theOne()
+	if err != nil {
+		return err
+	}
+	w.invsBefore = w.invSpy.count()
+	res, callErr := w.call(conn, tool)
+	w.straightAway = res
+	return callErr
+}
+
+func (w *toolsWorld) stepCallAfterMoment(tool string) error {
+	if wait := time.Until(w.moment); wait > 0 {
+		time.Sleep(wait + 50*time.Millisecond)
+	}
+	conn, err := w.theOne()
+	if err != nil {
+		return err
+	}
+	res, callErr := w.call(conn, tool)
+	w.afterMoment = res
+	w.lastCallTool = tool
+	return callErr
+}
+
+func (w *toolsWorld) stepMakeCalls(count int) error {
+	conn, err := w.theOne()
+	if err != nil {
+		return err
+	}
+	w.answered = 0
+	for i := 0; i < count; i++ {
+		// A mix on purpose: the cost claim is about a turn, and a turn calls
+		// gated and ungated tools alike.
+		tool := "resource_get"
+		if i%2 == 1 {
+			tool = "episodic_recall"
+		}
+		res, callErr := w.call(conn, tool)
+		if callErr != nil {
+			return callErr
+		}
+		if res == nil || refusedByGate(res) {
+			return fmt.Errorf("call %d to %q was not answered", i+1, tool)
+		}
+		w.answered++
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepRevoke(operator, key, subject string) error {
+	p, err := w.person(subject)
+	if err != nil {
+		return err
+	}
+	if _, err := w.person(operator); err != nil {
+		return err
+	}
+	removed, err := w.features.RevokeFromAgent(context.Background(), p.accountID, p.agentID, key)
+	if err != nil {
+		return err
+	}
+	if !removed {
+		return fmt.Errorf("there was no grant of %q to revoke from %q", key, subject)
+	}
+	return nil
+}
+
+// --- the in-app agent -----------------------------------------------------
+
+func (w *toolsWorld) stepAgentOpensToolset() error {
+	emails := w.signedIn()
+	if len(emails) != 1 {
+		return fmt.Errorf("%d people are signed in, so \"their\" agent is ambiguous", len(emails))
+	}
+	return w.stepNamedTakesATurn(emails[0])
+}
+
+func (w *toolsWorld) stepEachTakesATurn() error {
+	for _, email := range w.staged() {
+		if err := w.stepNamedTakesATurn(email); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepNamedTakesATurn(email string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	if _, err := w.agentToolset(p); err != nil {
+		return err
+	}
+	w.lastAgentEmail = email
+	return nil
+}
+
+// signedIn is whoever the scenario signed in, in the order it did so. Not
+// everyone who has an account: the background's owner has one, and a scenario
+// that signs in exactly one person means that person by "their".
+func (w *toolsWorld) signedIn() []string {
+	return w.signedInOrder
+}
+
+// --- outcomes -------------------------------------------------------------
+
+func (w *toolsWorld) currentListing() ([]string, error) {
+	conn, err := w.theOne()
+	if err != nil {
+		return nil, err
+	}
+	if conn.listed == nil {
+		return nil, fmt.Errorf("no tool listing has been fetched")
+	}
+	return conn.listed, nil
+}
+
+func (w *toolsWorld) stepListingHas(presence, tool string) error {
+	names, err := w.currentListing()
+	if err != nil {
+		return err
+	}
+	got := contains(names, tool)
+	if presence == "includes" && !got {
+		return fmt.Errorf("the listing does not offer %q; it offers %v", tool, names)
+	}
+	if presence == "omits" && got {
+		return fmt.Errorf("the listing still offers %q", tool)
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepPersonShown(email, presence, tool string) error {
+	names, ok := w.listings[email]
+	if !ok {
+		return fmt.Errorf("%q has not listed the server's tools", email)
+	}
+	got := contains(names, tool)
+	if presence == "shown" && !got {
+		return fmt.Errorf("%q was not shown %q; they were shown %v", email, tool, names)
+	}
+	if presence == "not shown" && got {
+		return fmt.Errorf("%q was shown %q, which they may not use", email, tool)
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepBothShown(tool string) error {
+	for _, email := range w.staged() {
+		if err := w.stepPersonShown(email, "shown", tool); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepAdvertisedAnnotation(tool string) error {
+	advertised, err := w.advertised(tool)
+	if err != nil {
+		return err
+	}
+	if advertised.Annotations == nil {
+		return fmt.Errorf("%q is advertised with no annotations at all", tool)
+	}
+	if !advertised.Annotations.ReadOnlyHint {
+		return fmt.Errorf("%q lost its read-only annotation when it gained a gate", tool)
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepAdvertisedSchema(tool string) error {
+	advertised, err := w.advertised(tool)
+	if err != nil {
+		return err
+	}
+	if advertised.InputSchema == nil {
+		return fmt.Errorf("%q is advertised with no input schema", tool)
+	}
+	schema, ok := advertised.InputSchema.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%q advertises an input schema of an unreadable shape", tool)
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok || len(props) == 0 {
+		return fmt.Errorf("%q advertises an input schema with no properties: %v", tool, schema)
+	}
+	// The declared filters, not a stub.
+	for _, want := range []string{"from", "until", "about"} {
+		if _, ok := props[want]; !ok {
+			return fmt.Errorf("%q advertises a schema without its declared %q filter", tool, want)
+		}
+	}
+	return nil
+}
+
+func (w *toolsWorld) advertised(tool string) (*advertisedTool, error) {
+	conn, err := w.theOne()
+	if err != nil {
+		return nil, err
+	}
+	tools, err := w.listedTools(conn)
+	if err != nil {
+		return nil, err
+	}
+	t, ok := tools[tool]
+	if !ok {
+		return nil, fmt.Errorf("%q is not in the listing", tool)
+	}
+	return &advertisedTool{Annotations: t.Annotations, InputSchema: t.InputSchema}, nil
+}
+
+func (w *toolsWorld) stepCallingOutcome(tool, outcome string) error {
+	conn, err := w.theOne()
+	if err != nil {
+		return err
+	}
+	res, callErr := w.call(conn, tool)
+	if callErr != nil {
+		return fmt.Errorf("calling %q failed at the protocol level: %w", tool, callErr)
+	}
+	refused := refusedByGate(res)
+	switch outcome {
+	case "succeeds":
+		if refused {
+			return fmt.Errorf("calling %q was refused: %s", tool, mcpText(res))
+		}
+		if res.IsError {
+			return fmt.Errorf("calling %q failed: %s", tool, mcpText(res))
+		}
+	case "is refused":
+		if !refused {
+			return fmt.Errorf("calling %q was not refused", tool)
+		}
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepShownWereCallable() error {
+	names, err := w.currentListing()
+	if err != nil {
+		return err
+	}
+	conn, err := w.theOne()
+	if err != nil {
+		return err
+	}
+	for tool := range gatedTools {
+		if !contains(names, tool) {
+			continue
+		}
+		res, err := w.resultFor(conn.person.email, tool)
+		if err != nil {
+			return err
+		}
+		if refusedByGate(res) {
+			return fmt.Errorf("%q was in the listing but the call was refused", tool)
+		}
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepWithheldWereRefused() error {
+	names, err := w.currentListing()
+	if err != nil {
+		return err
+	}
+	conn, err := w.theOne()
+	if err != nil {
+		return err
+	}
+	checked := 0
+	for tool := range gatedTools {
+		if contains(names, tool) {
+			continue
+		}
+		res, err := w.resultFor(conn.person.email, tool)
+		if err != nil {
+			return err
+		}
+		if !refusedByGate(res) {
+			return fmt.Errorf("%q was withheld from the listing but the call went through", tool)
+		}
+		checked++
+	}
+	if checked == 0 {
+		return fmt.Errorf("the listing withheld no gated tool, so this proves nothing")
+	}
+	return nil
+}
+
+func (w *toolsWorld) lastResult() (*gomcpResult, error) {
+	email := w.lastCallEmail
+	if email == "" {
+		conn, err := w.theOne()
+		if err != nil {
+			return nil, err
+		}
+		if conn.person != nil {
+			email = conn.person.email
+		}
+	}
+	res, err := w.resultFor(email, w.lastCallTool)
+	if err != nil {
+		return nil, err
+	}
+	return &gomcpResult{res: res, tool: w.lastCallTool}, nil
+}
+
+func (w *toolsWorld) stepCallRefused() error {
+	last, err := w.lastResult()
+	if err != nil {
+		return err
+	}
+	if !refusedByGate(last.res) {
+		return fmt.Errorf("the call to %q was not refused", last.tool)
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepCallRefusedReadable() error {
+	if err := w.stepCallRefused(); err != nil {
+		return err
+	}
+	last, _ := w.lastResult()
+	if !last.res.IsError {
+		return fmt.Errorf("the refusal did not mark itself an error, so a client cannot tell")
+	}
+	if strings.TrimSpace(mcpText(last.res)) == "" {
+		return fmt.Errorf("the refusal carries no text a client can read")
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepRefusalNamesTool(tool string) error {
+	last, err := w.lastResult()
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(mcpText(last.res), tool) {
+		return fmt.Errorf("the refusal does not name %q: %s", tool, mcpText(last.res))
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepRefusalSaysNotEnabled() error {
+	last, err := w.lastResult()
+	if err != nil {
+		return err
+	}
+	text := mcpText(last.res)
+	if !strings.Contains(text, "not enabled for you") {
+		return fmt.Errorf("the refusal does not say the capability is not enabled: %s", text)
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepRefusalNotPartial() error {
+	last, err := w.lastResult()
+	if err != nil {
+		return err
+	}
+	if last.res.StructuredContent != nil {
+		return fmt.Errorf("the refusal carried structured output: %v", last.res.StructuredContent)
+	}
+	if len(last.res.Content) != 1 {
+		return fmt.Errorf("the refusal carried %d content blocks, want only the refusal",
+			len(last.res.Content))
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepNoExportRecorded() error {
+	if w.exportsSeen != 0 {
+		return fmt.Errorf("the refused call still wrote %d ledger export(s)", w.exportsSeen)
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepStraightAwaySucceeded() error {
+	if w.straightAway == nil {
+		return fmt.Errorf("no call was made straight away")
+	}
+	if refusedByGate(w.straightAway) {
+		return fmt.Errorf("the call straight away was refused: %s", mcpText(w.straightAway))
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepAfterMomentRefused() error {
+	if w.afterMoment == nil {
+		return fmt.Errorf("no call was made after the moment passed")
+	}
+	if !refusedByGate(w.afterMoment) {
+		return fmt.Errorf("the call after the window closed was not refused")
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepEveryCallAnswered() error {
+	if w.answered != 30 {
+		return fmt.Errorf("%d of 30 calls were answered", w.answered)
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepReadOnlyDuringListing() error {
+	if w.readsAfterListing <= w.readsBefore {
+		return fmt.Errorf("answering the listing read no feature state at all, so the count proves nothing")
+	}
+	if got := w.settings.count(); got != w.readsAfterListing {
+		return fmt.Errorf("the 30 calls made %d further read(s) of feature state; a turn must resolve once",
+			got-w.readsAfterListing)
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepLoggedUndeclaredOnce() error {
+	lines := w.logs.matching("nobody declared")
+	if len(lines) != 1 {
+		return fmt.Errorf("the undeclared key was logged %d times, want once: %v", len(lines), lines)
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepLogNamesKey(key string) error {
+	lines := w.logs.matching("nobody declared", key)
+	if len(lines) == 0 {
+		return fmt.Errorf("no log line names the key %q: %v", key, w.logs.matching("nobody declared"))
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepLoggedFailure() error {
+	if len(w.logs.matching("feature evaluation failed")) == 0 {
+		return fmt.Errorf("nothing was logged when the store could not be read")
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepStillConnected(email string) error {
+	conn, err := w.connectionFor(email)
+	if err != nil {
+		return err
+	}
+	if _, err := conn.client.ListTools(context.Background(), nil); err != nil {
+		return fmt.Errorf("%q's MCP session is gone: %w", email, err)
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepNotSignedOut() error {
+	for email := range w.connections {
+		if err := w.stepStillConnected(email); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepNotReconnected() error {
+	for email, n := range w.connects {
+		if n != 1 {
+			return fmt.Errorf("%q connected %d times; the change should reach the session they held", email, n)
+		}
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepNotRestarted() error {
+	if w.boots != w.restartBaseline {
+		return fmt.Errorf("the instance restarted %d time(s) during the scenario",
+			w.boots-w.restartBaseline)
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepNothingInvalidated() error {
+	if got := w.invSpy.count(); got != w.invsBefore {
+		return fmt.Errorf("%d invalidation(s) fired; a window that closes must announce nothing",
+			got-w.invsBefore)
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepCacheAgeHadNotRunOut() error {
+	if w.maxCacheAge <= 0 {
+		return fmt.Errorf("no maximum cache age was configured, so this proves nothing")
+	}
+	if elapsed := time.Since(w.windowStart); elapsed >= w.maxCacheAge {
+		return fmt.Errorf("the scenario took %s, which is past the %s cache age", elapsed, w.maxCacheAge)
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepToolsetMatchesListing() error {
+	email := w.lastAgentEmail
+	toolset, ok := w.toolsets[email]
+	if !ok {
+		return fmt.Errorf("%q took no turn with the in-app agent", email)
+	}
+	listing, ok := w.listings[email]
+	if !ok {
+		return fmt.Errorf("%q did not list the server's tools over MCP", email)
+	}
+	a, b := append([]string(nil), toolset...), append([]string(nil), listing...)
+	sort.Strings(a)
+	sort.Strings(b)
+	if !reflect.DeepEqual(a, b) {
+		return fmt.Errorf("the agent's toolset and the MCP listing differ:\n agent: %v\n mcp:   %v", a, b)
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepToolsetHas(presence, tool string) error {
+	names, ok := w.toolsets[w.lastAgentEmail]
+	if !ok {
+		return fmt.Errorf("no in-app agent turn has been taken")
+	}
+	got := contains(names, tool)
+	if presence == "holds" && !got {
+		return fmt.Errorf("the agent's toolset does not hold %q; it holds %v", tool, names)
+	}
+	if presence == "does not hold" && got {
+		return fmt.Errorf("the agent's toolset still holds %q", tool)
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepWasOffered(email, presence, tool string) error {
+	names, ok := w.toolsets[email]
+	if !ok {
+		return fmt.Errorf("%q took no turn with the in-app agent", email)
+	}
+	got := contains(names, tool)
+	if presence == "offered" && !got {
+		return fmt.Errorf("%q was not offered %q; they were offered %v", email, tool, names)
+	}
+	if presence == "not offered" && got {
+		return fmt.Errorf("%q was offered %q, which they may not use", email, tool)
+	}
+	return nil
+}
+
+func (w *toolsWorld) stepAgentCallSucceeds(tool string) error {
+	p, err := w.person(w.lastAgentEmail)
+	if err != nil {
+		return err
+	}
+	return w.callFromAgentToolset(p, tool)
+}
+
+func (w *toolsWorld) stepNoAccountLayerRead() error {
+	if got := w.settings.accountCount(); got != 0 {
+		return fmt.Errorf("%d account override read(s) happened on a transport with no account", got)
+	}
+	if got := w.grants.count(); got != 0 {
+		return fmt.Errorf("%d grant read(s) happened on a transport with no caller", got)
+	}
+	return nil
+}

--- a/tests/e2e/feature_mcp_tools_world_test.go
+++ b/tests/e2e/feature_mcp_tools_world_test.go
@@ -859,30 +859,14 @@ func (w *toolsWorld) callFromAgentToolset(p *featurePerson, name string) error {
 		if !ok {
 			return fmt.Errorf("%q is not callable from the agent's toolset", name)
 		}
-		out, runErr := runner.Run(&agentContext{ctx: ctx}, map[string]any{})
-		if runErr != nil {
-			return runErr
-		}
-		if refusedText(out) != "" {
-			return fmt.Errorf("the agent's call to %q was refused: %s", name, refusedText(out))
-		}
-		return nil
+		// A refusal arrives as an error, not as output: ADK's mcpTool.Run
+		// checks IsError before it looks at structured content, so the
+		// refusal text comes back in the error and never reaches output
+		// validation. Returning it is enough to fail a "succeeds" step.
+		_, runErr := runner.Run(&agentContext{ctx: ctx}, map[string]any{})
+		return runErr
 	}
 	return fmt.Errorf("the agent's toolset does not hold %q", name)
-}
-
-// refusedText pulls a gate refusal out of an ADK tool result. The MCP client
-// inside the toolset turns an IsError result into content the agent can read,
-// so a refused call must not be mistaken for a successful one.
-func refusedText(out map[string]any) string {
-	raw, err := json.Marshal(out)
-	if err != nil {
-		return ""
-	}
-	if strings.Contains(string(raw), refusalMarker) {
-		return string(raw)
-	}
-	return ""
 }
 
 func contains(names []string, want string) bool {

--- a/tests/e2e/feature_mcp_tools_world_test.go
+++ b/tests/e2e/feature_mcp_tools_world_test.go
@@ -1,0 +1,911 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cucumber/godog"
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/open-feature/go-sdk/openfeature"
+	"go.uber.org/fx"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
+	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
+	authentities "github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
+
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/application/presets"
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
+	"github.com/wepala/weos/v3/internal/config"
+	mcpserver "github.com/wepala/weos/v3/internal/mcp"
+
+	adkagent "google.golang.org/adk/v2/agent"
+)
+
+// TestFeatureMCPTools runs the acceptance contract for story #484.
+//
+//	GODOG_TAGS=@story-484 go test ./tests/e2e/ -run TestFeatureMCPTools
+func TestFeatureMCPTools(t *testing.T) {
+	tags := "~@wip"
+	if v := os.Getenv("GODOG_TAGS"); v != "" {
+		tags = v
+	}
+	suite := godog.TestSuite{
+		ScenarioInitializer: initFeatureMCPToolsScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"features/feature_flag_mcp_tools.feature"},
+			Tags:     tags,
+			Strict:   true,
+			TestingT: t,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("MCP tool gating acceptance scenarios failed")
+	}
+}
+
+// --- the harness-registered tool ------------------------------------------
+
+// activeToolsWorld is the world the ledger_export configurer writes into.
+//
+// The configurer is a process-global (that is what RegisterMCPConfigurer is),
+// so it is registered once and does nothing unless a #484 scenario is running.
+// Without this guard every other suite's NewConfiguredServer would grow a tool
+// it never asked for.
+var (
+	activeToolsMu sync.Mutex
+	activeTools   *toolsWorld
+)
+
+func setActiveToolsWorld(w *toolsWorld) {
+	activeToolsMu.Lock()
+	defer activeToolsMu.Unlock()
+	activeTools = w
+}
+
+func currentToolsWorld() *toolsWorld {
+	activeToolsMu.Lock()
+	defer activeToolsMu.Unlock()
+	return activeTools
+}
+
+// ledgerExportInput is deliberately empty: the tool exists to be gated and to
+// prove a refused call writes nothing, not to do work.
+type ledgerExportInput struct{}
+
+type ledgerExportOutput struct {
+	Rows int `json:"rows"`
+}
+
+func init() {
+	mcpserver.RegisterMCPConfigurer(func(server *gomcp.Server, deps mcpserver.ConfigurerDeps) {
+		w := currentToolsWorld()
+		if w == nil {
+			return
+		}
+		// Registered exactly the way a downstream binary registers a custom
+		// tool, and gated exactly the way a built-in one is: at its own
+		// AddTool call site. It mutates, so a refused call is provable by the
+		// absence of what it would have written.
+		mcpserver.AddGatedTool(server, deps.Gates, w.ledgerGateKey, &gomcp.Tool{
+			Name:        "ledger_export",
+			Description: "Export the ledger to a spreadsheet.",
+		}, func(
+			_ context.Context, _ *gomcp.CallToolRequest, _ ledgerExportInput,
+		) (*gomcp.CallToolResult, ledgerExportOutput, error) {
+			return nil, ledgerExportOutput{Rows: w.recordExport()}, nil
+		})
+	})
+}
+
+// --- spies ----------------------------------------------------------------
+
+// settingsSpy counts reads of the stored feature state and can be made
+// unreadable, so "resolved once" and "the store cannot be read" are both
+// measurements rather than intentions.
+type toolsSettingsSpy struct {
+	inner repositories.FeatureSettingsRepository
+	mu    sync.Mutex
+	// Counted apart, because the stdio scenarios ask specifically whether an
+	// account override was read — an answer that a combined counter, which the
+	// instance read always moves, could not give.
+	instanceReads int
+	accountReads  int
+	down          bool
+}
+
+var errStoreDown = fmt.Errorf("the feature store is unreadable")
+
+func (s *toolsSettingsSpy) InstanceOverrides(ctx context.Context) (map[string]bool, error) {
+	s.mu.Lock()
+	s.instanceReads++
+	down := s.down
+	s.mu.Unlock()
+	if down {
+		return nil, errStoreDown
+	}
+	return s.inner.InstanceOverrides(ctx)
+}
+
+func (s *toolsSettingsSpy) AccountOverrides(ctx context.Context, accountID string) (map[string]bool, error) {
+	s.mu.Lock()
+	s.accountReads++
+	down := s.down
+	s.mu.Unlock()
+	if down {
+		return nil, errStoreDown
+	}
+	return s.inner.AccountOverrides(ctx, accountID)
+}
+
+func (s *toolsSettingsSpy) SetOverride(ctx context.Context, scopeType, scopeID, key string, on bool) error {
+	return s.inner.SetOverride(ctx, scopeType, scopeID, key, on)
+}
+
+func (s *toolsSettingsSpy) ClearOverride(ctx context.Context, scopeType, scopeID, key string) error {
+	return s.inner.ClearOverride(ctx, scopeType, scopeID, key)
+}
+
+// count is every read of stored feature state, which is what the cost
+// assertion is about.
+func (s *toolsSettingsSpy) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.instanceReads + s.accountReads
+}
+
+func (s *toolsSettingsSpy) accountCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.accountReads
+}
+
+func (s *toolsSettingsSpy) setDown(down bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.down = down
+}
+
+// toolsGrantSpy counts grant reads and can be made unreadable alongside the
+// settings store — the scenarios speak of one store holding both.
+type toolsGrantSpy struct {
+	inner repositories.FeatureGrantRepository
+	mu    sync.Mutex
+	reads int
+	down  bool
+}
+
+func (g *toolsGrantSpy) GrantsFor(
+	ctx context.Context, accountID, agentID, roleID string,
+) ([]entities.FeatureGrantRecord, error) {
+	g.mu.Lock()
+	g.reads++
+	down := g.down
+	g.mu.Unlock()
+	if down {
+		return nil, errStoreDown
+	}
+	return g.inner.GrantsFor(ctx, accountID, agentID, roleID)
+}
+
+func (g *toolsGrantSpy) ListByFeature(
+	ctx context.Context, accountID, key string,
+) ([]entities.FeatureGrantRecord, error) {
+	return g.inner.ListByFeature(ctx, accountID, key)
+}
+
+func (g *toolsGrantSpy) Grant(ctx context.Context, record entities.FeatureGrantRecord) error {
+	return g.inner.Grant(ctx, record)
+}
+
+func (g *toolsGrantSpy) Revoke(
+	ctx context.Context, accountID, subjectType, subjectID, key string,
+) (bool, error) {
+	return g.inner.Revoke(ctx, accountID, subjectType, subjectID, key)
+}
+
+func (g *toolsGrantSpy) count() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.reads
+}
+
+func (g *toolsGrantSpy) setDown(down bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.down = down
+}
+
+// loggerSpy keeps every warning, so "logged once" and "logged the failure" are
+// assertions about what an operator can actually see.
+type loggerSpy struct {
+	inner entities.Logger
+	mu    sync.Mutex
+	warns []string
+}
+
+func (l *loggerSpy) Debug(ctx context.Context, msg string, f ...any) { l.inner.Debug(ctx, msg, f...) }
+func (l *loggerSpy) Info(ctx context.Context, msg string, f ...any)  { l.inner.Info(ctx, msg, f...) }
+func (l *loggerSpy) Error(ctx context.Context, msg string, f ...any) { l.inner.Error(ctx, msg, f...) }
+
+func (l *loggerSpy) Warn(ctx context.Context, msg string, fields ...any) {
+	l.mu.Lock()
+	line := msg
+	for _, f := range fields {
+		line += fmt.Sprintf(" %v", f)
+	}
+	l.warns = append(l.warns, line)
+	l.mu.Unlock()
+	l.inner.Warn(ctx, msg, fields...)
+}
+
+func (l *loggerSpy) matching(substrings ...string) []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	var out []string
+outer:
+	for _, line := range l.warns {
+		for _, s := range substrings {
+			if !strings.Contains(line, s) {
+				continue outer
+			}
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+// --- the world ------------------------------------------------------------
+
+// mcpConnection is one client's live MCP session. Held open across steps
+// because the contract turns on sessions outliving a change: a client that
+// listed before a revoke must be able to call, and to list again, in the
+// session it already had.
+type mcpConnection struct {
+	client *gomcp.ClientSession
+	server *gomcp.ServerSession
+	cancel context.CancelFunc
+	person *featurePerson
+	listed []string
+}
+
+type toolsWorld struct {
+	app    *fx.App
+	tmpDir string
+	dsn    string
+	boots  int
+
+	registry *application.FeatureRegistry
+	admin    *application.FeatureAdminService
+	features *application.FeatureService
+	resolver *application.FeatureResolver
+	client   *openfeature.Client
+	settings *toolsSettingsSpy
+	grants   *toolsGrantSpy
+	invSpy   *invalidatorSpy
+	logs     *loggerSpy
+	logger   entities.Logger
+
+	resources      application.ResourceService
+	rts            application.ResourceTypeService
+	episodicRecall application.EpisodicRecall
+
+	authService authapp.AuthenticationService
+	accountRepo authrepos.AccountRepository
+
+	server *gomcp.Server
+
+	declared      []entities.FeatureMeta
+	maxCacheAge   time.Duration
+	ledgerGateKey string
+	seededID      string
+
+	people   map[string]*featurePerson
+	accounts map[string]string
+
+	connections map[string]*mcpConnection
+	stdio       *mcpConnection
+	// connects counts how many times a caller opened a session, so "the MCP
+	// session was not reconnected" is a measurement.
+	connects map[string]int
+	// restartBaseline is the boot count when the scenario's action began, so
+	// "the instance was not restarted" survives a Given that legitimately
+	// reboots.
+	restartBaseline int
+
+	// what the steps observed
+	listings          map[string][]string
+	calls             map[string]*gomcp.CallToolResult
+	callErrs          map[string]error
+	toolsets          map[string][]string
+	readsBefore       int
+	readsAfterListing int
+	invsBefore        int
+	exportsSeen       int
+	answered          int
+	straightAway      *gomcp.CallToolResult
+	afterMoment       *gomcp.CallToolResult
+	windowStart       time.Time
+	moment            time.Time
+	lastCallTool      string
+	lastCallEmail     string
+	lastAgentEmail    string
+	signedInOrder     []string
+}
+
+// advertisedTool is the part of a listed tool the contract asserts about.
+type advertisedTool struct {
+	Annotations *gomcp.ToolAnnotations
+	InputSchema any
+}
+
+// gomcpResult pairs a call result with the tool it came from, so a failure
+// message can name it.
+type gomcpResult struct {
+	res  *gomcp.CallToolResult
+	tool string
+}
+
+func newToolsWorld() *toolsWorld {
+	return &toolsWorld{
+		ledgerGateKey: "ledger-export",
+		people:        map[string]*featurePerson{},
+		accounts:      map[string]string{},
+		connections:   map[string]*mcpConnection{},
+		connects:      map[string]int{},
+		listings:      map[string][]string{},
+		calls:         map[string]*gomcp.CallToolResult{},
+		callErrs:      map[string]error{},
+		toolsets:      map[string][]string{},
+	}
+}
+
+func (w *toolsWorld) recordExport() int {
+	w.exportsSeen++
+	return w.exportsSeen
+}
+
+func (w *toolsWorld) teardown() {
+	setActiveToolsWorld(nil)
+	for _, c := range w.connections {
+		c.close()
+	}
+	if w.stdio != nil {
+		w.stdio.close()
+	}
+	if w.app != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		defer cancel()
+		_ = w.app.Stop(ctx)
+		w.app = nil
+	}
+	if w.tmpDir != "" {
+		_ = os.RemoveAll(w.tmpDir)
+	}
+}
+
+func (c *mcpConnection) close() {
+	if c == nil {
+		return
+	}
+	if c.client != nil {
+		_ = c.client.Close()
+	}
+	if c.server != nil {
+		_ = c.server.Close()
+	}
+	if c.cancel != nil {
+		c.cancel()
+	}
+}
+
+func (w *toolsWorld) boot() error {
+	if w.app != nil {
+		return nil
+	}
+	setActiveToolsWorld(w)
+	if w.tmpDir == "" {
+		dir, err := os.MkdirTemp("", "weos-feature-tools-e2e-")
+		if err != nil {
+			return fmt.Errorf("could not create a temp dir: %w", err)
+		}
+		w.tmpDir = dir
+		w.dsn = filepath.Join(dir, "tools.db")
+	}
+	pw := "true"
+	os.Setenv("PASSWORD_AUTH_ENABLED", pw)
+	os.Unsetenv("GOOGLE_CLIENT_ID")
+	os.Unsetenv("GOOGLE_CLIENT_SECRET")
+
+	cfg := config.Default()
+	cfg.LoadFromEnvironment()
+	cfg.DatabaseDSN = w.dsn
+	cfg.LogLevel = "error"
+	if w.maxCacheAge > 0 {
+		cfg.Features.CacheMaxAge = w.maxCacheAge
+	}
+	// The background's declarations arrive through FEATURES, the same channel
+	// an operator uses, so the suite does not need a code change to declare a
+	// feature. episodic-recall is dropped from the list: core declares it
+	// itself now that it gates a shipped tool, and two declarations of one key
+	// is an error by design.
+	cfg.Features.Declared = w.configDeclarations()
+
+	w.settings = &toolsSettingsSpy{}
+	w.grants = &toolsGrantSpy{}
+	w.invSpy = &invalidatorSpy{}
+	w.logs = &loggerSpy{}
+
+	app := fx.New(
+		fx.NopLogger,
+		application.Module(cfg, presets.NewDefaultRegistry()),
+		fx.Decorate(func(inner repositories.FeatureSettingsRepository) repositories.FeatureSettingsRepository {
+			w.settings.inner = inner
+			return w.settings
+		}),
+		fx.Decorate(func(inner repositories.FeatureGrantRepository) repositories.FeatureGrantRepository {
+			w.grants.inner = inner
+			return w.grants
+		}),
+		fx.Decorate(func(inner repositories.FeatureCacheInvalidator) repositories.FeatureCacheInvalidator {
+			w.invSpy.inner = inner
+			return w.invSpy
+		}),
+		fx.Decorate(func(inner entities.Logger) entities.Logger {
+			w.logs.inner = inner
+			return w.logs
+		}),
+		fx.Populate(&w.registry, &w.admin, &w.features, &w.resolver, &w.client),
+		fx.Populate(&w.resources, &w.rts, &w.episodicRecall, &w.logger),
+		fx.Populate(&w.authService, &w.accountRepo),
+	)
+	startCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+	defer cancel()
+	if err := app.Start(startCtx); err != nil {
+		return fmt.Errorf("failed to start app: %w", err)
+	}
+	w.app = app
+	w.boots++
+	w.server = nil
+	// The database outlives a reboot, so the seed is written once. Seeding
+	// again would collide with the resource type that is already there.
+	if w.seededID == "" {
+		if err := w.seedResource(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// configDeclarations is the background's table minus anything core declares
+// itself, so the suite declares each key exactly once.
+func (w *toolsWorld) configDeclarations() []entities.FeatureMeta {
+	return declarationsBeyondCore(w.declared)
+}
+
+func coreDeclared() map[string]entities.FeatureMeta {
+	out := map[string]entities.FeatureMeta{}
+	for _, m := range application.CoreFeatureDeclarations() {
+		out[m.Key] = m
+	}
+	return out
+}
+
+// coreAlreadyDeclares reports whether core declares this feature itself, so a
+// suite's Background does not declare it a second time — which is an error by
+// design, because two declarations of one key means two things believe they own
+// it.
+//
+// It also checks that core says what the contract's table says, so a scenario
+// can never prove something about a feature nobody has. The description is left
+// out of the comparison on purpose: it is prose an operator reads, and
+// improving it must not fail an acceptance run.
+//
+// Shared by every feature suite. Since #484 core declares episodic-recall,
+// because a shipped tool is gated on it.
+func coreAlreadyDeclares(m entities.FeatureMeta) (bool, error) {
+	got, ok := coreDeclared()[m.Key]
+	if !ok {
+		return false, nil
+	}
+	got.Description, m.Description = "", ""
+	if got != m {
+		return true, fmt.Errorf("core declares %q as %+v, but the contract says %+v", m.Key, got, m)
+	}
+	return true, nil
+}
+
+// seedResource gives resource_get something real to fetch, so "calling
+// resource_get succeeds" means the call succeeded rather than merely that the
+// gate let it past.
+func (w *toolsWorld) seedResource() error {
+	ctx := context.Background()
+	if _, err := w.rts.Create(ctx, application.CreateResourceTypeCommand{
+		Name:        "Note",
+		Slug:        "note",
+		Description: "A note",
+		Context:     json.RawMessage(`{"@vocab":"https://schema.org/"}`),
+		Schema:      json.RawMessage(`{"type":"object","properties":{"title":{"type":"string"}}}`),
+	}); err != nil {
+		return fmt.Errorf("could not seed the note resource type: %w", err)
+	}
+	res, err := w.resources.Create(ctx, application.CreateResourceCommand{
+		TypeSlug: "note",
+		Data:     json.RawMessage(`{"title":"a seeded note"}`),
+	})
+	if err != nil {
+		return fmt.Errorf("could not seed a note: %w", err)
+	}
+	w.seededID = res.GetID()
+	return nil
+}
+
+func (w *toolsWorld) reboot() error {
+	for email, c := range w.connections {
+		c.close()
+		delete(w.connections, email)
+	}
+	if w.stdio != nil {
+		w.stdio.close()
+		w.stdio = nil
+	}
+	if w.app != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		defer cancel()
+		if err := w.app.Stop(ctx); err != nil {
+			return err
+		}
+		w.app = nil
+	}
+	return w.boot()
+}
+
+// mcpServer builds the tool surface the way serve.go does — through
+// NewConfiguredServer, with the real OpenFeature-backed gate and every
+// downstream configurer applied. Built lazily so a scenario can change a gate
+// key or an override before the first client connects.
+func (w *toolsWorld) mcpServer() (*gomcp.Server, error) {
+	if w.server != nil {
+		return w.server, nil
+	}
+	server, err := mcpserver.NewConfiguredServer(
+		w.rts, w.resources, nil, nil, w.episodicRecall, w.admin,
+		application.ToolFeatureGate(w.client), slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	)
+	if err != nil {
+		return nil, err
+	}
+	w.server = server
+	return server, nil
+}
+
+// --- people and accounts --------------------------------------------------
+
+func (w *toolsWorld) personFor(email, password string) (*featurePerson, error) {
+	if p, ok := w.people[email]; ok {
+		return p, nil
+	}
+	ctx := context.Background()
+	agent, _, account, err := w.authService.RegisterPassword(ctx, email, displayNameForFeature(email), password)
+	if err != nil {
+		return nil, fmt.Errorf("could not create %q: %w", email, err)
+	}
+	p := &featurePerson{email: email, password: password, agentID: agent.GetID()}
+	if account != nil {
+		p.accountID = account.GetID()
+		if err := w.accountRepo.SaveMember(ctx, account.GetID(), agent.GetID(), authentities.RoleOwner); err != nil {
+			return nil, err
+		}
+	}
+	w.people[email] = p
+	return p, nil
+}
+
+func (w *toolsWorld) person(email string) (*featurePerson, error) {
+	p, ok := w.people[email]
+	if !ok {
+		return nil, fmt.Errorf("no person named %q has been staged", email)
+	}
+	return p, nil
+}
+
+func (w *toolsWorld) accountFor(name string) (string, error) {
+	id, ok := w.accounts[name]
+	if !ok {
+		return "", fmt.Errorf("no account named %q has been staged", name)
+	}
+	return id, nil
+}
+
+func (w *toolsWorld) addToAccount(email, accountName string) error {
+	accountID, err := w.accountFor(accountName)
+	if err != nil {
+		return err
+	}
+	p, err := w.personFor(email, "correct-horse-battery-staple")
+	if err != nil {
+		return err
+	}
+	if err := w.accountRepo.SaveMember(
+		context.Background(), accountID, p.agentID, authentities.RoleMember); err != nil {
+		return err
+	}
+	w.resolver.InvalidateAgents(context.Background(), accountID, p.agentID)
+	p.accountID = accountID
+	return nil
+}
+
+func (w *toolsWorld) ctxFor(p *featurePerson) context.Context {
+	return auth.ContextWithAgent(context.Background(),
+		&auth.Identity{AgentID: p.agentID, ActiveAccountID: p.accountID})
+}
+
+// --- connecting -----------------------------------------------------------
+
+// connect opens a live MCP session under a caller's identity and keeps it. A
+// nil person is the local stdio transport: no session, no token, no active
+// account, so resolution reaches the instance layer and stops.
+func (w *toolsWorld) connect(p *featurePerson, local bool) (*mcpConnection, error) {
+	server, err := w.mcpServer()
+	if err != nil {
+		return nil, err
+	}
+	base := context.Background()
+	if p != nil {
+		base = w.ctxFor(p)
+	}
+	if local {
+		base = application.WithLocalTransport(base)
+	}
+	ctx, cancel := context.WithCancel(base)
+
+	serverTransport, clientTransport := gomcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	client := gomcp.NewClient(&gomcp.Implementation{Name: "godog", Version: "0.1.0"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	conn := &mcpConnection{client: clientSession, server: serverSession, cancel: cancel, person: p}
+	if p != nil {
+		w.connections[p.email] = conn
+		w.connects[p.email]++
+	} else {
+		w.stdio = conn
+		w.connects["stdio"]++
+	}
+	w.restartBaseline = w.boots
+	return conn, nil
+}
+
+func (w *toolsWorld) connectionFor(email string) (*mcpConnection, error) {
+	c, ok := w.connections[email]
+	if !ok {
+		return nil, fmt.Errorf("%q is not connected over MCP", email)
+	}
+	return c, nil
+}
+
+// theOne returns the single connection a scenario has, for the steps that say
+// "they" without naming anybody.
+func (w *toolsWorld) theOne() (*mcpConnection, error) {
+	if w.stdio != nil && len(w.connections) == 0 {
+		return w.stdio, nil
+	}
+	if len(w.connections) != 1 {
+		return nil, fmt.Errorf("%d MCP connections are open, so \"they\" is ambiguous", len(w.connections))
+	}
+	for _, c := range w.connections {
+		return c, nil
+	}
+	return nil, fmt.Errorf("no MCP connection is open")
+}
+
+// --- listing and calling --------------------------------------------------
+
+func (w *toolsWorld) list(conn *mcpConnection) ([]string, error) {
+	ctx := context.Background()
+	res, err := conn.client.ListTools(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(res.Tools))
+	for _, t := range res.Tools {
+		names = append(names, t.Name)
+	}
+	conn.listed = names
+	key := "stdio"
+	if conn.person != nil {
+		key = conn.person.email
+	}
+	w.listings[key] = names
+	return names, nil
+}
+
+func (w *toolsWorld) listedTools(conn *mcpConnection) (map[string]*gomcp.Tool, error) {
+	res, err := conn.client.ListTools(context.Background(), nil)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]*gomcp.Tool, len(res.Tools))
+	for _, t := range res.Tools {
+		out[t.Name] = t
+	}
+	return out, nil
+}
+
+// argsFor supplies whatever a tool needs to be able to succeed, so a call that
+// fails failed for the reason under test.
+func (w *toolsWorld) argsFor(tool string) map[string]any {
+	switch tool {
+	case "resource_get":
+		return map[string]any{"id": w.seededID}
+	default:
+		return map[string]any{}
+	}
+}
+
+func (w *toolsWorld) call(conn *mcpConnection, tool string) (*gomcp.CallToolResult, error) {
+	res, err := conn.client.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name: tool, Arguments: w.argsFor(tool),
+	})
+	key := tool
+	if conn.person != nil {
+		key = conn.person.email + "|" + tool
+	}
+	w.calls[key] = res
+	w.callErrs[key] = err
+	return res, err
+}
+
+func (w *toolsWorld) resultFor(email, tool string) (*gomcp.CallToolResult, error) {
+	key := tool
+	if email != "" {
+		key = email + "|" + tool
+	}
+	res, ok := w.calls[key]
+	if !ok {
+		return nil, fmt.Errorf("no call to %q was made", tool)
+	}
+	return res, nil
+}
+
+// refusalMarker is the phrase the gate's refusal carries. Matching on it is
+// what separates "the gate refused this" from "the tool ran and failed",
+// which the contract needs to tell apart in both directions.
+const refusalMarker = "is not available: the"
+
+func refusedByGate(res *gomcp.CallToolResult) bool {
+	return res != nil && res.IsError && strings.Contains(mcpText(res), refusalMarker)
+}
+
+// --- the in-app agent -----------------------------------------------------
+
+// agentContext adapts a plain context to the ADK agent context a toolset needs,
+// so a turn can be driven outside a running agent. The embedded mock covers the
+// agent-side methods; the context methods delegate to a real ctx, which is what
+// carries the caller's identity to the gate.
+type agentContext struct {
+	adkagent.ContextMock
+	ctx context.Context
+}
+
+func (a *agentContext) Deadline() (time.Time, bool) { return a.ctx.Deadline() }
+func (a *agentContext) Done() <-chan struct{}       { return a.ctx.Done() }
+func (a *agentContext) Err() error                  { return a.ctx.Err() }
+func (a *agentContext) Value(key any) any           { return a.ctx.Value(key) }
+
+func (w *toolsWorld) agentToolset(p *featurePerson) ([]string, error) {
+	server, err := w.mcpServer()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithCancel(w.ctxFor(p))
+	defer cancel()
+	ts, err := mcpserver.NewAgentToolset(ctx, server, mcpserver.AgentToolsetConfig{})
+	if err != nil {
+		return nil, err
+	}
+	tools, err := ts.Tools(&agentContext{ctx: ctx})
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(tools))
+	for _, t := range tools {
+		names = append(names, t.Name())
+	}
+	w.toolsets[p.email] = names
+	return names, nil
+}
+
+func (w *toolsWorld) callFromAgentToolset(p *featurePerson, name string) error {
+	server, err := w.mcpServer()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithCancel(w.ctxFor(p))
+	defer cancel()
+	ts, err := mcpserver.NewAgentToolset(ctx, server, mcpserver.AgentToolsetConfig{})
+	if err != nil {
+		return err
+	}
+	tools, err := ts.Tools(&agentContext{ctx: ctx})
+	if err != nil {
+		return err
+	}
+	for _, t := range tools {
+		if t.Name() != name {
+			continue
+		}
+		runner, ok := t.(interface {
+			Run(adkagent.Context, any) (map[string]any, error)
+		})
+		if !ok {
+			return fmt.Errorf("%q is not callable from the agent's toolset", name)
+		}
+		out, runErr := runner.Run(&agentContext{ctx: ctx}, map[string]any{})
+		if runErr != nil {
+			return runErr
+		}
+		if refusedText(out) != "" {
+			return fmt.Errorf("the agent's call to %q was refused: %s", name, refusedText(out))
+		}
+		return nil
+	}
+	return fmt.Errorf("the agent's toolset does not hold %q", name)
+}
+
+// refusedText pulls a gate refusal out of an ADK tool result. The MCP client
+// inside the toolset turns an IsError result into content the agent can read,
+// so a refused call must not be mistaken for a successful one.
+func refusedText(out map[string]any) string {
+	raw, err := json.Marshal(out)
+	if err != nil {
+		return ""
+	}
+	if strings.Contains(string(raw), refusalMarker) {
+		return string(raw)
+	}
+	return ""
+}
+
+func contains(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
+}
+
+var _ = testing.Verbose
+
+// declarationsBeyondCore drops the features core declares itself, so a suite's
+// Background reaches the registry through FEATURES without colliding with the
+// code declaration of the same key.
+func declarationsBeyondCore(declared []entities.FeatureMeta) []entities.FeatureMeta {
+	out := make([]entities.FeatureMeta, 0, len(declared))
+	for _, m := range declared {
+		if core, _ := coreAlreadyDeclares(m); core {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}

--- a/tests/e2e/feature_operator_world_test.go
+++ b/tests/e2e/feature_operator_world_test.go
@@ -199,7 +199,9 @@ func (w *operatorWorld) boot() error {
 	// CLI subprocess sees exactly the features this instance does. Two
 	// processes can only agree about which features exist by reading the same
 	// declarations, and nothing is persisted for them to share.
-	cfg.Features.Declared = append([]entities.FeatureMeta(nil), w.declared...)
+	// A key core declares in code is left out of FEATURES: declaring it twice
+	// is an error by design. See coreAlreadyDeclares.
+	cfg.Features.Declared = declarationsBeyondCore(w.declared)
 	cfg.Features.PrimaryAccountID = w.primaryAccountID
 
 	app := fx.New(
@@ -418,7 +420,10 @@ func (w *operatorWorld) runCLI(command string) error {
 		dsn = "DATABASE_DSN="
 	}
 	env := append(os.Environ(), dsn, "LOG_LEVEL=error")
-	if declared, err := json.Marshal(w.declared); err == nil && len(w.declared) > 0 {
+	// The CLI reads its declarations from the same env channel the server
+	// does, minus whatever core declares in code. See coreAlreadyDeclares.
+	beyondCore := declarationsBeyondCore(w.declared)
+	if declared, err := json.Marshal(beyondCore); err == nil && len(beyondCore) > 0 {
 		env = append(env, "FEATURES="+string(declared))
 	}
 	cmd.Env = env
@@ -448,7 +453,7 @@ func (w *operatorWorld) runCLI(command string) error {
 func (w *operatorWorld) callMCP(
 	p *featurePerson, local bool, tool string, args map[string]any,
 ) error {
-	server, err := mcpserver.NewMCPServer(w.rts, w.resources, nil, nil, nil, w.admin, []string{"feature"})
+	server, err := mcpserver.NewMCPServer(w.rts, w.resources, nil, nil, nil, w.admin, nil, []string{"feature"})
 	if err != nil {
 		return fmt.Errorf("could not build the MCP server: %w", err)
 	}

--- a/tests/e2e/features/feature_flag_mcp_tools.feature
+++ b/tests/e2e/features/feature_flag_mcp_tools.feature
@@ -1,4 +1,4 @@
-@wip @epic-480 @story-484
+@epic-480 @story-484
 Feature: A disabled MCP tool never reaches the LLM
   As someone whose LLM talks to a WeOS instance over MCP
   I want the tools for a capability I do not have to be absent from the list, and refused

--- a/tests/e2e/features/feature_flag_mcp_tools.feature
+++ b/tests/e2e/features/feature_flag_mcp_tools.feature
@@ -1,0 +1,302 @@
+@wip @epic-480 @story-484
+Feature: A disabled MCP tool never reaches the LLM
+  As someone whose LLM talks to a WeOS instance over MCP
+  I want the tools for a capability I do not have to be absent from the list, and refused
+  if called anyway
+  So that the model cannot offer me something the instance will not do, and cannot be
+  talked into calling it
+
+  #481 built resolution, #482 gave an operator the switch, #483 gave an admin the grant.
+  All three ended at an answer nobody acts on: a boolean, correct and cheap, with no call
+  site consuming it. This story is the first consumer, and it is the one the epic was
+  written for — an agent turn is where thirty evaluations happen, and the MCP tool surface
+  is where "off" has to mean something a model can see.
+
+  So nothing below re-derives resolution. Which layer beats which, that an explicit off is
+  final downward, that a store failure answers off, that an undeclared key answers the
+  caller's default and is logged once, that a change reaches sessions already open without
+  signing anybody out, that a window is read at resolution rather than swept by a job — all
+  of that is feature_flag_resolution.feature and feature_flag_grants.feature and stays
+  there. What is new here is what the MCP surface does with the answer: what the tool list
+  contains, what a call does when the list and the caller disagree, and that the in-app
+  agent and a third-party client are shown the same set.
+
+  Two gates, not one, and they are not equally important. A tool missing from `tools/list`
+  is a convenience for the model: it cannot propose what it cannot see, so it cannot
+  hallucinate a call, and the user is never offered a capability that will fail. A tool
+  that refuses when called is the gate. Every scenario that hides a tool therefore also
+  calls it, because an implementation that filters the listing and forgets the handler has
+  built a UI affordance and called it a control, and the difference is invisible right up
+  until a client calls a tool by name from a list it cached an hour ago.
+
+  Which brings up the one thing this contract deliberately does not require: a
+  `tools/list_changed` notification. The MCP protocol has one, the Go SDK can send one, and
+  it is the obvious thing to reach for — and it cannot be the mechanism here, for a reason
+  that is structural rather than a matter of effort. Grant expiry is lazy by design: #483
+  settled that a validity window is read at resolution and that nothing fires when
+  `validThrough` passes, because a row that has run out is simply not counted. So at the
+  moment a window closes, there is no event to hang a notification on, and there never will
+  be without a scheduler this epic explicitly does not want. A contract that demanded a
+  notification whenever the resolved tool list changed would be unsatisfiable on the very
+  case it most needs to cover. The scenarios below therefore pin the property that holds in
+  every case: **a stale tool list is never authorization**. A client that still has the tool
+  and calls it is refused, whether the change came from an operator's flip a second ago or
+  from a window that closed on its own. A client that lists again gets the truth, with no
+  reconnect and no restart. Whether an implementation additionally sends a notification on
+  the changes it *can* see is left open — it would be a courtesy that saves a model one
+  wasted call, and if it is added it must not become the thing anything relies on.
+
+  The stdio transport has no caller, and that is a limit worth writing down rather than
+  discovering. `weos mcp` is one local process with no session, no bearer token and no
+  active account; `auth.AgentFromCtx` is nil there and resolution reaches the instance
+  layer and stops. So on stdio, gating is instance-wide and can be nothing else: an
+  operator's instance-level off hides and refuses the tool, and an account override or a
+  personal grant makes no difference at all. Two scenarios below say so out loud, because
+  stdio is mini-me's primary surface and somebody will otherwise assume the per-user
+  behaviour these scenarios prove over HTTP applies there too. It does not, and cannot,
+  until the local transport carries an identity — which is a different story than this one.
+
+  Where the gate is declared is the same place the tool is: at its `mcp.AddTool` call site,
+  beside the name, the schema and the annotations, because a tool declared in one file and
+  gated in a registry somewhere else is two things that will drift. A tool that names no
+  feature is ungated and nothing about it changes — no lookup, no resolver, no new failure
+  mode — which is what the first scenarios below pin, against tools that ship today.
+
+  A key nobody declared is not a store failure and the two must not be conflated. #481
+  already settled the general rule and it is the epic's rule: an undeclared key is registry
+  drift and answers the caller's default, logged once; a read that fails is closed. Applied
+  here, that means a typo in a gate leaves the tool where it was and says so in the log,
+  while a database that cannot be read takes the gated tools away and leaves the ungated
+  ones alone. The alternative — hiding every tool whose gate key does not resolve — turns
+  one mistyped constant into a silent capability outage across an instance, with a tool
+  surface that looks deliberate.
+
+  The cost assertion is the epic's own: a turn that calls thirty tools resolves once. It is
+  pinned here rather than in #481 because this is the surface where the number thirty comes
+  from, and because the per-call gate is exactly where a plausible implementation reaches
+  for the resolver again instead of the set it already has.
+
+  Two tools carry gates in these scenarios. `episodic_recall` is a real shipped tool gated
+  at its own call site by the `episodic-recall` feature the other three contracts already
+  declare, so the mechanism is exercised through the code path it actually ships in.
+  `ledger_export` is registered by the harness through the configurer seam downstream
+  binaries use, and it mutates: it exists so the contract can exercise a gate whose feature
+  is declared off, and prove a refused call writes nothing, without this story having to
+  decide which shipped tool ought to be dark by default.
+
+  Background:
+    Given a WeOS instance where password sign-in is enabled and requests are authenticated by their session
+    And the instance declares these features in code:
+      | key             | display name    | description                              | default | manageable | grantable |
+      | episodic-recall | Episodic recall | Recall past events during a conversation | on      | yes        | yes       |
+      | ledger-export   | Ledger export   | Export the ledger to a spreadsheet       | off     | yes        | yes       |
+      | audit-trail     | Audit trail     | Record who read what, for compliance     | on      | no         | no        |
+    And these tools declare the feature that gates them:
+      | tool            | gated by        | mutates |
+      | episodic_recall | episodic-recall | no      |
+      | ledger_export   | ledger-export   | yes     |
+    And the account "Harbor Legal", whose owner "ops@harborlegal.example" signs in with password "correct-horse-battery-staple"
+
+  # --- A tool that names no feature is untouched ---
+
+  Scenario: Tools that name no feature are listed and callable however the features stand
+    Given the operator has turned the feature "episodic-recall" off for the instance
+    And "ops@harborlegal.example" is connected over MCP
+    When they list the server's tools
+    Then the listing includes "resource_get"
+    And the listing includes "person_list"
+    And calling "resource_get" succeeds
+
+  Scenario: A gated tool that is on is listed and called exactly as it was before it had a gate
+    Given "ops@harborlegal.example" is connected over MCP
+    When they list the server's tools
+    Then the listing includes "episodic_recall"
+    And "episodic_recall" is advertised with the annotation it declares
+    And "episodic_recall" is advertised with the input schema it declares
+    And calling "episodic_recall" succeeds
+
+  Scenario: A gate naming a key nobody declared leaves the tool where it was, and says so once
+    Given the tool "ledger_export" is gated by the undeclared feature "shpping-labels"
+    And "ops@harborlegal.example" is connected over MCP
+    When they list the server's tools 20 times
+    Then the listing includes "ledger_export"
+    And calling "ledger_export" succeeds
+    And the instance logged the undeclared feature key once
+    And the log names the key "shpping-labels"
+
+  # --- What the model is shown ---
+
+  Scenario Outline: A gated tool is listed only when its feature is on for the caller
+    Given <precondition>
+    And "ops@harborlegal.example" is connected over MCP
+    When they list the server's tools
+    Then the listing <presence> "<tool>"
+
+    Examples:
+      | precondition                                                               | tool            | presence |
+      | nothing has been overridden or granted on this instance                    | episodic_recall | includes |
+      | nothing has been overridden or granted on this instance                    | ledger_export   | omits    |
+      | the operator has turned the feature "episodic-recall" off for the instance | episodic_recall | omits    |
+      | "Harbor Legal" has turned the feature "ledger-export" on                   | ledger_export   | includes |
+
+  Scenario: Two people on one instance are shown two different tool lists
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" has been granted the feature "ledger-export"
+    And both of them are connected over MCP, each in their own session
+    When each of them lists the server's tools
+    Then "counsel@harborlegal.example" is shown "ledger_export"
+    And "ops@harborlegal.example" is not shown "ledger_export"
+    And both of them are shown "resource_get"
+
+  Scenario: One person acting in two accounts is shown two different tool lists
+    Given the account "Cedar Realty", whose owner "broker@cedarrealty.example" signs in with password "trellis-anchor-mango-9"
+    And "ops@harborlegal.example" also belongs to "Cedar Realty"
+    And "Harbor Legal" has turned the feature "ledger-export" on
+    And "ops@harborlegal.example" is connected over MCP acting in "Harbor Legal"
+    And they have listed the server's tools and been shown "ledger_export"
+    When they act in "Cedar Realty" and list the server's tools again
+    Then the listing omits "ledger_export"
+    And the listing includes "resource_get"
+
+  Scenario: The list and the call agree, in both directions
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" has been granted the feature "ledger-export"
+    And the operator has turned the feature "episodic-recall" off for the instance
+    And "counsel@harborlegal.example" is connected over MCP
+    When they list the server's tools
+    And they call every gated tool the instance declares
+    Then every tool the listing showed them was callable
+    And every gated tool the listing withheld was refused
+
+  # --- The call is the gate ---
+
+  Scenario: Calling a tool whose feature is off is refused, and nothing it would have done was done
+    Given "ops@harborlegal.example" is connected over MCP
+    When they call "ledger_export"
+    Then the call is refused with an error the client can read
+    And the refusal names the tool "ledger_export"
+    And the refusal says the capability is not enabled for them
+    And no ledger export was recorded
+    And the refusal is not a partial result
+
+  Scenario: A tool list fetched before the change is not authorization to call what is on it
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" has been granted the feature "ledger-export"
+    And "counsel@harborlegal.example" is connected over MCP
+    And they have listed the server's tools and been shown "ledger_export"
+    When "ops@harborlegal.example" revokes "ledger-export" from "counsel@harborlegal.example"
+    And "counsel@harborlegal.example" calls "ledger_export" from the list they already hold
+    Then the call is refused
+    And "counsel@harborlegal.example" is still connected
+    And they were not signed out
+
+  Scenario: Listing again after a change returns the truth, with no reconnect and no restart
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" has been granted the feature "ledger-export"
+    And "counsel@harborlegal.example" is connected over MCP
+    And they have listed the server's tools and been shown "ledger_export"
+    When "ops@harborlegal.example" revokes "ledger-export" from "counsel@harborlegal.example"
+    And "counsel@harborlegal.example" lists the server's tools again in the session they already held
+    Then the listing omits "ledger_export"
+    And the MCP session was not reconnected
+    And the instance was not restarted
+
+  Scenario: A grant that runs out mid-session refuses the call, though nothing announced it
+    Given the instance is configured with a maximum cache age of 10 minutes
+    And "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" holds a grant of "ledger-export" valid until 2 seconds from now
+    And "counsel@harborlegal.example" is connected over MCP
+    And they have listed the server's tools and been shown "ledger_export"
+    When they call "ledger_export" straight away
+    And they call "ledger_export" again once that moment has passed
+    And they list the server's tools again
+    Then the call straight away succeeded
+    And the call after that moment is refused
+    And the listing now omits "ledger_export"
+    And nothing invalidated the session in between
+    And the maximum cache age had not run out
+    And "counsel@harborlegal.example" is still connected
+
+  # --- Failing closed ---
+
+  Scenario: When the store cannot be read the gated tools go, and the rest stay
+    Given the store holding account overrides and grants cannot be read
+    And "ops@harborlegal.example" is connected over MCP
+    When they list the server's tools
+    Then the listing omits "episodic_recall"
+    And the listing includes "resource_get"
+    And calling "episodic_recall" is refused
+    And calling "resource_get" succeeds
+    And the instance logged the failure
+
+  Scenario: A store failure is not remembered as an answer
+    Given the store holding account overrides and grants cannot be read
+    And "ops@harborlegal.example" is connected over MCP
+    And they have listed the server's tools and not been shown "episodic_recall"
+    When the store can be read again
+    And they list the server's tools again in the session they already held
+    Then the listing includes "episodic_recall"
+    And calling "episodic_recall" succeeds
+
+  # --- What the gate costs ---
+
+  Scenario: A turn that lists once and calls thirty tools resolves once
+    Given "ops@harborlegal.example" is connected over MCP
+    When they list the server's tools
+    And they make 30 tool calls in that session
+    Then every call was answered
+    And feature state was read from the database only while the listing was answered
+
+  # --- The in-app agent is shown the same set ---
+
+  Scenario: The in-app agent's tools for a turn are the ones the same person sees over MCP
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" has been granted the feature "ledger-export"
+    And the operator has turned the feature "episodic-recall" off for the instance
+    And "counsel@harborlegal.example" is signed in to "Harbor Legal"
+    When their in-app agent opens a toolset for a turn
+    And they list the server's tools over MCP in the same session
+    Then the toolset holds exactly the tools the MCP listing showed
+    And the toolset holds "ledger_export"
+    And the toolset does not hold "episodic_recall"
+
+  Scenario: Two people talking to the in-app agent get two different toolsets
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" has been granted the feature "ledger-export"
+    And both of them are signed in to "Harbor Legal"
+    When each of them takes a turn with the in-app agent
+    Then "counsel@harborlegal.example" was offered "ledger_export"
+    And "ops@harborlegal.example" was not offered "ledger_export"
+
+  Scenario: A tool turned on after boot is usable by the in-app agent without a restart
+    Given the instance booted with the feature "ledger-export" off for the instance
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When the operator turns the feature "ledger-export" on for the instance
+    And "ops@harborlegal.example" takes a turn with the in-app agent
+    Then the toolset holds "ledger_export"
+    And the agent's call to "ledger_export" succeeds
+    And the instance was not restarted
+
+  # --- The local stdio transport has no caller ---
+
+  Scenario Outline: On stdio the instance layer alone decides which gated tools exist
+    Given <precondition>
+    And an MCP client attached to the store over the local stdio transport
+    When it lists the server's tools
+    Then the listing <presence> "<tool>"
+    And calling "<tool>" <outcome>
+
+    Examples:
+      | precondition                                                               | tool            | presence | outcome     |
+      | nothing has been overridden or granted on this instance                    | episodic_recall | includes | succeeds    |
+      | the operator has turned the feature "episodic-recall" off for the instance | episodic_recall | omits    | is refused  |
+      | the operator has turned the feature "ledger-export" on for the instance    | ledger_export   | includes | succeeds    |
+
+  Scenario: On stdio an account override and a personal grant reach nothing
+    Given "Harbor Legal" has turned the feature "ledger-export" on
+    And "ops@harborlegal.example" has been granted the feature "ledger-export"
+    And an MCP client attached to the store over the local stdio transport
+    When it lists the server's tools
+    Then the listing omits "ledger_export"
+    And calling "ledger_export" is refused
+    And no account override or grant was read to answer either

--- a/tests/e2e/mcp_resource_create_test.go
+++ b/tests/e2e/mcp_resource_create_test.go
@@ -140,7 +140,7 @@ func (w *mcpWorld) aCleanKnowledgeGraph(_ context.Context) error {
 	w.eventStore = eventStore
 	w.manager = manager
 
-	server, err := mcpserver.NewMCPServer(rts, rs, kg, nil, episodic, nil, nil)
+	server, err := mcpserver.NewMCPServer(rts, rs, kg, nil, episodic, nil, nil, nil)
 	if err != nil {
 		return fmt.Errorf("failed to build MCP server: %w", err)
 	}

--- a/tests/e2e/oauth_authorize_session_test.go
+++ b/tests/e2e/oauth_authorize_session_test.go
@@ -314,7 +314,7 @@ func (w *oauthWorld) boot(opts bootOpts) error {
 		// auth serve.go puts in front of it.
 		mcpSrv, mcpErr := mcpserver.NewConfiguredServer(
 			resourceTypeService, w.resourceService, kgService, lexicalSearch, episodicRecall,
-			nil, slog.Default())
+			nil, ungatedForOAuthSuite, slog.Default())
 		if mcpErr != nil {
 			return fmt.Errorf("failed to create the MCP server: %w", mcpErr)
 		}
@@ -937,3 +937,9 @@ func (w *oauthWorld) lastTaskOwner(name string) (string, error) {
 	}
 	return "", nil
 }
+
+// ungatedForOAuthSuite says out loud that this suite is about bearer auth, not
+// about feature gating: every gated tool is available so the scenarios exercise
+// the auth path alone. Stated rather than left as a nil gate, which
+// NewConfiguredServer refuses.
+func ungatedForOAuthSuite(context.Context, string) bool { return true }

--- a/tests/e2e/per_account_knowledge_graph_test.go
+++ b/tests/e2e/per_account_knowledge_graph_test.go
@@ -202,7 +202,7 @@ func (w *perAccountKGWorld) bootPerAccount(cfg config.Config) error {
 	w.manager = manager
 	w.rts = rts
 
-	server, err := mcpserver.NewMCPServer(rts, rs, kg, nil, episodic, nil, nil)
+	server, err := mcpserver.NewMCPServer(rts, rs, kg, nil, episodic, nil, nil, nil)
 	if err != nil {
 		return fmt.Errorf("build MCP server: %w", err)
 	}


### PR DESCRIPTION
Story #484 of epic #480. The first consumer of the feature-flag resolution built in #481–#483: an MCP tool whose feature is off is absent from `tools/list` and refused on `tools/call`.

Stacked on #501.

## Two gates, and they are not equally important

Filtering the listing is a convenience for the model — it cannot propose what it cannot see, so it cannot hallucinate a call the instance will refuse. **Refusing the call is the control.** An implementation that filtered the listing and forgot the handler would have built a UI affordance and called it authorization, and the difference stays invisible right up until a client calls a tool by name from a list it cached an hour ago. Every scenario that hides a tool therefore also calls it.

## No `tools/list_changed` notification, deliberately

The protocol has one and the SDK can send one. It cannot be the mechanism here, for a structural reason rather than a matter of effort: grant expiry is lazy by design (#483), so at the moment a validity window closes there is no event to hang a notification on, and there would not be one without a scheduler this epic does not want. A contract demanding a notification whenever the resolved tool list changed would be unsatisfiable on the very case it most needs to cover.

What is pinned instead holds in every case: **a stale tool list is never authorization.** A client that still holds the tool is refused when it calls, whether the answer changed from an operator's flip a second ago or from a window that closed on its own. A client that lists again gets the truth, with no reconnect and no restart. A courtesy notification may be added later for the changes an implementation *can* see; nothing may be built on top of it.

## Where the gate lives

At the tool's own `mcp.AddTool` call site, through `AddGatedTool`, beside its name, schema and annotations — a tool declared in one file and gated in a registry somewhere else is two things that will drift. `FeatureGates` is an index of those declarations, not a second place to declare. Downstream binaries reach it through `ConfigurerDeps.Gates`, so a custom tool gates exactly the way a built-in one does.

A tool that names no feature is untouched: no lookup, no resolver, no new failure mode.

## Drift is not a store failure

`ToolFeatureGate` evaluates through the OpenFeature client and passes `true` as the client default. That is not a fail-open. A store that cannot be read resolves off through the provider's ERROR reason, which the client does not overrule, so gated tools still disappear during an outage. The default is reached only when nobody declared the key — registry drift — and there the tool must stay exactly where it was, logged once. Closing every gate whose key does not resolve would turn one mistyped constant into a silent capability outage across an instance, with a tool surface that looks deliberate.

## `episodic_recall` is gated, ON by default

Core now declares the `episodic-recall` feature itself, because it ships the call site that reads it. Declared ON: the tool ships today and instances rely on it, so introducing the gate with a default of off would take a working capability away from everyone until somebody noticed. An operator who wants it dark turns it off, and that is a decision with a name on it.

## Two guards worth naming

**`NewConfiguredServer` now refuses a nil gate.** It builds the surface real callers reach, so a wiring slip there would leave every gated tool open on every transport while every test still passed — which is exactly how the feature provider itself once shipped inert (#481). A build that genuinely wants no gating says so with a gate that always answers true; the low-level `NewMCPServer` still accepts nil.

**`serverTools` marks its context as a tool inventory**, which the gate honors on the listing and never on a call. Its three consumers — skill-allowlist validation, the read-only classification behind human-in-the-loop confirmation, and the coordinator's default tool names — run once at boot with no caller, and each result is later intersected with the per-turn gated toolset. Resolving them against the anonymous caller would freeze a feature's boot-time value into lists that outlive it, so a tool turned on afterwards would stay missing until a restart.

## stdio has no caller

`weos mcp` is one local process with no session, no bearer token and no active account, so resolution reaches the instance layer and stops. Gating there is instance-wide and can be nothing else. Two scenarios say so out loud, because stdio is mini-me's primary surface and somebody will otherwise assume the per-user behavior proven over HTTP applies there too.

## Evidence

`tests/e2e/features/feature_flag_mcp_tools.feature` — 19 scenarios (24 expanded), 257 steps, all green, promoted out of `@wip`. All four epic suites run together: 127 scenarios, 1177 steps.

Five mutations were run against the contract, and each was caught by exactly the scenarios that own the behavior:

| Mutation | Scenarios that failed |
|---|---|
| the call gate never refuses | 7 |
| the listing is never filtered | 14 |
| an undeclared gate key closes the gate | 1 |
| a store failure answers the caller's default | 2 |
| the resolved set is never cached | 1 |

Removing the gate from `episodic_recall`'s call site fails its unit test.

Closes #484
