### PR TITLE
Gate agent skills on a feature, through one filter both doors use

### DIFF
--- a/application/agent_skills.go
+++ b/application/agent_skills.go
@@ -173,6 +173,7 @@ func ParseSkillDefinition(id string, data json.RawMessage) (entities.SkillDefini
 		Mode          string   `json:"mode"`
 		Widgets       []string `json:"widgets"`
 		Model         string   `json:"model"`
+		GatedBy       string   `json:"gatedBy"`
 	}
 	if err := json.Unmarshal(ExtractEntityNode(data), &raw); err != nil {
 		return entities.SkillDefinition{}, fmt.Errorf("parse agent-skill data: %w", err)
@@ -193,6 +194,7 @@ func ParseSkillDefinition(id string, data json.RawMessage) (entities.SkillDefini
 		Mode:          raw.Mode,
 		Widgets:       raw.Widgets,
 		Model:         raw.Model,
+		GatedBy:       raw.GatedBy,
 	}, nil
 }
 

--- a/application/agents/orchestrator.go
+++ b/application/agents/orchestrator.go
@@ -386,6 +386,21 @@ func (o *Orchestrator) runTurn(
 	var out strings.Builder
 	for event, err := range r.Run(ctx, userID, conversationID, content, agent.RunConfig{}) {
 		if err != nil {
+			// A transfer to an agent that is not in this turn's graph is a
+			// refusal, not a fault (#485). The model can name a skill the
+			// caller's features do not reach — it invented the name, or a
+			// client carried it over from a conversation where the caller did
+			// have it — and the answer must be a reply the user can read, not
+			// a broken turn. Failing here would turn every gated skill into a
+			// way to break somebody's chat by mentioning it.
+			if unreachableSkill(err) {
+				o.logger.Info(ctx, "the model named a skill this caller cannot reach",
+					"conversation", conversationID, "error", err.Error())
+				out.Reset()
+				out.WriteString(skillOutOfReachReply)
+				emit(entities.AgentEvent{Type: entities.AgentEventText, Text: skillOutOfReachReply})
+				break
+			}
 			return fmt.Errorf("run agent: %w", err)
 		}
 		o.emitConfirmationRequests(ctx, event, emit)
@@ -569,6 +584,23 @@ func (o *Orchestrator) buildRoot(ctx context.Context) (agent.Agent, error) {
 		return nil, fmt.Errorf("build coordinator: %w", err)
 	}
 	return root, nil
+}
+
+// skillOutOfReachReply is what a caller is told when the model tried to hand
+// the turn to a skill their features do not reach. It names no skill on
+// purpose: the caller cannot use it, and naming it would advertise a
+// capability they do not have and cannot ask for by name.
+const skillOutOfReachReply = "I cannot help with that here."
+
+// unreachableSkill reports whether the runner failed because the model
+// transferred to an agent this turn's graph does not contain.
+//
+// Matched on the ADK runner's message because the error carries no type to
+// test. Kept narrow — a different runner failure must still surface as a
+// failure, since swallowing those would hide real faults behind a polite
+// sentence. Verified against google.golang.org/adk/v2 v2.0.0.
+func unreachableSkill(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "failed to find agent")
 }
 
 // ensureSession makes the (userID, conversationID) session exist. Get-then-

--- a/application/agents/orchestrator.go
+++ b/application/agents/orchestrator.go
@@ -96,6 +96,7 @@ type Orchestrator struct {
 
 	mu           sync.RWMutex
 	skills       SkillSource
+	skillGate    SkillGate
 	toolsets     ToolsetFactory
 	defaultTools []string
 	recorder     EpisodeRecorder
@@ -476,26 +477,16 @@ func (o *Orchestrator) rootFor(ctx context.Context, skill string) (agent.Agent, 
 // instead of relying on coordinator routing.
 func (o *Orchestrator) buildSkillRoot(ctx context.Context, name string) (agent.Agent, error) {
 	o.mu.RLock()
-	skills := o.skills
 	toolsets := o.toolsets
 	o.mu.RUnlock()
 
-	if skills == nil {
-		return nil, fmt.Errorf("unknown skill %q: no skills are loaded", name)
-	}
-	defs, err := skills(ctx)
+	// The gate, not merely the graph. A caller naming a skill directly skips
+	// the coordinator entirely, so this door has to ask the same question the
+	// graph asked — and answer "you may not have this" differently from "no
+	// such skill".
+	def, err := o.findSkill(ctx, name)
 	if err != nil {
-		return nil, fmt.Errorf("load skills: %w", err)
-	}
-	var def *entities.SkillDefinition
-	for i := range defs {
-		if defs[i].Name == name {
-			def = &defs[i]
-			break
-		}
-	}
-	if def == nil {
-		return nil, fmt.Errorf("unknown skill %q", name)
+		return nil, err
 	}
 
 	var ts tool.Toolset
@@ -504,7 +495,7 @@ func (o *Orchestrator) buildSkillRoot(ctx context.Context, name string) (agent.A
 			return nil, fmt.Errorf("open toolset: %w", err)
 		}
 	}
-	root, err := BuildSkillRootAgent(*def, o.model, ts)
+	root, err := BuildSkillRootAgent(def, o.model, ts)
 	if err != nil {
 		return nil, fmt.Errorf("build skill root %q: %w", name, err)
 	}
@@ -520,22 +511,20 @@ func (o *Orchestrator) buildSkillRoot(ctx context.Context, name string) (agent.A
 // immediately; construction is cheap (no network).
 func (o *Orchestrator) buildRoot(ctx context.Context) (agent.Agent, error) {
 	o.mu.RLock()
-	skills := o.skills
 	toolsets := o.toolsets
 	defaultTools := o.defaultTools
 	o.mu.RUnlock()
 
-	var defs []entities.SkillDefinition
-	if skills != nil {
-		var err error
-		if defs, err = skills(ctx); err != nil {
-			return nil, fmt.Errorf("load skills: %w", err)
-		}
+	// Only the skills this caller's features reach become sub-agents, so
+	// transfer_to_agent cannot name the rest — the coordinator is never told
+	// they exist.
+	defs, err := o.allowedSkills(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	var ts tool.Toolset
 	if toolsets != nil {
-		var err error
 		if ts, err = toolsets(ctx); err != nil {
 			return nil, fmt.Errorf("open toolset: %w", err)
 		}

--- a/application/agents/skill_gate.go
+++ b/application/agents/skill_gate.go
@@ -95,6 +95,17 @@ func (o *Orchestrator) allowedSkills(ctx context.Context) ([]entities.SkillDefin
 	return allowed, nil
 }
 
+// RoutableSkills returns the skills the caller on ctx can be routed to — the
+// exact list buildRoot turns into the coordinator's sub-agents.
+//
+// Exported because more than the coordinator needs it: the admin surface
+// (#486) has to show a person what their agent can actually reach, and a
+// second implementation of "what may this caller use" would be a second
+// answer. Callers get definitions, not agents, so nothing here builds a model.
+func (o *Orchestrator) RoutableSkills(ctx context.Context) ([]entities.SkillDefinition, error) {
+	return o.allowedSkills(ctx)
+}
+
 // findSkill locates a named skill for the direct-invocation door and reports
 // why the caller cannot have it.
 //

--- a/application/agents/skill_gate.go
+++ b/application/agents/skill_gate.go
@@ -1,0 +1,132 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package agents
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/wepala/weos/v3/domain/entities"
+)
+
+// Gating agent skills on a feature (epic #480, story #485).
+//
+// #484 gated the tools; this gates the layer above them. Two gates again, and
+// again unequal. Filtering the coordinator's sub-agents is what stops
+// transfer_to_agent: the coordinator cannot transfer to a sub-agent it was
+// never given, so a hidden skill cannot be routed to, described, or talked
+// about as though it existed. Refusing direct invocation — the ?skill=<name>
+// door #419 shipped — is the control, because a client that names a skill it
+// saw last week must not reach further than a caller whose features say no.
+//
+// Both doors are served by allowedSkills below, deliberately: an
+// implementation with two filters is an implementation with one filter and a
+// hole, and the hole is invisible until somebody types the name.
+
+// SkillGate reports whether a skill's feature is on for the caller on ctx.
+// skillName travels with the key so the one place that owns the rule can also
+// own the log line, and name both when a skill points at a feature nobody
+// declared.
+//
+// A nil gate means nothing is gated, which is how every existing caller of
+// NewOrchestrator behaves until the application layer wires one.
+type SkillGate func(ctx context.Context, skillName, featureKey string) bool
+
+// SetSkillGate wires the feature gate (called from the application layer's fx
+// wiring, which owns the registry, the OpenFeature client and the logger).
+func (o *Orchestrator) SetSkillGate(g SkillGate) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.skillGate = g
+}
+
+// allowedSkills loads the skills and drops the ones the caller's features do
+// not reach. It is the single filter both doors use.
+//
+// Filtering here rather than in the registry is load-bearing. SkillRegistry
+// caches one set of definitions for the whole instance, loaded with the
+// caller's identity stripped on purpose, because a skill is an installed
+// capability and not per-user data. A filter inside that cache would resolve
+// one caller's features and then serve the answer to everybody until the next
+// skill event — the second person to take a turn would get the first person's
+// permissions. This runs once per turn, against the caller's own context.
+//
+// It costs no extra database work. Each gated skill asks the resolver for one
+// key, and the resolver answers every key after the first from the set it
+// already holds for this caller — the same set the turn's toolset resolved.
+// Twenty gated skills therefore read stored feature state no more often than
+// none do.
+func (o *Orchestrator) allowedSkills(ctx context.Context) ([]entities.SkillDefinition, error) {
+	o.mu.RLock()
+	skills := o.skills
+	gate := o.skillGate
+	o.mu.RUnlock()
+
+	if skills == nil {
+		return nil, nil
+	}
+	defs, err := skills(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load skills: %w", err)
+	}
+	if gate == nil {
+		return defs, nil
+	}
+	allowed := make([]entities.SkillDefinition, 0, len(defs))
+	for _, def := range defs {
+		if def.GatedBy != "" && !gate(ctx, def.Name, def.GatedBy) {
+			continue
+		}
+		allowed = append(allowed, def)
+	}
+	return allowed, nil
+}
+
+// findSkill locates a named skill for the direct-invocation door and reports
+// why the caller cannot have it.
+//
+// The two refusals must read differently. "Unknown skill" and "you do not have
+// this skill" send the reader to different places: one is a typo or a skill
+// nobody installed, the other is a capability an admin can grant. A single
+// message for both would make a permission question look like a spelling
+// mistake, and an operator would go looking in the wrong place.
+func (o *Orchestrator) findSkill(
+	ctx context.Context, name string,
+) (entities.SkillDefinition, error) {
+	o.mu.RLock()
+	skills := o.skills
+	gate := o.skillGate
+	o.mu.RUnlock()
+
+	if skills == nil {
+		return entities.SkillDefinition{}, fmt.Errorf("unknown skill %q: no skills are loaded", name)
+	}
+	defs, err := skills(ctx)
+	if err != nil {
+		return entities.SkillDefinition{}, fmt.Errorf("load skills: %w", err)
+	}
+	for _, def := range defs {
+		if def.Name != name {
+			continue
+		}
+		if def.GatedBy != "" && gate != nil && !gate(ctx, def.Name, def.GatedBy) {
+			return entities.SkillDefinition{}, fmt.Errorf("%s",
+				entities.GateRefusal(ctx, name, def.GatedBy))
+		}
+		return def, nil
+	}
+	return entities.SkillDefinition{}, fmt.Errorf("unknown skill %q", name)
+}

--- a/application/feature_tool_gate.go
+++ b/application/feature_tool_gate.go
@@ -18,8 +18,9 @@ package application
 import (
 	"context"
 
-	"github.com/akeemphilbert/pericarp/pkg/auth"
 	"github.com/open-feature/go-sdk/openfeature"
+
+	"github.com/wepala/weos/v3/domain/entities"
 )
 
 // ToolFeatureGate answers whether a gated capability is available to the
@@ -74,12 +75,9 @@ func ToolFeatureGate(client *openfeature.Client) func(context.Context, string) b
 
 // HasCallerIdentity reports whether ctx carries an authenticated caller.
 //
-// It is the exact condition under which resolution reaches the account layer
-// and the caller's grants at all: with no identity, ResolvedSet stops at the
-// instance layer. A refusal uses it to be truthful about whose answer it is —
-// telling a local stdio user that a capability is "not enabled for you" would
-// send them looking for a grant that cannot apply on a transport with no
-// caller.
+// Kept as the application-layer name for entities.HasCallerIdentity, which is
+// where every gating surface reads it from. One definition, because it decides
+// how a refusal is worded and a second copy would drift.
 func HasCallerIdentity(ctx context.Context) bool {
-	return auth.AgentFromCtx(ctx) != nil
+	return entities.HasCallerIdentity(ctx)
 }

--- a/application/module.go
+++ b/application/module.go
@@ -227,8 +227,16 @@ func Module(cfg config.Config, registry *PresetRegistry) fx.Option {
 		// command once the MCP server exists.
 		fx.Provide(infraagents.ProvideOrchestrator),
 		fx.Provide(func(o *appagents.Orchestrator) ConversationalAgent { return o }),
-		fx.Invoke(func(o *appagents.Orchestrator, r *SkillRegistry, rs ResourceService) {
+		fx.Invoke(func(
+			o *appagents.Orchestrator, r *SkillRegistry, rs ResourceService,
+			client *openfeature.Client, features *FeatureRegistry, logger entities.Logger,
+		) {
 			o.SetSkillSource(r.Skills)
+			// A gated skill is not offered to the coordinator and cannot be
+			// named directly (#485). Wired here rather than left to a caller
+			// for the reason #481 learned the hard way: a gate nothing depends
+			// on is a gate that never runs.
+			o.SetSkillGate(SkillFeatureGate(client, features, logger))
 			// Completed turns become note resources — the episodic memory
 			// that #386 consolidation distills facts from.
 			o.SetEpisodeRecorder(RecordAgentTurn(rs))

--- a/application/skill_feature_gate.go
+++ b/application/skill_feature_gate.go
@@ -1,0 +1,74 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"context"
+	"sync"
+
+	"github.com/open-feature/go-sdk/openfeature"
+
+	"github.com/wepala/weos/v3/application/agents"
+	"github.com/wepala/weos/v3/domain/entities"
+)
+
+// SkillFeatureGate answers whether an agent skill's feature is on for the
+// caller (#485). It is ToolFeatureGate pointed at a different surface — the
+// same OpenFeature client, the same per-caller resolved set, the same
+// precedence — with one addition: it can name the skill in the drift log.
+//
+// A skill's gate key is authored in data, through the API, through MCP, or in
+// a seed file, where no compiler and no reviewer ever sees it. So a key nobody
+// declared is likelier here than it is for a tool, and the log line has to
+// carry the skill's name or an operator cannot find which resource to fix.
+//
+// The rule itself is #484's, deliberately: a skill naming an undeclared key
+// stays offered. A skill closed by drift produces no event at all — the
+// coordinator simply never routes there, the caller is told the agent cannot
+// help, and nothing anywhere says why. What a drifted skill exposes is bounded
+// by #484 in turn: every gated tool gates at its own call site against this
+// same caller, so the skill can be reached and can still run nothing the
+// caller's features do not already allow. A description escapes, not a
+// capability. See tests/e2e/features/feature_flag_agent_skills.feature for the
+// full reasoning and the counter-argument this was chosen over.
+func SkillFeatureGate(
+	client *openfeature.Client, registry *FeatureRegistry, logger entities.Logger,
+) agents.SkillGate {
+	if client == nil {
+		return nil
+	}
+	gate := ToolFeatureGate(client)
+	var loggedDrift sync.Map
+	return func(ctx context.Context, skillName, featureKey string) bool {
+		if featureKey == "" {
+			return true
+		}
+		if registry != nil && logger != nil {
+			if _, declared := registry.Lookup(featureKey); !declared {
+				// Once per skill and key. A coordinator graph is rebuilt every
+				// turn, so logging per evaluation would bury the one line that
+				// says a deploy has drifted under a copy of itself per message.
+				if _, seen := loggedDrift.LoadOrStore(skillName+"\x00"+featureKey, struct{}{}); !seen {
+					logger.Warn(ctx,
+						"an agent skill names a feature nobody declared; the skill stays available "+
+							"and is not gated by anything",
+						"skill", skillName, "feature", featureKey)
+				}
+			}
+		}
+		return gate(ctx, featureKey)
+	}
+}

--- a/domain/entities/agent_skill.go
+++ b/domain/entities/agent_skill.go
@@ -60,6 +60,20 @@ type SkillDefinition struct {
 	Widgets []string
 	// Model optionally overrides the instance's default model ID.
 	Model string
+	// GatedBy names the feature that controls this skill (#485). Empty means
+	// ungated, which is every skill that shipped before gates existed: an
+	// ungated skill is offered and invocable exactly as it always was, with no
+	// lookup and no new failure mode.
+	//
+	// When set, the skill is a routing target only for a caller whose features
+	// reach it, and naming it directly is refused for anybody else. The key is
+	// NOT validated against the registry here. A skill naming a feature nobody
+	// declared keeps its place and the instance logs the drift once — the same
+	// rule #484 applies to tools, kept deliberately identical because both
+	// surfaces ask one gate function with one default. See
+	// tests/e2e/features/feature_flag_agent_skills.feature for the reasoning
+	// and for the counter-argument it was chosen over.
+	GatedBy string
 }
 
 // Validate reports why the definition cannot be loaded. knownTools guards

--- a/domain/entities/feature_gate_refusal.go
+++ b/domain/entities/feature_gate_refusal.go
@@ -1,0 +1,63 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package entities
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
+)
+
+// How a gated capability refuses, in one place for every surface that gates
+// (#484 tools, #485 agent skills, #486 the admin UI).
+//
+// It lives here rather than in each surface because the wording is a decision,
+// not a string: it tells the reader whose answer they are looking at, and a
+// surface that worded it differently would send that reader somewhere else.
+
+// HasCallerIdentity reports whether ctx carries an authenticated caller.
+//
+// It is the exact condition under which resolution reaches the account layer
+// and the caller's grants at all: with no identity, a resolved set is built
+// from the instance layer alone. Every gate that words a refusal branches on
+// this, so the wording cannot drift from the answer.
+func HasCallerIdentity(ctx context.Context) bool {
+	return auth.AgentFromCtx(ctx) != nil
+}
+
+// RefusalScope says whose answer a refusal is.
+//
+// With a caller the answer came from their account and their grants, so "for
+// you" is exact and an admin can change it for them. With none — the local
+// stdio transport, or an anonymous request — resolution stopped at the
+// instance layer, and no account override or personal grant could have
+// reached it. Saying "for you" there would send somebody looking for a grant
+// that cannot apply on the transport they are using.
+func RefusalScope(ctx context.Context) string {
+	if HasCallerIdentity(ctx) {
+		return "for you"
+	}
+	return "on this server"
+}
+
+// GateRefusal is what a caller is told when a gated capability is not theirs.
+// subject is the thing they asked for, named so they can tell this apart from
+// asking for something that does not exist at all.
+func GateRefusal(ctx context.Context, subject, featureKey string) string {
+	return fmt.Sprintf("%s is not available: the %q capability is not enabled %s.",
+		subject, featureKey, RefusalScope(ctx))
+}

--- a/internal/mcp/feature_gate.go
+++ b/internal/mcp/feature_gate.go
@@ -17,12 +17,11 @@ package mcp
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/domain/entities"
 )
 
 // Gating an MCP tool on a feature (epic #480, story #484).
@@ -258,24 +257,8 @@ func refuseGatedCall(
 	}
 	return &mcp.CallToolResult{
 		IsError: true,
-		Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf(
-			"%s is not available: the %q capability is not enabled %s.",
-			call.Params.Name, key, refusalScope(ctx))}},
+		Content: []mcp.Content{&mcp.TextContent{
+			Text: entities.GateRefusal(ctx, call.Params.Name, key),
+		}},
 	}
-}
-
-// refusalScope says whose answer the refusal is, because the two cases send a
-// reader somewhere different.
-//
-// With a caller, the answer came from their account and their grants, so "for
-// you" is exact and an admin can change it for them. With no caller —  the
-// local stdio transport, or an anonymous request — resolution stopped at the
-// instance layer, and no account override or personal grant could have
-// reached it. Saying "for you" there would send a mini-me user looking for a
-// grant that cannot apply on the transport they are using.
-func refusalScope(ctx context.Context) string {
-	if application.HasCallerIdentity(ctx) {
-		return "for you"
-	}
-	return "on this server"
 }

--- a/tests/e2e/feature_agent_skills_steps_test.go
+++ b/tests/e2e/feature_agent_skills_steps_test.go
@@ -1,0 +1,1220 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cucumber/godog"
+
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/domain/entities"
+)
+
+//nolint:funlen // a step table is one statement per contract sentence
+func initFeatureAgentSkillsScenario(sc *godog.ScenarioContext) {
+	w := newSkillsWorld()
+	sc.After(func(ctx context.Context, _ *godog.Scenario, err error) (context.Context, error) {
+		w.teardown()
+		return ctx, err
+	})
+
+	// --- background -------------------------------------------------------
+	sc.Given(`^a WeOS instance where password sign-in is enabled and requests are `+
+		`authenticated by their session$`, func() error { return nil })
+	sc.Given(`^the "([^"]*)" preset is installed$`, w.stepInstallPreset)
+	sc.Given(`^the instance declares these features in code:$`, w.stepDeclareFeatures)
+	sc.Given(`^these agent skills are installed, each naming the feature that gates it:$`, w.stepInstallSkills)
+	sc.Given(`^the tool "([^"]*)" is gated by the feature "([^"]*)"$`, w.stepToolGatedBy)
+	sc.Given(`^the in-app agent is configured with a scripted model$`, func() error { return nil })
+	sc.Given(`^the account "([^"]*)", whose owner "([^"]*)" signs in with password "([^"]*)"$`,
+		w.stepAccountWithOwner)
+
+	// --- staging ----------------------------------------------------------
+	sc.Given(`^nothing has been overridden or granted on this instance$`, func() error { return nil })
+	sc.Given(`^the operator has turned the feature "([^"]*)" (on|off) for the instance$`, w.stepInstanceFlag)
+	sc.When(`^the operator turns the feature "([^"]*)" (on|off) for the instance$`, w.stepInstanceFlag)
+	sc.Given(`^the instance booted with the feature "([^"]*)" (on|off) for the instance$`, w.stepBootedWith)
+	sc.Given(`^"([^"]*)" has turned the feature "([^"]*)" (on|off)$`, w.stepAccountFlag)
+	sc.Given(`^"([^"]*)" also belongs to "([^"]*)"$`, w.stepAlsoBelongs)
+	sc.Given(`^"([^"]*)" has been granted the feature "([^"]*)"$`, w.stepGranted)
+	sc.When(`^"([^"]*)" grants "([^"]*)" to "([^"]*)"$`, w.stepGrantsTo)
+	sc.Given(`^"([^"]*)" holds a grant of "([^"]*)" valid until (\d+) seconds from now$`, w.stepGrantUntil)
+	sc.When(`^"([^"]*)" revokes "([^"]*)" from "([^"]*)"$`, w.stepRevoke)
+	sc.Given(`^the skill "([^"]*)" is gated by the undeclared feature "([^"]*)"$`, w.stepSkillGatedByUndeclared)
+	sc.Given(`^the instance is configured with a maximum cache age of (\d+) minutes$`, w.stepCacheAge)
+	sc.Given(`^the instance has (\d+) skills gated by "([^"]*)"$`, w.stepManySkills)
+	sc.Given(`^the store holding account overrides and grants cannot be read$`, w.stepStoreDown)
+	sc.When(`^the store can be read again$`, w.stepStoreUp)
+	sc.Given(`^the scripted model transfers to "([^"]*)" whatever it is offered$`, w.stepScriptAlwaysTransfers)
+	sc.Given(`^the scripted model routes "([^"]*)" to "([^"]*)"$`, w.stepScriptRoutes)
+
+	// --- signing in -------------------------------------------------------
+	sc.Given(`^"([^"]*)" is signed in to "([^"]*)"$`, w.stepSignedIn)
+	sc.Given(`^both of them are signed in to "([^"]*)"$`, w.stepBothSignedIn)
+
+	// --- turns ------------------------------------------------------------
+	sc.When(`^they take a turn with the in-app agent$`, w.stepTakeTurn)
+	sc.Given(`^they have already taken a turn with the in-app agent$`, w.stepTakeTurn)
+	sc.When(`^they take (\d+) turns with the in-app agent$`, w.stepTakeTurns)
+	sc.When(`^each of them takes a turn with the in-app agent$`, w.stepEachTakesTurn)
+	sc.When(`^"([^"]*)" takes a turn with the in-app agent$`, w.stepNamedTakesTurn)
+	sc.Given(`^they have taken a turn and been offered "([^"]*)"$`, w.stepTookTurnAndOffered)
+	sc.Given(`^they have taken a turn and not been offered "([^"]*)"$`, w.stepTookTurnAndNotOffered)
+	sc.Given(`^"([^"]*)" has already taken a turn and not been offered "([^"]*)"$`, w.stepNamedTookTurnNotOffered)
+	sc.When(`^they take another turn in the same conversation$`, w.stepAnotherTurn)
+	sc.When(`^"([^"]*)" takes another turn in the same conversation$`, w.stepNamedAnotherTurn)
+	sc.When(`^they act in "([^"]*)" and take another turn$`, w.stepActInAndTurn)
+	sc.When(`^they take a turn straight away$`, w.stepTurnStraightAway)
+	sc.Given(`^a turn taken with nobody on the context$`, w.stepAnonymousTurn)
+	sc.When(`^each of them sends "([^"]*)" to the in-app agent$`, w.stepEachSends)
+	sc.When(`^they send "([^"]*)" to the in-app agent$`, w.stepTheySend)
+	sc.Given(`^they have sent "([^"]*)" and not been answered by any skill$`, w.stepSentAndNotAnswered)
+	sc.When(`^"([^"]*)" sends "([^"]*)" again in the same conversation$`, w.stepNamedSendsAgain)
+
+	// --- invoking ---------------------------------------------------------
+	sc.When(`^they invoke the skill "([^"]*)" directly$`, w.stepInvoke)
+	sc.When(`^"([^"]*)" invokes the skill "([^"]*)" directly$`, w.stepNamedInvokes)
+	sc.When(`^they invoke every gated skill the instance has installed$`, w.stepInvokeEveryGated)
+	sc.When(`^they invoke the skill "([^"]*)" directly once that moment has passed$`, w.stepInvokeAfterMoment)
+	sc.When(`^the skill calls the tool "([^"]*)"$`, w.stepSkillCallsTool)
+
+	// --- outcomes ---------------------------------------------------------
+	sc.Then(`^the coordinator (was offered|was not offered) the skill "([^"]*)"$`, w.stepCoordinatorOffered)
+	sc.Then(`^"([^"]*)" was (offered|not offered) "([^"]*)"$`, w.stepPersonOffered)
+	sc.Then(`^both of them were offered "([^"]*)"$`, w.stepBothOffered)
+	sc.Then(`^"([^"]*)" is offered with the description it declares$`, w.stepOfferedWithDescription)
+	sc.Then(`^"([^"]*)" runs with the tools its allowlist declares$`, w.stepRunsWithDeclaredTools)
+	sc.Then(`^invoking the skill "([^"]*)" directly (succeeds|is refused)$`, w.stepInvokingOutcome)
+	sc.Then(`^invoking "([^"]*)" directly (succeeds|is refused)$`, w.stepInvokingOutcome)
+	sc.Then(`^no feature was evaluated for that skill$`, w.stepNoFeatureEvaluated)
+	sc.Then(`^every skill the coordinator was offered was invocable directly$`, w.stepOfferedWereInvocable)
+	sc.Then(`^every gated skill the coordinator was not offered was refused$`, w.stepWithheldWereRefused)
+	sc.Then(`^the invocation is refused with an error the client can read$`, w.stepInvocationRefusedReadable)
+	sc.Then(`^the invocation is refused$`, w.stepInvocationRefused)
+	sc.Then(`^the refusal names the skill "([^"]*)"$`, w.stepRefusalNamesSkill)
+	sc.Then(`^the refusal says the capability is not enabled for them$`, w.stepRefusalSaysNotEnabled)
+	sc.Then(`^the refusal for "([^"]*)" says the capability is not enabled for them$`, w.stepNamedRefusalNotEnabled)
+	sc.Then(`^the refusal for "([^"]*)" says no such skill exists$`, w.stepNamedRefusalUnknown)
+	sc.Then(`^neither refusal ran a skill$`, w.stepNeitherRan)
+	sc.Then(`^the skill's instructions never ran$`, w.stepInstructionsNeverRan)
+	sc.Then(`^no ledger export was recorded$`, w.stepNoLedgerExport)
+	sc.Then(`^the refusal is not a partial reply$`, w.stepRefusalNotPartial)
+	sc.Then(`^the turn did not run "([^"]*)"$`, w.stepTurnDidNotRun)
+	sc.Then(`^the user was given a reply rather than a broken turn$`, w.stepReplyNotBroken)
+	sc.Then(`^the turn ended with a reply the user can read$`, w.stepReplyNotBroken)
+	sc.Then(`^the reply does not name "([^"]*)"$`, w.stepReplyDoesNotName)
+	sc.Then(`^the conversation kept its history$`, w.stepConversationKeptHistory)
+	sc.Then(`^"([^"]*)" is still signed in$`, w.stepStillSignedIn)
+	sc.Then(`^they were not signed out$`, w.stepNotSignedOut)
+	sc.Then(`^the instance was not restarted$`, w.stepNotRestarted)
+	sc.Then(`^the instance was not restarted between the two turns$`, w.stepNotRestarted)
+	sc.Then(`^the turn straight away was offered "([^"]*)"$`, w.stepStraightAwayOffered)
+	sc.Then(`^the invocation after that moment is refused$`, w.stepAfterMomentRefused)
+	sc.Then(`^the later turn was not offered "([^"]*)"$`, w.stepLaterNotOffered)
+	sc.Then(`^nothing invalidated the session in between$`, w.stepNothingInvalidated)
+	sc.Then(`^the maximum cache age had not run out$`, w.stepCacheAgeHadNotRunOut)
+	sc.Then(`^the instance logged the failure$`, w.stepLoggedFailure)
+	sc.Then(`^the instance logged the undeclared feature key once$`, w.stepLoggedDriftOnce)
+	sc.Then(`^the log names the key "([^"]*)"$`, w.stepLogNamesKey)
+	sc.Then(`^the log names the skill "([^"]*)"$`, w.stepLogNamesSkill)
+	sc.Then(`^the skill was reached$`, w.stepSkillWasReached)
+	sc.Then(`^the tool call is refused because the capability is not enabled$`, w.stepToolCallRefused)
+	sc.Then(`^the turn was answered$`, w.stepTurnAnswered)
+	sc.Then(`^both turns were answered$`, w.stepBothTurnsAnswered)
+	sc.Then(`^feature state was read from the database only while that turn was answered$`, w.stepReadOnlyDuringTurn)
+	sc.Then(`^the graph was built without reading feature state once per skill$`, w.stepNotPerSkill)
+	sc.Then(`^no feature state was read from the database after the first turn$`, w.stepNoReadsAfterFirst)
+	sc.Then(`^the skill registry loaded the definitions once for both of them$`, w.stepRegistryLoadedOnce)
+	sc.Then(`^"([^"]*)" was answered by the skill "([^"]*)"$`, w.stepAnsweredBySkill)
+	sc.Then(`^"([^"]*)" was not answered by any skill$`, w.stepNotAnsweredByAnySkill)
+	sc.Then(`^they were answered by the skill "([^"]*)"$`, w.stepTheyAnsweredBySkill)
+	sc.Then(`^"([^"]*)" was given a reply rather than a broken turn$`, w.stepNamedReplyNotBroken)
+	sc.Then(`^no account override or grant was read to answer either$`, w.stepNoAccountLayerRead)
+}
+
+// --- background -----------------------------------------------------------
+
+// stepInstallPreset brings in the agent-skill resource type. The skills the
+// Background installs are ordinary resources of that type, so without it there
+// is nothing to install them into.
+func (w *skillsWorld) stepInstallPreset(name string) error {
+	// Recorded, not installed. This step comes BEFORE the Background declares
+	// the instance's features, and booting here would build the registry from
+	// an empty declaration list.
+	w.presets = append(w.presets, name)
+	return nil
+}
+
+func (w *skillsWorld) stepDeclareFeatures(table *godog.Table) error {
+	metas, err := featureMetasFrom(table)
+	if err != nil {
+		return err
+	}
+	w.declared = metas
+	for _, m := range metas {
+		if _, err := coreAlreadyDeclares(m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepInstallSkills(table *godog.Table) error {
+	for _, row := range table.Rows[1:] {
+		name := strings.TrimSpace(row.Cells[0].Value)
+		gate := strings.TrimSpace(row.Cells[1].Value)
+		install := skillInstall{name: name, gatedBy: gate}
+		if name == "episode_summarizer" {
+			// A non-empty allowlist, so "runs with the tools its allowlist
+			// declares" compares something rather than two empty lists.
+			install.tools = []string{"episodic_recall"}
+		}
+		w.installs = append(w.installs, install)
+	}
+	return nil
+}
+
+// stepToolGatedBy records the Background's statement about the tool surface.
+// #484 owns that gate; this suite only needs to know which tool to try.
+func (w *skillsWorld) stepToolGatedBy(tool, key string) error {
+	if key == "" {
+		return fmt.Errorf("the contract names no feature for the tool %q", tool)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepAccountWithOwner(name, email, password string) error {
+	if err := w.boot(); err != nil {
+		return err
+	}
+	p, err := w.personFor(email, password)
+	if err != nil {
+		return err
+	}
+	if p.accountID == "" {
+		return fmt.Errorf("registering %q created no account", email)
+	}
+	w.accounts[name] = p.accountID
+	return nil
+}
+
+// --- staging --------------------------------------------------------------
+
+func (w *skillsWorld) stepInstanceFlag(key, state string) error {
+	if err := w.boot(); err != nil {
+		return err
+	}
+	return w.features.SetInstanceFeature(context.Background(), key, state == "on")
+}
+
+func (w *skillsWorld) stepBootedWith(key, state string) error {
+	if err := w.stepInstanceFlag(key, state); err != nil {
+		return err
+	}
+	return w.reboot()
+}
+
+func (w *skillsWorld) stepAccountFlag(accountName, key, state string) error {
+	accountID, err := w.accountFor(accountName)
+	if err != nil {
+		return err
+	}
+	return w.features.SetAccountFeature(context.Background(), accountID, key, state == "on")
+}
+
+func (w *skillsWorld) stepAlsoBelongs(email, accountName string) error {
+	return w.addToAccount(email, accountName)
+}
+
+func (w *skillsWorld) stepGranted(email, key string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	return w.features.GrantToAgent(context.Background(), p.accountID, p.agentID, key, application.GrantTerms{
+		GrantedByEmail: "ops@harborlegal.example", Source: "test",
+	})
+}
+
+func (w *skillsWorld) stepGrantsTo(_, key, email string) error {
+	return w.stepGranted(email, key)
+}
+
+func (w *skillsWorld) stepGrantUntil(email, key string, seconds int) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	w.moment = time.Now().Add(time.Duration(seconds) * time.Second)
+	w.momentSet = true
+	w.windowStart = time.Now()
+	through := w.moment
+	return w.features.GrantToAgent(context.Background(), p.accountID, p.agentID, key, application.GrantTerms{
+		ValidThrough: &through, GrantedByEmail: "ops@harborlegal.example", Source: "test",
+	})
+}
+
+func (w *skillsWorld) stepRevoke(_, key, subject string) error {
+	p, err := w.person(subject)
+	if err != nil {
+		return err
+	}
+	removed, err := w.features.RevokeFromAgent(context.Background(), p.accountID, p.agentID, key)
+	if err != nil {
+		return err
+	}
+	if !removed {
+		return fmt.Errorf("there was no grant of %q to revoke from %q", key, subject)
+	}
+	return nil
+}
+
+// stepSkillGatedByUndeclared rewrites a skill's gate to a key nobody declared,
+// which is what a typo in an agent-skill resource looks like.
+func (w *skillsWorld) stepSkillGatedByUndeclared(skill, key string) error {
+	for i := range w.installs {
+		if w.installs[i].name == skill {
+			w.installs[i].gatedBy = key
+			return nil
+		}
+	}
+	return fmt.Errorf("no skill named %q is installed", skill)
+}
+
+func (w *skillsWorld) stepCacheAge(minutes int) error {
+	w.maxCacheAge = time.Duration(minutes) * time.Minute
+	if w.app == nil {
+		return nil
+	}
+	return w.reboot()
+}
+
+// stepManySkills installs enough gated skills that a per-skill evaluation
+// would show up in the read count.
+func (w *skillsWorld) stepManySkills(count int, key string) error {
+	for i := 0; i < count; i++ {
+		w.installs = append(w.installs, skillInstall{
+			name: fmt.Sprintf("bulk_skill_%02d", i), gatedBy: key,
+		})
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepStoreDown() error {
+	if err := w.boot(); err != nil {
+		return err
+	}
+	w.settings.setDown(true)
+	w.grants.setDown(true)
+	return nil
+}
+
+func (w *skillsWorld) stepStoreUp() error {
+	w.settings.setDown(false)
+	w.grants.setDown(false)
+	return nil
+}
+
+// --- the script -----------------------------------------------------------
+
+// reloadScript rebuilds the model from the new script. The scripted model is
+// constructed at boot from WEOS_AGENT_SCRIPT, so a scenario that sets its
+// script after the Background has booted would otherwise run the default one —
+// and a scenario asserting a skill was NOT reached would pass for the wrong
+// reason.
+func (w *skillsWorld) reloadScript() error {
+	if w.app == nil {
+		return nil
+	}
+	return w.reboot()
+}
+
+func (w *skillsWorld) stepScriptAlwaysTransfers(skill string) error {
+	w.scriptRules = []map[string]any{
+		{"call": map[string]any{"tool": "transfer_to_agent", "args": map[string]any{"agent_name": skill}}},
+		{"afterTool": "transfer_to_agent", "reply": skillAnsweredMarker + skill},
+		{"afterToolFailed": "transfer_to_agent", "reply": "I cannot help with that."},
+		{"reply": "I cannot help with that."},
+	}
+	return w.reloadScript()
+}
+
+func (w *skillsWorld) stepScriptRoutes(prompt, skill string) error {
+	w.scriptRules = []map[string]any{
+		{"whenMessageContains": prompt,
+			"call": map[string]any{"tool": "transfer_to_agent", "args": map[string]any{"agent_name": skill}}},
+		{"afterTool": "transfer_to_agent", "reply": skillAnsweredMarker + skill},
+		{"afterToolFailed": "transfer_to_agent", "reply": "I cannot help with that."},
+		{"reply": "I cannot help with that."},
+	}
+	return w.reloadScript()
+}
+
+// --- signing in -----------------------------------------------------------
+
+func (w *skillsWorld) stepSignedIn(email, accountName string) error {
+	if err := w.boot(); err != nil {
+		return err
+	}
+	if _, err := w.personFor(email, "correct-horse-battery-staple"); err != nil {
+		return err
+	}
+	if err := w.actIn(email, accountName); err != nil {
+		return err
+	}
+	if !contains(w.signedInOrder, email) {
+		w.signedInOrder = append(w.signedInOrder, email)
+	}
+	w.restartBaseline = w.boots
+	return nil
+}
+
+// actorOrNobody is whoever the scenario is acting as, or nobody at all for the
+// scenarios that take a turn with no caller on the context.
+func (w *skillsWorld) actorOrNobody() (*featurePerson, string, error) {
+	if len(w.signedInOrder) == 0 {
+		return nil, "conv-anonymous", nil
+	}
+	p, err := w.soleActor()
+	if err != nil {
+		return nil, "", err
+	}
+	return p, w.conversationFor(p.email), nil
+}
+
+func (w *skillsWorld) actIn(email, accountName string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	accountID, err := w.accountFor(accountName)
+	if err != nil {
+		return err
+	}
+	p.accountID = accountID
+	return nil
+}
+
+func (w *skillsWorld) stepBothSignedIn(accountName string) error {
+	for _, email := range w.staged() {
+		if err := w.stepSignedIn(email, accountName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// --- turns ----------------------------------------------------------------
+
+func (w *skillsWorld) conversationFor(email string) string { return "conv-" + email }
+
+func (w *skillsWorld) stepTakeTurn() error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	return w.recordTurn(p, "hello")
+}
+
+func (w *skillsWorld) recordTurn(p *featurePerson, message string) error {
+	if err := w.ensureSkills(); err != nil {
+		return err
+	}
+	w.readsBefore = w.settings.count()
+	rec := w.takeTurn(p, message, w.conversationFor(p.email))
+	w.readsAfterTurn = w.settings.count()
+	if rec.err != nil {
+		return fmt.Errorf("the turn failed: %w", rec.err)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepTakeTurns(count int) error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	for i := 0; i < count; i++ {
+		if err := w.recordTurn(p, "hello"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepEachTakesTurn() error {
+	for _, email := range w.signedInOrder {
+		if err := w.stepNamedTakesTurn(email); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepNamedTakesTurn(email string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	return w.recordTurn(p, "hello")
+}
+
+func (w *skillsWorld) stepTookTurnAndOffered(skill string) error {
+	if err := w.stepTakeTurn(); err != nil {
+		return err
+	}
+	return w.stepCoordinatorOffered("was offered", skill)
+}
+
+func (w *skillsWorld) stepTookTurnAndNotOffered(skill string) error {
+	if err := w.stepTakeTurn(); err != nil {
+		return err
+	}
+	return w.stepCoordinatorOffered("was not offered", skill)
+}
+
+func (w *skillsWorld) stepNamedTookTurnNotOffered(email, skill string) error {
+	if err := w.stepNamedTakesTurn(email); err != nil {
+		return err
+	}
+	return w.stepPersonOffered(email, "not offered", skill)
+}
+
+func (w *skillsWorld) stepAnotherTurn() error { return w.stepTakeTurn() }
+
+func (w *skillsWorld) stepNamedAnotherTurn(email string) error { return w.stepNamedTakesTurn(email) }
+
+func (w *skillsWorld) stepActInAndTurn(accountName string) error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	if err := w.actIn(p.email, accountName); err != nil {
+		return err
+	}
+	return w.recordTurn(p, "hello")
+}
+
+func (w *skillsWorld) stepTurnStraightAway() error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	w.invsBefore = w.invSpy.count()
+	if err := w.recordTurn(p, "hello"); err != nil {
+		return err
+	}
+	rec, err := w.turnFor(p.email)
+	if err != nil {
+		return err
+	}
+	w.straightAwayOffered = rec.offered
+	return nil
+}
+
+func (w *skillsWorld) stepAnonymousTurn() error {
+	if err := w.boot(); err != nil {
+		return err
+	}
+	w.takeTurn(nil, "hello", "conv-anonymous")
+	w.lastActor = ""
+	return nil
+}
+
+func (w *skillsWorld) stepEachSends(message string) error {
+	for _, email := range w.signedInOrder {
+		p, err := w.person(email)
+		if err != nil {
+			return err
+		}
+		if err := w.recordTurn(p, message); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepTheySend(message string) error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	return w.recordTurn(p, message)
+}
+
+func (w *skillsWorld) stepSentAndNotAnswered(message string) error {
+	if err := w.stepTheySend(message); err != nil {
+		return err
+	}
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	return w.stepNotAnsweredByAnySkill(p.email)
+}
+
+func (w *skillsWorld) stepNamedSendsAgain(email, message string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	return w.recordTurn(p, message)
+}
+
+// --- invoking -------------------------------------------------------------
+
+func (w *skillsWorld) stepInvoke(skill string) error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	w.invokeSkill(p, skill, w.conversationFor(p.email))
+	return nil
+}
+
+func (w *skillsWorld) stepNamedInvokes(email, skill string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	w.invokeSkill(p, skill, w.conversationFor(email))
+	return nil
+}
+
+func (w *skillsWorld) stepInvokeEveryGated() error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	for _, s := range w.installs {
+		if s.gatedBy == "" {
+			continue
+		}
+		w.invokeSkill(p, s.name, w.conversationFor(p.email)+"-"+s.name)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepInvokeAfterMoment(skill string) error {
+	if w.momentSet {
+		if wait := time.Until(w.moment); wait > 0 {
+			time.Sleep(wait + 50*time.Millisecond)
+		}
+	}
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	w.afterMomentErr = w.invokeSkill(p, skill, w.conversationFor(p.email)+"-after")
+	return nil
+}
+
+// stepSkillCallsTool exercises the tool the reached skill would use. The tool
+// gate is #484's and answers for the same caller, which is the whole reason a
+// skill exposed by drift is bounded.
+func (w *skillsWorld) stepSkillCallsTool(tool string) error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	gate := application.ToolFeatureGate(w.client)
+	if gate == nil {
+		return fmt.Errorf("the tool gate is not wired")
+	}
+	w.toolCallAttempted = true
+	w.toolCallAllowed = gate(w.ctxFor(p), "ledger-export")
+	return nil
+}
+
+// --- outcomes -------------------------------------------------------------
+
+func (w *skillsWorld) stepCoordinatorOffered(presence, skill string) error {
+	rec, err := w.soleTurn()
+	if err != nil {
+		return err
+	}
+	got := contains(rec.offered, skill)
+	if presence == "was offered" && !got {
+		return fmt.Errorf("the coordinator was not offered %q; it was offered %v", skill, rec.offered)
+	}
+	if presence == "was not offered" && got {
+		return fmt.Errorf("the coordinator was still offered %q", skill)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepPersonOffered(email, presence, skill string) error {
+	rec, err := w.turnFor(email)
+	if err != nil {
+		return err
+	}
+	got := contains(rec.offered, skill)
+	if presence == "offered" && !got {
+		return fmt.Errorf("%q was not offered %q; they were offered %v", email, skill, rec.offered)
+	}
+	if presence == "not offered" && got {
+		return fmt.Errorf("%q was offered %q, which they may not use", email, skill)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepBothOffered(skill string) error {
+	for _, email := range w.signedInOrder {
+		if err := w.stepPersonOffered(email, "offered", skill); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *skillsWorld) offeredDefinition(skill string) (entities.SkillDefinition, error) {
+	p, err := w.soleActor()
+	if err != nil {
+		return entities.SkillDefinition{}, err
+	}
+	defs, err := w.orchestrator.RoutableSkills(w.ctxFor(p))
+	if err != nil {
+		return entities.SkillDefinition{}, err
+	}
+	for _, def := range defs {
+		if def.Name == skill {
+			return def, nil
+		}
+	}
+	return entities.SkillDefinition{}, fmt.Errorf("%q is not among the offered skills", skill)
+}
+
+func (w *skillsWorld) stepOfferedWithDescription(skill string) error {
+	def, err := w.offeredDefinition(skill)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(def.Description) == "" {
+		return fmt.Errorf("%q is offered with no description; the coordinator routes on it", skill)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepRunsWithDeclaredTools(skill string) error {
+	def, err := w.offeredDefinition(skill)
+	if err != nil {
+		return err
+	}
+	for _, s := range w.installs {
+		if s.name != skill {
+			continue
+		}
+		if len(def.Tools) != len(s.tools) {
+			return fmt.Errorf("%q was declared with tools %v but is offered with %v", skill, s.tools, def.Tools)
+		}
+		return nil
+	}
+	return fmt.Errorf("no skill named %q was installed", skill)
+}
+
+func (w *skillsWorld) stepInvokingOutcome(skill, outcome string) error {
+	p, conversation, err := w.actorOrNobody()
+	if err != nil {
+		return err
+	}
+	invErr := w.invokeSkill(p, skill, conversation+"-check-"+skill)
+	switch outcome {
+	case "succeeds":
+		if refusedBySkillGate(invErr) {
+			return fmt.Errorf("invoking %q was refused: %v", skill, invErr)
+		}
+		if invErr != nil {
+			return fmt.Errorf("invoking %q failed: %v", skill, invErr)
+		}
+	case "is refused":
+		if !refusedBySkillGate(invErr) {
+			return fmt.Errorf("invoking %q was not refused; got %v", skill, invErr)
+		}
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepNoFeatureEvaluated() error {
+	// An ungated skill takes the no-lookup path: the gate is never asked, so
+	// no read is attributable to it. Proven by the read count not moving
+	// across an invocation of it.
+	before := w.settings.count()
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	w.invokeSkill(p, "knowledge_graph_researcher", w.conversationFor(p.email)+"-ungated")
+	if got := w.settings.count(); got != before {
+		return fmt.Errorf("invoking an ungated skill read feature state %d time(s)", got-before)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepOfferedWereInvocable() error {
+	rec, err := w.soleTurn()
+	if err != nil {
+		return err
+	}
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	for _, s := range w.installs {
+		if s.gatedBy == "" || !contains(rec.offered, s.name) {
+			continue
+		}
+		invErr, ok := w.invocationFor(p.email, s.name)
+		if !ok {
+			return fmt.Errorf("%q was offered but never invoked", s.name)
+		}
+		if refusedBySkillGate(invErr) {
+			return fmt.Errorf("%q was offered but the direct door refused it", s.name)
+		}
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepWithheldWereRefused() error {
+	rec, err := w.soleTurn()
+	if err != nil {
+		return err
+	}
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	checked := 0
+	for _, s := range w.installs {
+		if s.gatedBy == "" || contains(rec.offered, s.name) {
+			continue
+		}
+		invErr, ok := w.invocationFor(p.email, s.name)
+		if !ok {
+			return fmt.Errorf("%q was withheld but never invoked", s.name)
+		}
+		if !refusedBySkillGate(invErr) {
+			return fmt.Errorf("%q was withheld from the graph but the direct door let it through", s.name)
+		}
+		checked++
+	}
+	if checked == 0 {
+		return fmt.Errorf("no gated skill was withheld, so this proves nothing")
+	}
+	return nil
+}
+
+func (w *skillsWorld) lastInvocation() (string, error, error) {
+	p, err := w.soleActor()
+	if err != nil {
+		return "", nil, err
+	}
+	var name string
+	var last error
+	for key, invErr := range w.invocations {
+		if !strings.HasPrefix(key, p.email+"|") {
+			continue
+		}
+		if refusedBySkillGate(invErr) || refusedAsUnknown(invErr) {
+			name = strings.TrimPrefix(key, p.email+"|")
+			last = invErr
+		}
+	}
+	if name == "" {
+		return "", nil, fmt.Errorf("no invocation was refused")
+	}
+	return name, last, nil
+}
+
+func (w *skillsWorld) stepInvocationRefused() error {
+	_, _, err := w.lastInvocation()
+	return err
+}
+
+func (w *skillsWorld) stepInvocationRefusedReadable() error {
+	_, invErr, err := w.lastInvocation()
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(invErr.Error()) == "" {
+		return fmt.Errorf("the refusal carries no text a client can read")
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepRefusalNamesSkill(skill string) error {
+	_, invErr, err := w.lastInvocation()
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(invErr.Error(), skill) {
+		return fmt.Errorf("the refusal does not name %q: %v", skill, invErr)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepRefusalSaysNotEnabled() error {
+	_, invErr, err := w.lastInvocation()
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(invErr.Error(), "not enabled") {
+		return fmt.Errorf("the refusal does not say the capability is not enabled: %v", invErr)
+	}
+	return nil
+}
+
+func (w *skillsWorld) namedInvocation(skill string) (error, error) {
+	p, err := w.soleActor()
+	if err != nil {
+		return nil, err
+	}
+	invErr, ok := w.invocationFor(p.email, skill)
+	if !ok {
+		return nil, fmt.Errorf("%q was never invoked", skill)
+	}
+	return invErr, nil
+}
+
+func (w *skillsWorld) stepNamedRefusalNotEnabled(skill string) error {
+	invErr, err := w.namedInvocation(skill)
+	if err != nil {
+		return err
+	}
+	if !refusedBySkillGate(invErr) {
+		return fmt.Errorf("invoking %q was not refused as a capability: %v", skill, invErr)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepNamedRefusalUnknown(skill string) error {
+	invErr, err := w.namedInvocation(skill)
+	if err != nil {
+		return err
+	}
+	if !refusedAsUnknown(invErr) {
+		return fmt.Errorf("invoking %q did not say no such skill exists: %v", skill, invErr)
+	}
+	if refusedBySkillGate(invErr) {
+		return fmt.Errorf("a missing skill was refused as though it were a permission problem: %v", invErr)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepNeitherRan() error {
+	if len(w.skillRuns) != 0 {
+		return fmt.Errorf("a refused invocation still ran a skill: %v", w.skillRuns)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepInstructionsNeverRan() error { return w.stepNeitherRan() }
+
+// stepNoLedgerExport asserts nothing an export would need actually happened.
+// The two scenarios that use it stop the work at different points, and both
+// must be real: one refuses the skill outright, the other lets a drifted skill
+// be reached and then refuses the tool underneath it.
+func (w *skillsWorld) stepNoLedgerExport() error {
+	if w.toolCallAttempted {
+		if w.toolCallAllowed {
+			return fmt.Errorf("the tool gate allowed the export for a caller whose feature is off")
+		}
+		return nil
+	}
+	if w.skillRuns["ledger_reporter"] != 0 {
+		return fmt.Errorf("the refused skill ran %d time(s)", w.skillRuns["ledger_reporter"])
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepRefusalNotPartial() error {
+	_, invErr, err := w.lastInvocation()
+	if err != nil {
+		return err
+	}
+	if invErr == nil {
+		return fmt.Errorf("the invocation was not refused at all")
+	}
+	return w.stepNeitherRan()
+}
+
+func (w *skillsWorld) stepTurnDidNotRun(skill string) error {
+	rec, err := w.soleTurn()
+	if err != nil {
+		return err
+	}
+	if rec.ranSkill == skill {
+		return fmt.Errorf("the turn was answered by %q, which the caller may not reach", skill)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepReplyNotBroken() error {
+	rec, err := w.soleTurn()
+	if err != nil {
+		return err
+	}
+	if rec.err != nil {
+		return fmt.Errorf("the turn ended in an error rather than a reply: %v", rec.err)
+	}
+	if strings.TrimSpace(rec.reply) == "" {
+		return fmt.Errorf("the turn produced no reply at all")
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepNamedReplyNotBroken(email string) error {
+	rec, err := w.turnFor(email)
+	if err != nil {
+		return err
+	}
+	if rec.err != nil {
+		return fmt.Errorf("%q's turn ended in an error: %v", email, rec.err)
+	}
+	if strings.TrimSpace(rec.reply) == "" {
+		return fmt.Errorf("%q got no reply at all", email)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepReplyDoesNotName(skill string) error {
+	rec, err := w.soleTurn()
+	if err != nil {
+		return err
+	}
+	if strings.Contains(rec.reply, skill) {
+		return fmt.Errorf("the reply named a skill the caller cannot reach: %q", rec.reply)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepConversationKeptHistory() error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	history, err := w.orchestrator.History(w.ctxFor(p), w.conversationFor(p.email), p.agentID)
+	if err != nil {
+		return fmt.Errorf("could not read the conversation: %w", err)
+	}
+	if len(history) < 2 {
+		return fmt.Errorf("the conversation holds %d message(s); the earlier turn was lost", len(history))
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepStillSignedIn(email string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	if p.accountID == "" {
+		return fmt.Errorf("%q is no longer acting in any account", email)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepNotSignedOut() error {
+	for _, email := range w.signedInOrder {
+		if err := w.stepStillSignedIn(email); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepNotRestarted() error {
+	if w.boots != w.restartBaseline {
+		return fmt.Errorf("the instance restarted %d time(s) during the scenario", w.boots-w.restartBaseline)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepStraightAwayOffered(skill string) error {
+	if !contains(w.straightAwayOffered, skill) {
+		return fmt.Errorf("the turn straight away was not offered %q; it had %v", skill, w.straightAwayOffered)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepAfterMomentRefused() error {
+	if !refusedBySkillGate(w.afterMomentErr) {
+		return fmt.Errorf("the invocation after the window closed was not refused: %v", w.afterMomentErr)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepLaterNotOffered(skill string) error {
+	rec, err := w.soleTurn()
+	if err != nil {
+		return err
+	}
+	if contains(rec.offered, skill) {
+		return fmt.Errorf("the later turn was still offered %q after the window closed", skill)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepNothingInvalidated() error {
+	if got := w.invSpy.count(); got != w.invsBefore {
+		return fmt.Errorf("%d invalidation(s) fired; a window that closes must announce nothing", got-w.invsBefore)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepCacheAgeHadNotRunOut() error {
+	if w.maxCacheAge <= 0 {
+		return fmt.Errorf("no maximum cache age was configured, so this proves nothing")
+	}
+	if elapsed := time.Since(w.windowStart); elapsed >= w.maxCacheAge {
+		return fmt.Errorf("the scenario took %s, which is past the %s cache age", elapsed, w.maxCacheAge)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepLoggedFailure() error {
+	if len(w.logs.matching("feature evaluation failed")) == 0 {
+		return fmt.Errorf("nothing was logged when the store could not be read")
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepLoggedDriftOnce() error {
+	lines := w.logs.matching("an agent skill names a feature nobody declared")
+	if len(lines) != 1 {
+		return fmt.Errorf("the undeclared key was logged %d times, want once: %v", len(lines), lines)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepLogNamesKey(key string) error {
+	if len(w.logs.matching("an agent skill names a feature", key)) == 0 {
+		return fmt.Errorf("no log line names the key %q: %v", key, w.logs.matching("an agent skill names a feature"))
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepLogNamesSkill(skill string) error {
+	if len(w.logs.matching("an agent skill names a feature", skill)) == 0 {
+		return fmt.Errorf("no log line names the skill %q: %v", skill, w.logs.matching("an agent skill names a feature"))
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepSkillWasReached() error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	invErr, ok := w.invocationFor(p.email, "ledger_reporter")
+	if !ok {
+		return fmt.Errorf("the skill was never invoked")
+	}
+	if refusedBySkillGate(invErr) {
+		return fmt.Errorf("the skill was refused, so drift did not leave it in place: %v", invErr)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepToolCallRefused() error {
+	if !w.toolCallAttempted {
+		return fmt.Errorf("no tool call was attempted, so this proves nothing")
+	}
+	if w.toolCallAllowed {
+		return fmt.Errorf("the tool the drifted skill reached for was allowed; " +
+			"a skill exposed by drift must still reach no capability")
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepTurnAnswered() error { return w.stepReplyNotBroken() }
+
+func (w *skillsWorld) stepBothTurnsAnswered() error { return w.stepReplyNotBroken() }
+
+func (w *skillsWorld) stepReadOnlyDuringTurn() error {
+	if w.readsAfterTurn <= w.readsBefore {
+		return fmt.Errorf("answering the turn read no feature state at all, so the count proves nothing")
+	}
+	return nil
+}
+
+// stepNotPerSkill is the cost claim: twenty gated skills must not cost twenty
+// reads. One resolve serves them all.
+func (w *skillsWorld) stepNotPerSkill() error {
+	gated := 0
+	for _, s := range w.installs {
+		if s.gatedBy != "" {
+			gated++
+		}
+	}
+	if gated < 20 {
+		return fmt.Errorf("only %d gated skills are installed, so this proves nothing", gated)
+	}
+	reads := w.readsAfterTurn - w.readsBefore
+	if reads >= gated {
+		return fmt.Errorf("the turn read feature state %d times for %d gated skills; one resolve must serve them all",
+			reads, gated)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepNoReadsAfterFirst() error {
+	if got := w.settings.count(); got != w.readsAfterTurn {
+		return fmt.Errorf("%d further read(s) happened after the first turn", got-w.readsAfterTurn)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepRegistryLoadedOnce() error {
+	// The registry caches until a skill event marks it dirty; no scenario here
+	// installs a skill mid-run, so both callers share one load. Asserted by
+	// the definitions being identical for two different callers' filters.
+	if len(w.signedInOrder) < 2 {
+		return fmt.Errorf("only %d people took a turn, so this proves nothing", len(w.signedInOrder))
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepAnsweredBySkill(email, skill string) error {
+	rec, err := w.turnFor(email)
+	if err != nil {
+		return err
+	}
+	if rec.ranSkill != skill {
+		return fmt.Errorf("%q was answered by %q, not by %q (reply: %q)", email, rec.ranSkill, skill, rec.reply)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepTheyAnsweredBySkill(skill string) error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	return w.stepAnsweredBySkill(p.email, skill)
+}
+
+func (w *skillsWorld) stepNotAnsweredByAnySkill(email string) error {
+	rec, err := w.turnFor(email)
+	if err != nil {
+		return err
+	}
+	if rec.ranSkill != "" {
+		return fmt.Errorf("%q was answered by the skill %q, which they may not reach", email, rec.ranSkill)
+	}
+	return nil
+}
+
+func (w *skillsWorld) stepNoAccountLayerRead() error {
+	if got := w.settings.accountCount(); got != 0 {
+		return fmt.Errorf("%d account override read(s) happened for a turn with nobody on the context", got)
+	}
+	if got := w.grants.count(); got != 0 {
+		return fmt.Errorf("%d grant read(s) happened for a turn with nobody on the context", got)
+	}
+	return nil
+}
+
+var _ = sort.Strings

--- a/tests/e2e/feature_agent_skills_world_test.go
+++ b/tests/e2e/feature_agent_skills_world_test.go
@@ -1,0 +1,549 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cucumber/godog"
+	"github.com/open-feature/go-sdk/openfeature"
+	"go.uber.org/fx"
+
+	"github.com/akeemphilbert/pericarp/pkg/auth"
+	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
+	authentities "github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
+
+	"github.com/wepala/weos/v3/application"
+	appagents "github.com/wepala/weos/v3/application/agents"
+	"github.com/wepala/weos/v3/application/presets"
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
+	"github.com/wepala/weos/v3/infrastructure/agents"
+	"github.com/wepala/weos/v3/internal/config"
+)
+
+// TestFeatureAgentSkills runs the acceptance contract for story #485.
+//
+//	GODOG_TAGS=@story-485 go test ./tests/e2e/ -run TestFeatureAgentSkills
+func TestFeatureAgentSkills(t *testing.T) {
+	tags := "~@wip"
+	if v := os.Getenv("GODOG_TAGS"); v != "" {
+		tags = v
+	}
+	suite := godog.TestSuite{
+		ScenarioInitializer: initFeatureAgentSkillsScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"features/feature_flag_agent_skills.feature"},
+			Tags:     tags,
+			Strict:   true,
+			TestingT: t,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("agent skill gating acceptance scenarios failed")
+	}
+}
+
+// --- the world -------------------------------------------------------------
+
+// skillInstall is one agent-skill resource the Background installs.
+type skillInstall struct {
+	name    string
+	gatedBy string
+	tools   []string
+}
+
+// turnRecord is what one conversation turn observed, kept per person so a
+// scenario can compare two people without re-running either turn.
+type turnRecord struct {
+	offered  []string
+	reply    string
+	err      error
+	ranSkill string
+}
+
+type skillsWorld struct {
+	app    *fx.App
+	tmpDir string
+	dsn    string
+	boots  int
+
+	registry     *application.FeatureRegistry
+	features     *application.FeatureService
+	resolver     *application.FeatureResolver
+	client       *openfeature.Client
+	orchestrator *appagents.Orchestrator
+	skillReg     *application.SkillRegistry
+
+	settings *toolsSettingsSpy
+	grants   *toolsGrantSpy
+	invSpy   *invalidatorSpy
+	logs     *loggerSpy
+
+	resources application.ResourceService
+	rts       application.ResourceTypeService
+
+	authService authapp.AuthenticationService
+	accountRepo authrepos.AccountRepository
+
+	declared    []entities.FeatureMeta
+	installs    []skillInstall
+	maxCacheAge time.Duration
+	scriptPath  string
+	scriptRules []map[string]any
+
+	people   map[string]*featurePerson
+	accounts map[string]string
+
+	signedInOrder []string
+	turns         map[string]*turnRecord
+	invocations   map[string]error
+	skillRuns     map[string]int
+
+	restartBaseline int
+	readsBefore     int
+	readsAfterTurn  int
+	invsBefore      int
+
+	straightAwayOffered []string
+	afterMomentErr      error
+	momentSet           bool
+	moment              time.Time
+	windowStart         time.Time
+
+	lastActor         string
+	skillsInstalled   bool
+	presets           []string
+	toolCallAttempted bool
+	toolCallAllowed   bool
+}
+
+func newSkillsWorld() *skillsWorld {
+	return &skillsWorld{
+		people:      map[string]*featurePerson{},
+		accounts:    map[string]string{},
+		turns:       map[string]*turnRecord{},
+		invocations: map[string]error{},
+		skillRuns:   map[string]int{},
+	}
+}
+
+func (w *skillsWorld) teardown() {
+	if w.app != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		defer cancel()
+		_ = w.app.Stop(ctx)
+		w.app = nil
+	}
+	os.Unsetenv(agents.AgentScriptEnv)
+	if w.tmpDir != "" {
+		_ = os.RemoveAll(w.tmpDir)
+	}
+}
+
+// defaultScript answers every turn with a plain reply. Scenarios that need
+// routing replace it before the app boots.
+func defaultSkillScript() []map[string]any {
+	return []map[string]any{
+		{"reply": "I looked at that for you."},
+	}
+}
+
+func (w *skillsWorld) writeScript() error {
+	rules := w.scriptRules
+	if rules == nil {
+		rules = defaultSkillScript()
+	}
+	raw, err := json.Marshal(map[string]any{"rules": rules})
+	if err != nil {
+		return err
+	}
+	w.scriptPath = filepath.Join(w.tmpDir, "agent-script.json")
+	if err := os.WriteFile(w.scriptPath, raw, 0o600); err != nil {
+		return err
+	}
+	os.Setenv(agents.AgentScriptEnv, w.scriptPath)
+	return nil
+}
+
+func (w *skillsWorld) boot() error {
+	if w.app != nil {
+		return nil
+	}
+	if w.tmpDir == "" {
+		dir, err := os.MkdirTemp("", "weos-feature-skills-e2e-")
+		if err != nil {
+			return fmt.Errorf("could not create a temp dir: %w", err)
+		}
+		w.tmpDir = dir
+		w.dsn = filepath.Join(dir, "skills.db")
+	}
+	if err := w.writeScript(); err != nil {
+		return err
+	}
+	pw := "true"
+	os.Setenv("PASSWORD_AUTH_ENABLED", pw)
+	os.Unsetenv("GOOGLE_CLIENT_ID")
+	os.Unsetenv("GOOGLE_CLIENT_SECRET")
+
+	cfg := config.Default()
+	cfg.LoadFromEnvironment()
+	cfg.DatabaseDSN = w.dsn
+	cfg.LogLevel = "error"
+	if w.maxCacheAge > 0 {
+		cfg.Features.CacheMaxAge = w.maxCacheAge
+	}
+	cfg.Features.Declared = declarationsBeyondCore(w.declared)
+
+	w.settings = &toolsSettingsSpy{}
+	w.grants = &toolsGrantSpy{}
+	w.invSpy = &invalidatorSpy{}
+	w.logs = &loggerSpy{}
+
+	app := fx.New(
+		fx.NopLogger,
+		application.Module(cfg, presets.NewDefaultRegistry()),
+		fx.Decorate(func(inner repositories.FeatureSettingsRepository) repositories.FeatureSettingsRepository {
+			w.settings.inner = inner
+			return w.settings
+		}),
+		fx.Decorate(func(inner repositories.FeatureGrantRepository) repositories.FeatureGrantRepository {
+			w.grants.inner = inner
+			return w.grants
+		}),
+		fx.Decorate(func(inner repositories.FeatureCacheInvalidator) repositories.FeatureCacheInvalidator {
+			w.invSpy.inner = inner
+			return w.invSpy
+		}),
+		fx.Decorate(func(inner entities.Logger) entities.Logger {
+			w.logs.inner = inner
+			return w.logs
+		}),
+		fx.Populate(&w.registry, &w.features, &w.resolver, &w.client),
+		fx.Populate(&w.orchestrator, &w.skillReg),
+		fx.Populate(&w.resources, &w.rts),
+		fx.Populate(&w.authService, &w.accountRepo),
+	)
+	startCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+	defer cancel()
+	if err := app.Start(startCtx); err != nil {
+		return fmt.Errorf("failed to start app: %w", err)
+	}
+	w.app = app
+	w.boots++
+	w.restartBaseline = w.boots
+	// The skills are installed by whichever step first needs them: the
+	// agent-skill resource type arrives with the preset, which the Background
+	// installs after the application is up.
+	w.skillsInstalled = false
+	return nil
+}
+
+// ensureSkills installs the Background's skills the first time a step needs
+// them, and after a reboot finds them already in the database.
+func (w *skillsWorld) ensureSkills() error {
+	if w.skillsInstalled {
+		return nil
+	}
+	for _, name := range w.presets {
+		if _, err := w.rts.InstallPreset(context.Background(), name, true); err != nil {
+			return fmt.Errorf("could not install the %q preset: %w", name, err)
+		}
+	}
+	existing, err := w.skillReg.Skills(context.Background())
+	if err == nil && len(existing) >= len(w.installs) && len(w.installs) > 0 {
+		w.skillsInstalled = true
+		return nil
+	}
+	if err := w.installSkills(); err != nil {
+		return err
+	}
+	w.skillsInstalled = true
+	return nil
+}
+
+func (w *skillsWorld) reboot() error {
+	if w.app != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		defer cancel()
+		if err := w.app.Stop(ctx); err != nil {
+			return err
+		}
+		w.app = nil
+	}
+	return w.boot()
+}
+
+// installSkills creates the agent-skill resources the Background names. The
+// resources are created once; a reboot finds them already there.
+func (w *skillsWorld) installSkills() error {
+	ctx := context.Background()
+	existing, err := w.skillReg.Skills(ctx)
+	if err == nil && len(existing) >= len(w.installs) && len(w.installs) > 0 {
+		return nil
+	}
+	for _, s := range w.installs {
+		if err := w.installSkill(s); err != nil {
+			return err
+		}
+	}
+	w.skillReg.MarkDirty()
+	return nil
+}
+
+func (w *skillsWorld) installSkill(s skillInstall) error {
+	tools := s.tools
+	if tools == nil {
+		tools = []string{}
+	}
+	body := map[string]any{
+		"schemaVersion": entities.SkillSchemaVersion,
+		"name":          s.name,
+		"description":   "Handles " + strings.ReplaceAll(s.name, "_", " ") + " requests",
+		"instructions":  "You are the " + s.name + " skill. Answer briefly.",
+		"tools":         tools,
+		"mode":          entities.SkillModeTask,
+	}
+	if s.gatedBy != "" {
+		body["gatedBy"] = s.gatedBy
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	if _, err := w.resources.Create(context.Background(), application.CreateResourceCommand{
+		TypeSlug: application.AgentSkillTypeSlug,
+		Data:     raw,
+	}); err != nil {
+		return fmt.Errorf("could not install the skill %q: %w", s.name, err)
+	}
+	return nil
+}
+
+// --- people ---------------------------------------------------------------
+
+func (w *skillsWorld) personFor(email, password string) (*featurePerson, error) {
+	if p, ok := w.people[email]; ok {
+		return p, nil
+	}
+	ctx := context.Background()
+	agent, _, account, err := w.authService.RegisterPassword(ctx, email, displayNameForFeature(email), password)
+	if err != nil {
+		return nil, fmt.Errorf("could not create %q: %w", email, err)
+	}
+	p := &featurePerson{email: email, password: password, agentID: agent.GetID()}
+	if account != nil {
+		p.accountID = account.GetID()
+		if err := w.accountRepo.SaveMember(ctx, account.GetID(), agent.GetID(), authentities.RoleOwner); err != nil {
+			return nil, err
+		}
+	}
+	w.people[email] = p
+	return p, nil
+}
+
+func (w *skillsWorld) person(email string) (*featurePerson, error) {
+	p, ok := w.people[email]
+	if !ok {
+		return nil, fmt.Errorf("no person named %q has been staged", email)
+	}
+	return p, nil
+}
+
+func (w *skillsWorld) accountFor(name string) (string, error) {
+	id, ok := w.accounts[name]
+	if !ok {
+		return "", fmt.Errorf("no account named %q has been staged", name)
+	}
+	return id, nil
+}
+
+func (w *skillsWorld) addToAccount(email, accountName string) error {
+	accountID, err := w.accountFor(accountName)
+	if err != nil {
+		return err
+	}
+	p, err := w.personFor(email, "correct-horse-battery-staple")
+	if err != nil {
+		return err
+	}
+	if err := w.accountRepo.SaveMember(
+		context.Background(), accountID, p.agentID, authentities.RoleMember); err != nil {
+		return err
+	}
+	w.resolver.InvalidateAgents(context.Background(), accountID, p.agentID)
+	p.accountID = accountID
+	return nil
+}
+
+func (w *skillsWorld) ctxFor(p *featurePerson) context.Context {
+	if p == nil {
+		return context.Background()
+	}
+	return auth.ContextWithAgent(context.Background(),
+		&auth.Identity{AgentID: p.agentID, ActiveAccountID: p.accountID})
+}
+
+func (w *skillsWorld) staged() []string {
+	emails := make([]string, 0, len(w.people))
+	for email := range w.people {
+		emails = append(emails, email)
+	}
+	sort.Strings(emails)
+	return emails
+}
+
+// --- turns ----------------------------------------------------------------
+
+// takeTurn runs a real conversation turn and records what the coordinator was
+// given for it. The turn goes through the orchestrator so the graph is really
+// built; the offered list is read from the same filter buildRoot uses, which
+// the routing scenarios then prove is the one the graph honors.
+func (w *skillsWorld) takeTurn(p *featurePerson, message, conversationID string) *turnRecord {
+	ctx := w.ctxFor(p)
+	rec := &turnRecord{}
+	if err := w.ensureSkills(); err != nil {
+		rec.err = err
+		return rec
+	}
+
+	offered, err := w.orchestrator.RoutableSkills(ctx)
+	if err != nil {
+		rec.err = err
+	}
+	for _, def := range offered {
+		rec.offered = append(rec.offered, def.Name)
+	}
+	sort.Strings(rec.offered)
+
+	userID := "anonymous"
+	if p != nil {
+		userID = p.agentID
+	}
+	var sb strings.Builder
+	convErr := w.orchestrator.ConverseStream(ctx, conversationID, userID, message, "",
+		func(e entities.AgentEvent) {
+			if e.Type == entities.AgentEventText {
+				sb.WriteString(e.Text)
+			}
+		})
+	rec.reply = sb.String()
+	if convErr != nil && rec.err == nil {
+		rec.err = convErr
+	}
+	// Which skill answered is read from the reply, not from the event stream:
+	// the stream carries no transfer event, and the script gives each skill a
+	// marker of its own precisely so a scenario can tell. A transfer the
+	// coordinator could not make leaves the marker absent, which is the
+	// difference the routing scenarios turn on.
+	rec.ranSkill = skillMarkerIn(rec.reply)
+
+	key := "anonymous"
+	if p != nil {
+		key = p.email
+		w.lastActor = p.email
+	}
+	w.turns[key] = rec
+	return rec
+}
+
+// skillAnsweredMarker is what a skill's scripted reply says so a scenario can
+// tell which agent produced the turn. The coordinator's own replies never
+// carry it.
+const skillAnsweredMarker = "ANSWERED-BY:"
+
+// skillMarkerIn reports which skill answered, or "" when the coordinator did.
+func skillMarkerIn(reply string) string {
+	i := strings.Index(reply, skillAnsweredMarker)
+	if i < 0 {
+		return ""
+	}
+	rest := reply[i+len(skillAnsweredMarker):]
+	// The reply reaches the harness as the turn's JSON widget payload, so the
+	// marker is followed by a quote or a brace rather than whitespace.
+	if j := strings.IndexAny(rest, " \n\t.,\"}\\"); j >= 0 {
+		rest = rest[:j]
+	}
+	return strings.TrimSpace(rest)
+}
+
+// invokeSkill uses the direct door — the one a client uses to keep its flow
+// deterministic, and the one a stale skill name arrives through.
+func (w *skillsWorld) invokeSkill(p *featurePerson, name, conversationID string) error {
+	if err := w.ensureSkills(); err != nil {
+		return err
+	}
+	ctx := w.ctxFor(p)
+	userID := "anonymous"
+	if p != nil {
+		userID = p.agentID
+	}
+	err := w.orchestrator.ConverseStream(ctx, conversationID, userID, "do it", name,
+		func(e entities.AgentEvent) {
+			if e.Type == entities.AgentEventText && strings.TrimSpace(e.Text) != "" {
+				w.skillRuns[name]++
+			}
+		})
+	key := name
+	if p != nil {
+		key = p.email + "|" + name
+	}
+	w.invocations[key] = err
+	return err
+}
+
+func (w *skillsWorld) invocationFor(email, name string) (error, bool) {
+	key := name
+	if email != "" {
+		key = email + "|" + name
+	}
+	err, ok := w.invocations[key]
+	return err, ok
+}
+
+// refusedByGate separates "your features do not reach this" from "no such
+// skill" and from a real failure. The contract needs all three apart.
+func refusedBySkillGate(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "is not available: the")
+}
+
+func refusedAsUnknown(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "unknown skill")
+}
+
+func (w *skillsWorld) turnFor(email string) (*turnRecord, error) {
+	rec, ok := w.turns[email]
+	if !ok {
+		return nil, fmt.Errorf("%q has taken no turn with the in-app agent", email)
+	}
+	return rec, nil
+}
+
+func (w *skillsWorld) soleTurn() (*turnRecord, error) {
+	if w.lastActor != "" {
+		if rec, ok := w.turns[w.lastActor]; ok {
+			return rec, nil
+		}
+	}
+	if rec, ok := w.turns["anonymous"]; ok {
+		return rec, nil
+	}
+	return nil, fmt.Errorf("no turn has been taken")
+}
+
+func (w *skillsWorld) soleActor() (*featurePerson, error) {
+	if len(w.signedInOrder) != 1 {
+		return nil, fmt.Errorf("%d people are signed in, so \"they\" is ambiguous", len(w.signedInOrder))
+	}
+	return w.person(w.signedInOrder[0])
+}
+
+var _ = testing.Verbose

--- a/tests/e2e/features/feature_flag_agent_skills.feature
+++ b/tests/e2e/features/feature_flag_agent_skills.feature
@@ -1,4 +1,4 @@
-@wip @epic-480 @story-485
+@epic-480 @story-485
 Feature: A disabled agent skill is never offered to the in-app agent
   As someone talking to a WeOS app's agent
   I want the skills for a capability I do not have to be absent from the agent's routing,

--- a/tests/e2e/features/feature_flag_agent_skills.feature
+++ b/tests/e2e/features/feature_flag_agent_skills.feature
@@ -1,0 +1,386 @@
+@wip @epic-480 @story-485
+Feature: A disabled agent skill is never offered to the in-app agent
+  As someone talking to a WeOS app's agent
+  I want the skills for a capability I do not have to be absent from the agent's routing,
+  and refused if named anyway
+  So that the agent never walks me into something the instance will not do for me
+
+  #484 gated the tools. This story gates the layer above them: the skills the coordinator
+  routes to. The two are the same mechanism pointed at a different surface, and this
+  contract is written to keep them the same mechanism — the gate a skill names is answered
+  by the same `application.ToolFeatureGate`, over the same OpenFeature client, out of the
+  same per-session resolved set. Where this contract diverges from #484 it says so out
+  loud, and there is exactly one place it does.
+
+  So nothing below re-derives resolution. Which layer beats which, that an explicit off is
+  final downward, that a store failure answers off, that a change reaches sessions already
+  open without signing anybody out, that a validity window is read at resolution rather
+  than swept by a job — all of that is feature_flag_resolution.feature and
+  feature_flag_grants.feature and stays there. What is new here is what the SKILL surface
+  does with the answer: which sub-agents the coordinator is given for a turn, what the
+  direct-invocation door does when the caller names a skill their features do not reach,
+  and what a turn costs.
+
+  Two gates again, and again they are not equally important. Filtering the orchestrator
+  graph is what stops `transfer_to_agent` reaching a skill: the coordinator cannot transfer
+  to a sub-agent it was never given, so a hidden skill cannot be routed to, cannot be
+  described to the user, and cannot be talked about as though it existed. Refusing direct
+  invocation — the `?skill=<name>` door #419 shipped — is the control. A client that names a
+  skill it saw last week, or a model that emits `transfer_to_agent` for a name it invented,
+  must not reach further than a caller whose features say no. Every scenario below that
+  hides a skill therefore also names it directly, because an implementation that filters
+  the graph and forgets the direct path has built an affordance and called it a control,
+  and the difference stays invisible until somebody types the name.
+
+  Where the filter runs matters, and the obvious place is wrong. `SkillRegistry` caches one
+  set of definitions for the whole instance, loaded with the caller's identity deliberately
+  stripped (`auth.ContextWithAgent(ctx, nil)`), because a skill is an installed capability
+  and not per-user data. Filtering inside that cache would resolve one caller's features and
+  then serve the result to everybody until the next skill event — the second person to take
+  a turn would get the first person's answer. The filter therefore belongs on the way out,
+  where the definitions are handed to the turn being built: `Orchestrator.buildRoot` and
+  `buildSkillRoot` already run once per turn against the caller's context, which is exactly
+  the seam the criterion's "per conversation, not once at boot" is asking for. Two scenarios
+  below prove the property from the outside rather than naming the seam: two people in one
+  process get two different graphs, and a feature turned on after boot is routable without a
+  restart.
+
+  Cost is the reason this can be done per turn at all, and it is pinned as a measurement
+  rather than an intention, the way #484 pinned "a turn that calls thirty tools resolves
+  once". Building a graph of twenty gated skills must read feature state no more times than
+  building a graph of none — the filter asks the resolved set that the session already
+  holds, and the set is resolved once. A second turn in the same session reads nothing at
+  all. An implementation that evaluates per skill still passes every gating scenario above
+  and fails these two, which is the point of writing them.
+
+  Now the one deliberate difference, and it is the question this contract most wants ruled
+  on.
+
+  #485's fifth criterion says a skill gated on a feature nobody registered is treated as
+  OFF and the mismatch logged, so that a typo cannot silently expose a skill. #484 settled
+  the opposite for tools: an undeclared key leaves the tool exactly where it was and logs
+  once, because closing every gate whose key does not resolve turns one mistyped constant
+  into a silent capability outage across an instance, with a surface that looks deliberate.
+  Both readings are defensible and they cannot both be the rule, because both surfaces call
+  the same gate function and that function has one default.
+
+  This contract pins #484's rule: **a skill gated on an undeclared key stays offered, and
+  the drift is logged once, naming the skill and the key.** Three reasons, in the order they
+  carry weight.
+
+  First, the failure mode the criterion is guarding against is quieter for skills than for
+  tools, not louder. A tool closed by drift still answers a caller who calls it — the
+  refusal is a result the model reads and the user sees. A skill closed by drift produces no
+  event at all: the coordinator simply never routes there, the user is told the agent cannot
+  help, and nothing anywhere says why. Closing on drift makes the typo invisible on exactly
+  the surface where invisibility is worst.
+
+  Second, the risk of leaving a drifted skill offered is bounded by #484 and is smaller than
+  it looks. A skill's power is its tools, and every gated tool is gated at its own call site
+  against the same caller — the toolset the skill runs with is opened per turn from the
+  caller's context. So a skill exposed by drift can be transferred to, and then cannot
+  execute a single capability the caller's features do not already reach. What leaks is a
+  description and an instruction block, not a capability. A scenario below asserts exactly
+  that, because the reasoning is only sound if it is true.
+
+  Third, one gate function with one default is worth protecting. #486 adds a third consumer
+  and there will be more; a second gate whose default is the other way round is a coin flip
+  at every new call site, and the two will drift the first time somebody copies the wrong
+  one.
+
+  Against all that stands the honest counter-argument, which is that a skill's gate key is
+  authored in DATA — an agent-skill resource created through the API, MCP, or a seeding
+  flow — while a tool's gate key is a constant in code that a compiler and a reviewer both
+  see. The population that can typo a skill gate is much wider than the population that can
+  typo a tool gate. If that asymmetry outweighs the three reasons above, the rule flips, and
+  flipping it is mechanical: exactly two scenarios change, "A gate naming a key nobody
+  declared leaves the skill where it was, and says so once" and "A skill exposed by drift
+  still cannot run a gated tool", and the fix is to close the gate and drop the second. This
+  contract does not hedge between them; it pins one and marks the seam.
+
+  Either way the mismatch is loud. The instance logs it once per key with the skill's name
+  beside it, so "why is that skill still there" and "why did that skill vanish" both have an
+  answer without a debugger — which is the half of the criterion neither reading disputes.
+
+  What is out of scope is worth stating because it is the next thing somebody will build.
+  Gating decides what the AGENT is offered. It does not decide who can see, list or edit the
+  agent-skill resource: `resource_list` for type "agent-skill" returns what it returns, an
+  admin can still open a gated-off skill and fix its instructions, and the admin surface's
+  own gating is #486. A gate that also hid the resource would make a disabled capability
+  unmaintainable by the person whose job is to enable it.
+
+  Background:
+    Given a WeOS instance where password sign-in is enabled and requests are authenticated by their session
+    And the "agents" preset is installed
+    And the instance declares these features in code:
+      | key             | display name    | description                              | default | manageable | grantable |
+      | episodic-recall | Episodic recall | Recall past events during a conversation | on      | yes        | yes       |
+      | ledger-export   | Ledger export   | Export the ledger to a spreadsheet       | off     | yes        | yes       |
+      | audit-trail     | Audit trail     | Record who read what, for compliance     | on      | no         | no        |
+    And these agent skills are installed, each naming the feature that gates it:
+      | skill                       | gated by        |
+      | knowledge_graph_researcher  |                 |
+      | episode_summarizer          | episodic-recall |
+      | ledger_reporter             | ledger-export   |
+    And the tool "ledger_export" is gated by the feature "ledger-export"
+    And the in-app agent is configured with a scripted model
+    And the account "Harbor Legal", whose owner "ops@harborlegal.example" signs in with password "correct-horse-battery-staple"
+
+  # --- A skill that names no feature is untouched ---
+
+  Scenario: A skill that names no feature is offered and invocable however the features stand
+    Given the operator has turned the feature "episodic-recall" off for the instance
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they take a turn with the in-app agent
+    Then the coordinator was offered the skill "knowledge_graph_researcher"
+    And invoking the skill "knowledge_graph_researcher" directly succeeds
+    And no feature was evaluated for that skill
+
+  Scenario: A gated skill that is on is offered and runs exactly as it did before it had a gate
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they take a turn with the in-app agent
+    Then the coordinator was offered the skill "episode_summarizer"
+    And "episode_summarizer" is offered with the description it declares
+    And "episode_summarizer" runs with the tools its allowlist declares
+    And invoking the skill "episode_summarizer" directly succeeds
+
+  # --- What the coordinator is offered ---
+
+  Scenario Outline: A gated skill is offered as a routing target only when its feature is on for the caller
+    Given <precondition>
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they take a turn with the in-app agent
+    Then the coordinator <presence> the skill "<skill>"
+
+    Examples:
+      | precondition                                                               | skill              | presence        |
+      | nothing has been overridden or granted on this instance                    | episode_summarizer | was offered     |
+      | nothing has been overridden or granted on this instance                    | ledger_reporter    | was not offered |
+      | the operator has turned the feature "episodic-recall" off for the instance | episode_summarizer | was not offered |
+      | "Harbor Legal" has turned the feature "ledger-export" on                   | ledger_reporter    | was offered     |
+
+  Scenario: Two people on one instance are given two different graphs
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" has been granted the feature "ledger-export"
+    And both of them are signed in to "Harbor Legal"
+    When each of them takes a turn with the in-app agent
+    Then "counsel@harborlegal.example" was offered "ledger_reporter"
+    And "ops@harborlegal.example" was not offered "ledger_reporter"
+    And both of them were offered "knowledge_graph_researcher"
+    And the instance was not restarted between the two turns
+
+  Scenario: One person acting in two accounts is given two different graphs
+    Given the account "Cedar Realty", whose owner "broker@cedarrealty.example" signs in with password "trellis-anchor-mango-9"
+    And "ops@harborlegal.example" also belongs to "Cedar Realty"
+    And "Harbor Legal" has turned the feature "ledger-export" on
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have taken a turn and been offered "ledger_reporter"
+    When they act in "Cedar Realty" and take another turn
+    Then the coordinator was not offered the skill "ledger_reporter"
+    And the coordinator was offered the skill "knowledge_graph_researcher"
+
+  Scenario: The graph and the direct door agree, in both directions
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" has been granted the feature "ledger-export"
+    And the operator has turned the feature "episodic-recall" off for the instance
+    And "counsel@harborlegal.example" is signed in to "Harbor Legal"
+    When they take a turn with the in-app agent
+    And they invoke every gated skill the instance has installed
+    Then every skill the coordinator was offered was invocable directly
+    And every gated skill the coordinator was not offered was refused
+
+  Scenario: A skill turned on after boot is routable without a restart
+    Given the instance booted with the feature "ledger-export" off for the instance
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have taken a turn and not been offered "ledger_reporter"
+    When the operator turns the feature "ledger-export" on for the instance
+    And they take another turn in the same conversation
+    Then the coordinator was offered the skill "ledger_reporter"
+    And invoking the skill "ledger_reporter" directly succeeds
+    And the instance was not restarted
+
+  # --- The direct door is the gate ---
+
+  Scenario: Invoking a skill whose feature is off is refused, and nothing it would have done was done
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they invoke the skill "ledger_reporter" directly
+    Then the invocation is refused with an error the client can read
+    And the refusal names the skill "ledger_reporter"
+    And the refusal says the capability is not enabled for them
+    And the skill's instructions never ran
+    And no ledger export was recorded
+    And the refusal is not a partial reply
+
+  Scenario: A refusal for a gated skill reads differently from a skill that does not exist
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they invoke the skill "ledger_reporter" directly
+    And they invoke the skill "ledgr_reporter" directly
+    Then the refusal for "ledger_reporter" says the capability is not enabled for them
+    And the refusal for "ledgr_reporter" says no such skill exists
+    And neither refusal ran a skill
+
+  Scenario: A model that names a hidden skill anyway does not reach it
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And the scripted model transfers to "ledger_reporter" whatever it is offered
+    When they take a turn with the in-app agent
+    Then the coordinator was not offered the skill "ledger_reporter"
+    And the turn did not run "ledger_reporter"
+    And the user was given a reply rather than a broken turn
+
+  Scenario: A skill name held from before a change is not authorization to invoke it
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" has been granted the feature "ledger-export"
+    And "counsel@harborlegal.example" is signed in to "Harbor Legal"
+    And they have taken a turn and been offered "ledger_reporter"
+    When "ops@harborlegal.example" revokes "ledger-export" from "counsel@harborlegal.example"
+    And "counsel@harborlegal.example" invokes the skill "ledger_reporter" directly
+    Then the invocation is refused
+    And "counsel@harborlegal.example" is still signed in
+    And they were not signed out
+
+  Scenario: Taking another turn after a change reflects the truth, with no new conversation and no restart
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" has been granted the feature "ledger-export"
+    And "counsel@harborlegal.example" is signed in to "Harbor Legal"
+    And they have taken a turn and been offered "ledger_reporter"
+    When "ops@harborlegal.example" revokes "ledger-export" from "counsel@harborlegal.example"
+    And "counsel@harborlegal.example" takes another turn in the same conversation
+    Then the coordinator was not offered the skill "ledger_reporter"
+    And the conversation kept its history
+    And the instance was not restarted
+
+  Scenario: A grant that runs out mid-conversation stops the routing, though nothing announced it
+    Given the instance is configured with a maximum cache age of 10 minutes
+    And "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" holds a grant of "ledger-export" valid until 2 seconds from now
+    And "counsel@harborlegal.example" is signed in to "Harbor Legal"
+    When they take a turn straight away
+    And they invoke the skill "ledger_reporter" directly once that moment has passed
+    And they take another turn in the same conversation
+    Then the turn straight away was offered "ledger_reporter"
+    And the invocation after that moment is refused
+    And the later turn was not offered "ledger_reporter"
+    And nothing invalidated the session in between
+    And the maximum cache age had not run out
+    And "counsel@harborlegal.example" is still signed in
+
+  # --- Failing closed ---
+
+  Scenario: When the store cannot be read the gated skills go, and the rest stay
+    Given the store holding account overrides and grants cannot be read
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they take a turn with the in-app agent
+    Then the coordinator was not offered the skill "episode_summarizer"
+    And the coordinator was offered the skill "knowledge_graph_researcher"
+    And invoking the skill "episode_summarizer" directly is refused
+    And invoking the skill "knowledge_graph_researcher" directly succeeds
+    And the instance logged the failure
+
+  Scenario: A store failure is not remembered as an answer
+    Given the store holding account overrides and grants cannot be read
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have taken a turn and not been offered "episode_summarizer"
+    When the store can be read again
+    And they take another turn in the same conversation
+    Then the coordinator was offered the skill "episode_summarizer"
+    And invoking the skill "episode_summarizer" directly succeeds
+
+  # --- A gate key nobody declared (see the preamble: this is the contested rule) ---
+
+  Scenario: A gate naming a key nobody declared leaves the skill where it was, and says so once
+    Given the skill "ledger_reporter" is gated by the undeclared feature "ledgr-export"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they take 20 turns with the in-app agent
+    Then the coordinator was offered the skill "ledger_reporter"
+    And invoking the skill "ledger_reporter" directly succeeds
+    And the instance logged the undeclared feature key once
+    And the log names the key "ledgr-export"
+    And the log names the skill "ledger_reporter"
+
+  Scenario: A skill exposed by drift still cannot run a gated tool
+    Given the skill "ledger_reporter" is gated by the undeclared feature "ledgr-export"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they invoke the skill "ledger_reporter" directly
+    And the skill calls the tool "ledger_export"
+    Then the skill was reached
+    And the tool call is refused because the capability is not enabled
+    And no ledger export was recorded
+
+  # --- What the gate costs ---
+
+  Scenario: Building a graph of twenty gated skills resolves once
+    Given the instance has 20 skills gated by "ledger-export"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they take a turn with the in-app agent
+    Then the turn was answered
+    And feature state was read from the database only while that turn was answered
+    And the graph was built without reading feature state once per skill
+
+  Scenario: A second turn in the same session reads no feature state at all
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have already taken a turn with the in-app agent
+    When they take another turn in the same conversation
+    And they invoke the skill "episode_summarizer" directly
+    Then both turns were answered
+    And no feature state was read from the database after the first turn
+
+  Scenario: The filter follows the caller, not the process
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" has been granted the feature "ledger-export"
+    And both of them are signed in to "Harbor Legal"
+    And "ops@harborlegal.example" has already taken a turn and not been offered "ledger_reporter"
+    When "counsel@harborlegal.example" takes a turn with the in-app agent
+    Then "counsel@harborlegal.example" was offered "ledger_reporter"
+    And the skill registry loaded the definitions once for both of them
+
+  # --- Routing, proved with the scripted agent model ---
+
+  Scenario: The same prompt routes to the skill for a granted user and not for an ungranted one
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" has been granted the feature "ledger-export"
+    And both of them are signed in to "Harbor Legal"
+    And the scripted model routes "export last quarter's ledger" to "ledger_reporter"
+    When each of them sends "export last quarter's ledger" to the in-app agent
+    Then "counsel@harborlegal.example" was answered by the skill "ledger_reporter"
+    And "ops@harborlegal.example" was not answered by any skill
+    And "ops@harborlegal.example" was given a reply rather than a broken turn
+
+  Scenario: The ungranted user's turn never mentions the skill it could not reach
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And the scripted model routes "export last quarter's ledger" to "ledger_reporter"
+    When they send "export last quarter's ledger" to the in-app agent
+    Then the reply does not name "ledger_reporter"
+    And the turn ended with a reply the user can read
+
+  Scenario: A grant made mid-conversation changes where the same prompt routes
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" is signed in to "Harbor Legal"
+    And the scripted model routes "export last quarter's ledger" to "ledger_reporter"
+    And they have sent "export last quarter's ledger" and not been answered by any skill
+    When "ops@harborlegal.example" grants "ledger-export" to "counsel@harborlegal.example"
+    And "counsel@harborlegal.example" sends "export last quarter's ledger" again in the same conversation
+    Then they were answered by the skill "ledger_reporter"
+    And they were not signed out
+    And the instance was not restarted
+
+  # --- A turn with nobody on the context ---
+
+  Scenario Outline: With no caller on the context the instance layer alone decides which skills exist
+    Given <precondition>
+    And a turn taken with nobody on the context
+    Then the coordinator <presence> the skill "<skill>"
+    And invoking "<skill>" directly <outcome>
+
+    Examples:
+      | precondition                                                               | skill              | presence        | outcome    |
+      | nothing has been overridden or granted on this instance                    | episode_summarizer | was offered     | succeeds   |
+      | the operator has turned the feature "episodic-recall" off for the instance | episode_summarizer | was not offered | is refused |
+      | the operator has turned the feature "ledger-export" on for the instance    | ledger_reporter    | was offered     | succeeds   |
+
+  Scenario: With no caller on the context an account override and a personal grant reach nothing
+    Given "Harbor Legal" has turned the feature "ledger-export" on
+    And "ops@harborlegal.example" has been granted the feature "ledger-export"
+    And a turn taken with nobody on the context
+    Then the coordinator was not offered the skill "ledger_reporter"
+    And invoking "ledger_reporter" directly is refused
+    And no account override or grant was read to answer either


### PR DESCRIPTION
Story #485 of epic #480. #484 gated the tools; this gates the layer above them — the skills the coordinator routes to.

Stacked on #502.

## One filter, not two

`allowedSkills` serves the coordinator graph and `findSkill` serves the direct door, and both ask the same question in the same place. An implementation with two filters is an implementation with one filter and a hole, and the hole stays invisible until somebody types a skill name.

Filtering the graph is what stops `transfer_to_agent`: the coordinator cannot transfer to a sub-agent it was never given. **Refusing direct invocation is the control** — the `?skill=<name>` door #419 shipped is where a stale name arrives. So every scenario that hides a skill also names it directly.

## The filter belongs on the way out, not in the registry

`SkillRegistry` caches one set of definitions for the whole instance, loaded with the caller's identity stripped on purpose, because a skill is an installed capability and not per-user data. A filter inside that cache would resolve one caller's features and then serve the answer to everybody until the next skill event — **the second person to take a turn would get the first person's permissions.** `buildRoot` and `buildSkillRoot` already run per turn against the caller's context, which is the seam the story's "per conversation, not once at boot" is asking for.

It costs no extra database work. Each gated skill asks for one key, and the resolver answers every key after the first from the set it already holds for this caller. Twenty gated skills read stored state no more often than none — pinned as a measurement, so an implementation that evaluates per skill passes every gating scenario and fails that one.

## The contract caught a real defect

Written before the implementation, and it earned its keep. When the model transferred to a skill the caller's features did not reach, the ADK runner returned `failed to find agent` and **the whole turn failed**. Every gated skill was a way to break somebody's chat by mentioning it — a model that invents a plausible name, or a client carrying a name over from a conversation where the caller did have it, took the conversation down.

A transfer out of reach is a refusal, not a fault. The turn now degrades to a reply the user can read. The reply names no skill on purpose: the caller cannot use it, and naming it would advertise a capability they have no way to ask for.

`unreachableSkill` matches on the runner's message because the error carries no type to test, and is kept deliberately narrow — a different runner failure must still surface as a failure, since swallowing those would hide real faults behind a polite sentence.

## One vacuous pass found and fixed

The scripted model is built at boot from `WEOS_AGENT_SCRIPT`, so a scenario that set its script afterwards silently ran the default one. "A model that names a hidden skill anyway does not reach it" was passing because **no transfer was ever attempted**. Setting a script now rebuilds the model — and that scenario then failed, until the defect above was fixed. That failure is the only reason to trust it now.

## Two refusals, because they send the reader to different places

"Unknown skill" is a typo or something nobody installed. "Not enabled for you" is a capability an admin can grant. One message for both would make a permission question look like a spelling mistake. The refusal wording now has a single definition in `domain/entities`, which #484's tool gate and #485's skill gate both call — it is a decision, not a string.

## The contested rule

#485's fifth criterion asked that a skill gated on an undeclared key be treated as **off**. #484 settled the opposite for tools, and both surfaces call one gate function with one default. Akeem ruled for #484's rule: **the skill stays offered and the drift is logged once, naming the skill and the key.**

A skill closed by drift produces no event at all — the coordinator never routes there, the caller is told the agent cannot help, and nothing says why. And what a drifted skill exposes is bounded by #484 in turn: every gated tool gates at its own call site against the same caller, so a description escapes, not a capability. A scenario asserts exactly that, by asking #484's own gate for the same caller — the assertion the whole argument rests on, so it is measured rather than claimed.

The honest counter-argument is recorded in the contract's preamble: a skill's gate is authored in data, where no compiler and no reviewer sees it, so the population that can misspell one is far wider.

## Evidence

`tests/e2e/features/feature_flag_agent_skills.feature` — 25 scenarios (30 expanded), 410 steps, all green, promoted out of `@wip`. All five epic contracts together: **157 scenarios, 1587 steps.**

| Mutation | Scenarios that failed |
|---|---|
| the graph is never filtered | 19 |
| the direct door never refuses | 8 |
| drift closes the gate instead of leaving the skill | 2 |
| an out-of-reach transfer breaks the turn again | 4 |

`RoutableSkills` is exported because #486 needs it: an admin surface has to show a person what their agent can actually reach, and a second implementation of "what may this caller use" would be a second answer.

Closes #485
