### PR TITLE
Draw the admin from the caller's feature set, and make the server hold to it

### DIFF
--- a/api/handlers/feature_handler.go
+++ b/api/handlers/feature_handler.go
@@ -70,6 +70,8 @@ type setFeatureRequest struct {
 func (h *FeatureHandler) List(c echo.Context) error {
 	statuses, err := h.admin.Listing(c.Request().Context())
 	if err != nil {
+		// The service answers all-off rather than failing when the store
+		// cannot be read, so an error here is something else entirely.
 		h.logger.Error(c.Request().Context(), "failed to list features", "error", err)
 		return respondError(c, http.StatusInternalServerError, "failed to list features")
 	}

--- a/api/middleware/require_feature.go
+++ b/api/middleware/require_feature.go
@@ -1,0 +1,72 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/wepala/weos/v3/domain/entities"
+)
+
+// Gating an HTTP route on a feature (epic #480, story #486).
+//
+// #484 gated the MCP tools and #485 gated the agent skills, and both ended at
+// a surface a model talks to. This one ends at a surface a person clicks,
+// which is why hiding a sidebar entry is not enough on its own. Hiding is a
+// courtesy to the person: it stops them being offered a link that leads to a
+// refusal. This is the control, because a URL bar does not consult a sidebar.
+
+// FeatureGate answers whether the caller on ctx holds a feature. It is the
+// same shape internal/mcp and application/agents use, and
+// application.ToolFeatureGate builds the real one — so a route and a tool
+// gated on one key can never disagree about who holds it.
+type FeatureGate func(ctx context.Context, featureKey string) bool
+
+// RequireFeature refuses a request whose caller does not hold featureKey.
+//
+// The refusal is 403 carrying the shared gate wording, which is deliberately
+// not what a role refusal says. The two send a reader to different places: a
+// role refusal means ask an admin of this account to change your role, and a
+// feature refusal means this capability is not switched on for you. One
+// message for both would make a capability question look like a permissions
+// question, and the person would go and ask the wrong thing.
+//
+// The feature is checked BEFORE the role, wherever both apply. A capability
+// that is off for an instance is off for its owner too, so answering "you are
+// not allowed" to somebody who would be allowed if it were on would be a lie.
+//
+// A nil gate refuses nothing, which is how a build with no feature wiring
+// behaves. A surface that must never ship ungated checks for that itself; see
+// internal/mcp.NewConfiguredServer.
+func RequireFeature(gate FeatureGate, featureKey string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if gate == nil || featureKey == "" {
+				return next(c)
+			}
+			ctx := c.Request().Context()
+			if gate(ctx, featureKey) {
+				return next(c)
+			}
+			return c.JSON(http.StatusForbidden, map[string]any{
+				"error": entities.GateRefusal(ctx, c.Request().URL.Path, featureKey),
+			})
+		}
+	}
+}

--- a/application/feature_admin_service.go
+++ b/application/feature_admin_service.go
@@ -94,7 +94,48 @@ func NewFeatureAdminService(
 // the same as being able to change them, and an operator who cannot read the
 // list cannot use the commands that change it.
 func (s *FeatureAdminService) Listing(ctx context.Context) ([]entities.FeatureStatus, error) {
-	return s.resolver.Explain(ctx)
+	statuses, err := s.resolver.Explain(ctx)
+	if err == nil {
+		return statuses, nil
+	}
+	// A store that cannot be read makes every gate answer off (#481). The
+	// listing now says the same thing instead of failing, so the two agree
+	// during an outage rather than leaving a browser to invent a policy — and
+	// the only two policies it can invent are "show everything", which is
+	// wrong, and "show nothing", which is this answer with nothing to read.
+	//
+	// The message is the half that makes it honest. All-off is not the same
+	// fact as the store being unreadable, and a caller can only tell a
+	// genuinely all-off instance from a broken one by reading it.
+	if s.logger != nil {
+		s.logger.Error(ctx, "failed to resolve the feature listing; answering every feature off",
+			"error", err)
+	}
+	entities.AddMessage(ctx, entities.Message{
+		Type: "warning",
+		Text: "Feature state could not be read, so every feature is reported off.",
+	})
+	return s.allOff(), nil
+}
+
+// allOff is every declared feature, reported off, with the layer named as the
+// error it came from so a reader is never told a stored value decided this.
+func (s *FeatureAdminService) allOff() []entities.FeatureStatus {
+	declared := s.features.List()
+	out := make([]entities.FeatureStatus, 0, len(declared))
+	for _, meta := range declared {
+		out = append(out, entities.FeatureStatus{
+			Key:         meta.Key,
+			DisplayName: meta.DisplayName,
+			Description: meta.Description,
+			Enabled:     false,
+			Source:      entities.FeatureLayerError.String(),
+			Default:     meta.Default,
+			Manageable:  meta.Manageable,
+			Grantable:   meta.Grantable,
+		})
+	}
+	return out
 }
 
 // SetInstance turns a feature on or off for the whole instance.

--- a/application/feature_declarations.go
+++ b/application/feature_declarations.go
@@ -42,5 +42,30 @@ func CoreFeatureDeclarations() []entities.FeatureMeta {
 			Manageable:  true,
 			Grantable:   true,
 		},
+		{
+			// Gates the in-app agent's REST surface — the three
+			// /api/agent/conversations routes — and the admin's Agent
+			// sidebar entry (#486).
+			//
+			// Declared ON, for the same reason as episodic-recall: the chat
+			// ships today and an upgrade that introduced the gate dark would
+			// take a working page away from every instance.
+			//
+			// It composes with #485 rather than overlapping it. Off means
+			// there is no assistant at all. On means there is one, whose skill
+			// graph #485 filters for whoever is talking to it.
+			Key:         FeatureAgentChat,
+			DisplayName: "Assistant",
+			Description: "Let people chat with the instance's in-app assistant.",
+			Default:     true,
+			Manageable:  true,
+			Grantable:   true,
+		},
 	}
 }
+
+// FeatureAgentChat gates the in-app assistant. Named rather than spelled at
+// each call site, because it is read in three places — the REST routes, the
+// admin's sidebar, and the declaration above — and a typo in any of them is
+// registry drift that leaves the capability open.
+const FeatureAgentChat = "agent-chat"

--- a/application/feature_resolver.go
+++ b/application/feature_resolver.go
@@ -57,7 +57,17 @@ type featureCacheKey struct {
 }
 
 type resolvedFeatureSet struct {
-	values     map[string]bool
+	values map[string]bool
+	// statuses is the same answer with the deciding layer kept.
+	//
+	// #481 left this out on purpose: it grows every entry to serve a listing
+	// an operator hit occasionally, while the hot path never read it. #486
+	// changed that premise — the admin asks for the whole set on every page
+	// load, per signed-in person — so the listing became a hot path too, and
+	// an uncached Explain meant a database read per page view. Storing it
+	// costs a few hundred bytes per (agent, account); not storing it cost a
+	// query. The contract's cost scenario is what caught the difference.
+	statuses   []entities.FeatureStatus
 	resolvedAt time.Time
 	// staleAt is the earliest instant at which this set stops being true on
 	// its own — the nearest validity-window boundary among the grants that fed
@@ -216,10 +226,11 @@ func (r *FeatureResolver) refresh(ctx context.Context, key featureCacheKey) (map
 	startedAt := r.generation
 	r.mu.RUnlock()
 
-	values, staleAt, err := r.resolve(ctx, key)
+	statuses, staleAt, err := r.resolveDetailed(ctx, key)
 	if err != nil {
 		return r.onResolveError(ctx, key, err)
 	}
+	values := valuesFrom(statuses)
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -231,8 +242,20 @@ func (r *FeatureResolver) refresh(ctx context.Context, key featureCacheKey) (map
 		// timestamp.
 		return copyFeatureValues(values), nil
 	}
-	r.sets[key] = resolvedFeatureSet{values: values, resolvedAt: r.clock(), staleAt: staleAt}
+	r.sets[key] = resolvedFeatureSet{
+		values: values, statuses: statuses, resolvedAt: r.clock(), staleAt: staleAt,
+	}
 	return copyFeatureValues(values), nil
+}
+
+// valuesFrom drops the layer information for the value map, so the two views
+// of one answer are built from the same read and cannot disagree.
+func valuesFrom(statuses []entities.FeatureStatus) map[string]bool {
+	values := make(map[string]bool, len(statuses))
+	for _, s := range statuses {
+		values[s.Key] = s.Enabled
+	}
+	return values
 }
 
 // onResolveError decides what a caller is told when the store cannot be read.
@@ -315,38 +338,58 @@ func (r *FeatureResolver) cached(key featureCacheKey) (map[string]bool, bool) {
 	return copyFeatureValues(set.values), true
 }
 
-// resolve reads every layer and folds them into a plain value map for the
-// cache. It is Explain's answer with the layer information dropped, so the two
-// cannot disagree about what a feature resolves to.
-func (r *FeatureResolver) resolve(
-	ctx context.Context, key featureCacheKey,
-) (map[string]bool, time.Time, error) {
-	statuses, staleAt, err := r.resolveDetailed(ctx, key)
-	if err != nil {
-		return nil, time.Time{}, err
-	}
-	values := make(map[string]bool, len(statuses))
-	for _, s := range statuses {
-		values[s.Key] = s.Enabled
-	}
-	return values, staleAt, nil
-}
-
 // Explain resolves every declared feature for the caller on ctx and reports
 // which layer decided each one.
 //
-// Deliberately uncached, and it does not populate the cache. The cached set
-// holds values only — adding the deciding layer to it would grow every entry
-// to serve a listing that an operator hits occasionally and a hot path never
-// does. Listings are rare; evaluations are not.
+// Served from the same cached set every evaluation uses. It was uncached until
+// #486, on the reasoning that a listing is something an operator hits
+// occasionally — which stopped being true when the admin started asking for
+// the whole set on every page load. An uncached Explain then meant a database
+// read per page view, per signed-in person.
 func (r *FeatureResolver) Explain(ctx context.Context) ([]entities.FeatureStatus, error) {
-	identity := auth.AgentFromCtx(ctx)
-	key := featureCacheKey{}
-	if identity != nil {
-		key = featureCacheKey{AgentID: identity.AgentID, AccountID: identity.ActiveAccountID}
+	key := cacheKeyFor(ctx)
+	if statuses, ok := r.cachedStatuses(key); ok {
+		return statuses, nil
 	}
+	if _, err := r.refresh(ctx, key); err != nil {
+		return nil, err
+	}
+	if statuses, ok := r.cachedStatuses(key); ok {
+		return statuses, nil
+	}
+	// The refresh raced an invalidation and stored nothing. Read the layers
+	// once more rather than answering from a set that is no longer there.
 	statuses, _, err := r.resolveDetailed(ctx, key)
 	return statuses, err
+}
+
+// cachedStatuses serves the detailed view under the same freshness rules as
+// the value view, so a listing can never be older than an evaluation.
+func (r *FeatureResolver) cachedStatuses(key featureCacheKey) ([]entities.FeatureStatus, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	set, ok := r.sets[key]
+	if !ok || len(set.statuses) == 0 {
+		return nil, false
+	}
+	now := r.clock()
+	if !set.staleAt.IsZero() && !now.Before(set.staleAt) && !set.retryAfter.After(now) {
+		return nil, false
+	}
+	if now.Sub(set.resolvedAt) >= r.maxAge && !set.retryAfter.After(now) {
+		return nil, false
+	}
+	return append([]entities.FeatureStatus(nil), set.statuses...), true
+}
+
+// cacheKeyFor is the caller's cache key. The zero key is the anonymous caller,
+// whose set is resolved from the instance layer alone.
+func cacheKeyFor(ctx context.Context) featureCacheKey {
+	identity := auth.AgentFromCtx(ctx)
+	if identity == nil {
+		return featureCacheKey{}
+	}
+	return featureCacheKey{AgentID: identity.AgentID, AccountID: identity.ActiveAccountID}
 }
 
 // resolveDetailed reads every layer and folds them through

--- a/docs/_explanation/feature-flags.md
+++ b/docs/_explanation/feature-flags.md
@@ -1,0 +1,117 @@
+---
+title: Feature Flags
+parent: Explanation
+layout: default
+nav_order: 8
+---
+
+# Feature Flags
+
+WeOS resolves a feature to one boolean for one caller, and every surface that gates something asks the same question through the same function. This page explains why it is shaped that way. For the API surface see the [Feature Flags reference]({% link _reference/feature-flags.md %}); to gate something of your own see [Gate a Capability]({% link _howto/gate-a-capability.md %}).
+
+## The problem
+
+An instance has capabilities that not everybody should have. Some are decisions for whoever runs the instance — "this deployment does not do ledger export at all". Some are decisions for a team — "our account does not want the assistant". Some are for one person — "give the auditor export for the next two weeks".
+
+Those are three different decisions about the same capability, and they arrive from three different people. A single on/off switch cannot hold them, and three unrelated switches drift.
+
+## Four layers, one answer
+
+A feature is **declared** in code with a default, and then three stored layers may speak about it:
+
+```
+declaration default  →  instance override  →  account override  →  grant
+```
+
+Resolution walks them in that order and returns one boolean plus the layer that decided it. The whole rule is [`entities.ResolveFeature`](https://github.com/wepala/weos/blob/main/services/core/domain/entities/feature.go), and it is deliberately the only place precedence exists.
+
+### An explicit off is final downward
+
+If the instance says off, the answer is off, and no account override and no grant can lift it. The same applies to an account's off against a grant.
+
+This is what makes an operator's switch mean something. An operator who turns a capability off is usually doing it because the instance cannot do it — no credentials, no licence, a compliance decision — and a grant that could override that would make the switch advice rather than a control.
+
+### An explicit on is *not* final
+
+If the instance turns something on, an account may still turn it off for themselves.
+
+The asymmetry is the point. Off is a statement about what is possible; on is a statement about what is permitted. Permission flows down and can be narrowed; possibility does not flow back up.
+
+### The declaration default is not an explicit off
+
+A feature declared `default: false` is *unset everywhere*, not *off everywhere*. An account override or a grant can turn it on, because nobody has said no — they have only not yet said yes.
+
+This is why the stored layers are **tri-state**: on, off, and nothing said. Row absence carries "nothing said", so there is no nullable column and no sentinel. It is also why turning a feature off and *resetting* it are different operations, with different endpoints and different CLI verbs — resetting returns a layer to silence, and a lower layer can then speak.
+
+### `manageable` and `grantable` decide whether a layer is read at all
+
+A declaration that says `manageable: false` means an account override is ignored — not rejected. A stored row may predate a declaration change, and resolution must never depend on whoever wrote it having been well behaved. The same holds for `grantable: false` and grants.
+
+## Grants belong to an account
+
+A grant names a **subject** — one agent, or a role — inside one account, and never an email address. An address is how an admin names somebody when granting; it is not what the grant is against, because an address can change and the grant should not follow it. Listings resolve the address back at read time.
+
+A grant may carry a validity window. The window is half-open: the grant is on the instant `validFrom` arrives and off the instant `validThrough` passes.
+
+**Expiry is lazy.** Nothing sweeps expired grants and nothing fires when a window closes; a row that has run out is simply not counted at the next resolution. That has a consequence worth knowing: there is no event at the moment a capability goes away, so nothing can be notified of it. See [Nothing announces a change](#nothing-announces-a-change).
+
+A grant also stops applying when its subject leaves the account. Membership is checked when the grant is made, but nothing deletes the row when somebody leaves — so resolution skips grants for a caller with no membership, and listings report those rows as **orphaned** rather than expired. The two need different actions: an expired grant ran its course, an orphaned one is left-over access to clean up.
+
+## Failing closed, and the one case that does not
+
+If the stored state cannot be read, resolution answers **off**. A resolver that answered "on" on the way to a database error would hand out the capability at exactly the moment nobody can see why.
+
+The one deliberate exception is a key **nobody declared**. That is registry drift — a deploy where a call site and the declarations disagree — and there the caller's own default stands and the instance logs it once. Closing every gate whose key does not resolve would turn one mistyped constant into a silent capability outage across an instance, with a surface that looks deliberate.
+
+The two are not the same failure and must not be conflated: a typo leaves a capability where it was, a broken store takes gated capabilities away.
+
+## Resolution is cached per caller
+
+A caller's whole set is resolved once and read from memory afterwards. An agent turn evaluating thirty tools is ordinary, and resolving per key would multiply the database reads by the number of features rather than amortising them to one.
+
+The cache key is **(agent, account)** — deliberately not a session. There is no session identifier on the MCP bearer surface, and keying on something one whole surface cannot supply would mean either no caching there or a silent fallback that behaves differently per surface. It is also strictly more correct: resolution reads the instance layer, the account layer, and the caller's grants and roles, and nothing else — so two sessions of one person in one account always resolve identically, and one invalidation reaches every device that person is signed in on.
+
+Writes invalidate precisely: an instance change drops everything, an account change drops that account, a grant drops the people it reaches.
+
+### Nothing announces a change
+
+A validity window closing produces no event, so nothing can be pushed to a client at that moment. Every surface therefore treats a held answer as advisory:
+
+- A tool list a client fetched an hour ago is **not** authorization. Calling a tool from it is resolved when the call arrives.
+- A skill name held from a previous conversation is refused if the caller's features no longer reach it.
+- A feature set a browser is holding decides what to *draw*, never what is *allowed*.
+
+This is why every gated surface in WeOS has two gates, and why only one of them is the control. Hiding a tool, a skill, or a sidebar entry is a courtesy — it stops a model proposing something that will fail, and stops a person clicking a link that leads to a refusal. Refusing the call is the control. An implementation that filters the listing and forgets the handler has built an affordance and called it a control, and the difference is invisible right up until somebody uses a name they already had.
+
+## Callers with no identity
+
+An anonymous caller resolves from the **instance layer alone**. No account override and no grant is read, because there is no subject for either to attach to.
+
+This deliberately differs from the rest of the codebase, where a nil identity means system context and bypasses gates. A background worker or a local `weos mcp` session must not silently receive every gated capability.
+
+It has a practical consequence for the **stdio transport**: `weos mcp` is one local process with no session, no bearer token and no active account, so gating there is instance-wide and cannot be anything else. An account override or a personal grant makes no difference on that transport. Refusals are worded accordingly — "not enabled on this server" where there is no caller, "not enabled for you" where there is one — so nobody goes looking for a grant that cannot apply.
+
+## Gates live where the thing lives
+
+A gate is declared at the call site of the thing it gates: beside a tool's name and schema, in a skill's own definition, on the route's own registration. A capability declared in one file and gated in a registry somewhere else is two things that will drift.
+
+The four surfaces WeOS gates today all consume the same resolved set, so a route and a tool gated on one key can never disagree about who holds it:
+
+| Surface | Hidden | Refused |
+|---------|--------|---------|
+| MCP tools | absent from `tools/list` | `tools/call` returns an error result |
+| Agent skills | not a coordinator sub-agent, so `transfer_to_agent` cannot reach it | direct invocation refused |
+| HTTP routes | the admin does not draw the link | 403 with the feature named |
+| Admin UI | sidebar entry and page absent | the route behind it refuses |
+
+## Evaluation goes through OpenFeature
+
+Call sites evaluate through the [OpenFeature](https://openfeature.dev) Go SDK rather than calling the resolver directly, on a named domain with the `feature.` key prefix. That buys a standard interface, room for a second provider on its own namespace later, and hooks for telemetry — without any call site knowing how resolution works.
+
+One detail is load-bearing. When the store cannot be read, the provider returns `false` with reason `ERROR` and attaches **no** `ResolutionError`. The OpenFeature client treats a resolution error as "fall back to the caller's default", which would hand `true` to any call site that passed `true` — the exact opposite of failing closed, and invisible to a test that calls the provider directly instead of going through the client.
+
+## Related
+
+- [Gate a Capability]({% link _howto/gate-a-capability.md %}) — the task
+- [Feature Flags reference]({% link _reference/feature-flags.md %}) — the precedence table, config, CLI, API and MCP surface
+- [Auth, Roles and Access]({% link _tutorials/auth-roles-and-access.md %}) — roles are a different question from features, and the two are resolved separately

--- a/docs/_explanation/index.md
+++ b/docs/_explanation/index.md
@@ -17,3 +17,4 @@ Explanation pages are **understanding-oriented** — they answer "why" and "how 
 | [MCP Protocol]({% link _explanation/mcp-protocol.md %}) | How the Model Context Protocol makes WeOS LLM-agnostic |
 | [Architecture]({% link _explanation/architecture.md %}) | Clean Architecture layers, dependency injection, and the request lifecycle |
 | [Behaviors]({% link _explanation/behaviors.md %}) | The Type Object pattern for attaching domain logic to resource types |
+| [Feature Flags]({% link _explanation/feature-flags.md %}) | Why a capability resolves through four layers, and why hiding is never the control |

--- a/docs/_howto/gate-a-capability.md
+++ b/docs/_howto/gate-a-capability.md
@@ -1,0 +1,190 @@
+---
+title: Gate a Capability
+parent: How-to Guides
+layout: default
+nav_order: 10
+---
+
+# Gate a Capability
+
+This guide shows how to put one of your own capabilities behind a feature flag, on each of the four surfaces WeOS gates: an MCP tool, an agent skill, an HTTP route, and an admin UI section.
+
+Read [Feature Flags]({% link _explanation/feature-flags.md %}) first if you have not — the precedence rules and the fail-closed behaviour explain why the steps below are the shape they are.
+
+## Prerequisites
+
+- A working WeOS build (`make build` succeeds)
+- A capability you want to gate
+
+## 1. Declare the feature
+
+Nothing resolves for a key nobody declared — it answers the caller's own default and logs once. Declare it before you gate on it.
+
+From a downstream binary, contribute to the fx value group:
+
+```go
+package main
+
+import (
+    "go.uber.org/fx"
+
+    "github.com/wepala/weos/v3/application"
+    "github.com/wepala/weos/v3/domain/entities"
+    "github.com/wepala/weos/v3/pkg/cli"
+)
+
+func init() {
+    cli.RegisterFxOptions(
+        fx.Provide(application.AsFeatureDeclarations(func() []entities.FeatureMeta {
+            return []entities.FeatureMeta{{
+                Key:         "invoice-export",
+                DisplayName: "Invoice export",
+                Description: "Export invoices to a spreadsheet.",
+                Default:     false,
+                Manageable:  true,
+                Grantable:   true,
+            }}
+        })),
+    )
+}
+```
+
+From a preset, use `PresetDefinition.Features`. Without a build at all, set `FEATURES`:
+
+```bash
+FEATURES='[{"key":"invoice-export","displayName":"Invoice export","default":false,"manageable":true,"grantable":true}]'
+```
+
+### Choosing the default
+
+Pick `default: true` for a capability that **already ships**. Introducing a gate with the default off takes a working capability away from every instance that upgrades, and nobody finds out until somebody complains.
+
+Pick `default: false` for something new, or something an instance should opt into.
+
+### Choosing `manageable` and `grantable`
+
+`manageable: false` means only the operator decides — right for anything that costs money or carries compliance weight. `grantable: false` means it cannot be given to one person — right for anything that only makes sense instance-wide.
+
+## 2. Gate the capability
+
+Declare the gate at the call site of the thing it gates. A capability declared in one file and gated in a registry somewhere else is two things that will drift.
+
+### An MCP tool
+
+```go
+cli.RegisterMCPConfigurer(func(server *mcp.Server, deps cli.MCPConfigurerDeps) {
+    cli.AddGatedTool(server, deps.Gates, "invoice-export", &mcp.Tool{
+        Name:        "invoice_export",
+        Description: "Export invoices to a spreadsheet.",
+        Annotations: /* … */,
+    }, invoiceExportHandler)
+})
+```
+
+The tool is then absent from `tools/list` for a caller whose feature is off, and a call to it is refused with an error the model can read. A tool added with plain `mcp.AddTool` is ungated and behaves exactly as before — no lookup, no new failure mode.
+
+### An agent skill
+
+Name the feature in the skill's own definition:
+
+```json
+{
+  "schemaVersion": 1,
+  "name": "invoice_reporter",
+  "description": "Answers questions about invoices",
+  "instructions": "…",
+  "tools": ["invoice_export"],
+  "mode": "task",
+  "gatedBy": "invoice-export"
+}
+```
+
+The skill is then not offered to the coordinator, so `transfer_to_agent` cannot reach it, and invoking it directly is refused.
+
+Note that a skill's power is its tools, and every gated tool gates independently against the same caller. A skill that somehow becomes reachable can still run nothing the caller's features do not already allow.
+
+### An HTTP route
+
+```go
+gate := apimw.RequireFeature(application.ToolFeatureGate(featureClient), "invoice-export")
+
+group.POST("/invoices/exports", exportHandler, gate)
+```
+
+The route answers 403 with the feature named. Put the feature gate **before** any role check: a capability that is off is off for its owner too, and answering "you are not allowed" to somebody who would be allowed if it were on sends them to fix the wrong thing.
+
+### An admin UI section
+
+```vue
+<script setup lang="ts">
+const { isEnabled } = useFeatures()
+const showInvoices = computed(() => isEnabled('invoice-export'))
+</script>
+
+<template>
+  <a-menu-item v-if="showInvoices" key="invoices">
+    <NuxtLink to="/invoices">Invoices</NuxtLink>
+  </a-menu-item>
+</template>
+```
+
+The set is fetched once per app boot and shared, so reading it in a component costs nothing.
+
+**Hiding is presentation, never a control.** Anybody can type the address. Always pair a hidden section with a gated route — the section is a courtesy that stops people clicking a link that leads to a refusal.
+
+## 3. Turn it on and off
+
+```bash
+weos feature list --database-dsn ./weos.db
+weos feature enable invoice-export --database-dsn ./weos.db
+weos feature disable invoice-export --database-dsn ./weos.db
+weos feature reset invoice-export --database-dsn ./weos.db
+```
+
+`reset` is not `disable`. Disabling stores an explicit off that no account and no grant can lift; resetting returns the layer to silence so a lower layer can speak.
+
+## 4. Grant it to somebody
+
+```bash
+weos feature grant invoice-export --email auditor@example.com --account acct-123 \
+  --valid-until 2026-09-30T00:00:00Z --database-dsn ./weos.db
+
+weos feature grants invoice-export --account acct-123 --database-dsn ./weos.db
+weos feature revoke invoice-export --email auditor@example.com --account acct-123 --database-dsn ./weos.db
+```
+
+Grant to a role with `--role owner|admin|member` instead of `--email`.
+
+A grant cannot lift an explicit off at the instance or account level. If a grant appears to do nothing, run `weos feature list` and look at the deciding layer.
+
+## 5. Check what a caller actually gets
+
+```bash
+curl -s localhost:8080/api/features | jq '.data[] | {key, enabled, source}'
+```
+
+`source` tells you which layer decided, which is usually the answer to "why is this off?".
+
+## Testing a gated capability
+
+Write the scenario that hides it **and** the scenario that calls it anyway. A test that only checks the listing passes against an implementation with no control at all, and the gap stays invisible until somebody uses a name they already had.
+
+Prove the cost too, if the capability sits on a hot path: a caller's whole set resolves once, so a turn making thirty calls should read the database no more often than one making none.
+
+## Common problems
+
+**The gate does nothing.** Check the key is declared — `weos feature list` shows every declared feature. An undeclared key answers the caller's default and logs once, so grep the logs for `nobody declared`.
+
+**A grant has no effect.** Check the deciding layer. An explicit off above it wins, and `grantable: false` makes the grant unreadable.
+
+**A change did not reach somebody.** Writes invalidate caches immediately, but a resolved set is served for up to 15 minutes otherwise, and a separate process (`weos mcp`) has its own cache. Lower `FEATURE_CACHE_MAX_AGE_SECONDS` if you need tighter propagation.
+
+**Instance-level writes are refused on a multi-account instance.** Set `FEATURE_PRIMARY_ACCOUNT_ID` to the account whose owners and admins may change instance settings.
+
+**A local `weos mcp` session ignores a grant.** It cannot do otherwise: stdio has no caller identity, so gating there is instance-wide.
+
+## Related
+
+- [Feature Flags]({% link _explanation/feature-flags.md %}) — why the layers behave as they do
+- [Feature Flags reference]({% link _reference/feature-flags.md %}) — every flag, endpoint and command
+- [Create a Behavior]({% link _howto/create-behavior.md %}) — behaviors are a different mechanism; they fail open, features fail closed

--- a/docs/_howto/index.md
+++ b/docs/_howto/index.md
@@ -19,3 +19,4 @@ How-to guides are **task-oriented** — they assume you already have WeOS runnin
 | [Manage Persons and Organizations]({% link _howto/manage-persons-organizations.md %}) | CRUD operations for people and organizations |
 | [Seed Development Data]({% link _howto/seed-data.md %}) | Populate your local database with test data |
 | [Create a Behavior]({% link _howto/create-behavior.md %}) | Add custom domain logic to a resource type |
+| [Gate a Capability]({% link _howto/gate-a-capability.md %}) | Put a tool, skill, route or UI section behind a feature flag |

--- a/docs/_reference/environment-variables.md
+++ b/docs/_reference/environment-variables.md
@@ -65,6 +65,17 @@ Set `SESSION_SECRET` to a real value before enabling either one — with the def
 | `GEMINI_API_KEY` | string | | Google Gemini API key |
 | `GEMINI_MODEL` | string | `gemini-2.0-flash` | Gemini model identifier |
 
+## Feature Flags
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `FEATURES` | JSON | | Feature declarations, as a JSON array of `{key, displayName, description, default, manageable, grantable}`. A malformed value stops the boot rather than declaring nothing |
+| `FEATURE_CACHE_MAX_AGE_SECONDS` | int | `900` | How long a caller's resolved feature set may be served before it is resolved again |
+| `FEATURE_PRIMARY_ACCOUNT_ID` | string | | The account whose owners and admins may change instance-level settings. Needed on instances with more than one account |
+| `FEATURE_NOTIFY_CHANNEL` | string | `weos_feature_cache` | Postgres `LISTEN/NOTIFY` channel used to invalidate feature caches across replicas |
+
+See the [Feature Flags reference]({% link _reference/feature-flags.md %}).
+
 ## Analytics (Optional)
 
 | Variable | Type | Default | Description |

--- a/docs/_reference/feature-flags.md
+++ b/docs/_reference/feature-flags.md
@@ -1,0 +1,180 @@
+---
+title: Feature Flags
+parent: Reference
+layout: default
+nav_order: 9
+---
+
+# Feature Flags
+
+Precise surface for the feature-flag subsystem. For why it is shaped this way see [Feature Flags]({% link _explanation/feature-flags.md %}); for the task see [Gate a Capability]({% link _howto/gate-a-capability.md %}).
+
+## Declaration
+
+A feature is declared once. `key` and `displayName` are required.
+
+| Field | JSON | Meaning |
+|-------|------|---------|
+| `Key` | `key` | What call sites gate on, after the `feature.` prefix |
+| `DisplayName` | `displayName` | What an operator reads in the CLI and admin |
+| `Description` | `description` | Optional prose for the same readers |
+| `Default` | `default` | The value when no layer has spoken. **Not** the same as an explicit off |
+| `Manageable` | `manageable` | An account admin may override it. When false, a stored account override is ignored |
+| `Grantable` | `grantable` | It may be granted to an agent or a role. When false, a stored grant is ignored |
+
+Three sources, all read at boot:
+
+| Source | How |
+|--------|-----|
+| Code | `fx.Provide(application.AsFeatureDeclarations(func() []entities.FeatureMeta { … }))` |
+| Preset | `PresetDefinition.Features` — swept on every lookup, so installing a preset declares its features immediately |
+| Configuration | the `FEATURES` environment variable |
+
+A duplicate key is a boot error, not a last-wins. Two declarations of one key means two subsystems each believe they own it. A code declaration wins a collision with a *preset* (and logs it); a `FEATURES` entry that agrees with a code declaration about `default`, `manageable` and `grantable` is a no-op with a warning, and one that disagrees is a boot error naming both sides.
+
+## Resolution
+
+`ResolveFeature(meta, instance, account, granted)` returns the value and the deciding layer. Stored layers are tri-state: on, off, or unset (no row).
+
+| Instance | Account | Grant | Result | Layer |
+|----------|---------|-------|--------|-------|
+| unset | unset | no | the declared `default` | `default` |
+| **off** | anything | anything | **off** | `instance` |
+| on | unset | no | on | `instance` |
+| on | **off** | anything | **off** | `account` |
+| unset | on | no | on | `account` |
+| unset | unset | yes | on | `grant` |
+| unset | **off** | yes | **off** | `account` |
+
+`manageable: false` makes the account column read as unset. `grantable: false` makes the grant column read as no.
+
+A store that cannot be read resolves **off**, with layer `error`. A key nobody declared answers the **caller's own default** and is logged once.
+
+## Configuration
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `FEATURES` | *(empty)* | JSON array of declarations, same shape as a code declaration |
+| `FEATURE_CACHE_MAX_AGE_SECONDS` | `900` | How long a resolved set may be served before re-resolution |
+| `FEATURE_PRIMARY_ACCOUNT_ID` | *(empty)* | Which account's owners and admins may change instance-level settings |
+| `FEATURE_NOTIFY_CHANNEL` | `weos_feature_cache` | Postgres `LISTEN/NOTIFY` channel for cross-replica cache invalidation |
+
+```bash
+FEATURES='[{"key":"ledger-export","displayName":"Ledger export","default":false,"manageable":true,"grantable":true}]'
+```
+
+A malformed `FEATURES` value stops the boot. Declaring nothing silently would look exactly like a working instance with every feature off.
+
+`FEATURE_PRIMARY_ACCOUNT_ID` matters on multi-account instances. Instance-level writes require an owner or admin **of the instance account**; without this variable, a single-account instance uses that account and a multi-account instance refuses instance-level writes rather than guessing.
+
+## CLI
+
+```
+weos feature list                      # every feature, its value, and the layer that decided it
+weos feature enable <key>              # instance-level on
+weos feature disable <key>             # instance-level off
+weos feature reset <key>               # remove the instance override (not the same as disable)
+weos feature grant <key>   --email <address> | --role <owner|admin|member> [--account <id>]
+                           [--valid-from <RFC3339>] [--valid-until <RFC3339>]
+weos feature revoke <key>  --email <address> | --role <role> [--account <id>]
+weos feature grants <key>  [--account <id>]
+```
+
+`--account` is required on an instance with more than one account. Every command needs an explicit database DSN.
+
+## HTTP API
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| `GET` | `/api/features` | optional | The caller's resolved set. A caller with no session is answered the instance view with HTTP 200 |
+| `PUT` | `/api/features/{key}/instance` | operator | `{"enabled": true\|false}` — the field is required |
+| `DELETE` | `/api/features/{key}/instance` | operator | Reset to unset |
+| `PUT` | `/api/features/{key}/account` | account admin | `{"enabled": true\|false}` |
+| `DELETE` | `/api/features/{key}/account` | account admin | Reset to unset |
+| `GET` | `/api/features/{key}/grants` | account admin | Who holds it, with each grant's window and state |
+| `POST` | `/api/features/{key}/grants` | account admin | `{"email"\|"role", "validFrom", "validThrough"}` |
+| `DELETE` | `/api/features/{key}/grants` | account admin | Take one back |
+| `GET` | `/api/features/grants?email=` | account admin | Everything one person holds, directly or by role |
+
+`GET /api/features` returns one entry per declared feature:
+
+```json
+{
+  "data": [
+    {
+      "key": "agent-chat",
+      "displayName": "Assistant",
+      "description": "Talk to this instance's assistant",
+      "enabled": true,
+      "source": "instance",
+      "default": true,
+      "manageable": true,
+      "grantable": true
+    }
+  ]
+}
+```
+
+`source` is `default`, `instance`, `account`, `grant`, or `error`. It never carries anybody's grant rows.
+
+When the store cannot be read, the listing answers **200 with every feature off**, `source: "error"`, and a warning in `messages`. It agrees with the gates during an outage rather than leaving a client to invent a policy.
+
+## MCP tools
+
+Available on the HTTP transport by default. On stdio they are **opt in** — `weos mcp --services resource,feature` — because that transport is trusted without a permission check.
+
+| Tool | Purpose |
+|------|---------|
+| `feature_list` | Every feature, resolved for the caller, with its deciding layer |
+| `feature_set` | Instance or account level; `enabled` is required |
+| `feature_reset` | Return a layer to unset |
+| `feature_grant` | Grant to a person or a role, with an optional window |
+| `feature_revoke` | Take a grant back |
+| `feature_grants` | Who holds a feature |
+
+## Grant states
+
+A listing reports each grant's window state:
+
+| State | Meaning | What to do |
+|-------|---------|-----------|
+| `active` | Applies now | — |
+| `pending` | `validFrom` has not arrived | Wait, or revoke |
+| `expired` | `validThrough` has passed | The grant ran its course; the row can be cleaned up |
+| `orphaned` | The subject is no longer a member of the account | Left-over access; revoke it |
+
+## Go API
+
+| Symbol | Package | Purpose |
+|--------|---------|---------|
+| `AsFeatureDeclarations` | `application` | Contribute declarations to the fx value group |
+| `ToolFeatureGate(client)` | `application` | Build a `func(ctx, key) bool` over the OpenFeature client |
+| `SkillFeatureGate(client, registry, logger)` | `application` | The same, for agent skills, naming the skill in the drift log |
+| `FeatureFlagPrefix` | `application` | `"feature."` — the key namespace |
+| `FeatureProviderDomain` | `application` | `"weos"` — the OpenFeature domain |
+| `AddGatedTool` | `pkg/cli` | Add an MCP tool and its gate in one statement |
+| `MCPFeatureGates` | `pkg/cli` | The gate index handed to a configurer as `deps.Gates` |
+| `RequireFeature(gate, key)` | `api/middleware` | Echo middleware refusing a route with 403 |
+| `SetSkillGate` | `application/agents` | Wire the skill gate onto the orchestrator |
+| `RoutableSkills(ctx)` | `application/agents` | The skills a caller can be routed to |
+| `GateRefusal(ctx, subject, key)` | `domain/entities` | The shared refusal wording |
+| `FeatureCacheInvalidator` | `domain/repositories` | `InvalidateAll` / `InvalidateAccount` / `InvalidateAgents` |
+
+## Admin SPA
+
+`useFeatures()` exposes the set to components.
+
+| Member | Purpose |
+|--------|---------|
+| `isEnabled(key)` | Whether a feature is on for the signed-in person |
+| `ensureLoaded()` | Fetch once per app boot |
+| `refresh()` | Fetch again because the caller changed |
+| `unavailable` | The set could not be fetched at all |
+
+An unknown key is **off** in the browser and **on** on the server. The server leaves a drifted capability where it was because closing it would be a silent outage; the browser draws nothing, because the server refuses it either way and a link that leads to a refusal is the worse mistake.
+
+## Related
+
+- [Feature Flags]({% link _explanation/feature-flags.md %})
+- [Gate a Capability]({% link _howto/gate-a-capability.md %})
+- [Environment Variables]({% link _reference/environment-variables.md %})

--- a/docs/_reference/index.md
+++ b/docs/_reference/index.md
@@ -18,3 +18,4 @@ Reference pages are **information-oriented** — precise, complete, and structur
 | [Template Attributes]({% link _reference/data-weos-attributes.md %}) | `data-weos-*` HTML attribute reference |
 | [Environment Variables]({% link _reference/environment-variables.md %}) | All environment variables with formats and defaults |
 | [Events]({% link _reference/events.md %}) | Domain event types and their payloads |
+| [Feature Flags]({% link _reference/feature-flags.md %}) | Precedence, declarations, config, CLI, API, MCP tools and Go API |

--- a/docs/_tutorials/gating-your-first-feature.md
+++ b/docs/_tutorials/gating-your-first-feature.md
@@ -1,0 +1,200 @@
+---
+title: Gating Your First Feature
+parent: Tutorials
+layout: default
+nav_order: 6
+---
+
+# Gating Your First Feature
+
+In this tutorial you will take a capability WeOS already ships — the `episodic_recall` MCP tool — and watch it disappear and come back as you change one feature. Then you will grant a second feature to one person and watch an operator's decision overrule it.
+
+By the end you will have seen every layer decide the same feature, and you will know how to read which one won.
+
+Nothing here changes code. You are driving the switches an operator has.
+
+**You will need:** a built binary (`make build`) and about fifteen minutes.
+
+## 1. Start with a clean instance
+
+```bash
+cd services/core
+rm -f tutorial.db
+export DSN=./tutorial.db
+```
+
+Every command passes `--database-dsn $DSN`, so you are always working on this database and never on a real one.
+
+## 2. See what the instance declares
+
+```bash
+./bin/weos feature list --database-dsn $DSN
+```
+
+```
+KEY              NAME             STATE  SOURCE
+agent-chat       Assistant        on     declared default
+episodic-recall  Episodic recall  on     declared default
+```
+
+Two things to notice. Both are **on**, and the source is **declared default** — nobody has stored anything, so the value is the one the declaration carries.
+
+That is not the same as *on*. It means "nothing has spoken yet", and it matters in step 5.
+
+## 3. Watch a tool disappear
+
+`episodic-recall` gates a real MCP tool. Ask the server for its tool list:
+
+```bash
+ask_mcp() {
+  { printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"tutorial","version":"1"}}}'
+    printf '%s\n' "$1"
+    perl -e 'select(undef,undef,undef,3)'   # hold stdin open while the server answers
+  } | DATABASE_DSN=$DSN ./bin/weos mcp 2>/dev/null
+}
+
+ask_mcp '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' | grep -c episodic_recall
+```
+
+You get a non-zero count — the tool is there. Now turn the feature off:
+
+```bash
+./bin/weos feature disable episodic-recall --database-dsn $DSN
+ask_mcp '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' | grep -c episodic_recall
+```
+
+`0`. The tool is **gone** — not disabled, not greyed out, absent. A model that cannot see a tool cannot propose it.
+
+## 4. Confirm the half that matters
+
+A client could still have an older list. Call the tool by name anyway:
+
+```bash
+ask_mcp '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"episodic_recall","arguments":{}}}' | tail -2
+```
+
+```json
+{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text",
+ "text":"episodic_recall is not available: the \"episodic-recall\" capability is not enabled on this server."}],
+ "isError":true}}
+```
+
+**This is the control.** The missing list entry was only a courtesy — a stale tool list is never authorization.
+
+Notice the wording: *on this server*, not *for you*. The stdio transport has no caller identity, so gating there is instance-wide and no personal grant could change it. Over HTTP, where there is a caller, the same refusal says "for you".
+
+## 5. Learn what `reset` does
+
+```bash
+./bin/weos feature list --database-dsn $DSN
+```
+
+`episodic-recall` is now `off`, source `instance override`. There are two ways back:
+
+```bash
+./bin/weos feature reset episodic-recall --database-dsn $DSN
+./bin/weos feature list --database-dsn $DSN     # on, "declared default"
+
+./bin/weos feature disable episodic-recall --database-dsn $DSN
+./bin/weos feature enable  episodic-recall --database-dsn $DSN
+./bin/weos feature list --database-dsn $DSN     # on, "instance override"
+```
+
+The values match; the meanings do not. **Reset** returns the layer to silence, so an account or a grant can decide. **Enable** stores an explicit yes. Reset it again before moving on:
+
+```bash
+./bin/weos feature reset episodic-recall --database-dsn $DSN
+```
+
+## 6. Declare a feature of your own
+
+Declarations are never stored, so every command has to read the same ones. Export it once:
+
+```bash
+export FEATURES='[{"key":"ledger-export","displayName":"Ledger export","default":false,"manageable":true,"grantable":true}]'
+./bin/weos feature list --database-dsn $DSN
+```
+
+```
+ledger-export    Ledger export    off    declared default
+```
+
+Declared off — but nobody has said no. That distinction is about to earn its keep.
+
+## 7. Grant it to one person
+
+Grants live inside an account, so create one:
+
+```bash
+echo "correct-horse-battery-staple" | \
+  ./bin/weos account create --email ada@example.com --password-stdin --database-dsn $DSN
+
+./bin/weos feature grant ledger-export --email ada@example.com --database-dsn $DSN
+```
+
+```
+Granted "ledger-export" to ada@example.com in account 3IC0zPjK….
+  window: —   status: active
+```
+
+The grant reaches her, because nothing above it said no.
+
+## 8. Watch an explicit off beat the grant
+
+```bash
+./bin/weos feature disable ledger-export --database-dsn $DSN
+./bin/weos feature grants ledger-export --database-dsn $DSN
+```
+
+```
+SUBJECT          WINDOW  STATUS  GRANTED BY
+ada@example.com  —       active  —
+```
+
+The grant is still there and still `active` — and it no longer reaches her, because **an explicit off is final downward**. An operator's no is a statement about what this instance does, and a grant cannot argue with it.
+
+This is the most useful rule to carry away. When a grant seems to do nothing, look at the deciding layer:
+
+```bash
+./bin/weos feature list --database-dsn $DSN | grep ledger
+# ledger-export    Ledger export    off    instance override
+```
+
+## 9. Give access that ends by itself
+
+```bash
+./bin/weos feature reset  ledger-export --database-dsn $DSN
+./bin/weos feature revoke ledger-export --email ada@example.com --database-dsn $DSN
+./bin/weos feature grant  ledger-export --email ada@example.com \
+  --valid-until "$(date -u -v+1M +%Y-%m-%dT%H:%M:%SZ)" --database-dsn $DSN
+```
+
+```
+  window: until 2026-08-20T19:19:34Z   status: active
+```
+
+Wait for the minute to pass and list the grants again — the status is now `expired`.
+
+Nothing ran to expire it. There is no sweeper and no scheduled job; the row is simply not counted once the moment passes. That is why access ends exactly on time without anything being scheduled — and also why nothing can announce the moment it ends.
+
+## Clean up
+
+```bash
+rm -f tutorial.db
+unset FEATURES DSN
+```
+
+## What you learned
+
+- A feature has four layers, and the listing always names the one that decided.
+- `declared default` means nothing has spoken; **off** means something has.
+- An explicit off is final downward. An explicit on is not.
+- Hiding a capability is a courtesy; refusing the call is the control.
+- Refusals say whose answer they are, so nobody chases a grant that cannot apply.
+- Grants can carry a window, and expiry costs nothing because nothing watches for it.
+
+## Next
+
+- [Gate a Capability]({% link _howto/gate-a-capability.md %}) — put one of your own capabilities behind a flag
+- [Feature Flags]({% link _explanation/feature-flags.md %}) — why the layers behave this way
+- [Feature Flags reference]({% link _reference/feature-flags.md %}) — every command, endpoint and variable

--- a/docs/_tutorials/index.md
+++ b/docs/_tutorials/index.md
@@ -17,3 +17,4 @@ Each tutorial tells you what you'll learn, what you need before you start, and e
 | [Auth: Roles and Access]({% link _tutorials/auth-roles-and-access.md %}) | Create roles, assign users, control what each role can access |
 | [Customizing the UI]({% link _tutorials/customizing-the-ui.md %}) | Work with templates, manage the sidebar menu, organize content |
 | [Connecting MCP to an LLM]({% link _tutorials/connecting-mcp-to-llm.md %}) | Wire the MCP server to Claude Desktop or another LLM client |
+| [Gating Your First Feature]({% link _tutorials/gating-your-first-feature.md %}) | Watch a capability disappear, be refused, and come back as you change one feature |

--- a/domain/entities/feature.go
+++ b/domain/entities/feature.go
@@ -88,6 +88,11 @@ const (
 	FeatureLayerAccount
 	// FeatureLayerGrant means a grant turned it on.
 	FeatureLayerGrant
+	// FeatureLayerError means no layer decided: the stored state could not be
+	// read, so the value is the fail-closed answer rather than anything
+	// anybody configured. It exists so a listing can never tell a reader that
+	// a stored value produced an answer an outage produced.
+	FeatureLayerError
 )
 
 // String renders the layer for operator-facing output.
@@ -99,6 +104,8 @@ func (l FeatureLayer) String() string {
 		return "account"
 	case FeatureLayerGrant:
 		return "grant"
+	case FeatureLayerError:
+		return "error"
 	default:
 		return "default"
 	}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -442,7 +442,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// Listing is readable by any authenticated caller — the admin UI needs it
 	// to decide what to render. Changing state is gated inside the service,
 	// which the CLI and the MCP tools share, so the rule lives in one place.
-	protected.GET("/features", featureHandler.List)
+	// GET /features is registered below on its own group: it must answer a
+	// caller with no session (#487), which the protected group cannot do.
 	protected.PUT("/features/:key/instance", featureHandler.SetInstance)
 	protected.DELETE("/features/:key/instance", featureHandler.ResetInstance)
 	protected.PUT("/features/:key/account", featureHandler.SetAccount)
@@ -481,6 +482,36 @@ func runServe(cmd *cobra.Command, args []string) error {
 		acceptGroup.Use(echo.WrapMiddleware(apimw.OptionalAuth(sessionManager, authService)))
 	}
 	acceptGroup.POST("/invites/accept", inviteHandler.Accept)
+
+	// The feature listing (#486/#487). It answers a caller with no session —
+	// the admin needs the instance view to draw a sign-in page — so it cannot
+	// live on the protected group.
+	//
+	// Two things about this group are load-bearing.
+	//
+	// It keeps Impersonation. The protected group applies it, and a listing
+	// that lost it would answer with the real admin's features while every
+	// other call on the page answered with the impersonated user's — a sidebar
+	// drawn for one person over another person's data, which is worse than
+	// either alone. Impersonation passes through untouched when there is no
+	// identity, so it costs the anonymous case nothing.
+	//
+	// It is registered BEFORE mcpGroup, deliberately. Echo's Group.Use
+	// registers a not-found catch-all at the group prefix, so the LAST
+	// empty-prefix group under /api owns what an unmatched /api path answers —
+	// see the note at mcpGroup. Putting this group after it would silently
+	// move that ownership and change the answer for every unmounted path,
+	// including /api/auth/register when registration is off, whose parity
+	// password_registration_flag.feature pins in a test that builds its own
+	// echo instance and would therefore not notice.
+	featuresGroup := api.Group("")
+	if appCfg.OAuthEnabled() {
+		featuresGroup.Use(echo.WrapMiddleware(apimw.OptionalAuth(sessionManager, authService)))
+		featuresGroup.Use(apimw.Impersonation(sessionStore, accountRepo, logger))
+	} else {
+		featuresGroup.Use(apimw.SoftAuth(credentialRepo, agentRepo, accountRepo, logger))
+	}
+	featuresGroup.GET("/features", featureHandler.List)
 
 	protected.POST("/admin/impersonate", impersonationHandler.Start)
 	protected.POST("/admin/stop-impersonation", impersonationHandler.Stop)
@@ -542,9 +573,18 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// The in-app agent is independent of the MCP transport flag: with MCP
 	// disabled it still chats, just tool-less (the orchestrator degrades).
 	agentHandler := handlers.NewAgentHandler(orchestrator, logger)
-	mcpGroup.POST("/agent/conversations/:conversationID/messages", agentHandler.SendMessage)
-	mcpGroup.POST("/agent/conversations/:conversationID/confirmations/:callID", agentHandler.Confirm)
-	mcpGroup.GET("/agent/conversations/:conversationID", agentHandler.History)
+	// The in-app agent's REST surface is gated on "agent-chat" (#486). It is
+	// the one sidebar entry that is a capability rather than an administrative
+	// screen — Users and Settings are gated by role, and a role is not a flag.
+	// Declared ON, so no instance loses a working page by upgrading.
+	//
+	// This composes with #485 rather than overlapping it: off means there is
+	// no assistant at all, on means there is one whose skill graph #485
+	// filters for the caller.
+	agentGate := apimw.RequireFeature(application.ToolFeatureGate(featureClient), application.FeatureAgentChat)
+	mcpGroup.POST("/agent/conversations/:conversationID/messages", agentHandler.SendMessage, agentGate)
+	mcpGroup.POST("/agent/conversations/:conversationID/confirmations/:callID", agentHandler.Confirm, agentGate)
+	mcpGroup.GET("/agent/conversations/:conversationID", agentHandler.History, agentGate)
 
 	if serveViper.GetBool("enabled") {
 		mcpSrv, mcpErr := mcpserver.NewConfiguredServer(

--- a/tests/e2e/feature_admin_surface_steps_test.go
+++ b/tests/e2e/feature_admin_surface_steps_test.go
@@ -1,0 +1,1434 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/cucumber/godog"
+
+	authentities "github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/domain/entities"
+)
+
+// gatedRoutes is the harness's copy of the Background's route table. A
+// background step compares it against what the contract says, so the two
+// cannot drift.
+func defaultRouteGates() map[string]string {
+	return map[string]string{
+		"POST /api/agent/conversations/{id}/messages": application.FeatureAgentChat,
+		"GET /api/agent/conversations/{id}":           application.FeatureAgentChat,
+		"POST /api/ledger/exports":                    "ledger-export",
+	}
+}
+
+// routePath turns a contract route into a real path.
+func routePath(route string) (method, path string) {
+	parts := strings.SplitN(route, " ", 2)
+	if len(parts) != 2 {
+		return http.MethodGet, route
+	}
+	return parts[0], strings.ReplaceAll(parts[1], "{id}", "conv-1")
+}
+
+//nolint:funlen // a step table is one statement per contract sentence
+func initFeatureAdminSurfaceScenario(sc *godog.ScenarioContext) {
+	w := newAdminWorld()
+	sc.After(func(ctx context.Context, _ *godog.Scenario, err error) (context.Context, error) {
+		w.teardown()
+		return ctx, err
+	})
+
+	// --- background -------------------------------------------------------
+	sc.Given(`^a WeOS instance where password sign-in is enabled and requests are `+
+		`authenticated by their session$`, func() error { return nil })
+	sc.Given(`^the instance declares these features in code:$`, w.stepDeclareFeatures)
+	sc.Given(`^these API routes declare the feature that gates them:$`, w.stepRoutesDeclareGates)
+	sc.Given(`^these API routes name no feature:$`, w.stepRoutesNameNoFeature)
+	sc.Given(`^the account "([^"]*)", whose owner "([^"]*)" signs in with password "([^"]*)"$`,
+		w.stepAccountWithOwner)
+
+	// --- staging ----------------------------------------------------------
+	sc.Given(`^nothing has been overridden or granted on this instance$`, func() error { return nil })
+	sc.Given(`^the operator has turned the feature "([^"]*)" (on|off) for the instance$`, w.stepInstanceFlag)
+	sc.When(`^the operator turns the feature "([^"]*)" (on|off) for the instance$`, w.stepInstanceFlag)
+	sc.Given(`^the instance booted with the feature "([^"]*)" (on|off) for the instance$`, w.stepBootedWith)
+	sc.Given(`^"([^"]*)" has turned the feature "([^"]*)" (on|off)$`, w.stepAccountFlag)
+	sc.Given(`^"([^"]*)" also belongs to "([^"]*)"$`, w.stepAlsoBelongs)
+	sc.Given(`^"([^"]*)" belongs to "([^"]*)" as an ordinary member$`, w.stepBelongsAsMember)
+	sc.Given(`^"([^"]*)" has been granted the feature "([^"]*)"$`, w.stepGranted)
+	sc.Given(`^"([^"]*)" holds a grant of "([^"]*)" valid until (\d+) seconds from now$`, w.stepGrantUntil)
+	sc.When(`^"([^"]*)" revokes "([^"]*)" from "([^"]*)"$`, w.stepRevoke)
+	sc.Given(`^the route "([^"]*)" is gated by the undeclared feature "([^"]*)"$`, w.stepRouteGatedByUndeclared)
+	sc.Given(`^the instance is configured with a maximum cache age of (\d+) minutes$`, w.stepCacheAge)
+	sc.Given(`^the store holding account overrides and grants cannot be read$`, w.stepStoreDown)
+	sc.When(`^the store can be read again$`, w.stepStoreUp)
+
+	// --- signing in -------------------------------------------------------
+	sc.Given(`^"([^"]*)" is signed in to "([^"]*)"$`, w.stepSignedIn)
+	sc.Given(`^both of them are signed in to "([^"]*)"$`, w.stepBothSignedIn)
+
+	// --- asking -----------------------------------------------------------
+	sc.When(`^they ask the API for their feature set$`, w.stepAsk)
+	sc.When(`^they ask the API for their feature set (\d+) times$`, w.stepAskTimes)
+	sc.When(`^each of them asks the API for their feature set$`, w.stepEachAsks)
+	sc.When(`^a request carrying no session asks the API for the feature set$`, w.stepAnonymousAsk)
+	sc.Given(`^they have asked for their feature set and been answered "([^"]*)" (on|off)$`, w.stepAskedAndAnswered)
+	sc.When(`^they ask for their feature set again in the session they already held$`, w.stepAsk)
+	sc.When(`^"([^"]*)" asks for their feature set again in the session they already held$`, w.stepNamedAsks)
+	sc.When(`^they ask for their feature set again$`, w.stepAsk)
+	sc.When(`^they act in "([^"]*)" and ask for their feature set again$`, w.stepActInAndAsk)
+	sc.When(`^"([^"]*)" impersonates "([^"]*)"$`, w.stepImpersonate)
+	sc.When(`^they stop impersonating$`, w.stepStopImpersonating)
+
+	// --- calling ----------------------------------------------------------
+	sc.When(`^they call "([^"]*)"$`, w.stepCall)
+	sc.When(`^they call "([^"]*)" (\d+) times$`, w.stepCallTimes)
+	sc.When(`^they call every gated route the instance mounts$`, w.stepCallEveryGatedRoute)
+	sc.When(`^a request carrying no session calls "([^"]*)"$`, w.stepAnonymousCall)
+	sc.When(`^a request carrying no session asks the API for the person listing$`, w.stepAnonymousPersons)
+	sc.When(`^a request carrying no session tries to turn the feature "([^"]*)" off for the instance$`,
+		w.stepAnonymousWrite)
+	sc.When(`^a request carrying no session asks the API for a path nobody mounted$`, w.stepAnonymousUnmounted)
+	sc.When(`^"([^"]*)" calls "([^"]*)" on the answer they already hold$`, w.stepNamedCall)
+	sc.When(`^they call "([^"]*)" straight away$`, w.stepCallStraightAway)
+	sc.When(`^they call "([^"]*)" again once that moment has passed$`, w.stepCallAfterMoment)
+	sc.When(`^they make (\d+) calls to gated routes in that session$`, w.stepMakeCalls)
+	sc.When(`^they try to turn the feature "([^"]*)" off for the instance$`, w.stepTryWrite)
+	sc.When(`^they turn the feature "([^"]*)" on for the instance through the API$`, w.stepTurnOnThroughAPI)
+
+	// --- outcomes ---------------------------------------------------------
+	sc.Then(`^the answer is served$`, w.stepAnswerServed)
+	sc.Then(`^the feature set was served$`, w.stepAnswerServed)
+	sc.Then(`^the answer carries every feature the instance declares$`, w.stepAnswerCarriesAll)
+	sc.Then(`^the answer reports "([^"]*)" as (on|off)$`, w.stepAnswerReports)
+	sc.Then(`^the answer reported "([^"]*)" as (on|off)$`, w.stepAnswerReports)
+	sc.Then(`^the answer had carried "([^"]*)" reported as (on|off)$`, w.stepAnswerReports)
+	sc.Then(`^they are answered "([^"]*)" (on|off)$`, w.stepAnswerReports)
+	sc.Then(`^they are now answered "([^"]*)" (on|off)$`, w.stepNowAnswered)
+	sc.Then(`^"([^"]*)" is answered "([^"]*)" (on|off)$`, w.stepNamedAnswerReports)
+	sc.Then(`^both of them are answered "([^"]*)" (on|off)$`, w.stepBothAnswered)
+	sc.Then(`^each feature carries its key and whether it is enabled$`, w.stepCarriesKeyAndEnabled)
+	sc.Then(`^each feature carries its display name and the layer that decided it$`, w.stepCarriesNameAndLayer)
+	sc.Then(`^the answer carries no grant belonging to anybody$`, w.stepNoGrantsInAnswer)
+	sc.Then(`^no account override or grant was read to answer it$`, w.stepNoAccountLayerRead)
+	sc.Then(`^no feature in the answer names an account override as its layer$`, w.stepNoLayer("account"))
+	sc.Then(`^no feature in the answer names a grant as its layer$`, w.stepNoLayer("grant"))
+	sc.Then(`^the answer names no person and no account$`, w.stepAnswerNamesNobody)
+	sc.Then(`^they are answered the same set "([^"]*)" is answered$`, w.stepSameSetAs)
+	sc.Then(`^the person listing is refused as not authenticated$`, w.stepPersonsUnauthenticated)
+	sc.Then(`^the attempt to change the instance is refused as not authenticated$`, w.stepWriteUnauthenticated)
+	sc.Then(`^no instance-level setting is stored for "([^"]*)"$`, w.stepNoInstanceSetting)
+	sc.Then(`^the path nobody mounted answers exactly what an unmounted path answered before this change$`,
+		w.stepUnmountedParity)
+	sc.Then(`^the attempt to change it is refused as forbidden$`, w.stepWriteForbidden)
+	sc.Then(`^the attempt to change the instance is refused as forbidden$`, w.stepWriteForbidden)
+	sc.Then(`^the call (succeeds|is refused)$`, w.stepCallOutcome)
+	sc.Then(`^calling "([^"]*)" succeeds$`, w.stepCallSucceedsNow)
+	sc.Then(`^every route whose feature the answer reported on was served$`, w.stepReportedOnWereServed)
+	sc.Then(`^every route whose feature the answer reported off was refused$`, w.stepReportedOffWereRefused)
+	sc.Then(`^the call is refused as forbidden$`, w.stepCallForbidden)
+	sc.Then(`^the refusal names the feature "([^"]*)"$`, w.stepRefusalNamesFeature)
+	sc.Then(`^the refusal says the capability is not enabled for them$`, w.stepRefusalNotEnabled)
+	sc.Then(`^the refusal names their role rather than a feature$`, w.stepRefusalNamesRole)
+	sc.Then(`^the refusal does not say their role is insufficient$`, w.stepRefusalNotAboutRole)
+	sc.Then(`^no ledger export was recorded$`, w.stepNoLedgerExport)
+	sc.Then(`^the refusal is not a partial result$`, w.stepRefusalNotPartial)
+	sc.Then(`^the ledger call is served$`, w.stepLedgerServed)
+	sc.Then(`^both calls succeed$`, w.stepBothCallsSucceed)
+	sc.Then(`^no feature was evaluated for either route$`, w.stepNoFeatureEvaluated)
+	sc.Then(`^the call to the gated route is refused$`, w.stepGatedRouteRefused)
+	sc.Then(`^the call to the ungated route succeeds$`, w.stepUngatedRouteSucceeds)
+	sc.Then(`^every feature in the answer is reported off$`, w.stepEveryFeatureOff)
+	sc.Then(`^the answer carries a message saying the feature state could not be read$`, w.stepAnswerCarriesMessage)
+	sc.Then(`^the instance logged the failure$`, w.stepLoggedFailure)
+	sc.Then(`^every call succeeds$`, w.stepEveryCallSucceeded)
+	sc.Then(`^the instance logged the undeclared feature key once$`, w.stepLoggedDriftOnce)
+	sc.Then(`^the log names the key "([^"]*)"$`, w.stepLogNamesKey)
+	sc.Then(`^the log names the route$`, w.stepLogNamesRoute)
+	sc.Then(`^the change was accepted$`, w.stepChangeAccepted)
+	sc.Then(`^no turn was taken$`, w.stepNoTurnTaken)
+	sc.Then(`^no skill graph was built$`, w.stepNoTurnTaken)
+	sc.Then(`^the call straight away succeeded$`, w.stepStraightAwaySucceeded)
+	sc.Then(`^the call after that moment is refused$`, w.stepAfterMomentRefused)
+	sc.Then(`^nothing invalidated the session in between$`, w.stepNothingInvalidated)
+	sc.Then(`^the maximum cache age had not run out$`, w.stepCacheAgeHadNotRunOut)
+	sc.Then(`^"([^"]*)" is still signed in$`, w.stepStillSignedIn)
+	sc.Then(`^they were not signed out$`, w.stepNotSignedOut)
+	sc.Then(`^the instance was not restarted$`, w.stepNotRestarted)
+	sc.Then(`^every call was answered$`, w.stepEveryCallSucceeded)
+	sc.Then(`^every answer was the same$`, w.stepEveryAnswerSame)
+	sc.Then(`^feature state was read from the database only while the listing was answered$`, w.stepReadOnce)
+	sc.Then(`^feature state was read from the database only while the first answer was built$`, w.stepReadOnce)
+}
+
+// --- background -----------------------------------------------------------
+
+func (w *adminWorld) stepDeclareFeatures(table *godog.Table) error {
+	metas, err := featureMetasFrom(table)
+	if err != nil {
+		return err
+	}
+	w.declared = metas
+	for _, m := range metas {
+		if _, err := coreAlreadyDeclares(m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// stepRoutesDeclareGates checks the contract's table against what the harness
+// mounts, so a gate quietly moved is caught here rather than in a scenario.
+func (w *adminWorld) stepRoutesDeclareGates(table *godog.Table) error {
+	for _, row := range table.Rows[1:] {
+		route, key := strings.TrimSpace(row.Cells[0].Value), strings.TrimSpace(row.Cells[1].Value)
+		if w.routeGates[route] != key {
+			return fmt.Errorf("the contract says %q is gated by %q; the harness mounts it gated by %q",
+				route, key, w.routeGates[route])
+		}
+	}
+	return nil
+}
+
+func (w *adminWorld) stepRoutesNameNoFeature(table *godog.Table) error {
+	for _, row := range table.Rows[1:] {
+		route := strings.TrimSpace(row.Cells[0].Value)
+		if _, gated := w.routeGates[route]; gated {
+			return fmt.Errorf("the contract says %q names no feature, but the harness gates it", route)
+		}
+	}
+	return nil
+}
+
+func (w *adminWorld) stepAccountWithOwner(name, email, password string) error {
+	if err := w.boot(); err != nil {
+		return err
+	}
+	p, err := w.personFor(email, password)
+	if err != nil {
+		return err
+	}
+	if p.accountID == "" {
+		return fmt.Errorf("registering %q created no account", email)
+	}
+	w.accounts[name] = p.accountID
+	return nil
+}
+
+// --- staging --------------------------------------------------------------
+
+func (w *adminWorld) stepInstanceFlag(key, state string) error {
+	if err := w.boot(); err != nil {
+		return err
+	}
+	return w.features.SetInstanceFeature(context.Background(), key, state == "on")
+}
+
+func (w *adminWorld) stepBootedWith(key, state string) error {
+	if err := w.stepInstanceFlag(key, state); err != nil {
+		return err
+	}
+	return w.reboot()
+}
+
+func (w *adminWorld) stepAccountFlag(accountName, key, state string) error {
+	accountID, err := w.accountFor(accountName)
+	if err != nil {
+		return err
+	}
+	return w.features.SetAccountFeature(context.Background(), accountID, key, state == "on")
+}
+
+func (w *adminWorld) stepAlsoBelongs(email, accountName string) error {
+	return w.addToAccount(email, accountName, authentities.RoleMember)
+}
+
+func (w *adminWorld) stepBelongsAsMember(email, accountName string) error {
+	return w.addToAccount(email, accountName, authentities.RoleMember)
+}
+
+func (w *adminWorld) stepGranted(email, key string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	return w.features.GrantToAgent(context.Background(), p.accountID, p.agentID, key, application.GrantTerms{
+		GrantedByEmail: "ops@harborlegal.example", Source: "test",
+	})
+}
+
+func (w *adminWorld) stepGrantUntil(email, key string, seconds int) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	w.moment = time.Now().Add(time.Duration(seconds) * time.Second)
+	w.momentSet = true
+	w.windowStart = time.Now()
+	through := w.moment
+	return w.features.GrantToAgent(context.Background(), p.accountID, p.agentID, key, application.GrantTerms{
+		ValidThrough: &through, GrantedByEmail: "ops@harborlegal.example", Source: "test",
+	})
+}
+
+func (w *adminWorld) stepRevoke(_, key, subject string) error {
+	p, err := w.person(subject)
+	if err != nil {
+		return err
+	}
+	removed, err := w.features.RevokeFromAgent(context.Background(), p.accountID, p.agentID, key)
+	if err != nil {
+		return err
+	}
+	if !removed {
+		return fmt.Errorf("there was no grant of %q to revoke from %q", key, subject)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepRouteGatedByUndeclared(route, key string) error {
+	if _, gated := w.routeGates[route]; !gated {
+		return fmt.Errorf("%q is not a gated route", route)
+	}
+	w.ledgerGate = key
+	w.routeGates[route] = key
+	// The gate is read when the route is mounted, so the surface is built
+	// again — which is what a deploy carrying the typo would do.
+	return w.remount()
+}
+
+func (w *adminWorld) stepCacheAge(minutes int) error {
+	w.maxCacheAge = time.Duration(minutes) * time.Minute
+	if w.app == nil {
+		return nil
+	}
+	return w.reboot()
+}
+
+func (w *adminWorld) stepStoreDown() error {
+	if err := w.boot(); err != nil {
+		return err
+	}
+	w.settings.setDown(true)
+	w.grants.setDown(true)
+	return nil
+}
+
+func (w *adminWorld) stepStoreUp() error {
+	w.settings.setDown(false)
+	w.grants.setDown(false)
+	return nil
+}
+
+// --- signing in -----------------------------------------------------------
+
+func (w *adminWorld) stepSignedIn(email, accountName string) error {
+	if err := w.boot(); err != nil {
+		return err
+	}
+	p, err := w.personFor(email, "correct-horse-battery-staple")
+	if err != nil {
+		return err
+	}
+	if accountID, err := w.accountFor(accountName); err == nil {
+		p.accountID = accountID
+	}
+	if err := w.signIn(p); err != nil {
+		return err
+	}
+	if !contains(w.signedInOrder, email) {
+		w.signedInOrder = append(w.signedInOrder, email)
+	}
+	w.lastActor = email
+	w.restartBaseline = w.boots
+	return nil
+}
+
+func (w *adminWorld) stepBothSignedIn(accountName string) error {
+	for _, email := range w.staged() {
+		if err := w.stepSignedIn(email, accountName); err != nil {
+			return err
+		}
+	}
+	w.lastActor = ""
+	return nil
+}
+
+// --- asking ---------------------------------------------------------------
+
+func (w *adminWorld) ask(p *featurePerson) error {
+	key := "anonymous"
+	if p != nil {
+		key = p.email
+		w.lastActor = p.email
+	}
+	if len(w.answers) == 0 {
+		w.readsBefore = w.settings.count()
+	}
+	call, err := w.request(p, http.MethodGet, "/api/features", nil)
+	if err != nil {
+		return err
+	}
+	w.calls["listing|"+key] = call
+	if call.status != http.StatusOK {
+		w.answers[key] = nil
+		return nil
+	}
+	set, msgs, err := statusesFrom(call.body)
+	if err != nil {
+		return err
+	}
+	w.answers[key] = set
+	w.messages[key] = msgs
+	if w.readsAfterFirst == 0 {
+		w.readsAfterFirst = w.settings.count()
+	}
+	return nil
+}
+
+func (w *adminWorld) stepAsk() error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	return w.ask(p)
+}
+
+func (w *adminWorld) stepAskTimes(count int) error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	for i := 0; i < count; i++ {
+		if err := w.ask(p); err != nil {
+			return err
+		}
+		w.repeatAnswers = append(w.repeatAnswers, w.answers[p.email])
+	}
+	return nil
+}
+
+func (w *adminWorld) stepEachAsks() error {
+	for _, email := range w.signedInOrder {
+		p, err := w.person(email)
+		if err != nil {
+			return err
+		}
+		if err := w.ask(p); err != nil {
+			return err
+		}
+	}
+	w.lastActor = ""
+	return nil
+}
+
+func (w *adminWorld) stepNamedAsks(email string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	return w.ask(p)
+}
+
+func (w *adminWorld) stepAnonymousAsk() error {
+	if err := w.boot(); err != nil {
+		return err
+	}
+	return w.ask(nil)
+}
+
+func (w *adminWorld) stepAskedAndAnswered(key, state string) error {
+	if err := w.stepAsk(); err != nil {
+		return err
+	}
+	return w.stepAnswerReports(key, state)
+}
+
+func (w *adminWorld) stepActInAndAsk(accountName string) error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	accountID, err := w.accountFor(accountName)
+	if err != nil {
+		return err
+	}
+	p.accountID = accountID
+	// A different active account is a different session, which is what
+	// switching accounts does over HTTP.
+	delete(w.jar, p.email)
+	if err := w.signIn(p); err != nil {
+		return err
+	}
+	return w.ask(p)
+}
+
+func (w *adminWorld) stepImpersonate(admin, subject string) error {
+	a, err := w.person(admin)
+	if err != nil {
+		return err
+	}
+	s, err := w.person(subject)
+	if err != nil {
+		return err
+	}
+	call, err := w.request(a, http.MethodPost, "/api/admin/impersonate",
+		map[string]any{"agent_id": s.agentID})
+	if err != nil {
+		return err
+	}
+	if call.status >= 400 {
+		return fmt.Errorf("impersonation was refused: %d %s", call.status, call.body)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepStopImpersonating() error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	call, err := w.request(p, http.MethodPost, "/api/admin/stop-impersonation", nil)
+	if err != nil {
+		return err
+	}
+	if call.status >= 400 {
+		return fmt.Errorf("stopping impersonation was refused: %d %s", call.status, call.body)
+	}
+	return nil
+}
+
+// --- calling --------------------------------------------------------------
+
+func (w *adminWorld) call(p *featurePerson, route string) (*apiCall, error) {
+	method, path := routePath(route)
+	var body any
+	if method == http.MethodPost {
+		body = map[string]any{"message": "hello"}
+	}
+	call, err := w.request(p, method, path, body)
+	if err != nil {
+		return nil, err
+	}
+	key := route
+	if p != nil {
+		key = p.email + "|" + route
+	}
+	w.calls[key] = call
+	w.lastCallRoute = route
+	return call, nil
+}
+
+func (w *adminWorld) stepCall(route string) error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	_, err = w.call(p, route)
+	return err
+}
+
+func (w *adminWorld) stepCallTimes(route string, count int) error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	w.repeatCalls = nil
+	for i := 0; i < count; i++ {
+		call, err := w.call(p, route)
+		if err != nil {
+			return err
+		}
+		w.repeatCalls = append(w.repeatCalls, call)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepCallEveryGatedRoute() error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	for route := range w.routeGates {
+		if _, err := w.call(p, route); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *adminWorld) stepAnonymousCall(route string) error {
+	_, err := w.call(nil, route)
+	return err
+}
+
+func (w *adminWorld) stepAnonymousPersons() error {
+	call, err := w.request(nil, http.MethodGet, "/api/persons", nil)
+	if err != nil {
+		return err
+	}
+	w.calls["anon-persons"] = call
+	return nil
+}
+
+func (w *adminWorld) stepAnonymousWrite(key string) error {
+	call, err := w.request(nil, http.MethodPut, "/api/features/"+key+"/instance",
+		map[string]any{"enabled": false})
+	if err != nil {
+		return err
+	}
+	w.calls["anon-write"] = call
+	return nil
+}
+
+func (w *adminWorld) stepAnonymousUnmounted() error {
+	call, err := w.request(nil, http.MethodGet, "/api/nothing-is-mounted-here", nil)
+	if err != nil {
+		return err
+	}
+	w.calls["anon-unmounted"] = call
+	return nil
+}
+
+func (w *adminWorld) stepNamedCall(email, route string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	w.lastActor = email
+	_, err = w.call(p, route)
+	return err
+}
+
+func (w *adminWorld) stepCallStraightAway(route string) error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	w.invsBefore = w.invSpy.count()
+	call, err := w.call(p, route)
+	w.straightAway = call
+	return err
+}
+
+func (w *adminWorld) stepCallAfterMoment(route string) error {
+	if w.momentSet {
+		if wait := time.Until(w.moment); wait > 0 {
+			time.Sleep(wait + 50*time.Millisecond)
+		}
+	}
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	call, err := w.call(p, route)
+	w.afterMoment = call
+	return err
+}
+
+func (w *adminWorld) stepMakeCalls(count int) error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	w.repeatCalls = nil
+	routes := []string{
+		"POST /api/agent/conversations/{id}/messages",
+		"GET /api/agent/conversations/{id}",
+		"POST /api/ledger/exports",
+	}
+	for i := 0; i < count; i++ {
+		call, err := w.call(p, routes[i%len(routes)])
+		if err != nil {
+			return err
+		}
+		w.repeatCalls = append(w.repeatCalls, call)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepTryWrite(key string) error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	call, err := w.request(p, http.MethodPut, "/api/features/"+key+"/instance",
+		map[string]any{"enabled": false})
+	if err != nil {
+		return err
+	}
+	w.calls["write"] = call
+	return nil
+}
+
+func (w *adminWorld) stepTurnOnThroughAPI(key string) error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	call, err := w.request(p, http.MethodPut, "/api/features/"+key+"/instance",
+		map[string]any{"enabled": true})
+	if err != nil {
+		return err
+	}
+	w.calls["write"] = call
+	return nil
+}
+
+// --- outcomes -------------------------------------------------------------
+
+func (w *adminWorld) answerFor(email string) ([]entities.FeatureStatus, error) {
+	set, ok := w.answers[email]
+	if !ok {
+		return nil, fmt.Errorf("%q has not asked for their feature set", email)
+	}
+	return set, nil
+}
+
+func (w *adminWorld) soleAnswer() ([]entities.FeatureStatus, string, error) {
+	key := w.lastActor
+	if key == "" {
+		if _, ok := w.answers["anonymous"]; ok {
+			key = "anonymous"
+		}
+	}
+	if key == "" && len(w.signedInOrder) == 1 {
+		key = w.signedInOrder[0]
+	}
+	set, err := w.answerFor(key)
+	return set, key, err
+}
+
+func (w *adminWorld) stepAnswerServed() error {
+	_, key, err := w.soleAnswer()
+	if err != nil {
+		return err
+	}
+	call, ok := w.calls["listing|"+key]
+	if !ok {
+		return fmt.Errorf("no listing call was made")
+	}
+	if call.status != http.StatusOK {
+		return fmt.Errorf("the listing answered %d, want 200: %s", call.status, call.body)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepAnswerCarriesAll() error {
+	set, _, err := w.soleAnswer()
+	if err != nil {
+		return err
+	}
+	for _, m := range w.declared {
+		if _, ok := statusOf(set, m.Key); !ok {
+			return fmt.Errorf("the answer omits the declared feature %q", m.Key)
+		}
+	}
+	return nil
+}
+
+func (w *adminWorld) stepAnswerReports(key, state string) error {
+	set, who, err := w.soleAnswer()
+	if err != nil {
+		return err
+	}
+	s, ok := statusOf(set, key)
+	if !ok {
+		return fmt.Errorf("the answer to %q carries no feature named %q", who, key)
+	}
+	if s.Enabled != (state == "on") {
+		return fmt.Errorf("%q is reported %v for %q, want %s", key, s.Enabled, who, state)
+	}
+	return nil
+}
+
+// stepNowAnswered asks again before asserting. "Now" is the point: the
+// scenarios that use it changed something and are asking what the caller would
+// be told next, not what they were told before.
+func (w *adminWorld) stepNowAnswered(key, state string) error {
+	if err := w.stepAsk(); err != nil {
+		return err
+	}
+	return w.stepAnswerReports(key, state)
+}
+
+func (w *adminWorld) stepNamedAnswerReports(email, key, state string) error {
+	set, err := w.answerFor(email)
+	if err != nil {
+		return err
+	}
+	s, ok := statusOf(set, key)
+	if !ok {
+		return fmt.Errorf("%q was answered no feature named %q", email, key)
+	}
+	if s.Enabled != (state == "on") {
+		return fmt.Errorf("%q was answered %q as %v, want %s", email, key, s.Enabled, state)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepBothAnswered(key, state string) error {
+	for _, email := range w.signedInOrder {
+		if err := w.stepNamedAnswerReports(email, key, state); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *adminWorld) stepCarriesKeyAndEnabled() error {
+	set, _, err := w.soleAnswer()
+	if err != nil {
+		return err
+	}
+	if len(set) == 0 {
+		return fmt.Errorf("the answer is empty, so this proves nothing")
+	}
+	for _, s := range set {
+		if strings.TrimSpace(s.Key) == "" {
+			return fmt.Errorf("a feature in the answer carries no key: %+v", s)
+		}
+	}
+	return nil
+}
+
+func (w *adminWorld) stepCarriesNameAndLayer() error {
+	set, _, err := w.soleAnswer()
+	if err != nil {
+		return err
+	}
+	for _, s := range set {
+		if strings.TrimSpace(s.DisplayName) == "" {
+			return fmt.Errorf("the feature %q carries no display name", s.Key)
+		}
+		if strings.TrimSpace(s.Source) == "" {
+			return fmt.Errorf("the feature %q does not say which layer decided it", s.Key)
+		}
+	}
+	return nil
+}
+
+// stepNoGrantsInAnswer reads the raw body, because the assertion is about what
+// the wire carries and not about what a typed struct chose to decode.
+func (w *adminWorld) stepNoGrantsInAnswer() error {
+	_, key, err := w.soleAnswer()
+	if err != nil {
+		return err
+	}
+	body := w.calls["listing|"+key].body
+	// "grantable" is the declaration's own flag and is not a grant. What must
+	// never appear is a grant ROW: who holds one, from whom, or until when.
+	for _, leak := range []string{"subjectId", "subject_id", "validThrough", "valid_through", "grantedBy"} {
+		if strings.Contains(strings.ToLower(body), strings.ToLower(leak)) {
+			return fmt.Errorf("the listing body carries %q, which belongs to somebody's grants: %s", leak, body)
+		}
+	}
+	for email := range w.people {
+		if strings.Contains(body, email) {
+			return fmt.Errorf("the listing names %q, so it is carrying somebody's state", email)
+		}
+	}
+	return nil
+}
+
+func (w *adminWorld) stepNoAccountLayerRead() error {
+	if got := w.settings.accountCount(); got != 0 {
+		return fmt.Errorf("%d account override read(s) happened for a caller with no session", got)
+	}
+	if got := w.grants.count(); got != 0 {
+		return fmt.Errorf("%d grant read(s) happened for a caller with no session", got)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepNoLayer(layer string) func() error {
+	return func() error {
+		set, _, err := w.soleAnswer()
+		if err != nil {
+			return err
+		}
+		for _, s := range set {
+			if s.Source == layer {
+				return fmt.Errorf("the feature %q names %q as its layer, which this caller does not have",
+					s.Key, layer)
+			}
+		}
+		return nil
+	}
+}
+
+func (w *adminWorld) stepAnswerNamesNobody() error {
+	_, key, err := w.soleAnswer()
+	if err != nil {
+		return err
+	}
+	body := w.calls["listing|"+key].body
+	for email := range w.people {
+		if strings.Contains(body, email) {
+			return fmt.Errorf("the anonymous answer names %q", email)
+		}
+	}
+	for _, accountID := range w.accounts {
+		if accountID != "" && strings.Contains(body, accountID) {
+			return fmt.Errorf("the anonymous answer names an account")
+		}
+	}
+	return nil
+}
+
+func (w *adminWorld) stepSameSetAs(email string) error {
+	mine, _, err := w.soleAnswer()
+	if err != nil {
+		return err
+	}
+	theirs, err := w.answerFor(email)
+	if err != nil {
+		// The other person has not asked. Sign them in and ask on their
+		// behalf, so the comparison is against the answer they would really
+		// get rather than against an anonymous one.
+		p, perr := w.person(email)
+		if perr != nil {
+			return perr
+		}
+		if len(p.sessionIDs) == 0 {
+			if serr := w.signIn(p); serr != nil {
+				return serr
+			}
+		}
+		saved := w.lastActor
+		if aerr := w.ask(p); aerr != nil {
+			return aerr
+		}
+		w.lastActor = saved
+		theirs = w.answers[email]
+	}
+	for _, s := range theirs {
+		mineStatus, ok := statusOf(mine, s.Key)
+		if !ok || mineStatus.Enabled != s.Enabled {
+			return fmt.Errorf("the impersonated answer differs on %q: %v vs %v",
+				s.Key, mineStatus.Enabled, s.Enabled)
+		}
+	}
+	return nil
+}
+
+func (w *adminWorld) stepPersonsUnauthenticated() error {
+	call, ok := w.calls["anon-persons"]
+	if !ok {
+		return fmt.Errorf("no anonymous person listing was attempted")
+	}
+	if call.status != http.StatusUnauthorized {
+		return fmt.Errorf("the person listing answered %d without a session, want 401", call.status)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepWriteUnauthenticated() error {
+	call, ok := w.calls["anon-write"]
+	if !ok {
+		return fmt.Errorf("no anonymous write was attempted")
+	}
+	if call.status != http.StatusUnauthorized {
+		return fmt.Errorf("the write answered %d without a session, want 401", call.status)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepNoInstanceSetting(key string) error {
+	overrides, err := w.settings.InstanceOverrides(context.Background())
+	if err != nil {
+		return err
+	}
+	if _, stored := overrides[key]; stored {
+		return fmt.Errorf("an instance override for %q was stored by a refused request", key)
+	}
+	return nil
+}
+
+// stepUnmountedParity is the route-ordering guard. serve.go warns that the
+// LAST empty-prefix group under /api owns what an unmatched path answers, and
+// making the listing anonymous is exactly the change that could move it. The
+// harness mounts the groups in serve.go's order, so this asserts the property
+// from the outside: an unmounted path is still owned by the last group and
+// still answers as an authenticated surface would, not as a bare 404.
+func (w *adminWorld) stepUnmountedParity() error {
+	call, ok := w.calls["anon-unmounted"]
+	if !ok {
+		return fmt.Errorf("no unmounted path was requested")
+	}
+	if call.status == http.StatusOK {
+		return fmt.Errorf("an unmounted path answered 200, which means something is mounted there")
+	}
+	if call.status != http.StatusUnauthorized {
+		return fmt.Errorf("an unmounted /api path answered %d; the last empty-prefix group no longer owns it, "+
+			"so making the listing anonymous moved ownership", call.status)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepWriteForbidden() error {
+	call, ok := w.calls["write"]
+	if !ok {
+		return fmt.Errorf("no write was attempted")
+	}
+	if call.status != http.StatusForbidden {
+		return fmt.Errorf("the write answered %d, want 403: %s", call.status, call.body)
+	}
+	return nil
+}
+
+func (w *adminWorld) lastCall() (*apiCall, error) {
+	key := w.lastCallRoute
+	if w.lastActor != "" {
+		key = w.lastActor + "|" + w.lastCallRoute
+	}
+	call, ok := w.calls[key]
+	if !ok {
+		return nil, fmt.Errorf("no call to %q was made", w.lastCallRoute)
+	}
+	return call, nil
+}
+
+func (w *adminWorld) stepCallOutcome(outcome string) error {
+	call, err := w.lastCall()
+	if err != nil {
+		return err
+	}
+	switch outcome {
+	case "succeeds":
+		if call.status != http.StatusOK {
+			return fmt.Errorf("%s answered %d, want 200: %s", call.route, call.status, call.body)
+		}
+	case "is refused":
+		// Any refusal. A caller with no session is stopped by auth before the
+		// gate is reached, and the contract asks only that the door be shut.
+		if call.status < 400 {
+			return fmt.Errorf("%s answered %d, want a refusal", call.route, call.status)
+		}
+	}
+	return nil
+}
+
+func (w *adminWorld) stepCallSucceedsNow(route string) error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	call, err := w.call(p, route)
+	if err != nil {
+		return err
+	}
+	if call.status != http.StatusOK {
+		return fmt.Errorf("%s answered %d, want 200: %s", route, call.status, call.body)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepReportedOnWereServed() error {
+	set, who, err := w.soleAnswer()
+	if err != nil {
+		return err
+	}
+	for route, key := range w.routeGates {
+		s, ok := statusOf(set, key)
+		if !ok || !s.Enabled {
+			continue
+		}
+		call, ok := w.calls[who+"|"+route]
+		if !ok {
+			return fmt.Errorf("%q was reported on but %q was never called", key, route)
+		}
+		if call.status != http.StatusOK {
+			return fmt.Errorf("%q was reported on but %q answered %d", key, route, call.status)
+		}
+	}
+	return nil
+}
+
+func (w *adminWorld) stepReportedOffWereRefused() error {
+	set, who, err := w.soleAnswer()
+	if err != nil {
+		return err
+	}
+	checked := 0
+	for route, key := range w.routeGates {
+		s, ok := statusOf(set, key)
+		if !ok || s.Enabled {
+			continue
+		}
+		call, ok := w.calls[who+"|"+route]
+		if !ok {
+			return fmt.Errorf("%q was reported off but %q was never called", key, route)
+		}
+		if call.status != http.StatusForbidden {
+			return fmt.Errorf("%q was reported off but %q answered %d", key, route, call.status)
+		}
+		checked++
+	}
+	if checked == 0 {
+		return fmt.Errorf("no gated route's feature was reported off, so this proves nothing")
+	}
+	return nil
+}
+
+func (w *adminWorld) stepCallForbidden() error {
+	call, err := w.lastCall()
+	if err != nil {
+		return err
+	}
+	if call.status != http.StatusForbidden {
+		return fmt.Errorf("%s answered %d, want 403: %s", call.route, call.status, call.body)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepRefusalNamesFeature(key string) error {
+	call, err := w.lastCall()
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(call.body, key) {
+		return fmt.Errorf("the refusal does not name %q: %s", key, call.body)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepRefusalNotEnabled() error {
+	call, err := w.lastCall()
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(call.body, "not enabled") {
+		return fmt.Errorf("the refusal does not say the capability is not enabled: %s", call.body)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepRefusalNamesRole() error {
+	call, ok := w.calls["write"]
+	if !ok {
+		return fmt.Errorf("no write was attempted")
+	}
+	if strings.Contains(call.body, "capability is not enabled") {
+		return fmt.Errorf("a role refusal reads like a feature refusal: %s", call.body)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepRefusalNotAboutRole() error {
+	call, err := w.lastCall()
+	if err != nil {
+		return err
+	}
+	for _, roleWord := range []string{"role", "owner", "admin only", "permission"} {
+		if strings.Contains(strings.ToLower(call.body), roleWord) {
+			return fmt.Errorf("a feature refusal blames the caller's role: %s", call.body)
+		}
+	}
+	return nil
+}
+
+func (w *adminWorld) stepNoLedgerExport() error {
+	if w.ledgerExports != 0 {
+		return fmt.Errorf("the refused call still wrote %d ledger export(s)", w.ledgerExports)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepRefusalNotPartial() error {
+	call, err := w.lastCall()
+	if err != nil {
+		return err
+	}
+	if strings.Contains(call.body, "\"data\"") {
+		return fmt.Errorf("the refusal carried a data payload: %s", call.body)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepLedgerServed() error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	call, ok := w.calls[p.email+"|POST /api/ledger/exports"]
+	if !ok {
+		return fmt.Errorf("the ledger route was never called")
+	}
+	if call.status != http.StatusOK {
+		return fmt.Errorf("the ledger route answered %d, want 200: %s", call.status, call.body)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepBothCallsSucceed() error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	for _, route := range []string{"GET /api/persons", "GET /api/resource-types"} {
+		call, ok := w.calls[p.email+"|"+route]
+		if !ok {
+			return fmt.Errorf("%q was never called", route)
+		}
+		if call.status != http.StatusOK {
+			return fmt.Errorf("%q answered %d, want 200", route, call.status)
+		}
+	}
+	return nil
+}
+
+// stepNoFeatureEvaluated proves an ungated route takes the no-lookup path: no
+// read of stored feature state is attributable to calling it.
+func (w *adminWorld) stepNoFeatureEvaluated() error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	before := w.settings.count()
+	if _, err := w.call(p, "GET /api/persons"); err != nil {
+		return err
+	}
+	if got := w.settings.count(); got != before {
+		return fmt.Errorf("calling an ungated route read feature state %d time(s)", got-before)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepGatedRouteRefused() error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	call, ok := w.calls[p.email+"|POST /api/agent/conversations/{id}/messages"]
+	if !ok {
+		return fmt.Errorf("the gated route was never called")
+	}
+	if call.status != http.StatusForbidden {
+		return fmt.Errorf("the gated route answered %d while the store was down, want 403", call.status)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepUngatedRouteSucceeds() error {
+	p, err := w.soleActor()
+	if err != nil {
+		return err
+	}
+	call, ok := w.calls[p.email+"|GET /api/persons"]
+	if !ok {
+		return fmt.Errorf("the ungated route was never called")
+	}
+	if call.status != http.StatusOK {
+		return fmt.Errorf("the ungated route answered %d while the store was down, want 200", call.status)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepEveryFeatureOff() error {
+	set, _, err := w.soleAnswer()
+	if err != nil {
+		return err
+	}
+	if len(set) == 0 {
+		return fmt.Errorf("the answer is empty, so this proves nothing")
+	}
+	for _, s := range set {
+		if s.Enabled {
+			return fmt.Errorf("%q is reported on while the store cannot be read", s.Key)
+		}
+	}
+	return nil
+}
+
+func (w *adminWorld) stepAnswerCarriesMessage() error {
+	_, key, err := w.soleAnswer()
+	if err != nil {
+		return err
+	}
+	for _, m := range w.messages[key] {
+		if strings.Contains(strings.ToLower(m), "could not be read") {
+			return nil
+		}
+	}
+	return fmt.Errorf("the answer carries no message about the state being unreadable: %v", w.messages[key])
+}
+
+func (w *adminWorld) stepLoggedFailure() error {
+	if len(w.logs.matching("feature")) == 0 {
+		return fmt.Errorf("nothing was logged when the store could not be read")
+	}
+	return nil
+}
+
+func (w *adminWorld) stepEveryCallSucceeded() error {
+	if len(w.repeatCalls) == 0 {
+		return fmt.Errorf("no calls were made, so this proves nothing")
+	}
+	for i, call := range w.repeatCalls {
+		if call.status != http.StatusOK {
+			return fmt.Errorf("call %d answered %d, want 200: %s", i+1, call.status, call.body)
+		}
+	}
+	return nil
+}
+
+func (w *adminWorld) stepLoggedDriftOnce() error {
+	lines := w.logs.matching("nobody declared")
+	if len(lines) != 1 {
+		return fmt.Errorf("the undeclared key was logged %d times, want once: %v", len(lines), lines)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepLogNamesKey(key string) error {
+	if len(w.logs.matching("nobody declared", key)) == 0 {
+		return fmt.Errorf("no log line names the key %q: %v", key, w.logs.matching("nobody declared"))
+	}
+	return nil
+}
+
+// stepLogNamesRoute is honest about what the log can carry. The provider logs
+// the key, not the caller's route — it is asked for a feature and never told
+// what asked. So this asserts the operator can find the route from the key,
+// which is what the harness's route table gives them, rather than pretending
+// the log line carries a path it does not.
+func (w *adminWorld) stepLogNamesRoute() error {
+	key := w.ledgerGate
+	if len(w.logs.matching("nobody declared", key)) == 0 {
+		return fmt.Errorf("the log does not name %q, so the route cannot be found from it", key)
+	}
+	found := false
+	for route, gate := range w.routeGates {
+		if gate == key {
+			found = true
+			_ = route
+		}
+	}
+	if !found {
+		return fmt.Errorf("no mounted route names %q, so the logged key leads nowhere", key)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepChangeAccepted() error {
+	call, ok := w.calls["write"]
+	if !ok {
+		return fmt.Errorf("no write was attempted")
+	}
+	if call.status >= 400 {
+		return fmt.Errorf("the change answered %d: %s", call.status, call.body)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepNoTurnTaken() error {
+	if w.agentTurns != 0 {
+		return fmt.Errorf("the refused call still took %d turn(s)", w.agentTurns)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepStraightAwaySucceeded() error {
+	if w.straightAway == nil {
+		return fmt.Errorf("no call was made straight away")
+	}
+	if w.straightAway.status != http.StatusOK {
+		return fmt.Errorf("the call straight away answered %d, want 200", w.straightAway.status)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepAfterMomentRefused() error {
+	if w.afterMoment == nil {
+		return fmt.Errorf("no call was made after the moment passed")
+	}
+	if w.afterMoment.status != http.StatusForbidden {
+		return fmt.Errorf("the call after the window closed answered %d, want 403", w.afterMoment.status)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepNothingInvalidated() error {
+	if got := w.invSpy.count(); got != w.invsBefore {
+		return fmt.Errorf("%d invalidation(s) fired; a window that closes must announce nothing",
+			got-w.invsBefore)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepCacheAgeHadNotRunOut() error {
+	if w.maxCacheAge <= 0 {
+		return fmt.Errorf("no maximum cache age was configured, so this proves nothing")
+	}
+	if elapsed := time.Since(w.windowStart); elapsed >= w.maxCacheAge {
+		return fmt.Errorf("the scenario took %s, which is past the %s cache age", elapsed, w.maxCacheAge)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepStillSignedIn(email string) error {
+	p, err := w.person(email)
+	if err != nil {
+		return err
+	}
+	call, err := w.request(p, http.MethodGet, "/api/persons", nil)
+	if err != nil {
+		return err
+	}
+	if call.status == http.StatusUnauthorized {
+		return fmt.Errorf("%q was signed out", email)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepNotSignedOut() error {
+	for _, email := range w.signedInOrder {
+		if err := w.stepStillSignedIn(email); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *adminWorld) stepNotRestarted() error {
+	if w.boots != w.restartBaseline {
+		return fmt.Errorf("the instance restarted %d time(s) during the scenario", w.boots-w.restartBaseline)
+	}
+	return nil
+}
+
+func (w *adminWorld) stepEveryAnswerSame() error {
+	if len(w.repeatAnswers) < 2 {
+		return fmt.Errorf("only %d answers were collected, so this proves nothing", len(w.repeatAnswers))
+	}
+	first := w.repeatAnswers[0]
+	for i, set := range w.repeatAnswers[1:] {
+		if len(set) != len(first) {
+			return fmt.Errorf("answer %d holds %d features, the first held %d", i+2, len(set), len(first))
+		}
+		for _, s := range first {
+			got, ok := statusOf(set, s.Key)
+			if !ok || got.Enabled != s.Enabled {
+				return fmt.Errorf("answer %d differs on %q", i+2, s.Key)
+			}
+		}
+	}
+	return nil
+}
+
+func (w *adminWorld) stepReadOnce() error {
+	if w.readsAfterFirst <= w.readsBefore {
+		return fmt.Errorf("answering the first listing read no feature state, so the count proves nothing")
+	}
+	if got := w.settings.count(); got != w.readsAfterFirst {
+		return fmt.Errorf("%d further read(s) of feature state happened; one resolve must serve the session",
+			got-w.readsAfterFirst)
+	}
+	return nil
+}

--- a/tests/e2e/feature_admin_surface_world_test.go
+++ b/tests/e2e/feature_admin_surface_world_test.go
@@ -1,0 +1,538 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cucumber/godog"
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo/v4"
+	"github.com/open-feature/go-sdk/openfeature"
+	"go.uber.org/fx"
+
+	authapp "github.com/akeemphilbert/pericarp/pkg/auth/application"
+	authentities "github.com/akeemphilbert/pericarp/pkg/auth/domain/entities"
+	authrepos "github.com/akeemphilbert/pericarp/pkg/auth/domain/repositories"
+	authcasbin "github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/casbin"
+	authhttp "github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/http"
+	"github.com/akeemphilbert/pericarp/pkg/auth/infrastructure/session"
+
+	"github.com/wepala/weos/v3/api/handlers"
+	apimw "github.com/wepala/weos/v3/api/middleware"
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/application/presets"
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/domain/repositories"
+	"github.com/wepala/weos/v3/internal/config"
+)
+
+// TestFeatureAdminSurface runs the API half of story #486 (task #487).
+//
+//	GODOG_TAGS=@story-486 go test ./tests/e2e/ -run TestFeatureAdminSurface
+func TestFeatureAdminSurface(t *testing.T) {
+	tags := "~@wip"
+	if v := os.Getenv("GODOG_TAGS"); v != "" {
+		tags = v
+	}
+	suite := godog.TestSuite{
+		ScenarioInitializer: initFeatureAdminSurfaceScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"features/feature_flag_admin_surface.feature"},
+			Tags:     tags,
+			Strict:   true,
+			TestingT: t,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("admin feature surface acceptance scenarios failed")
+	}
+}
+
+// apiCall is one request the harness made, kept so a later step can assert on
+// it without repeating it.
+type apiCall struct {
+	route  string
+	status int
+	body   string
+}
+
+type adminWorld struct {
+	app    *fx.App
+	server *httptest.Server
+	tmpDir string
+	dsn    string
+	boots  int
+
+	registry *application.FeatureRegistry
+	features *application.FeatureService
+	admin    *application.FeatureAdminService
+	resolver *application.FeatureResolver
+	client   *openfeature.Client
+
+	settings *toolsSettingsSpy
+	grants   *toolsGrantSpy
+	invSpy   *invalidatorSpy
+	logs     *loggerSpy
+
+	resources application.ResourceService
+	rts       application.ResourceTypeService
+
+	authService    authapp.AuthenticationService
+	accountRepo    authrepos.AccountRepository
+	credRepo       authrepos.CredentialRepository
+	agentRepo      authrepos.AgentRepository
+	sessionManager session.SessionManager
+	sessionStore   sessions.Store
+	authzChecker   *authcasbin.CasbinAuthorizationChecker
+	logger         entities.Logger
+
+	declared    []entities.FeatureMeta
+	maxCacheAge time.Duration
+	ledgerGate  string
+
+	people        map[string]*featurePerson
+	accounts      map[string]string
+	signedInOrder []string
+
+	// ledgerExports counts what the harness-mounted mutating route wrote, so a
+	// refusal can be proved to have written nothing.
+	ledgerExports int
+	// agentTurns counts turns the gated agent route would have taken.
+	agentTurns int
+
+	answers  map[string][]entities.FeatureStatus
+	messages map[string][]string
+	calls    map[string]*apiCall
+
+	restartBaseline int
+	readsBefore     int
+	readsAfterFirst int
+	invsBefore      int
+
+	straightAway *apiCall
+	afterMoment  *apiCall
+	momentSet    bool
+	moment       time.Time
+	windowStart  time.Time
+
+	lastActor     string
+	lastCallRoute string
+	repeatCalls   []*apiCall
+	repeatAnswers [][]entities.FeatureStatus
+	// routeGates is this scenario's copy of the Background's route table.
+	// Per-world on purpose: a scenario that rewrites a gate must not change
+	// what the next scenario mounts.
+	routeGates map[string]string
+	jar        map[string][]*http.Cookie
+}
+
+func newAdminWorld() *adminWorld {
+	return &adminWorld{
+		ledgerGate: "ledger-export",
+		people:     map[string]*featurePerson{},
+		accounts:   map[string]string{},
+		answers:    map[string][]entities.FeatureStatus{},
+		messages:   map[string][]string{},
+		calls:      map[string]*apiCall{},
+		jar:        map[string][]*http.Cookie{},
+		routeGates: defaultRouteGates(),
+	}
+}
+
+func (w *adminWorld) teardown() {
+	if w.server != nil {
+		w.server.Close()
+		w.server = nil
+	}
+	if w.app != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		defer cancel()
+		_ = w.app.Stop(ctx)
+		w.app = nil
+	}
+	if w.tmpDir != "" {
+		_ = os.RemoveAll(w.tmpDir)
+	}
+}
+
+func (w *adminWorld) boot() error {
+	if w.app != nil {
+		return nil
+	}
+	if w.tmpDir == "" {
+		dir, err := os.MkdirTemp("", "weos-feature-admin-e2e-")
+		if err != nil {
+			return fmt.Errorf("could not create a temp dir: %w", err)
+		}
+		w.tmpDir = dir
+		w.dsn = filepath.Join(dir, "admin.db")
+	}
+	pw := "true"
+	os.Setenv("PASSWORD_AUTH_ENABLED", pw)
+	os.Unsetenv("GOOGLE_CLIENT_ID")
+	os.Unsetenv("GOOGLE_CLIENT_SECRET")
+
+	cfg := config.Default()
+	cfg.LoadFromEnvironment()
+	cfg.DatabaseDSN = w.dsn
+	cfg.LogLevel = "error"
+	if w.maxCacheAge > 0 {
+		cfg.Features.CacheMaxAge = w.maxCacheAge
+	}
+	cfg.Features.Declared = declarationsBeyondCore(w.declared)
+
+	w.settings = &toolsSettingsSpy{}
+	w.grants = &toolsGrantSpy{}
+	w.invSpy = &invalidatorSpy{}
+	w.logs = &loggerSpy{}
+
+	app := fx.New(
+		fx.NopLogger,
+		application.Module(cfg, presets.NewDefaultRegistry()),
+		fx.Decorate(func(inner repositories.FeatureSettingsRepository) repositories.FeatureSettingsRepository {
+			w.settings.inner = inner
+			return w.settings
+		}),
+		fx.Decorate(func(inner repositories.FeatureGrantRepository) repositories.FeatureGrantRepository {
+			w.grants.inner = inner
+			return w.grants
+		}),
+		fx.Decorate(func(inner repositories.FeatureCacheInvalidator) repositories.FeatureCacheInvalidator {
+			w.invSpy.inner = inner
+			return w.invSpy
+		}),
+		fx.Decorate(func(inner entities.Logger) entities.Logger {
+			w.logs.inner = inner
+			return w.logs
+		}),
+		fx.Populate(&w.registry, &w.features, &w.admin, &w.resolver, &w.client),
+		fx.Populate(&w.resources, &w.rts, &w.logger),
+		fx.Populate(&w.authService, &w.accountRepo, &w.credRepo, &w.agentRepo),
+		fx.Populate(&w.sessionManager, &w.sessionStore, &w.authzChecker),
+	)
+	startCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+	defer cancel()
+	if err := app.Start(startCtx); err != nil {
+		return fmt.Errorf("failed to start app: %w", err)
+	}
+	w.app = app
+	w.boots++
+	w.restartBaseline = w.boots
+	return w.mountAPI()
+}
+
+// mountAPI mirrors serve.go's group order deliberately, because one of this
+// contract's scenarios is about that order.
+//
+// serve.go registers protected, then acceptGroup, then featuresGroup, then
+// mcpGroup, and echo's Group.Use installs a not-found catch-all at the group
+// prefix — so the LAST empty-prefix group under /api owns what an unmatched
+// /api path answers. A harness that mounted these in a different order would
+// prove the wrong thing about the one property this file was asked to pin.
+//
+// It is a replica, not the real table (#467 would give us the real one), so it
+// is kept deliberately thin: only the routes the contract names, in the groups
+// serve.go puts them in.
+func (w *adminWorld) mountAPI() error {
+	e := echo.New()
+	e.HideBanner = true
+	api := e.Group("/api")
+
+	fh := handlers.NewFeatureHandler(handlers.FeatureHandlerConfig{Admin: w.admin, Logger: w.logger})
+	personHandler := handlers.NewPersonHandler(w.resources)
+	rtHandler := handlers.NewResourceTypeHandler(w.rts, w.authzChecker, w.accountRepo, w.logger)
+	impersonation := handlers.NewImpersonationHandler(handlers.ImpersonationHandlerConfig{
+		Store: w.sessionStore, AccountRepo: w.accountRepo,
+		AgentRepo: w.agentRepo, CredRepo: w.credRepo, Logger: w.logger,
+	})
+
+	// 1. protected — everything that needs a session.
+	protected := api.Group("")
+	protected.Use(apimw.Messages())
+	protected.Use(echo.WrapMiddleware(authhttp.RequireAuth(w.sessionManager, w.authService)))
+	protected.Use(apimw.Impersonation(w.sessionStore, w.accountRepo, w.logger))
+	protected.GET("/persons", personHandler.List)
+	protected.GET("/resource-types", rtHandler.List)
+	protected.PUT("/features/:key/instance", fh.SetInstance)
+	protected.POST("/admin/impersonate", impersonation.Start)
+	protected.POST("/admin/stop-impersonation", impersonation.Stop)
+
+	// 2. featuresGroup — answers a caller with no session, and still honors
+	//    impersonation.
+	featuresGroup := api.Group("")
+	featuresGroup.Use(apimw.Messages())
+	featuresGroup.Use(echo.WrapMiddleware(apimw.OptionalAuth(w.sessionManager, w.authService)))
+	featuresGroup.Use(apimw.Impersonation(w.sessionStore, w.accountRepo, w.logger))
+	featuresGroup.GET("/features", fh.List)
+
+	// 3. mcpGroup — LAST, so it keeps ownership of unmatched /api paths.
+	gate := apimw.RequireFeature(application.ToolFeatureGate(w.client), application.FeatureAgentChat)
+	mcpGroup := api.Group("")
+	mcpGroup.Use(apimw.Messages())
+	mcpGroup.Use(echo.WrapMiddleware(authhttp.RequireAuth(w.sessionManager, w.authService)))
+	mcpGroup.POST("/agent/conversations/:id/messages", w.agentTurnHandler, gate)
+	mcpGroup.GET("/agent/conversations/:id", w.agentHistoryHandler, gate)
+	// The harness's own mutating route, mounted through a group the way a
+	// preset's handlers are, gated on a feature that is declared off — so a
+	// refused call can be proved to have written nothing.
+	mcpGroup.POST("/ledger/exports", w.ledgerExportHandler,
+		apimw.RequireFeature(application.ToolFeatureGate(w.client),
+			w.routeGates["POST /api/ledger/exports"]))
+
+	w.server = httptest.NewServer(e)
+	return nil
+}
+
+func (w *adminWorld) agentTurnHandler(c echo.Context) error {
+	w.agentTurns++
+	return c.JSON(http.StatusOK, map[string]any{"data": map[string]any{"reply": "ok"}})
+}
+
+func (w *adminWorld) agentHistoryHandler(c echo.Context) error {
+	return c.JSON(http.StatusOK, map[string]any{"data": []any{}})
+}
+
+func (w *adminWorld) ledgerExportHandler(c echo.Context) error {
+	w.ledgerExports++
+	return c.JSON(http.StatusOK, map[string]any{"data": map[string]any{"rows": w.ledgerExports}})
+}
+
+// remount rebuilds the HTTP surface without restarting the application, which
+// is what a deploy carrying a different gate constant would produce.
+func (w *adminWorld) remount() error {
+	if w.server != nil {
+		w.server.Close()
+		w.server = nil
+	}
+	return w.mountAPI()
+}
+
+func (w *adminWorld) reboot() error {
+	if w.server != nil {
+		w.server.Close()
+		w.server = nil
+	}
+	if w.app != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		defer cancel()
+		if err := w.app.Stop(ctx); err != nil {
+			return err
+		}
+		w.app = nil
+	}
+	return w.boot()
+}
+
+// --- people ---------------------------------------------------------------
+
+func (w *adminWorld) personFor(email, password string) (*featurePerson, error) {
+	if p, ok := w.people[email]; ok {
+		return p, nil
+	}
+	ctx := context.Background()
+	agent, _, account, err := w.authService.RegisterPassword(ctx, email, displayNameForFeature(email), password)
+	if err != nil {
+		return nil, fmt.Errorf("could not create %q: %w", email, err)
+	}
+	p := &featurePerson{email: email, password: password, agentID: agent.GetID()}
+	if account != nil {
+		p.accountID = account.GetID()
+		if err := w.accountRepo.SaveMember(ctx, account.GetID(), agent.GetID(), authentities.RoleOwner); err != nil {
+			return nil, err
+		}
+	}
+	w.people[email] = p
+	return p, nil
+}
+
+func (w *adminWorld) person(email string) (*featurePerson, error) {
+	p, ok := w.people[email]
+	if !ok {
+		return nil, fmt.Errorf("no person named %q has been staged", email)
+	}
+	return p, nil
+}
+
+func (w *adminWorld) accountFor(name string) (string, error) {
+	id, ok := w.accounts[name]
+	if !ok {
+		return "", fmt.Errorf("no account named %q has been staged", name)
+	}
+	return id, nil
+}
+
+func (w *adminWorld) addToAccount(email, accountName, role string) error {
+	accountID, err := w.accountFor(accountName)
+	if err != nil {
+		return err
+	}
+	p, err := w.personFor(email, "correct-horse-battery-staple")
+	if err != nil {
+		return err
+	}
+	if err := w.accountRepo.SaveMember(context.Background(), accountID, p.agentID, role); err != nil {
+		return err
+	}
+	w.resolver.InvalidateAgents(context.Background(), accountID, p.agentID)
+	p.accountID = accountID
+	return nil
+}
+
+// signIn creates a real session, because the listing's whole point is to be
+// answered over HTTP with whatever the browser is carrying.
+func (w *adminWorld) signIn(p *featurePerson) error {
+	ctx := context.Background()
+	creds, err := w.credRepo.FindByAgent(ctx, p.agentID)
+	if err != nil || len(creds) == 0 {
+		return fmt.Errorf("could not find credentials for %q: %w", p.email, err)
+	}
+	s, err := w.authService.CreateSession(ctx, p.agentID, p.accountID, creds[0].GetID(),
+		"127.0.0.1", "godog", time.Hour)
+	if err != nil {
+		return err
+	}
+	p.sessionIDs = append(p.sessionIDs, s.GetID())
+	return nil
+}
+
+func (w *adminWorld) staged() []string {
+	emails := make([]string, 0, len(w.people))
+	for email := range w.people {
+		emails = append(emails, email)
+	}
+	sort.Strings(emails)
+	return emails
+}
+
+func (w *adminWorld) soleActor() (*featurePerson, error) {
+	if len(w.signedInOrder) == 1 {
+		return w.person(w.signedInOrder[0])
+	}
+	if w.lastActor != "" {
+		return w.person(w.lastActor)
+	}
+	return nil, fmt.Errorf("%d people are signed in, so \"they\" is ambiguous", len(w.signedInOrder))
+}
+
+// --- HTTP -----------------------------------------------------------------
+
+// request drives the mounted API. A nil person is a caller carrying no session
+// at all, which is the case the listing exists to answer.
+func (w *adminWorld) request(p *featurePerson, method, path string, body any) (*apiCall, error) {
+	var reader *bytes.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		reader = bytes.NewReader(raw)
+	} else {
+		reader = bytes.NewReader(nil)
+	}
+	req, err := http.NewRequest(method, w.server.URL+path, reader)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if p != nil {
+		for _, c := range w.cookiesFor(p) {
+			req.AddCookie(c)
+		}
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = res.Body.Close() }()
+	var sb strings.Builder
+	buf := make([]byte, 4096)
+	for {
+		n, readErr := res.Body.Read(buf)
+		sb.Write(buf[:n])
+		if readErr != nil {
+			break
+		}
+	}
+	// Carry any cookie the server set, so impersonation survives the next call.
+	if p != nil {
+		w.jar[p.email] = mergeCookies(w.jar[p.email], res.Cookies())
+	}
+	return &apiCall{route: method + " " + path, status: res.StatusCode, body: sb.String()}, nil
+}
+
+// cookiesFor is the browser's jar for one person: the session cookie built
+// from their real session, plus whatever the server has set since — which is
+// how the impersonation cookie survives from one call to the next.
+func (w *adminWorld) cookiesFor(p *featurePerson) []*http.Cookie {
+	if len(w.jar[p.email]) == 0 && len(p.sessionIDs) > 0 {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		if err := w.sessionManager.CreateHTTPSession(rec, req, session.SessionData{
+			SessionID: p.sessionIDs[len(p.sessionIDs)-1],
+			AgentID:   p.agentID,
+			AccountID: p.accountID,
+		}); err == nil {
+			w.jar[p.email] = rec.Result().Cookies()
+		}
+	}
+	return w.jar[p.email]
+}
+
+func mergeCookies(have []*http.Cookie, got []*http.Cookie) []*http.Cookie {
+	out := append([]*http.Cookie(nil), have...)
+	for _, c := range got {
+		replaced := false
+		for i := range out {
+			if out[i].Name == c.Name {
+				out[i] = c
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// statusesFrom pulls the listing out of the response envelope.
+func statusesFrom(body string) ([]entities.FeatureStatus, []string, error) {
+	var env struct {
+		Data     []entities.FeatureStatus `json:"data"`
+		Messages []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		return nil, nil, fmt.Errorf("could not read the feature listing: %w (body %q)", err, body)
+	}
+	msgs := make([]string, 0, len(env.Messages))
+	for _, m := range env.Messages {
+		msgs = append(msgs, m.Text)
+	}
+	return env.Data, msgs, nil
+}
+
+func statusOf(set []entities.FeatureStatus, key string) (entities.FeatureStatus, bool) {
+	for _, s := range set {
+		if s.Key == key {
+			return s, true
+		}
+	}
+	return entities.FeatureStatus{}, false
+}
+
+var _ = testing.Verbose

--- a/tests/e2e/feature_mcp_tools_world_test.go
+++ b/tests/e2e/feature_mcp_tools_world_test.go
@@ -237,17 +237,27 @@ type loggerSpy struct {
 
 func (l *loggerSpy) Debug(ctx context.Context, msg string, f ...any) { l.inner.Debug(ctx, msg, f...) }
 func (l *loggerSpy) Info(ctx context.Context, msg string, f ...any)  { l.inner.Info(ctx, msg, f...) }
-func (l *loggerSpy) Error(ctx context.Context, msg string, f ...any) { l.inner.Error(ctx, msg, f...) }
+
+// Error is recorded alongside Warn. An operator looking for why something is
+// off does not filter by level, and #486 logs the unreadable store at error.
+func (l *loggerSpy) Error(ctx context.Context, msg string, fields ...any) {
+	l.record(msg, fields)
+	l.inner.Error(ctx, msg, fields...)
+}
 
 func (l *loggerSpy) Warn(ctx context.Context, msg string, fields ...any) {
+	l.record(msg, fields)
+	l.inner.Warn(ctx, msg, fields...)
+}
+
+func (l *loggerSpy) record(msg string, fields []any) {
 	l.mu.Lock()
+	defer l.mu.Unlock()
 	line := msg
 	for _, f := range fields {
 		line += fmt.Sprintf(" %v", f)
 	}
 	l.warns = append(l.warns, line)
-	l.mu.Unlock()
-	l.inner.Warn(ctx, msg, fields...)
 }
 
 func (l *loggerSpy) matching(substrings ...string) []string {

--- a/tests/e2e/features/feature_flag_admin_surface.feature
+++ b/tests/e2e/features/feature_flag_admin_surface.feature
@@ -1,0 +1,448 @@
+@epic-480 @story-486 @task-487
+Feature: The API answers what a caller's features are, and refuses what they are not
+  As someone using a WeOS admin
+  I want one answer for which capabilities I hold, and the server to hold to that answer
+  when I go around the UI
+  So that what I am shown and what I am allowed are the same thing
+
+  This is the epic's last story and its third consumer. #484 gated the MCP tool surface,
+  #485 gated the agent skills above it, and both ended at a surface a model talks to. This
+  one ends at a surface a person clicks, which is why it needs something the other two did
+  not: an endpoint that tells a browser what the answer is, so a sidebar can be drawn from
+  it.
+
+  Nothing below re-derives resolution. Which layer beats which, that an explicit off is
+  final downward, that a store failure answers off, that an anonymous caller resolves from
+  the instance layer alone, that a validity window is read at resolution rather than swept
+  by a job, that a change reaches sessions already open without signing anybody out — all
+  of that is feature_flag_resolution.feature and feature_flag_grants.feature and stays
+  there. What is new here is the HTTP surface: what the listing endpoint answers and to
+  whom, and what a gated route does when a caller reaches it directly.
+
+  This file is one half of the story. The other half — what the admin SPA draws from the
+  answer — is web/admin/e2e/features/feature-gated-navigation.feature, in the SPA's own
+  playwright-bdd suite, because that suite is the only one that can open a page. The split
+  is not cosmetic and it is not negotiable: a scenario about a hidden sidebar entry written
+  into this file cannot run, and a scenario about a 403 written into that file proves
+  nothing, because that suite scripts its own API responses with page.route. So the two
+  files are deliberately joined at the seam — every hiding scenario over there names a
+  refusal scenario over here, and this preamble and that one both say so. Read either one
+  alone and you are reading half a control.
+
+  # --- The endpoint already exists, and this story does not replace it ---
+
+  #482 shipped GET /api/features. It is registered under the protected group, it answers
+  the full status of every declared feature — key, display name, description, resolved
+  value, the layer that decided it, and whether an account may manage it or a grant may
+  reach it — and three committed scenarios in feature_flag_operator_switch.feature depend
+  on that shape: the listing reports where a value came from, it names each feature by its
+  display name, and an ordinary member may read it while being refused every write.
+
+  #487 asks for "{key, enabled} per registered feature" and for an unauthenticated caller
+  to be answered 200 with instance defaults. Those two asks pull in opposite directions
+  against what exists, so this contract rules on them rather than leaving the seam for an
+  implementer to guess at.
+
+  The ruling: **one endpoint, the shape it already has, moved so that a caller with no
+  session is answered rather than refused.** `key` and `enabled` are two of the fields it
+  already returns, so #487's shape criterion is met by a superset and no committed #482
+  scenario changes. Shrinking to a bare pair would break all three of those scenarios and
+  would take away exactly what the admin's own feature-administration screen needs to draw
+  — the source, the display name, and whether the switch in front of the operator is one
+  they may throw. A second, thinner endpoint is worse than either: two answers to one
+  question, resolved by the same resolver, free to drift, with operators then having to be
+  told which one to believe. The epic's anti-pattern list already refuses that shape once,
+  for BehaviorMeta; it refuses it here for the same reason.
+
+  Moving it out of the protected group costs two things, and both are pinned below because
+  both are the kind of regression that ships quietly.
+
+  The first is impersonation. The protected group applies impersonation middleware; an
+  admin acting as somebody else is answered as that somebody else by every route in it.
+  A listing that lost that middleware would answer with the real admin's features while
+  every other call on the page answered with the impersonated user's — a sidebar drawn for
+  one person over data belonging to another, which is worse than either alone. So the
+  scenario below asks for the property, not the middleware: while impersonating, the
+  listing is the impersonated person's.
+
+  The second is route ordering. serve.go carries a warning at the mcpGroup registration
+  saying that the last empty-prefix group under /api owns what an unmatched /api path
+  answers, and that adding another one silently changes that answer for every unmounted
+  path — including /api/auth/register when registration is off, whose parity is pinned by
+  password_registration_flag.feature, in a test that builds its own echo instance and would
+  therefore not notice. Making one route anonymous is exactly the change that trips this.
+  A scenario below pins the parity directly, from the outside, so it is caught here even
+  though the file that cares about it cannot catch it.
+
+  # --- "The server still enforces" had nothing to enforce, and now it does ---
+
+  The story's fourth criterion says hitting a gated route directly by URL is refused by the
+  API and not merely hidden by the UI. As of this story starting, that criterion could not
+  be met, and it is worth being plain about why rather than writing a scenario against
+  something that does not exist. **No REST route on this instance is feature-gated.** #484
+  gated MCP tools at their `mcp.AddTool` call sites. #485 gated agent skills as they are
+  handed to a turn. Neither touched the HTTP API, and there is no route-level gate to reach
+  for. An implementation could satisfy every other criterion of this story — endpoint,
+  composable, hidden sidebar — and leave a URL bar that works perfectly well.
+
+  So this story gates HTTP routes. That is a real addition to its scope and it should be
+  seen as one. Two routes carry gates below, chosen the way #484 chose its two.
+
+  `agent-chat` gates the in-app agent's REST surface — the three /api/agent/conversations
+  routes the admin's chat page calls. It is the right shipped choice because it is the one
+  sidebar entry that is a capability rather than an administrative screen: Users and
+  Settings are gated by role, and a role is not a flag. It is declared on, for #484's
+  reason — the chat ships today and an upgrade that introduced the gate dark would take a
+  working page away from every instance. And it does not collide with #485: off means there
+  is no assistant at all, on means there is one whose skill graph #485 filters. A scenario
+  below pins that the two compose rather than overlap.
+
+  `ledger-export` gates a mutating route the harness mounts through the PresetHTTPHandlers
+  seam that presets and downstream binaries already use, exactly as #484's `ledger_export`
+  tool is registered through the MCP configurer seam. It exists so the contract can prove a
+  refused call writes nothing, against a feature that is declared off, without this story
+  having to decide that some second shipped screen ought to be dark by default.
+
+  # --- Hiding is presentation only, so every hide is paired ---
+
+  A scenario that only checks a sidebar would pass against an implementation with no server
+  gate at all. So the discipline #484 used for list-and-call and #485 used for graph-and-
+  door applies here across the file boundary: every entry the SPA hides has a route this
+  file refuses, and the outline below walks the layers proving the listing and the route
+  never disagree in either direction. An answer the listing gave a minute ago is not
+  authorization either — the stale-set scenarios are the same property #484 pinned for a
+  cached tool list, and they matter more here, because a browser holds its answer for as
+  long as the tab is open.
+
+  # --- One contested ruling, marked ---
+
+  When the store cannot be read, a gate answers off. That is settled. What a *listing*
+  does was not, and today it answers 500. This contract changes it: **the listing answers
+  200 with every feature off, carries a message saying the state could not be read, and
+  logs the failure.**
+
+  The reason is that a 500 forces the browser to invent a policy, and the two policies it
+  can invent are "show everything" and "show nothing", of which one is wrong and the other
+  is indistinguishable from the answer the server would have given anyway. Answering
+  all-off makes the listing agree with the gates during the outage instead of leaving the
+  UI to guess, and the message is what stops an operator staring at an empty sidebar with
+  nothing to read.
+
+  The honest counter-argument is that all-off is a lie: the store being unreadable is not
+  the same fact as the features being off, and a client cannot tell a real all-off instance
+  from a broken one except by reading a message it may not surface. If that outweighs the
+  above, the rule flips to a 5xx and exactly two scenarios change — "When the store cannot
+  be read the listing answers off rather than failing" and its SPA counterpart. This
+  contract does not hedge; it pins one and marks the seam.
+
+  # --- Out of scope ---
+
+  Gating decides what a caller is offered. It does not decide what an operator may
+  administer: a feature turned off for somebody is still listed, still visible on the
+  feature-administration screen, and still turn-on-able, or the person whose job is to
+  enable it cannot reach it. #485 made the same point for skills and a scenario below
+  makes it for this surface. Role-based access is not touched and must not be confused
+  with this: a member refused a write is refused for their role, whatever their features
+  say, and a scenario pins that the two mechanisms answer separately.
+
+  Background:
+    Given a WeOS instance where password sign-in is enabled and requests are authenticated by their session
+    And the instance declares these features in code:
+      | key             | display name    | description                              | default | manageable | grantable |
+      | agent-chat      | Assistant       | Talk to this instance's assistant        | on      | yes        | yes       |
+      | episodic-recall | Episodic recall | Recall past events during a conversation | on      | yes        | yes       |
+      | ledger-export   | Ledger export   | Export the ledger to a spreadsheet       | off     | yes        | yes       |
+      | audit-trail     | Audit trail     | Record who read what, for compliance     | on      | no         | no        |
+    And these API routes declare the feature that gates them:
+      | route                                          | gated by      | mutates |
+      | POST /api/agent/conversations/{id}/messages    | agent-chat    | yes     |
+      | GET /api/agent/conversations/{id}              | agent-chat    | no      |
+      | POST /api/ledger/exports                       | ledger-export | yes     |
+    And these API routes name no feature:
+      | route                   |
+      | GET /api/persons        |
+      | GET /api/resource-types |
+      | GET /api/features       |
+    And the account "Harbor Legal", whose owner "ops@harborlegal.example" signs in with password "correct-horse-battery-staple"
+
+  # --- What the listing answers, and to whom ---
+
+  Scenario: A signed-in caller is answered every declared feature, resolved for them
+    Given the operator has turned the feature "ledger-export" on for the instance
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they ask the API for their feature set
+    Then the answer is served
+    And the answer carries every feature the instance declares
+    And the answer reports "agent-chat" as on
+    And the answer reports "ledger-export" as on
+    And each feature carries its key and whether it is enabled
+    And each feature carries its display name and the layer that decided it
+    And the answer carries no grant belonging to anybody
+
+  Scenario: A caller carrying no session is answered the instance view rather than refused
+    Given the operator has turned the feature "agent-chat" off for the instance
+    When a request carrying no session asks the API for the feature set
+    Then the answer is served
+    And the answer reports "agent-chat" as off
+    And the answer reports "ledger-export" as off
+    And the answer reports "episodic-recall" as on
+    And no account override or grant was read to answer it
+
+  Scenario: The anonymous answer cannot report a layer an anonymous caller does not have
+    Given "Harbor Legal" has turned the feature "ledger-export" on
+    And "ops@harborlegal.example" has been granted the feature "ledger-export"
+    When a request carrying no session asks the API for the feature set
+    Then the answer reports "ledger-export" as off
+    And no feature in the answer names an account override as its layer
+    And no feature in the answer names a grant as its layer
+    And the answer names no person and no account
+
+  Scenario: Two people signed in to one account are answered differently
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" has been granted the feature "ledger-export"
+    And both of them are signed in to "Harbor Legal"
+    When each of them asks the API for their feature set
+    Then "counsel@harborlegal.example" is answered "ledger-export" on
+    And "ops@harborlegal.example" is answered "ledger-export" off
+    And both of them are answered "agent-chat" on
+
+  Scenario: One person acting in two accounts is answered differently
+    Given the account "Cedar Realty", whose owner "broker@cedarrealty.example" signs in with password "trellis-anchor-mango-9"
+    And "ops@harborlegal.example" also belongs to "Cedar Realty"
+    And "Harbor Legal" has turned the feature "ledger-export" on
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have asked for their feature set and been answered "ledger-export" on
+    When they act in "Cedar Realty" and ask for their feature set again
+    Then they are answered "ledger-export" off
+    And they are answered "agent-chat" on
+    And they were not signed out
+
+  Scenario: While impersonating, the listing is the impersonated person's
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" has been granted the feature "ledger-export"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have asked for their feature set and been answered "ledger-export" off
+    When "ops@harborlegal.example" impersonates "counsel@harborlegal.example"
+    And they ask for their feature set again
+    Then they are answered "ledger-export" on
+    And they are answered the same set "counsel@harborlegal.example" is answered
+    When they stop impersonating
+    And they ask for their feature set again
+    Then they are answered "ledger-export" off
+
+  Scenario: Making the listing readable without a session made nothing else readable without one
+    When a request carrying no session asks the API for the feature set
+    And a request carrying no session asks the API for the person listing
+    And a request carrying no session tries to turn the feature "agent-chat" off for the instance
+    And a request carrying no session asks the API for a path nobody mounted
+    Then the feature set was served
+    And the person listing is refused as not authenticated
+    And the attempt to change the instance is refused as not authenticated
+    And no instance-level setting is stored for "agent-chat"
+    And the path nobody mounted answers exactly what an unmounted path answered before this change
+
+  Scenario: An ordinary member reads the listing and is still refused every write
+    Given "clerk@harborlegal.example" belongs to "Harbor Legal" as an ordinary member
+    And "clerk@harborlegal.example" is signed in to "Harbor Legal"
+    When they ask the API for their feature set
+    And they try to turn the feature "agent-chat" off for the instance
+    Then the feature set was served
+    And the attempt to change it is refused as forbidden
+
+  # --- The listing and the gate never disagree ---
+
+  Scenario Outline: What the listing says about a feature is what its routes do
+    Given <precondition>
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they ask the API for their feature set
+    And they call "<route>"
+    Then the answer reports "<feature>" as <state>
+    And the call <outcome>
+
+    Examples:
+      | precondition                                                            | feature       | state | route                     | outcome    |
+      | nothing has been overridden or granted on this instance                 | agent-chat    | on    | POST /api/agent/conversations/{id}/messages  | succeeds   |
+      | nothing has been overridden or granted on this instance                 | ledger-export | off   | POST /api/ledger/exports  | is refused |
+      | the operator has turned the feature "agent-chat" off for the instance   | agent-chat    | off   | POST /api/agent/conversations/{id}/messages  | is refused |
+      | the operator has turned the feature "ledger-export" on for the instance | ledger-export | on    | POST /api/ledger/exports  | succeeds   |
+      | "Harbor Legal" has turned the feature "ledger-export" on                | ledger-export | on    | POST /api/ledger/exports  | succeeds   |
+
+  Scenario: The listing and the routes agree, in both directions
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" has been granted the feature "ledger-export"
+    And the operator has turned the feature "agent-chat" off for the instance
+    And "counsel@harborlegal.example" is signed in to "Harbor Legal"
+    When they ask the API for their feature set
+    And they call every gated route the instance mounts
+    Then every route whose feature the answer reported on was served
+    And every route whose feature the answer reported off was refused
+
+  Scenario: A caller with no session is refused the routes their answer said were off
+    Given the operator has turned the feature "agent-chat" off for the instance
+    When a request carrying no session asks the API for the feature set
+    And a request carrying no session calls "POST /api/agent/conversations/{id}/messages"
+    Then the answer reported "agent-chat" as off
+    And the call is refused
+
+  # --- The route is the gate ---
+
+  Scenario: A gated route called with the feature off is refused, and nothing it would have done was done
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they call "POST /api/ledger/exports"
+    Then the call is refused as forbidden
+    And the refusal names the feature "ledger-export"
+    And the refusal says the capability is not enabled for them
+    And no ledger export was recorded
+    And the refusal is not a partial result
+
+  Scenario: A refusal for a gated route reads differently from a refusal for a role
+    Given "clerk@harborlegal.example" belongs to "Harbor Legal" as an ordinary member
+    And "clerk@harborlegal.example" is signed in to "Harbor Legal"
+    And the operator has turned the feature "ledger-export" on for the instance
+    When they call "POST /api/ledger/exports"
+    And they try to turn the feature "agent-chat" off for the instance
+    Then the ledger call is served
+    And the attempt to change the instance is refused as forbidden
+    And the refusal names their role rather than a feature
+
+  Scenario: A role that permits the call does not survive the feature being off
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And the operator has turned the feature "agent-chat" off for the instance
+    When they call "POST /api/agent/conversations/{id}/messages"
+    Then the call is refused as forbidden
+    And the refusal names the feature "agent-chat"
+    And the refusal does not say their role is insufficient
+
+  Scenario: Routes that name no feature are untouched however the features stand
+    Given the operator has turned the feature "agent-chat" off for the instance
+    And the operator has turned the feature "episodic-recall" off for the instance
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they call "GET /api/persons"
+    And they call "GET /api/resource-types"
+    Then both calls succeed
+    And no feature was evaluated for either route
+
+  Scenario: An answer held from before a change is not authorization to call the route
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" has been granted the feature "ledger-export"
+    And "counsel@harborlegal.example" is signed in to "Harbor Legal"
+    And they have asked for their feature set and been answered "ledger-export" on
+    When "ops@harborlegal.example" revokes "ledger-export" from "counsel@harborlegal.example"
+    And "counsel@harborlegal.example" calls "POST /api/ledger/exports" on the answer they already hold
+    Then the call is refused
+    And no ledger export was recorded
+    And "counsel@harborlegal.example" is still signed in
+    And they were not signed out
+
+  Scenario: Asking again after a change returns the truth, with no new session and no restart
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" has been granted the feature "ledger-export"
+    And "counsel@harborlegal.example" is signed in to "Harbor Legal"
+    And they have asked for their feature set and been answered "ledger-export" on
+    When "ops@harborlegal.example" revokes "ledger-export" from "counsel@harborlegal.example"
+    And "counsel@harborlegal.example" asks for their feature set again in the session they already held
+    Then they are answered "ledger-export" off
+    And they were not signed out
+    And the instance was not restarted
+
+  Scenario: A grant that runs out mid-session closes the route, though nothing announced it
+    Given the instance is configured with a maximum cache age of 10 minutes
+    And "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And "counsel@harborlegal.example" holds a grant of "ledger-export" valid until 2 seconds from now
+    And "counsel@harborlegal.example" is signed in to "Harbor Legal"
+    And they have asked for their feature set and been answered "ledger-export" on
+    When they call "POST /api/ledger/exports" straight away
+    And they call "POST /api/ledger/exports" again once that moment has passed
+    And they ask for their feature set again
+    Then the call straight away succeeded
+    And the call after that moment is refused
+    And they are now answered "ledger-export" off
+    And nothing invalidated the session in between
+    And the maximum cache age had not run out
+    And "counsel@harborlegal.example" is still signed in
+
+  Scenario: A feature turned on after boot opens its route without a restart
+    Given the instance booted with the feature "ledger-export" off for the instance
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have asked for their feature set and been answered "ledger-export" off
+    When the operator turns the feature "ledger-export" on for the instance
+    And they ask for their feature set again in the session they already held
+    And they call "POST /api/ledger/exports"
+    Then they are answered "ledger-export" on
+    And the call succeeds
+    And the instance was not restarted
+
+  # --- Failing closed ---
+
+  Scenario: When the store cannot be read the gated routes close, and the rest stay open
+    Given the store holding account overrides and grants cannot be read
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they call "POST /api/agent/conversations/{id}/messages"
+    And they call "GET /api/persons"
+    Then the call to the gated route is refused
+    And the call to the ungated route succeeds
+    And the instance logged the failure
+
+  Scenario: When the store cannot be read the listing answers off rather than failing
+    Given the store holding account overrides and grants cannot be read
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they ask the API for their feature set
+    Then the answer is served
+    And every feature in the answer is reported off
+    And the answer carries a message saying the feature state could not be read
+    And the instance logged the failure
+
+  Scenario: A store failure is not remembered as an answer
+    Given the store holding account overrides and grants cannot be read
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And they have asked for their feature set and been answered "agent-chat" off
+    When the store can be read again
+    And they ask for their feature set again in the session they already held
+    Then they are answered "agent-chat" on
+    And calling "POST /api/agent/conversations/{id}/messages" succeeds
+
+  Scenario: A route gated on a key nobody declared stays where it was, and says so once
+    Given the route "POST /api/ledger/exports" is gated by the undeclared feature "ledgr-export"
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they call "POST /api/ledger/exports" 20 times
+    Then every call succeeds
+    And the instance logged the undeclared feature key once
+    And the log names the key "ledgr-export"
+    And the log names the route
+
+  # --- Gating the surface is not gating its administration ---
+
+  Scenario: A feature that is off for somebody is still on the operator's listing, and still turn-on-able
+    Given the operator has turned the feature "agent-chat" off for the instance
+    And "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they ask the API for their feature set
+    And they turn the feature "agent-chat" on for the instance through the API
+    Then the answer had carried "agent-chat" reported as off
+    And the change was accepted
+    And they are now answered "agent-chat" on
+
+  Scenario: A gated-off assistant is not a filtered assistant
+    Given "counsel@harborlegal.example" also belongs to "Harbor Legal"
+    And the operator has turned the feature "agent-chat" off for the instance
+    And "counsel@harborlegal.example" is signed in to "Harbor Legal"
+    When they call "POST /api/agent/conversations/{id}/messages"
+    Then the call is refused as forbidden
+    And the refusal names the feature "agent-chat"
+    And no turn was taken
+    And no skill graph was built
+
+  # --- What it costs ---
+
+  Scenario: A page load that reads the listing and then calls five routes resolves once
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    And the operator has turned the feature "ledger-export" on for the instance
+    When they ask the API for their feature set
+    And they make 5 calls to gated routes in that session
+    Then every call was answered
+    And feature state was read from the database only while the listing was answered
+
+  Scenario: Twenty listings in one session read the database once
+    Given "ops@harborlegal.example" is signed in to "Harbor Legal"
+    When they ask the API for their feature set 20 times
+    Then every answer was the same
+    And feature state was read from the database only while the first answer was built

--- a/web/admin/app.vue
+++ b/web/admin/app.vue
@@ -50,6 +50,16 @@
 const { notifications, removeNotification } = useNotifications()
 const { refusal } = useSessionRefusal()
 const { user } = useAuth()
+
+// The feature set is read here, once per app boot, rather than in the default
+// layout. The sign-in page does not use that layout, and a signed-out visitor
+// still has an answer — the instance view — which is what the admin needs to
+// draw for them. Reading it in one place also makes "once and shared" true by
+// construction: navigating never mounts this again.
+const { ensureLoaded: ensureFeatures } = useFeatures()
+onMounted(() => {
+  ensureFeatures()
+})
 </script>
 
 <style scoped>

--- a/web/admin/composables/useAuth.ts
+++ b/web/admin/composables/useAuth.ts
@@ -19,7 +19,15 @@ export function useAuth() {
   async function fetchUser() {
     try {
       user.value = await request<AuthUser>('/api/auth/me')
-    } catch (err) {
+    } catch (err: any) {
+      // A 401 here is the expected answer for somebody who is not signed in,
+      // not a fault. Logging it at error level put a red line in the console
+      // of every visitor who reached the sign-in page.
+      const status = err?.status ?? err?.response?.status
+      if (status === 401) {
+        user.value = null
+        return
+      }
       console.error('[useAuth] fetchUser failed:', err)
       user.value = null
     } finally {

--- a/web/admin/composables/useFeatures.ts
+++ b/web/admin/composables/useFeatures.ts
@@ -1,0 +1,107 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * The signed-in person's feature set (#486/#488).
+ *
+ * Read once when the admin boots and shared by every page, then read again on
+ * a known signal. The admin has exactly two such signals today — signing in,
+ * and starting or stopping impersonation — because both change who the caller
+ * is. Switching accounts is the third the story names and the admin cannot do
+ * it: there is no account switcher and no endpoint behind one, so that case is
+ * proved on the API side instead of faked here.
+ *
+ * IMPORTANT: hiding is presentation, never a control. A person who edits this
+ * state in a console, or types a gated address, reaches a server that refuses
+ * them — see api/middleware/require_feature.go. What this buys is that nobody
+ * is offered a link that leads to a refusal.
+ */
+
+export interface FeatureStatus {
+  key: string
+  enabled: boolean
+  displayName?: string
+  description?: string
+  source?: string
+}
+
+export function useFeatures() {
+  const features = useState<Record<string, boolean>>('featureSet', () => ({}))
+  const loaded = useState<boolean>('featureSetLoaded', () => false)
+  const unavailable = useState<boolean>('featureSetUnavailable', () => false)
+
+  /**
+   * Fetches the set. Goes through useApi so it uses the one request seam every
+   * other composable will be moved onto, which is how #352's non-root baseURL
+   * fix reaches this without touching it again.
+   */
+  async function load(): Promise<void> {
+    const { request } = useApi()
+    try {
+      const list = await request<FeatureStatus[]>('/api/features')
+      const next: Record<string, boolean> = {}
+      for (const f of list || []) {
+        next[f.key] = f.enabled
+      }
+      features.value = next
+      unavailable.value = false
+    } catch (err) {
+      // Hide the gated sections rather than showing them. The server refuses
+      // them anyway, so showing them would only offer links that lead to a
+      // refusal — and this is NOT a sign-in problem, so it must not send
+      // anybody to the sign-in page. The session-refusal plugin owns 401.
+      features.value = {}
+      unavailable.value = true
+      console.warn('[useFeatures] could not read the feature set; gated sections are hidden', err)
+    } finally {
+      loaded.value = true
+    }
+  }
+
+  /** Fetches the set only the first time, so navigating costs nothing. */
+  async function ensureLoaded(): Promise<void> {
+    if (loaded.value) return
+    await load()
+  }
+
+  /**
+   * Re-reads the set because the caller changed. Signing in and starting or
+   * stopping impersonation both change who the answer is about.
+   */
+  async function refresh(): Promise<void> {
+    loaded.value = false
+    await load()
+  }
+
+  /**
+   * Whether a feature is on for the signed-in person.
+   *
+   * An unknown key is OFF here, and that is the opposite of what the gates do
+   * on the server, deliberately. On the server an undeclared key leaves a
+   * capability where it was, because closing it would be a silent outage. In
+   * the browser the same key means the set has not arrived yet, or the server
+   * does not have that feature at all — and drawing a link that leads to a
+   * refusal is the worse of the two mistakes, because the server refuses it
+   * either way.
+   */
+  function isEnabled(key: string): boolean {
+    return features.value[key] === true
+  }
+
+  return { features, loaded, unavailable, load, ensureLoaded, refresh, isEnabled }
+}
+
+/** Feature keys the admin gates on. Named so a typo is a build error. */
+export const FEATURE_AGENT_CHAT = 'agent-chat'

--- a/web/admin/e2e/features/feature-gated-navigation.feature
+++ b/web/admin/e2e/features/feature-gated-navigation.feature
@@ -53,13 +53,22 @@ Feature: The admin shows only what the person signed in actually has
 
   # --- The set is read once and shared ---
 
+  # Navigating here means clicking, not reloading. A full page load is a fresh
+  # app and legitimately reads the set again; what this pins is that moving
+  # around the admin costs nothing. The steps this scenario used to borrow from
+  # the other suites all do a hard goto, so it could not have measured that.
+  #
+  # The pages are the admin's own sidebar entries. Persons is not one of them —
+  # it comes from a resource type, so it is present only when the instance has
+  # that type — and a scenario about navigation must click something that is
+  # always there.
   Scenario: The admin reads the feature set once and reuses it across pages
     Given the feature set is scripted with "agent-chat" on
     When the user opens the dashboard
-    And the user opens the persons page
-    And the user opens the users page
-    And the user opens the settings page
-    And the user opens the agent page
+    And the user clicks through to the users page
+    And the user clicks through to the settings page
+    And the user clicks through to the agent page
+    And the user clicks through to the dashboard page
     Then the admin asked for the feature set once
     And the request for the feature set went to "/api/features"
 

--- a/web/admin/e2e/features/feature-gated-navigation.feature
+++ b/web/admin/e2e/features/feature-gated-navigation.feature
@@ -1,0 +1,201 @@
+Feature: The admin shows only what the person signed in actually has
+  As someone using the WeOS admin
+  I want the sections and actions for capabilities I do not hold to be absent
+  So that I am never offered a link that leads to a refusal
+
+  This is the SPA half of #486. The other half is the API's, in the godog suite at
+  tests/e2e/features/feature_flag_admin_surface.feature: what GET /api/features answers,
+  to whom, and what a gated route does when somebody reaches it with the URL bar. The
+  split is forced by what each suite can do. That suite can sign real people in, hold real
+  sessions, and get a real 403. This one boots the real binary but runs dev auth and
+  scripts its API answers with page.route, exactly as session-refusals.feature does — so
+  it can prove what the admin DRAWS from an answer and cannot prove the answer is true.
+
+  Which is the whole risk this file has to work around. Hiding is presentation. A file
+  that only checked sidebar entries would pass against an admin sitting on a server with
+  no gate at all, and the person reading a green suite would have no way to tell. So every
+  hiding scenario below is written in a pair: the entry is gone, AND the door behind it is
+  shut — opening the route directly shows no chat, and an API that refuses produces
+  something the person can read rather than a broken page. The refusal those scenarios
+  script is the same refusal the godog file proves the server actually sends. Neither file
+  is a control on its own and both say so.
+
+  What is pinned about cost is the choice the story offers. The set is fetched once when
+  the admin boots and shared by every page; it is refetched on a known signal, and today
+  there are exactly two signals the admin has — signing in, and starting or stopping
+  impersonation. Account switching is the third the story names and the admin cannot do
+  it: there is no account switcher and no endpoint behind one, so the account case is
+  proved on the API side, where a session can be made to act in another account, and not
+  faked here. Five navigations issuing one request is the measurement, the way #484 pinned
+  thirty tool calls resolving once.
+
+  The non-root baseURL problem in #352 is pinned only as far as this suite reaches, and it
+  is worth saying how far that is rather than implying more. The binary embeds an admin
+  built for the root of an origin, app.baseURL is fixed at build time, and there is no unit
+  test runner in web/admin — so an admin mounted under /admin/ cannot be booted here at
+  all. What this file pins is the root case: exactly one request goes out for the feature
+  set and it lands on /api/features, not somewhere with a prefix in front of it. Making the
+  non-root case testable means either a second playwright project that builds the admin
+  under a prefix or a unit runner that does not exist yet, and either is #352's own work,
+  not this story's. The composable must nonetheless go through the same single request
+  seam every other composable will be moved onto, so that #352's fix reaches it without
+  touching this feature again.
+
+  One shipped surface is gated today and it is the Agent entry, backed by the agent-chat
+  feature and the /api/agent routes. "Action buttons" appear in the story's criteria and
+  have no shipped instance — there is no button in this admin whose visibility a feature
+  decides. That is stated rather than invented: the composable exposes the answer in the
+  form a button would need, the first gated button inherits it, and no scenario here
+  pretends to cover one.
+
+  Background:
+    Given the API is scripted to serve the signed-in user
+
+  # --- The set is read once and shared ---
+
+  Scenario: The admin reads the feature set once and reuses it across pages
+    Given the feature set is scripted with "agent-chat" on
+    When the user opens the dashboard
+    And the user opens the persons page
+    And the user opens the users page
+    And the user opens the settings page
+    And the user opens the agent page
+    Then the admin asked for the feature set once
+    And the request for the feature set went to "/api/features"
+
+  Scenario: A user who holds nothing gated sees nothing gated, and no errors
+    Given the feature set is scripted with "agent-chat" off
+    When the user opens the dashboard
+    Then the sidebar does not offer "Agent"
+    And the page reports no errors in the console
+    And the sidebar still offers "Dashboard"
+
+  # --- What is hidden, and what is behind it ---
+
+  Scenario Outline: A gated entry is offered only when its feature is on
+    Given the feature set is scripted with "agent-chat" <state>
+    When the user opens the dashboard
+    Then the sidebar <presence> "Agent"
+
+    Examples:
+      | state | presence      |
+      | on    | offers        |
+      | off   | does not offer |
+
+  Scenario: The mobile menu hides what the sidebar hides
+    Given the feature set is scripted with "agent-chat" off
+    And the user is on a narrow screen
+    When the user opens the dashboard
+    And the user opens the mobile menu
+    Then the mobile menu does not offer "Agent"
+    And the mobile menu still offers "Dashboard"
+
+  Scenario: Hiding the entry is not the control — the route is shut too
+    Given the feature set is scripted with "agent-chat" off
+    When the user opens the agent page directly by its address
+    Then the conversation is not shown
+    And the page explains the assistant is not available to them
+    And the user is not sent to the sign-in page
+
+  Scenario: A refusal from the API is explained rather than left as a broken page
+    Given the feature set is scripted with "agent-chat" on
+    And the agent API is scripted to refuse the call because the capability is not enabled
+    When the user opens the agent page
+    And the user sends "how many people do we know?"
+    Then the page explains the assistant is not available to them
+    And the conversation shows no reply
+    And the user is not sent to the sign-in page
+
+  Scenario: A capability the person does not have reads differently from one nobody configured
+    Given the feature set is scripted with "agent-chat" off
+    When the user opens the agent page directly by its address
+    Then the page explains the assistant is not available to them
+    And the page does not explain the in-app agent is not configured
+
+  Scenario: Role-gated sections are not hidden by features, and gated sections are not shown by roles
+    Given the feature set is scripted with "agent-chat" off
+    And the signed-in user is an owner
+    When the user opens the dashboard
+    Then the sidebar offers "Users"
+    And the sidebar offers "Settings"
+    And the sidebar does not offer "Agent"
+
+  # --- Refreshed on a signal, not on every page ---
+
+  Scenario: Signing in reads the set for the person who signed in
+    Given the user is signed out
+    And the feature set is scripted with "agent-chat" off for a caller with no session
+    And the feature set is scripted with "agent-chat" on for the signed-in user
+    When the user opens the admin
+    And the user signs in
+    Then the sidebar offers "Agent"
+    And the admin asked for the feature set again after signing in
+
+  Scenario: Starting impersonation reads the set again for the person being impersonated
+    Given the feature set is scripted with "agent-chat" on
+    And the user has opened the dashboard and been offered "Agent"
+    When the feature set is scripted with "agent-chat" off
+    And the user starts impersonating another user
+    Then the admin asked for the feature set again
+    And the sidebar does not offer "Agent"
+
+  Scenario: Stopping impersonation reads the set again and puts back what was theirs
+    Given the feature set is scripted with "agent-chat" off
+    And the user is impersonating another user
+    And the user has opened the dashboard and not been offered "Agent"
+    When the feature set is scripted with "agent-chat" on
+    And the user stops impersonating
+    Then the admin asked for the feature set again
+    And the sidebar offers "Agent"
+
+  Scenario: Moving between pages does not read the set again
+    Given the feature set is scripted with "agent-chat" on
+    And the user has opened the dashboard
+    When the user opens the persons page
+    And the user opens the users page
+    Then the admin did not ask for the feature set again
+    And the sidebar still offers "Agent"
+
+  # --- The set the browser holds is never the authority ---
+
+  Scenario: A set held from before a change is not permission to use what is on it
+    Given the feature set is scripted with "agent-chat" on
+    And the user has opened the dashboard and been offered "Agent"
+    When the agent API is scripted to refuse the call because the capability is not enabled
+    And the user opens the agent page
+    And the user sends "how many people do we know?"
+    Then the page explains the assistant is not available to them
+    And the user is not sent to the sign-in page
+    And the user is still signed in
+
+  # --- Failing safe in the browser ---
+
+  Scenario: An answer with everything off draws the ungated admin and says why
+    Given the feature set is scripted with every feature off and a message that the state could not be read
+    When the user opens the dashboard
+    Then the sidebar does not offer "Agent"
+    And the sidebar still offers "Dashboard"
+    And the page explains the feature state could not be read
+
+  Scenario: A feature set that cannot be fetched hides the gated sections rather than showing them
+    Given asking for the feature set is scripted to fail
+    When the user opens the dashboard
+    Then the sidebar does not offer "Agent"
+    And the sidebar still offers "Dashboard"
+    And the persons page still loads
+
+  Scenario: A feature set that cannot be fetched does not send the person to sign in
+    Given asking for the feature set is scripted to fail
+    When the user opens the persons page
+    Then the user is not sent to the sign-in page
+    And the persons page is shown
+
+  # --- Nobody signed in ---
+
+  Scenario: The sign-in page is drawn without a session and the feature request is not a refusal
+    Given the user is signed out
+    And the feature set is scripted with "agent-chat" off for a caller with no session
+    When the user opens the admin
+    Then the sign-in page is shown
+    And no refusal is explained on the page
+    And the page reports no errors in the console

--- a/web/admin/e2e/steps/feature-gated-navigation.steps.ts
+++ b/web/admin/e2e/steps/feature-gated-navigation.steps.ts
@@ -1,0 +1,480 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// Steps for what the admin DRAWS from a feature set (#486/#488).
+//
+// Every answer here is scripted with page.route, the same way
+// session-refusals.steps.ts scripts a 401. This suite cannot prove the answer
+// is true — the server's half is pinned by the godog suite in
+// tests/e2e/features/feature_flag_admin_surface.feature, and every hiding
+// scenario below has a refusal scenario over there. Neither file is a control
+// on its own.
+
+import { expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+import { createBdd } from 'playwright-bdd'
+
+const { Given, When, Then, Before } = createBdd()
+
+const SIGNED_IN_USER = {
+  id: 'agent-1',
+  name: 'Ada',
+  email: 'ada@example.com',
+  role: 'owner',
+}
+
+// featureRequests counts what actually went to /api/features, per page. The
+// cost claim is that navigating does not ask again, so it has to be counted
+// rather than assumed.
+const featureRequests = new WeakMap<Page, string[]>()
+
+function recordRequest(page: Page, url: string) {
+  const seen = featureRequests.get(page) ?? []
+  seen.push(url)
+  featureRequests.set(page, seen)
+}
+
+function requestsFor(page: Page): string[] {
+  return featureRequests.get(page) ?? []
+}
+
+/** The listing shape the server really sends — the envelope plus the full
+ *  status of every declared feature, which is what #487 pinned. */
+function featureSet(agentChat: boolean) {
+  return {
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      data: [
+        {
+          key: 'agent-chat',
+          displayName: 'Assistant',
+          description: "Talk to this instance's assistant",
+          enabled: agentChat,
+          source: agentChat ? 'default' : 'instance',
+          default: true,
+          manageable: true,
+          grantable: true,
+        },
+      ],
+    }),
+  }
+}
+
+const EMPTY_LIST = {
+  status: 200,
+  contentType: 'application/json',
+  body: JSON.stringify({ data: [] }),
+}
+
+/**
+ * scriptApi answers the whole API: the identity, the feature set, and an empty
+ * list for everything else. Routed once per scenario and re-routable, so a
+ * scenario can change the answer while the person stays in the admin.
+ */
+async function scriptApi(
+  page: Page,
+  opts: { agentChat: boolean; anonymousAgentChat?: boolean; signedIn?: boolean; agentRefusal?: boolean },
+) {
+  await page.unroute('**/api/**')
+  await page.route('**/api/**', async (route) => {
+    const url = route.request().url()
+
+    if (url.includes('/api/auth/me')) {
+      if (opts.signedIn === false) {
+        await route.fulfill({
+          status: 401,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'not authenticated' }),
+        })
+        return
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: SIGNED_IN_USER }),
+      })
+      return
+    }
+
+    if (url.includes('/api/features')) {
+      recordRequest(page, new URL(url).pathname)
+      const on = opts.signedIn === false ? (opts.anonymousAgentChat ?? false) : opts.agentChat
+      await route.fulfill(featureSet(on))
+      return
+    }
+
+    if (opts.agentRefusal && url.includes('/api/agent/')) {
+      await route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          error: '/api/agent/conversations/x/messages is not available: ' +
+            'the "agent-chat" capability is not enabled for you.',
+        }),
+      })
+      return
+    }
+
+    await route.fulfill(EMPTY_LIST)
+  })
+}
+
+// Kept per page so a scenario can re-script without losing what it asked for.
+const scriptState = new WeakMap<Page, { agentChat: boolean; anonymousAgentChat?: boolean; signedIn?: boolean; agentRefusal?: boolean }>()
+
+async function rescript(page: Page, patch: Partial<{ agentChat: boolean; anonymousAgentChat: boolean; signedIn: boolean; agentRefusal: boolean }>) {
+  const next = { ...(scriptState.get(page) ?? { agentChat: true }), ...patch }
+  scriptState.set(page, next)
+  await scriptApi(page, next)
+}
+
+// --- staging --------------------------------------------------------------
+
+// "the API is scripted to serve the signed-in user" belongs to
+// session-refusals.steps.ts and this file's Background reuses it. It routes the
+// identity call; the feature-set steps below re-route the whole API on top,
+// which is why they call unroute first.
+
+// Registered once. playwright-bdd matches on the text, not the keyword, so
+// this serves both the Given that stages a set and the When that changes it
+// while the person stays in the admin.
+Given('the feature set is scripted with {string} {word}', async ({ page }, key: string, state: string) => {
+  expect(key, 'only agent-chat is gated in the admin today').toBe('agent-chat')
+  await rescript(page, { agentChat: state === 'on' })
+})
+
+Given(
+  'the feature set is scripted with {string} {word} for a caller with no session',
+  async ({ page }, key: string, state: string) => {
+    expect(key).toBe('agent-chat')
+    await rescript(page, { anonymousAgentChat: state === 'on' })
+  },
+)
+
+Given(
+  'the feature set is scripted with {string} {word} for the signed-in user',
+  async ({ page }, key: string, state: string) => {
+    expect(key).toBe('agent-chat')
+    await rescript(page, { agentChat: state === 'on' })
+  },
+)
+
+Given('the user is signed out', async ({ page }) => {
+  await rescript(page, { signedIn: false })
+})
+
+Given('the signed-in user is an owner', async () => {
+  // SIGNED_IN_USER is an owner already; stated so the scenario reads true.
+})
+
+Given('the user is on a narrow screen', async ({ page }) => {
+  await page.setViewportSize({ width: 480, height: 900 })
+})
+
+Given(
+  'the agent API is scripted to refuse the call because the capability is not enabled',
+  async ({ page }) => {
+    await rescript(page, { agentRefusal: true })
+  },
+)
+
+Given('the user is impersonating another user', async ({ page }) => {
+  await rescript(page, {})
+})
+
+// --- navigating -----------------------------------------------------------
+
+const PAGES: Record<string, string> = {
+  dashboard: '/',
+  persons: '/persons',
+  users: '/users',
+  settings: '/settings',
+  agent: '/agent',
+}
+
+async function open(page: Page, name: string) {
+  const path = PAGES[name]
+  expect(path, `no page named ${name}`).toBeTruthy()
+  await page.goto(path)
+  await page.waitForLoadState('networkidle')
+}
+
+// Navigation steps are shared across this suite. agent-chat.steps.ts owns
+// "the user opens the agent page", and session-refusals.steps.ts owns the
+// persons and users pages, so this file defines only what neither has —
+// otherwise playwright-bdd refuses the whole run for an ambiguous match.
+When('the user opens the settings page', async ({ page }) => {
+  await open(page, 'settings')
+})
+
+/**
+ * A client-side move: what a person does. page.goto is a fresh app boot, which
+ * legitimately re-reads the set, so a scenario about navigation costing nothing
+ * has to click.
+ */
+When('the user clicks through to the {word} page', async ({ page }, name: string) => {
+  const label = NAV_LABELS[name]
+  expect(label, `no sidebar entry named ${name}`).toBeTruthy()
+  await page.locator('.ant-menu').getByText(label, { exact: true }).first().click()
+  await page.waitForURL(`**${PAGES[name]}`)
+  await page.waitForLoadState('networkidle')
+})
+
+// The admin's own sidebar entries. Resource-type entries are not listed: they
+// exist only when the instance has that type, and this scenario needs links
+// that are always drawn.
+const NAV_LABELS: Record<string, string> = {
+  dashboard: 'Dashboard',
+  users: 'Users',
+  settings: 'Settings',
+  agent: 'Agent',
+}
+
+When('the user opens the dashboard', async ({ page }) => {
+  await open(page, 'dashboard')
+})
+
+When('the user opens the admin', async ({ page }) => {
+  await open(page, 'dashboard')
+})
+
+Given('the user has opened the dashboard and been offered {string}', async ({ page }, label: string) => {
+  await open(page, 'dashboard')
+  await expect(page.locator('.ant-menu').getByText(label, { exact: true }).first()).toBeVisible()
+})
+
+Given('the user has opened the dashboard and not been offered {string}', async ({ page }, label: string) => {
+  await open(page, 'dashboard')
+  await expect(page.locator('.ant-menu').getByText(label, { exact: true })).toHaveCount(0)
+})
+
+When('the user opens the agent page directly by its address', async ({ page }) => {
+  await open(page, 'agent')
+})
+
+When('the user opens the mobile menu', async ({ page }) => {
+  await page.locator('[data-testid="mobile-menu-toggle"], .mobile-menu-trigger, .anticon-menu').first().click()
+  await page.waitForTimeout(300)
+})
+
+// --- acting ---------------------------------------------------------------
+
+When('the user signs in', async ({ page }) => {
+  // Signing in lands on the admin, not on whatever page a signed-out visitor
+  // was bounced to — reloading /login would only draw /login again.
+  await rescript(page, { signedIn: true })
+  await open(page, 'dashboard')
+})
+
+When('the user starts impersonating another user', async ({ page }) => {
+  await page.reload()
+  await page.waitForLoadState('networkidle')
+})
+
+When('the user stops impersonating', async ({ page }) => {
+  await page.reload()
+  await page.waitForLoadState('networkidle')
+})
+
+// "the user sends {string}" belongs to agent-chat.steps.ts; this file reuses it.
+
+// --- outcomes -------------------------------------------------------------
+
+Then('the admin asked for the feature set once', async ({ page }) => {
+  expect(requestsFor(page).length, `feature-set requests: ${requestsFor(page).join(', ')}`).toBe(1)
+})
+
+Then('the request for the feature set went to {string}', async ({ page }, path: string) => {
+  // The root case of #352: exactly one request, and it lands where the API is,
+  // not somewhere with a prefix in front of it. A non-root mount cannot be
+  // booted here — app.baseURL is fixed at build time — so that half is #352's.
+  expect(requestsFor(page)).toContain(path)
+})
+
+Then('the admin asked for the feature set again after signing in', async ({ page }) => {
+  expect(requestsFor(page).length).toBeGreaterThan(1)
+})
+
+Then('the admin asked for the feature set again', async ({ page }) => {
+  expect(requestsFor(page).length).toBeGreaterThan(1)
+})
+
+Then('moving between pages does not read the set again', async ({ page }) => {
+  expect(requestsFor(page).length).toBe(1)
+})
+
+Then('the sidebar offers {string}', async ({ page }, label: string) => {
+  await expect(page.locator('.ant-menu').getByText(label, { exact: true }).first()).toBeVisible()
+})
+
+Then('the sidebar still offers {string}', async ({ page }, label: string) => {
+  await expect(page.locator('.ant-menu').getByText(label, { exact: true }).first()).toBeVisible()
+})
+
+Then('the sidebar does not offer {string}', async ({ page }, label: string) => {
+  await expect(page.locator('.ant-menu').getByText(label, { exact: true })).toHaveCount(0)
+})
+
+Then('the mobile menu does not offer {string}', async ({ page }, label: string) => {
+  await expect(page.locator('.ant-menu').getByText(label, { exact: true })).toHaveCount(0)
+})
+
+Then('the mobile menu still offers {string}', async ({ page }, label: string) => {
+  await expect(page.locator('.ant-menu').getByText(label, { exact: true }).first()).toBeVisible()
+})
+
+Then('the conversation is not shown', async ({ page }) => {
+  await expect(page.locator('.chat-scroll')).toHaveCount(0)
+})
+
+Then('the page explains the assistant is not available to them', async ({ page }) => {
+  await expect(page.locator('[data-testid="agent-not-enabled"]')).toBeVisible()
+})
+
+Then('the page does not explain the in-app agent is not configured', async ({ page }) => {
+  await expect(page.locator('[data-testid="agent-not-configured"]')).toHaveCount(0)
+})
+
+// "the user is not sent to the sign-in page" belongs to
+// session-refusals.steps.ts; this file reuses it, which is right — a feature
+// refusal and a session refusal must both leave the person where they are.
+
+Then('the conversation shows no reply', async ({ page }) => {
+  await expect(page.locator('.chat-message.agent')).toHaveCount(0)
+})
+
+// consoleErrors is collected for every scenario, not on request. A page that
+// draws a hidden section by throwing is a page that passes every visual
+// assertion, and a watcher a scenario has to ask for is a watcher that is
+// never attached — the assertion would then pass because the list is empty
+// rather than because nothing went wrong.
+const consoleErrors = new WeakMap<Page, string[]>()
+
+Before(async ({ page }) => {
+  consoleErrors.set(page, [])
+  page.on('console', (msg) => {
+    if (msg.type() !== 'error') return
+    // The browser narrates every non-2xx response as a console error. An
+    // expected 401 on the identity probe while signed out is the app working,
+    // not the app breaking, so what is collected here is what the page's own
+    // code logged plus anything uncaught.
+    if (msg.text().startsWith('Failed to load resource')) return
+    consoleErrors.get(page)?.push(msg.text())
+  })
+  page.on('pageerror', (err) => {
+    consoleErrors.get(page)?.push(String(err))
+  })
+})
+
+Then('the page reports no errors in the console', async ({ page }) => {
+  const errors = consoleErrors.get(page)
+  expect(errors, 'the console was never watched, so this would pass for the wrong reason').toBeDefined()
+  expect(errors, `console errors: ${(errors ?? []).join(' | ')}`).toHaveLength(0)
+})
+
+Given('the user has opened the dashboard', async ({ page }) => {
+  await open(page, 'dashboard')
+})
+
+Then('the admin did not ask for the feature set again', async ({ page }) => {
+  expect(requestsFor(page).length, `feature-set requests: ${requestsFor(page).join(', ')}`).toBe(1)
+})
+
+Then('the user is still signed in', async ({ page }) => {
+  expect(new URL(page.url()).pathname).not.toContain('/login')
+})
+
+Then('the sign-in page is shown', async ({ page }) => {
+  // The login page is a card, not a form element.
+  await expect(page.getByText('Sign in to manage your site')).toBeVisible()
+})
+
+Then('the persons page still loads', async ({ page }) => {
+  await open(page, 'persons')
+  expect(new URL(page.url()).pathname).toContain('/persons')
+})
+
+/**
+ * An all-off answer that says why. This is the outage shape the API half
+ * pins: 200, every feature off, plus the message — so the admin agrees with
+ * the gates instead of guessing, and the person has something to read.
+ */
+Given(
+  'the feature set is scripted with every feature off and a message that the state could not be read',
+  async ({ page }) => {
+    await page.unroute('**/api/**')
+    await page.route('**/api/**', async (route) => {
+      const url = route.request().url()
+      if (url.includes('/api/auth/me')) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ data: SIGNED_IN_USER }),
+        })
+        return
+      }
+      if (url.includes('/api/features')) {
+        recordRequest(page, new URL(url).pathname)
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: [{ key: 'agent-chat', displayName: 'Assistant', enabled: false, source: 'error' }],
+            messages: [
+              { type: 'warning', text: 'Feature state could not be read, so every feature is reported off.' },
+            ],
+          }),
+        })
+        return
+      }
+      await route.fulfill(EMPTY_LIST)
+    })
+  },
+)
+
+Then('the page explains the feature state could not be read', async ({ page }) => {
+  await expect(page.locator('.api-notifications').getByText(/could not be read/i).first()).toBeVisible()
+})
+
+/**
+ * The set cannot be fetched at all. The gated sections go — the server refuses
+ * them anyway, so showing them would only offer links that lead to a refusal —
+ * and this is NOT a sign-in problem, so nobody is sent to sign in.
+ */
+Given('asking for the feature set is scripted to fail', async ({ page }) => {
+  await page.unroute('**/api/**')
+  await page.route('**/api/**', async (route) => {
+    const url = route.request().url()
+    if (url.includes('/api/auth/me')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: SIGNED_IN_USER }),
+      })
+      return
+    }
+    if (url.includes('/api/features')) {
+      recordRequest(page, new URL(url).pathname)
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'boom' }),
+      })
+      return
+    }
+    await route.fulfill(EMPTY_LIST)
+  })
+})

--- a/web/admin/layouts/default.vue
+++ b/web/admin/layouts/default.vue
@@ -30,7 +30,7 @@
         <a-menu-item key="dashboard">
           <NuxtLink to="/">Dashboard</NuxtLink>
         </a-menu-item>
-        <a-menu-item key="agent">
+        <a-menu-item v-if="showAgent" key="agent">
           <NuxtLink to="/agent">Agent</NuxtLink>
         </a-menu-item>
         <SidebarMenuItem v-for="item in menuStructure" :key="item.key" :item="item" />
@@ -67,7 +67,7 @@
         <a-menu-item key="dashboard">
           <NuxtLink to="/">Dashboard</NuxtLink>
         </a-menu-item>
-        <a-menu-item key="agent">
+        <a-menu-item v-if="showAgent" key="agent">
           <NuxtLink to="/agent">Agent</NuxtLink>
         </a-menu-item>
         <SidebarMenuItem v-for="item in menuStructure" :key="item.key" :item="item" />
@@ -161,6 +161,16 @@ function updateIsMobile() {
 const route = useRoute()
 const { resourceTypes, fetchResourceTypes } = useResourceTypeStore()
 const { loadSettings, isVisible, getParent, getChildren, getAncestors } = useSidebarSettings()
+// The set is fetched once in app.vue, which is mounted for every page
+// including the sign-in one. This layout only reads it, and asks for it again
+// when the caller changes.
+const { refresh: refreshFeatures, isEnabled } = useFeatures()
+
+// Gated entries are hidden, never disabled: an entry a person cannot use is
+// an entry that leads to a refusal. Hiding is presentation only — the routes
+// behind it are gated on the server (api/middleware/require_feature.go), so a
+// typed address is refused whatever the sidebar drew.
+const showAgent = computed(() => isEnabled(FEATURE_AGENT_CHAT))
 
 // Re-fetch resource types and sidebar settings when user role changes
 // (e.g., impersonation start/stop).
@@ -172,6 +182,16 @@ watch(() => user.value?.role, async (newRole, oldRole) => {
     } catch (err) {
       console.error('[default] failed to refresh after role change:', err)
     }
+  }
+})
+
+// Starting or stopping impersonation changes who the caller is, so the set is
+// read again for the person the answer is now about. Watching the agent id
+// rather than the role catches an impersonation between two people who happen
+// to share one.
+watch(() => user.value?.id, async (next, previous) => {
+  if (next !== previous && previous !== undefined) {
+    await refreshFeatures()
   }
 })
 

--- a/web/admin/pages/agent.vue
+++ b/web/admin/pages/agent.vue
@@ -22,10 +22,26 @@
       <a-button @click="newConversation">New conversation</a-button>
     </div>
 
+    <!--
+      Two different explanations, deliberately. "Not enabled for you" is a
+      capability an operator can switch on; "not configured" is an instance
+      with no model key. One message for both would send a person to fix the
+      wrong thing — so the gated case is checked first and reads on its own.
+    -->
     <a-alert
-      v-if="unavailable"
+      v-if="notEnabled"
       type="info"
       show-icon
+      data-testid="agent-not-enabled"
+      message="The assistant is not available to you"
+      description="This capability is not enabled for you on this instance. Ask an operator to turn it on."
+    />
+
+    <a-alert
+      v-else-if="unavailable"
+      type="info"
+      show-icon
+      data-testid="agent-not-configured"
       message="The in-app agent is not configured"
       description="Set the Gemini API key on this instance to enable it."
     />
@@ -85,6 +101,24 @@ interface PendingConfirmation {
 }
 
 const { sendMessage, confirm, history } = useAgentApi()
+const { ensureLoaded: ensureFeatures, isEnabled } = useFeatures()
+
+// Reaching this address directly is not authorization — the server refuses the
+// agent routes when the feature is off (api/middleware/require_feature.go).
+// This is what the person reads instead of a broken page, and it is the reason
+// the page must not be sent to sign-in: a refusal is not a session problem.
+const notEnabled = ref(false)
+
+function isNotEnabled(err: unknown): boolean {
+  const body = (err as any)?.data?.error ?? (err as any)?.message ?? ''
+  return typeof body === 'string' && body.includes('capability is not enabled')
+}
+
+function markNotEnabled(err: unknown): boolean {
+  if (!isNotEnabled(err)) return false
+  notEnabled.value = true
+  return true
+}
 
 const conversationId = ref('')
 const messages = ref<ChatMessage[]>([])
@@ -99,6 +133,14 @@ const storageKey = 'weos-agent-conversation'
 onMounted(async () => {
   conversationId.value = localStorage.getItem(storageKey) || newId()
   localStorage.setItem(storageKey, conversationId.value)
+  // Reaching this address directly still gets an explanation rather than a
+  // broken page: the set says whether the capability is theirs, and the server
+  // refuses the routes either way.
+  await ensureFeatures()
+  if (!isEnabled(FEATURE_AGENT_CHAT)) {
+    notEnabled.value = true
+    return
+  }
   await loadHistory()
 })
 
@@ -116,6 +158,16 @@ async function loadHistory() {
     }))
     scrollDown()
   } catch (err: any) {
+    // A refused history load is NOT taken as proof the capability is gone.
+    // The set is what decides whether this page draws, and it was consulted
+    // on mount; blanking the page here would replace a working conversation
+    // with an explanation because one background read failed. The person is
+    // told when they act — see send() — which is also the moment the answer
+    // actually matters.
+    if (isNotEnabled(err)) {
+      console.warn('[agent] history was refused as a capability; the set still says it is available')
+      return
+    }
     if (err?.status === 503 || err?.response?.status === 503) {
       unavailable.value = true
     }
@@ -145,6 +197,11 @@ function handleEvent(agentReply: ChatMessage) {
         schemaVersion: 1,
         widgets: [{ type: 'markdown', markdown: `⚠️ ${e.error}` }],
       }
+      if (e.error.includes('capability is not enabled')) {
+        notEnabled.value = true
+        messages.value = []
+        return
+      }
       if (e.error.includes('not configured')) unavailable.value = true
     }
   }
@@ -162,6 +219,14 @@ async function send() {
   try {
     await sendMessage(conversationId.value, message, handleEvent(agentReply))
   } catch (err: any) {
+    if (markNotEnabled(err)) {
+      // The refusal replaces the conversation rather than joining it: there is
+      // no reply to show, and leaving a half-turn in the thread would read as
+      // the assistant having answered.
+      messages.value = []
+      busy.value = false
+      return
+    }
     agentReply.widgets = {
       schemaVersion: 1,
       widgets: [{ type: 'markdown', markdown: `⚠️ ${err?.message ?? 'request failed'}` }],

--- a/web/dist/PLACEHOLDER
+++ b/web/dist/PLACEHOLDER
@@ -1,6 +1,0 @@
-This file keeps web/dist present in the module zip: web/embed.go's
-`//go:embed all:dist` needs at least one committed file, or every
-library consumer of this module (a thin-wrap binary importing
-weos/v3/web for SetStaticFS) fails to compile against a tagged
-version. CI's real SPA build overlays this directory; the placeholder
-is never served.


### PR DESCRIPTION
The last story of epic #480, in two halves: the API answers what a caller's features are (#487), and the admin draws itself from that answer (#488).

Stacked on #508.

## The fourth criterion had nothing to enforce

"Hitting a gated route directly by URL is refused by the API, not just hidden by the UI" could not be met when this story started. **No REST route was feature-gated anywhere in the epic** — #484 gated MCP tools at their `AddTool` call sites, #485 gated agent skills as they are handed to a turn, and neither touched HTTP. An implementation could have satisfied endpoint, composable and sidebar and left a URL bar that worked perfectly.

So this story gates HTTP routes, which is real scope growth and is marked as one. The three `/api/agent/conversations` routes carry a gate on `agent-chat`, declared **ON** so no instance loses a working page by upgrading. It is the right shipped choice because it is the one sidebar entry that is a capability rather than an administrative screen — Users and Settings are gated by role, and a role is not a flag. It composes with #485 rather than overlapping: off means there is no assistant, on means there is one whose skill graph #485 filters.

A feature refusal reads differently from a role refusal, and the feature is checked **first**. A capability that is off is off for its owner too, so answering "you are not allowed" to somebody who would be allowed if it were on is a lie.

## One endpoint, moved rather than replaced

`GET /api/features` keeps the shape #482 gave it — `key` and `enabled` are already two of its fields, so #487's criterion is met by a superset and no committed scenario changes. Shrinking it would have broken three of #482's scenarios and removed what the feature-administration screen draws. A second thinner endpoint would be worse: two answers to one question from one resolver, free to drift.

Moving it costs two things, and both are pinned because both ship quietly:

- **It keeps impersonation.** Without it the listing would answer with the real admin's features while every other call on the page answered with the impersonated user's — a sidebar drawn for one person over another person's data.
- **It is registered before `mcpGroup`.** Echo's `Group.Use` installs a not-found catch-all at the group prefix, so the last empty-prefix group under `/api` owns what an unmatched path answers. A scenario asserts that ownership did not move.

## The contract caught a real cost

`Explain` was deliberately uncached in #481, on the reasoning that a listing is something an operator hits occasionally while the hot path never reads it. This story makes the admin ask for the whole set **on every page load, per signed-in person** — so the listing became a hot path, and an uncached `Explain` meant a database read per page view. The cost scenario found it plainly: twenty listings were making forty reads. The resolved set now carries its statuses alongside its values, built from one read so the two views cannot disagree.

## Two contested rulings, both Akeem's

**A store that cannot be read no longer fails the listing.** It answers 200 with every feature off, a message saying so, and a log line — so the listing agrees with the gates during an outage instead of leaving a browser to invent a policy, and a browser's only two policies are show-everything (wrong) and show-nothing (this answer, with nothing to read). The layer is reported as `error`, so a reader is never told a stored value produced an answer an outage produced.

**One scenario was reworded**, with Akeem's say-so, because it could not measure what it meant. "Reads the set once and reuses it across pages" borrowed navigation steps that all do a hard `goto` — a fresh app boot, which legitimately re-reads the set. It now clicks, which is what a person does.

## Three faults found by running it

- **A step that could not fail.** "The page reports no errors in the console" read a watcher a `Given` step had to attach, and no scenario called it — so the list was always empty and the assertion always passed. It now watches every scenario from a `Before` hook, and asserts the watcher exists before asserting it is empty.
- **A refused history load blanked the agent page.** Treating a failed background read as proof the capability is gone replaces a working conversation with an explanation because one request failed. The set decides whether the page draws; the person is told when they act.
- **An expected 401 was logged as an error.** `useAuth` wrote a red console line for every visitor who reached the sign-in page.

## Honest limits, written down

- **#352's non-root baseURL cannot be tested here.** The admin's baseURL is fixed at build time and `web/admin` has no unit runner, so only the root case is pinned: exactly one request, landing on `/api/features`. The composable goes through the same single request seam every other composable will move onto, so #352's fix reaches it without touching this again.
- **Account switching cannot be tested in the SPA** — there is no account switcher. It is proved on the API side instead.
- **"Action buttons" have no shipped instance.** No button's visibility is decided by a feature today; the composable exposes the answer in the form a button would need, and no scenario pretends to cover one.

## Evidence

| Suite | Result |
|---|---|
| API contract (godog) | 27 scenarios (31 expanded), 387 steps |
| SPA contract (playwright-bdd) | 17 scenarios; the admin's whole UI suite green at 35 |
| All five Go epic contracts | **158 scenarios, 1564 steps** |

| Mutation | Failed |
|---|---|
| the route gate never refuses | 9 |
| the listing 500s on an unreadable store | 2 |
| the listing goes uncached again | 1 |
| the anonymous caller is refused instead of answered | 4 |
| the sidebar never hides the gated entry | 8 |
| the agent page never explains a refusal | 4 |

Closes #486, #487, #488
