### PR TITLE
Merge a preset's @context at boot, and unblock the gate that proves it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,14 @@ jobs:
         run: go mod download
 
       - name: Run tests
-        run: go test -v -race -coverprofile=coverage.out ./...
+        # tests/e2e takes ~504s under -race on a developer machine and more on
+        # a runner, against `go test`'s 600s default per-package timeout. The
+        # package was being killed mid-run and reported as a failure, which is
+        # why the gate has been red on v3 since 2026-08-20 regardless of the
+        # change under test. Raised with headroom rather than set just above
+        # the current figure, so the gate does not go red again on the next
+        # scenario added.
+        run: go test -v -race -timeout 20m -coverprofile=coverage.out ./...
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/application/builtin_resource_types.go
+++ b/application/builtin_resource_types.go
@@ -89,9 +89,9 @@ func ensureBuiltInResourceTypes(params struct {
 	return nil
 }
 
-// reconcilePresetSchemas merges a preset's additive schema changes into the
-// types already stored in this database and reports every outcome that means
-// data is still being dropped (issue #379).
+// reconcilePresetSchemas merges a preset's additive schema AND `@context`
+// changes into the types already stored in this database, and reports every
+// outcome that means data is still being dropped (issues #379 and #510).
 //
 // A reconcile failure is logged, not fatal. That is a deliberate asymmetry with
 // the terminal LinkActivator reconcile above, which does fail startup: link
@@ -112,7 +112,7 @@ func reconcilePresetSchemas(
 		return
 	}
 	for _, slug := range reconciled.Updated {
-		logger.Info(ctx, "reconciled resource type schema from preset",
+		logger.Info(ctx, "reconciled resource type schema and context from preset",
 			"preset", presetName, "slug", slug)
 	}
 	for slug, held := range reconciled.Refused {
@@ -132,8 +132,11 @@ func reconcilePresetSchemas(
 			"preset", presetName, "slug", slug, "heldContextTerms", held)
 	}
 	for slug, reason := range reconciled.Failed {
+		// The reason names what actually failed: a projection column that never
+		// appeared, a reference property with no `@context` term to resolve
+		// through, or both. Either way writes to those properties are dropped.
 		logger.Error(ctx,
-			"resource type NOT reconciled: writes to its new properties will be dropped",
+			"resource type NOT reconciled: writes to some of its properties will be dropped",
 			"preset", presetName, "slug", slug, "reason", reason)
 	}
 	for _, slug := range reconciled.NoSchema {

--- a/application/builtin_resource_types.go
+++ b/application/builtin_resource_types.go
@@ -123,6 +123,14 @@ func reconcilePresetSchemas(
 			"resource type properties held at their stored definition: preset diverges non-additively",
 			"preset", presetName, "slug", slug, "heldProperties", held)
 	}
+	for slug, held := range reconciled.RefusedContext {
+		// A context term the operator repointed. Held rather than overwritten,
+		// because existing edges are already keyed by the stored IRI and
+		// repointing it would orphan them (issue #510).
+		logger.Warn(ctx,
+			"resource type context terms held at their stored definition: preset declares a different IRI",
+			"preset", presetName, "slug", slug, "heldContextTerms", held)
+	}
 	for slug, reason := range reconciled.Failed {
 		logger.Error(ctx,
 			"resource type NOT reconciled: writes to its new properties will be dropped",

--- a/application/builtin_resource_types.go
+++ b/application/builtin_resource_types.go
@@ -105,7 +105,7 @@ func reconcilePresetSchemas(
 ) {
 	reconciled, err := svc.ReconcilePresetSchemas(ctx, presetName)
 	if err != nil {
-		logger.Error(ctx, "failed to reconcile preset schema",
+		logger.Error(ctx, "failed to reconcile preset",
 			"preset", presetName, "error", err)
 	}
 	if reconciled == nil {

--- a/application/preset_context_reconcile.go
+++ b/application/preset_context_reconcile.go
@@ -1,0 +1,196 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/wepala/weos/v3/pkg/jsonld"
+)
+
+// contextReconciliation reports what an additive reconcile would do to one
+// resource type's stored JSON-LD `@context` (issue #510).
+//
+// This is the sibling of schemaReconciliation, and deliberately so: issue #379
+// taught the boot reconcile to merge the SCHEMA additively so a preset's new
+// property reached an existing database, but left the stored `@context`
+// untouched. A REFERENCE property — one the schema marks with
+// `x-resource-type` — is stored as a JSON-LD edge keyed by its predicate IRI,
+// and FlattenGraph maps that IRI back to a property name through
+// jsonld.BuildReverseMap, which only ever sees EXPLICIT context entries
+// (ParseContext skips every `@`-prefixed keyword, so `@vocab` never appears in
+// it). An edge whose IRI has no reverse entry is skipped outright. So the
+// column arrived, the schema declared the property, and every write to it was
+// still dropped — with the API answering 201 the whole time.
+//
+// Literal properties are unaffected: they live in the graph's entity node,
+// which FlattenGraph copies verbatim without consulting the context at all.
+// That asymmetry is why only references need this.
+//
+// The merge rules mirror reconcileAdditiveSchema's exactly, for the same
+// reasons stated there:
+//
+//   - An entry the preset declares and the stored context lacks is MERGED IN.
+//     This is the whole point: it is what makes the reverse map resolve the new
+//     reference's predicate, so writes to it stop being dropped.
+//   - An entry the stored context has and the preset does not is PRESERVED.
+//     There is no provenance on a stored context either, so an operator's own
+//     term is indistinguishable from drift, and dropping it would break every
+//     reference already written under it.
+//   - An entry in BOTH whose definition differs is a CONFLICT: it is HELD at
+//     its stored definition and reported. Overwriting it would repoint a
+//     predicate that existing edges are already keyed by, orphaning them —
+//     strictly worse than the drop this fixes. Refusal is per-entry, so one
+//     diverging term never blocks the additive terms beside it.
+//
+// An absent or empty stored context adopts the preset's wholesale: there is
+// nothing to preserve and nothing that can conflict.
+//
+// Keywords are merged by the same rules as terms, without special-casing.
+// `@vocab`, `@base`, `@type` and prefix definitions are all just keys here, so
+// a preset that changes one an operator already edited finds it HELD
+// rather than overwritten. That is the conservative direction: `@vocab` is the
+// fallback every unmapped property resolves through, so silently repointing it
+// would move every literal's predicate at once.
+//
+// The merge is idempotent: re-running it against its own output reports
+// Changed=false, which is what keeps a restart from emitting a
+// ResourceTypeUpdated per type per boot.
+type contextReconciliation struct {
+	// Added names the terms present in the preset context but absent from the
+	// stored one. These are the entries whose absence was dropping writes.
+	Added []string
+	// Conflicts names terms present in BOTH whose definitions differ. They are
+	// left at their stored definition and reported for an operator to resolve.
+	Conflicts []string
+	// Context is the merged result. Nil unless Changed.
+	Context json.RawMessage
+	// Changed reports whether the stored context needs rewriting at all. False
+	// means this type's context is a no-op for the boot. Conflicts alone never
+	// make a context Changed — there is nothing to write if the only difference
+	// is a term being held back.
+	Changed bool
+}
+
+// reconcileAdditiveContext merges a preset's code-defined `@context` into the
+// context currently stored for a resource type, additively. See the
+// contextReconciliation doc comment for the rules and the reasoning.
+//
+// A context that is valid JSON but not an object — JSON-LD permits an array or
+// a remote IRI string — is an error rather than something to merge blind. No
+// preset or stored context in this tree uses those forms; reporting the type as
+// Failed is honest, where guessing at a merge would not be.
+func reconcileAdditiveContext(stored, preset json.RawMessage) (contextReconciliation, error) {
+	var out contextReconciliation
+
+	// Nothing declared in code means nothing to add. Never treat an empty
+	// preset context as an instruction to clear a stored one.
+	if len(preset) == 0 {
+		return out, nil
+	}
+
+	presetTerms, err := splitContext(preset)
+	if err != nil {
+		return out, fmt.Errorf("preset context: %w", err)
+	}
+
+	if len(stored) == 0 {
+		out.Added = sortedKeys(presetTerms)
+		out.Context = preset
+		out.Changed = true
+		return out, nil
+	}
+
+	storedTerms, err := splitContext(stored)
+	if err != nil {
+		return out, fmt.Errorf("stored context: %w", err)
+	}
+
+	merged := make(map[string]json.RawMessage, len(storedTerms)+len(presetTerms))
+	for term, def := range storedTerms {
+		merged[term] = def
+	}
+	for _, term := range sortedKeys(presetTerms) {
+		existing, inStored := storedTerms[term]
+		if !inStored {
+			merged[term] = presetTerms[term]
+			out.Added = append(out.Added, term)
+			continue
+		}
+		if !jsonEquivalent(existing, presetTerms[term]) {
+			// Held at the stored definition: merged already carries it, so
+			// simply not overwriting is what keeps the merge additive.
+			out.Conflicts = append(out.Conflicts, term)
+		}
+	}
+
+	if len(out.Added) == 0 {
+		return out, nil
+	}
+
+	encoded, err := json.Marshal(merged)
+	if err != nil {
+		return out, fmt.Errorf("failed to marshal merged context: %w", err)
+	}
+	out.Context = encoded
+	out.Changed = true
+	return out, nil
+}
+
+// splitContext decodes a JSON-LD `@context` into its term map. A context that
+// decodes as JSON `null` yields an empty — not nil — map so callers can range
+// over it freely.
+func splitContext(raw json.RawMessage) (map[string]json.RawMessage, error) {
+	var terms map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &terms); err != nil {
+		return nil, fmt.Errorf("not a JSON object: %w", err)
+	}
+	if terms == nil {
+		return map[string]json.RawMessage{}, nil
+	}
+	return terms, nil
+}
+
+// referencePropertiesWithoutContextEntry returns the reference properties the
+// schema declares that the context gives no explicit term for — exactly the
+// set whose writes FlattenGraph will drop.
+//
+// The check mirrors what the read path actually does rather than restating it:
+// a reference survives only if BuildReverseMap can map its predicate IRI back
+// to its property name, and that map is built solely from explicit terms. A
+// property resolving through `@vocab` therefore does NOT count as covered, even
+// though ResolvePredicateIRI happily produces an IRI for it.
+//
+// Two distinct properties mapped to the SAME IRI collide in the reverse map and
+// only one survives, so the round-trip is verified per property rather than by
+// counting terms.
+func referencePropertiesWithoutContextEntry(schema, ldContext json.RawMessage) []string {
+	refProps := ExtractReferenceProperties(schema, ldContext)
+	if len(refProps) == 0 {
+		return nil
+	}
+	reverse := jsonld.BuildReverseMap(ldContext)
+	var dropped []string
+	for _, ref := range refProps {
+		if reverse[ref.PredicateIRI] != ref.PropertyName {
+			dropped = append(dropped, ref.PropertyName)
+		}
+	}
+	sort.Strings(dropped)
+	return dropped
+}

--- a/application/preset_context_reconcile_test.go
+++ b/application/preset_context_reconcile_test.go
@@ -1,0 +1,289 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package application
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// contextTerms decodes a merged context so assertions can talk about terms
+// without depending on key order in the marshaled output.
+func contextTerms(t *testing.T, raw json.RawMessage) map[string]string {
+	t.Helper()
+	var terms map[string]any
+	if err := json.Unmarshal(raw, &terms); err != nil {
+		t.Fatalf("context is not a JSON object: %v", err)
+	}
+	out := map[string]string{}
+	for k, v := range terms {
+		switch val := v.(type) {
+		case string:
+			out[k] = val
+		default:
+			encoded, err := json.Marshal(val)
+			if err != nil {
+				t.Fatalf("term %q is not encodable: %v", k, err)
+			}
+			out[k] = string(encoded)
+		}
+	}
+	return out
+}
+
+// TestReconcileAdditiveContext_AddsMissingTerm is the defect in one case: the
+// preset gained a reference property's term and the stored context lacks it.
+func TestReconcileAdditiveContext_AddsMissingTerm(t *testing.T) {
+	stored := json.RawMessage(`{"@vocab":"https://schema.org/","maker":"https://schema.org/manufacturer"}`)
+	preset := json.RawMessage(`{"@vocab":"https://schema.org/",` +
+		`"maker":"https://schema.org/manufacturer","supplier":"https://schema.org/seller"}`)
+
+	rec, err := reconcileAdditiveContext(stored, preset)
+	if err != nil {
+		t.Fatalf("reconcileAdditiveContext: %v", err)
+	}
+	if !rec.Changed {
+		t.Fatal("expected the merge to report a change")
+	}
+	if !sameStrings(rec.Added, []string{"supplier"}) {
+		t.Errorf("Added = %v, want [supplier]", rec.Added)
+	}
+	if len(rec.Conflicts) != 0 {
+		t.Errorf("Conflicts = %v, want none", rec.Conflicts)
+	}
+	terms := contextTerms(t, rec.Context)
+	if terms["supplier"] != "https://schema.org/seller" {
+		t.Errorf("merged context lost the added term: %v", terms)
+	}
+	if terms["@vocab"] != "https://schema.org/" {
+		t.Errorf("merged context lost @vocab: %v", terms)
+	}
+}
+
+// TestReconcileAdditiveContext_PreservesOperatorTerm pins the mirror of the
+// schema merge's property-preservation rule: a term only the operator declared
+// survives, because existing edges are already keyed by it.
+func TestReconcileAdditiveContext_PreservesOperatorTerm(t *testing.T) {
+	stored := json.RawMessage(`{"@vocab":"https://schema.org/","warranty":"https://example.org/vocab/warranty"}`)
+	preset := json.RawMessage(`{"@vocab":"https://schema.org/","supplier":"https://schema.org/seller"}`)
+
+	rec, err := reconcileAdditiveContext(stored, preset)
+	if err != nil {
+		t.Fatalf("reconcileAdditiveContext: %v", err)
+	}
+	terms := contextTerms(t, rec.Context)
+	if terms["warranty"] != "https://example.org/vocab/warranty" {
+		t.Errorf("merge dropped the operator's own term: %v", terms)
+	}
+	if terms["supplier"] != "https://schema.org/seller" {
+		t.Errorf("merge failed to add the preset's term: %v", terms)
+	}
+}
+
+// TestReconcileAdditiveContext_HoldsDivergingTerm is the operator-customisation
+// guard: a term the operator repointed stays repointed, and is reported.
+// Overwriting it would orphan every edge already written under the stored IRI.
+func TestReconcileAdditiveContext_HoldsDivergingTerm(t *testing.T) {
+	stored := json.RawMessage(`{"@vocab":"https://schema.org/","maker":"https://example.org/vocab/madeBy"}`)
+	preset := json.RawMessage(`{"@vocab":"https://schema.org/",` +
+		`"maker":"https://schema.org/manufacturer","supplier":"https://schema.org/seller"}`)
+
+	rec, err := reconcileAdditiveContext(stored, preset)
+	if err != nil {
+		t.Fatalf("reconcileAdditiveContext: %v", err)
+	}
+	if !sameStrings(rec.Conflicts, []string{"maker"}) {
+		t.Errorf("Conflicts = %v, want [maker]", rec.Conflicts)
+	}
+	terms := contextTerms(t, rec.Context)
+	if terms["maker"] != "https://example.org/vocab/madeBy" {
+		t.Errorf("held term was overwritten: %v", terms)
+	}
+	// Refusal is per-term: the additive term beside it still landed.
+	if terms["supplier"] != "https://schema.org/seller" {
+		t.Errorf("a held term blocked an additive one: %v", terms)
+	}
+}
+
+// TestReconcileAdditiveContext_ConflictAloneIsNotAChange: with nothing to add,
+// a held term must not rewrite the stored context, or every restart would emit
+// a ResourceTypeUpdated for a type it changed nothing about.
+func TestReconcileAdditiveContext_ConflictAloneIsNotAChange(t *testing.T) {
+	stored := json.RawMessage(`{"@vocab":"https://schema.org/","maker":"https://example.org/vocab/madeBy"}`)
+	preset := json.RawMessage(`{"@vocab":"https://schema.org/","maker":"https://schema.org/manufacturer"}`)
+
+	rec, err := reconcileAdditiveContext(stored, preset)
+	if err != nil {
+		t.Fatalf("reconcileAdditiveContext: %v", err)
+	}
+	if rec.Changed {
+		t.Error("a held term alone must not report a change")
+	}
+	if !sameStrings(rec.Conflicts, []string{"maker"}) {
+		t.Errorf("Conflicts = %v, want [maker]", rec.Conflicts)
+	}
+}
+
+// TestReconcileAdditiveContext_HoldsDivergingKeyword: keywords are merged by
+// the same rules as terms. Repointing @vocab would move the predicate of every
+// property that resolves through it, so an operator-edited one is held.
+func TestReconcileAdditiveContext_HoldsDivergingKeyword(t *testing.T) {
+	stored := json.RawMessage(`{"@vocab":"https://example.org/vocab/"}`)
+	preset := json.RawMessage(`{"@vocab":"https://schema.org/","supplier":"https://schema.org/seller"}`)
+
+	rec, err := reconcileAdditiveContext(stored, preset)
+	if err != nil {
+		t.Fatalf("reconcileAdditiveContext: %v", err)
+	}
+	if !sameStrings(rec.Conflicts, []string{"@vocab"}) {
+		t.Errorf("Conflicts = %v, want [@vocab]", rec.Conflicts)
+	}
+	terms := contextTerms(t, rec.Context)
+	if terms["@vocab"] != "https://example.org/vocab/" {
+		t.Errorf("@vocab was overwritten: %v", terms)
+	}
+}
+
+// TestReconcileAdditiveContext_EmptyStoredAdoptsPreset: nothing to preserve,
+// nothing that can conflict.
+func TestReconcileAdditiveContext_EmptyStoredAdoptsPreset(t *testing.T) {
+	preset := json.RawMessage(`{"@vocab":"https://schema.org/","supplier":"https://schema.org/seller"}`)
+
+	for name, stored := range map[string]json.RawMessage{
+		"absent": nil,
+		"empty":  json.RawMessage(``),
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec, err := reconcileAdditiveContext(stored, preset)
+			if err != nil {
+				t.Fatalf("reconcileAdditiveContext: %v", err)
+			}
+			if !rec.Changed {
+				t.Fatal("expected the merge to report a change")
+			}
+			terms := contextTerms(t, rec.Context)
+			if terms["supplier"] != "https://schema.org/seller" {
+				t.Errorf("adopted context is missing the preset's term: %v", terms)
+			}
+		})
+	}
+}
+
+// TestReconcileAdditiveContext_EmptyPresetIsNeverAnInstructionToClear.
+func TestReconcileAdditiveContext_EmptyPresetIsNeverAnInstructionToClear(t *testing.T) {
+	stored := json.RawMessage(`{"@vocab":"https://schema.org/","maker":"https://schema.org/manufacturer"}`)
+
+	rec, err := reconcileAdditiveContext(stored, nil)
+	if err != nil {
+		t.Fatalf("reconcileAdditiveContext: %v", err)
+	}
+	if rec.Changed || rec.Context != nil {
+		t.Errorf("an empty preset context must be a no-op, got Changed=%v Context=%s", rec.Changed, rec.Context)
+	}
+}
+
+// TestReconcileAdditiveContext_Idempotent: re-running against its own output
+// reports no change, which is what keeps repeated restarts quiet.
+func TestReconcileAdditiveContext_Idempotent(t *testing.T) {
+	stored := json.RawMessage(`{"@vocab":"https://schema.org/"}`)
+	preset := json.RawMessage(`{"@vocab":"https://schema.org/","supplier":"https://schema.org/seller"}`)
+
+	first, err := reconcileAdditiveContext(stored, preset)
+	if err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	if !first.Changed {
+		t.Fatal("expected the first merge to change something")
+	}
+	second, err := reconcileAdditiveContext(first.Context, preset)
+	if err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	if second.Changed {
+		t.Errorf("merge is not idempotent: second pass reported Changed with Added=%v", second.Added)
+	}
+}
+
+// TestReconcileAdditiveContext_ObjectTermsCompareByValue: a term defined as an
+// object round-trips, and an equivalent one written differently is not a
+// conflict — otherwise every boot would hold a term over key order.
+func TestReconcileAdditiveContext_ObjectTermsCompareByValue(t *testing.T) {
+	stored := json.RawMessage(`{"supplier":{"@type":"@id","@id":"https://schema.org/seller"}}`)
+	preset := json.RawMessage(`{"supplier":{"@id":"https://schema.org/seller","@type":"@id"}}`)
+
+	rec, err := reconcileAdditiveContext(stored, preset)
+	if err != nil {
+		t.Fatalf("reconcileAdditiveContext: %v", err)
+	}
+	if rec.Changed || len(rec.Conflicts) != 0 {
+		t.Errorf("equivalent object terms must compare equal, got Changed=%v Conflicts=%v",
+			rec.Changed, rec.Conflicts)
+	}
+}
+
+// TestReconcileAdditiveContext_NonObjectIsAnError: JSON-LD permits an array or
+// a remote IRI string as a context. Nothing in this tree uses either, so
+// reporting the type rather than guessing at a merge is the honest outcome.
+func TestReconcileAdditiveContext_NonObjectIsAnError(t *testing.T) {
+	preset := json.RawMessage(`{"@vocab":"https://schema.org/"}`)
+
+	if _, err := reconcileAdditiveContext(json.RawMessage(`["https://schema.org/"]`), preset); err == nil {
+		t.Error("expected an error for a stored context that is not an object")
+	} else if !strings.Contains(err.Error(), "stored context") {
+		t.Errorf("error should name the stored side, got %v", err)
+	}
+	if _, err := reconcileAdditiveContext(preset, json.RawMessage(`"https://schema.org/"`)); err == nil {
+		t.Error("expected an error for a preset context that is not an object")
+	}
+}
+
+// TestReferencePropertiesWithoutContextEntry pins the detection the reconcile
+// reports Failed on: a reference resolving through @vocab has no reverse-map
+// entry, so its edge is dropped even though ResolvePredicateIRI yields an IRI.
+func TestReferencePropertiesWithoutContextEntry(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object","properties":{
+		"name":{"type":"string"},
+		"maker":{"type":"string","x-resource-type":"vendor"},
+		"supplier":{"type":"string","x-resource-type":"vendor"}}}`)
+
+	t.Run("names only the uncovered reference", func(t *testing.T) {
+		ldContext := json.RawMessage(`{"@vocab":"https://schema.org/","maker":"https://schema.org/manufacturer"}`)
+		got := referencePropertiesWithoutContextEntry(schema, ldContext)
+		if !sameStrings(got, []string{"supplier"}) {
+			t.Errorf("got %v, want [supplier]", got)
+		}
+	})
+
+	t.Run("a literal never counts as dropped", func(t *testing.T) {
+		ldContext := json.RawMessage(`{"@vocab":"https://schema.org/",` +
+			`"maker":"https://schema.org/manufacturer","supplier":"https://schema.org/seller"}`)
+		if got := referencePropertiesWithoutContextEntry(schema, ldContext); len(got) != 0 {
+			t.Errorf("got %v, want none — `name` is a literal and both references are covered", got)
+		}
+	})
+
+	// Two references mapped to the SAME IRI collide in the reverse map and only
+	// one survives, so a per-term existence check would miss this.
+	t.Run("colliding terms are reported", func(t *testing.T) {
+		ldContext := json.RawMessage(`{"@vocab":"https://schema.org/",` +
+			`"maker":"https://schema.org/seller","supplier":"https://schema.org/seller"}`)
+		got := referencePropertiesWithoutContextEntry(schema, ldContext)
+		if len(got) != 1 {
+			t.Errorf("expected exactly one of the colliding references to be reported, got %v", got)
+		}
+	})
+}

--- a/application/preset_context_reconcile_test.go
+++ b/application/preset_context_reconcile_test.go
@@ -287,3 +287,58 @@ func TestReferencePropertiesWithoutContextEntry(t *testing.T) {
 		}
 	})
 }
+
+// TestReconcileAdditiveContext_PrefixFormTerms covers the shape real presets
+// actually use: a term whose IRI is written against a prefix defined elsewhere
+// in the same context (`"recipeIngredient":"fo:hasIngredient"`). Both the
+// prefix and the term are ordinary keys here, so both merge — and the
+// detection must expand the prefix before deciding the reference is covered.
+func TestReconcileAdditiveContext_PrefixFormTerms(t *testing.T) {
+	stored := json.RawMessage(`{"@vocab":"https://schema.org/"}`)
+	preset := json.RawMessage(`{"@vocab":"https://schema.org/",` +
+		`"fo":"http://purl.org/foodontology#","ingredient":"fo:hasIngredient"}`)
+
+	rec, err := reconcileAdditiveContext(stored, preset)
+	if err != nil {
+		t.Fatalf("reconcileAdditiveContext: %v", err)
+	}
+	if !sameStrings(rec.Added, []string{"fo", "ingredient"}) {
+		t.Fatalf("Added = %v, want [fo ingredient] — the prefix must merge alongside the term", rec.Added)
+	}
+
+	schema := json.RawMessage(`{"type":"object","properties":{
+		"ingredient":{"type":"string","x-resource-type":"ingredient"}}}`)
+	if dropped := referencePropertiesWithoutContextEntry(schema, rec.Context); len(dropped) != 0 {
+		t.Errorf("a prefix-form term must count as covered, got %v", dropped)
+	}
+}
+
+// TestReconcileAdditiveContext_HeldPrefixRebindsItsTerms pins a consequence of
+// holding: when an operator repointed a PREFIX, a term the preset adds against
+// that prefix resolves into the operator's namespace, not the preset's. The
+// reference still round-trips — write and read expand through the same stored
+// context — so this is documented behavior rather than a defect, but it is the
+// one case where an added term does not mean what the preset author wrote.
+func TestReconcileAdditiveContext_HeldPrefixRebindsItsTerms(t *testing.T) {
+	stored := json.RawMessage(`{"@vocab":"https://schema.org/","fo":"https://example.org/food#"}`)
+	preset := json.RawMessage(`{"@vocab":"https://schema.org/",` +
+		`"fo":"http://purl.org/foodontology#","ingredient":"fo:hasIngredient"}`)
+
+	rec, err := reconcileAdditiveContext(stored, preset)
+	if err != nil {
+		t.Fatalf("reconcileAdditiveContext: %v", err)
+	}
+	if !sameStrings(rec.Conflicts, []string{"fo"}) {
+		t.Errorf("Conflicts = %v, want [fo]", rec.Conflicts)
+	}
+	terms := contextTerms(t, rec.Context)
+	if terms["fo"] != "https://example.org/food#" {
+		t.Errorf("the operator's prefix was overwritten: %v", terms)
+	}
+	// The term still resolves, against the operator's prefix — so writes land.
+	schema := json.RawMessage(`{"type":"object","properties":{
+		"ingredient":{"type":"string","x-resource-type":"ingredient"}}}`)
+	if dropped := referencePropertiesWithoutContextEntry(schema, rec.Context); len(dropped) != 0 {
+		t.Errorf("a term against a held prefix must still resolve, got %v", dropped)
+	}
+}

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -129,8 +129,13 @@ type InstallPresetResult struct {
 //     still land; what needs an operator is the divergence itself, not data
 //     loss.
 type ReconcilePresetResult struct {
-	// Updated lists types whose stored schema was rewritten AND whose new
-	// columns were confirmed present afterwards.
+	// Updated lists types whose stored schema, `@context`, or both were
+	// rewritten AND whose writes were confirmed able to land afterwards: every
+	// added property has its projection column, and every reference property
+	// has a `@context` term its predicate resolves back through. A type
+	// failing either check is reported under Failed instead — a column that
+	// cannot be written to and a reference that cannot be read back are the
+	// same silent drop, and neither is a completed reconcile.
 	Updated []string `json:"updated,omitempty"`
 	// Unchanged lists types already in sync — the steady-state boot.
 	Unchanged []string `json:"unchanged,omitempty"`

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -124,9 +124,10 @@ type InstallPresetResult struct {
 //
 //   - Failed and NoSchema mean writes to at least one property ARE still being
 //     dropped. Both are urgent.
-//   - Refused means a property definition diverged and is being held safely at
-//     its stored form. The column already exists and writes to it still land;
-//     what needs an operator is the divergence itself, not data loss.
+//   - Refused and RefusedContext mean a definition diverged and is being held
+//     safely at its stored form. The column already exists and writes to it
+//     still land; what needs an operator is the divergence itself, not data
+//     loss.
 type ReconcilePresetResult struct {
 	// Updated lists types whose stored schema was rewritten AND whose new
 	// columns were confirmed present afterwards.
@@ -139,6 +140,16 @@ type ReconcilePresetResult struct {
 	// per-property, not per-type), so a slug can appear here and in Updated at
 	// the same time. Held properties need an operator decision.
 	Refused map[string][]string `json:"refused,omitempty"`
+	// RefusedContext maps a slug to the `@context` terms whose definitions
+	// diverged from the preset's and were therefore HELD at their stored
+	// definition (issue #510). Reported apart from Refused because the two
+	// need different operator fixes: a held schema property is a shape
+	// disagreement about a column, while a held context term is a
+	// disagreement about which predicate a reference is keyed by — and
+	// repointing that one orphans edges already written under the stored IRI.
+	// As with Refused, holding is per-term and the type's additive terms
+	// still landed, so a slug can appear here and in Updated at once.
+	RefusedContext map[string][]string `json:"refusedContext,omitempty"`
 	// Failed maps a slug to why its reconcile could not be completed. A type
 	// here is NOT reconciled: either the update errored, or it reported success
 	// while the projection column did not actually appear.

--- a/application/presets/mealplanning/preset.go
+++ b/application/presets/mealplanning/preset.go
@@ -213,6 +213,7 @@ func ingredientType() application.PresetResourceType {
 	"@type":"fo:Food",
 	"fo":"http://purl.org/foodontology#",
 	"skos":"http://www.w3.org/2004/02/skos/core#",
+	"suitableForDiet":"https://schema.org/suitableForDiet",
 	"mp":"https://weos.org/vocab/meal-planning#",
 	"alternateNames":"skos:altLabel",
 	"shoppingCategory":"fo:ShoppingCategory",
@@ -327,7 +328,8 @@ func mealPlanType() application.PresetResourceType {
 		Name:        "Meal Plan",
 		Slug:        "meal-plan",
 		Description: "A weekly or custom-period meal plan",
-		Context:     schemaTypeContext("MealPlan", ""),
+		Context: schemaTypeContext("MealPlan",
+			`"suitableForDiet":"https://schema.org/suitableForDiet"`),
 		Schema: json.RawMessage(`{
 	"type":"object",
 	"properties":{

--- a/application/presets/preset_context_completeness_test.go
+++ b/application/presets/preset_context_completeness_test.go
@@ -1,0 +1,92 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package presets_test
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/application/presets"
+	"github.com/wepala/weos/v3/pkg/jsonld"
+)
+
+// TestEveryReferencePropertyHasAContextEntry is the packaging guard for issue
+// #510. A property the schema marks with `x-resource-type` is stored as a
+// JSON-LD edge keyed by its predicate IRI, and the read path maps that IRI back
+// to a property name through jsonld.BuildReverseMap — which is built ONLY from
+// explicit context terms, because ParseContext skips every `@`-prefixed
+// keyword. A reference resolving through `@vocab` therefore has no reverse
+// entry, FlattenGraph skips its edge, and every write to it is dropped while
+// the API still answers 201.
+//
+// The boot reconcile now reports this condition, but reporting is a backstop.
+// A preset shipped with the gap drops writes on every install of a FRESH
+// database too, where there is no stored context to reconcile against and
+// nothing to merge in. Catching it here is what keeps that from shipping:
+// meal-planning's `ingredient` and `meal-plan` types both had it.
+func TestEveryReferencePropertyHasAContextEntry(t *testing.T) {
+	registry := application.NewPresetRegistry()
+	presets.RegisterAll(registry)
+
+	for _, preset := range registry.List() {
+		for _, pt := range preset.Types {
+			if len(pt.Schema) == 0 {
+				continue
+			}
+			dropped := referencesWithoutContextEntry(t, pt)
+			if len(dropped) > 0 {
+				t.Errorf(
+					"preset %q type %q declares reference properties %v with no @context entry: "+
+						"writes to them are silently dropped. Add a term mapping each to its predicate IRI.",
+					preset.Name, pt.Slug, dropped)
+			}
+		}
+	}
+}
+
+// referencesWithoutContextEntry mirrors the read path rather than restating it:
+// a reference survives only if the reverse map resolves its predicate IRI back
+// to its own property name. Checking per property (not just "a term exists")
+// also catches two properties mapped to the same IRI, where the reverse map
+// collides and only one of them survives.
+func referencesWithoutContextEntry(t *testing.T, pt application.PresetResourceType) []string {
+	t.Helper()
+
+	var schema struct {
+		Properties map[string]json.RawMessage `json:"properties"`
+	}
+	if err := json.Unmarshal(pt.Schema, &schema); err != nil {
+		t.Fatalf("type %q has an unparseable schema: %v", pt.Slug, err)
+	}
+	if len(pt.Context) > 0 {
+		var probe map[string]json.RawMessage
+		if err := json.Unmarshal(pt.Context, &probe); err != nil {
+			t.Fatalf("type %q has an unparseable @context: %v", pt.Slug, err)
+		}
+	}
+
+	reverse := jsonld.BuildReverseMap(pt.Context)
+	var dropped []string
+	for _, ref := range application.ExtractReferenceProperties(pt.Schema, pt.Context) {
+		if reverse[ref.PredicateIRI] != ref.PropertyName {
+			dropped = append(dropped, ref.PropertyName)
+		}
+	}
+	sort.Strings(dropped)
+	return dropped
+}

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -566,7 +566,11 @@ func (s *resourceTypeService) missingColumns(slug string, properties []string) [
 func (s *resourceTypeService) recordReconcileFailure(
 	ctx context.Context, result *ReconcilePresetResult, presetName, slug string, err error,
 ) {
-	s.logger.Error(ctx, "failed to reconcile preset schema into resource type",
+	// Deliberately not "schema": this records every way a reconcile can fail —
+	// an unparseable schema OR context, a failed Update, a projection column
+	// that never appeared, and a reference property left with no context term.
+	// Naming only the schema would send an operator to the wrong half.
+	s.logger.Error(ctx, "failed to reconcile preset into resource type",
 		"preset", presetName, "slug", slug, "error", err)
 	if result.Failed == nil {
 		result.Failed = make(map[string]string)

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -446,7 +446,7 @@ func (s *resourceTypeService) reconcileOneType(
 	if !s.confirmWritesLand(ctx, result, presetName, pt, schema, ldContext, schemaRec.Added) {
 		return
 	}
-	s.logger.Info(ctx, "reconciled preset schema into existing resource type",
+	s.logger.Info(ctx, "reconciled preset schema and context into existing resource type",
 		"preset", presetName, "slug", pt.Slug,
 		"addedProperties", schemaRec.Added, "addedContextTerms", contextRec.Added)
 	result.Updated = append(result.Updated, pt.Slug)

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -2,9 +2,11 @@ package application
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/wepala/weos/v3/domain/entities"
 	"github.com/wepala/weos/v3/domain/repositories"
@@ -395,54 +397,129 @@ func (s *resourceTypeService) reconcileOneType(
 	ctx context.Context, result *ReconcilePresetResult,
 	presetName string, pt PresetResourceType, existing *entities.ResourceType,
 ) {
-	rec, err := reconcileAdditiveSchema(existing.Schema(), pt.Schema)
+	schemaRec, err := reconcileAdditiveSchema(existing.Schema(), pt.Schema)
 	if err != nil {
 		s.recordReconcileFailure(ctx, result, presetName, pt.Slug,
 			fmt.Errorf("failed to reconcile schema: %w", err))
 		return
 	}
-	if len(rec.Conflicts) > 0 {
-		// Held, not applied — and the rest of the merge still proceeds, so one
-		// changed property definition can't block every additive property beside
-		// it. Report which properties are stuck at their stored definition.
-		s.logger.Warn(ctx,
-			"preset property definitions diverge non-additively; holding them at their stored definition",
-			"preset", presetName, "slug", pt.Slug, "heldProperties", rec.Conflicts)
-		if result.Refused == nil {
-			result.Refused = make(map[string][]string)
-		}
-		result.Refused[pt.Slug] = rec.Conflicts
+	// The context is merged by the same additive rules as the schema (issue
+	// #510). Merging only the schema is what left a reference property with a
+	// column, a declaration, and nowhere for its predicate to resolve — so its
+	// writes went on being dropped while the reconcile reported success.
+	contextRec, err := reconcileAdditiveContext(existing.Context(), pt.Context)
+	if err != nil {
+		s.recordReconcileFailure(ctx, result, presetName, pt.Slug,
+			fmt.Errorf("failed to reconcile context: %w", err))
+		return
 	}
-	if !rec.Changed {
+	s.recordHeldDefinitions(ctx, result, presetName, pt.Slug, schemaRec, contextRec)
+
+	if !schemaRec.Changed && !contextRec.Changed {
 		result.Unchanged = append(result.Unchanged, pt.Slug)
 		return
 	}
+
+	// Each side falls back to what is stored when its own merge is a no-op, so
+	// a context-only change never rewrites the schema and vice versa.
+	schema := existing.Schema()
+	if schemaRec.Changed {
+		schema = schemaRec.Schema
+	}
+	ldContext := existing.Context()
+	if contextRec.Changed {
+		ldContext = contextRec.Context
+	}
+
 	if _, err := s.Update(ctx, UpdateResourceTypeCommand{
 		ID:          existing.GetID(),
 		Name:        existing.Name(),
 		Slug:        existing.Slug(),
 		Description: existing.Description(),
 		Status:      existing.Status(),
-		Context:     existing.Context(),
-		Schema:      rec.Schema,
+		Context:     ldContext,
+		Schema:      schema,
 	}); err != nil {
 		s.recordReconcileFailure(ctx, result, presetName, pt.Slug, err)
 		return
 	}
-	// A successful Update is NOT evidence the column exists. The column is added
-	// by the ResourceType.Updated handler, and SimpleUnitOfWork.Commit discards
-	// dispatch errors as non-fatal (eventual-consistency model), so EnsureTable
-	// can fail while Update still returns nil. Reporting "reconciled" on that
-	// basis would announce success over exactly the silent drop this change
-	// exists to end, so confirm the columns actually landed.
-	if missing := s.missingColumns(pt.Slug, rec.Added); len(missing) > 0 {
-		s.recordReconcileFailure(ctx, result, presetName, pt.Slug,
-			fmt.Errorf("stored schema updated but projection columns are still missing: %v", missing))
+	if !s.confirmWritesLand(ctx, result, presetName, pt, schema, ldContext, schemaRec.Added) {
 		return
 	}
 	s.logger.Info(ctx, "reconciled preset schema into existing resource type",
-		"preset", presetName, "slug", pt.Slug, "addedProperties", rec.Added)
+		"preset", presetName, "slug", pt.Slug,
+		"addedProperties", schemaRec.Added, "addedContextTerms", contextRec.Added)
 	result.Updated = append(result.Updated, pt.Slug)
+}
+
+// recordHeldDefinitions logs and records every definition held at its stored
+// form, keeping schema properties and context terms in separate categories:
+// they read the same on a boot line but need different operator fixes.
+func (s *resourceTypeService) recordHeldDefinitions(
+	ctx context.Context, result *ReconcilePresetResult, presetName, slug string,
+	schemaRec schemaReconciliation, contextRec contextReconciliation,
+) {
+	if len(schemaRec.Conflicts) > 0 {
+		// Held, not applied — and the rest of the merge still proceeds, so one
+		// changed property definition can't block every additive property beside
+		// it. Report which properties are stuck at their stored definition.
+		s.logger.Warn(ctx,
+			"preset property definitions diverge non-additively; holding them at their stored definition",
+			"preset", presetName, "slug", slug, "heldProperties", schemaRec.Conflicts)
+		if result.Refused == nil {
+			result.Refused = make(map[string][]string)
+		}
+		result.Refused[slug] = schemaRec.Conflicts
+	}
+	if len(contextRec.Conflicts) > 0 {
+		s.logger.Warn(ctx,
+			"preset context terms diverge; holding them at their stored definition",
+			"preset", presetName, "slug", slug, "heldContextTerms", contextRec.Conflicts)
+		if result.RefusedContext == nil {
+			result.RefusedContext = make(map[string][]string)
+		}
+		result.RefusedContext[slug] = contextRec.Conflicts
+	}
+}
+
+// confirmWritesLand verifies, after a successful Update, that writes to the
+// reconciled type's properties can actually land. It reports whether the type
+// may be counted as Updated.
+//
+// A successful Update is NOT evidence of either half. The column is added by
+// the ResourceType.Updated handler, and SimpleUnitOfWork.Commit discards
+// dispatch errors as non-fatal (eventual-consistency model), so EnsureTable can
+// fail while Update still returns nil. A reference property needs a second
+// thing the Update cannot vouch for: an explicit context term to key its edge
+// by. Reporting "reconciled" without checking both would announce success over
+// exactly the silent drop this exists to end.
+//
+// Both halves are reported together rather than short-circuiting, because
+// Failed carries one reason per slug and an operator fixing a type wants to see
+// everything wrong with it at once.
+func (s *resourceTypeService) confirmWritesLand(
+	ctx context.Context, result *ReconcilePresetResult,
+	presetName string, pt PresetResourceType,
+	schema, ldContext json.RawMessage, addedProperties []string,
+) bool {
+	var reasons []string
+	if missing := s.missingColumns(pt.Slug, addedProperties); len(missing) > 0 {
+		reasons = append(reasons,
+			fmt.Sprintf("stored schema updated but projection columns are still missing: %v", missing))
+	}
+	// A reference the preset's own context never declares cannot be fixed by an
+	// additive merge — nothing exists to merge in. That is a preset packaging
+	// mistake, and naming it is the only way an operator learns those writes are
+	// being dropped.
+	if dropped := referencePropertiesWithoutContextEntry(schema, ldContext); len(dropped) > 0 {
+		reasons = append(reasons,
+			fmt.Sprintf("reference properties have no @context entry, so their writes are dropped: %v", dropped))
+	}
+	if len(reasons) == 0 {
+		return true
+	}
+	s.recordReconcileFailure(ctx, result, presetName, pt.Slug, errors.New(strings.Join(reasons, "; ")))
+	return false
 }
 
 // columnlessProperties are schema property names that deliberately yield no

--- a/infrastructure/graph/oxigraph/embedded_stub.go
+++ b/infrastructure/graph/oxigraph/embedded_stub.go
@@ -9,11 +9,20 @@
 package oxigraph
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/wepala/weos/v3/domain/entities"
 	"github.com/wepala/weos/v3/domain/repositories"
 )
+
+// ErrEmbeddedUnavailable is what this build returns instead of a store. It is
+// a sentinel rather than a fresh fmt.Errorf so callers can errors.Is it, and
+// it is typed `error` rather than left to inference so a caller's `err != nil`
+// is not statically provable — in a no-embedded build that check IS always
+// true, and staticcheck flags it (SA4023), but the check is correct and
+// load-bearing in the embedded build compiled from embedded.go.
+var ErrEmbeddedUnavailable error = errors.New(
+	"oxigraph embedded: this binary was not built with the 'oxigraph_embedded' tag")
 
 // EmbeddedAvailable reports whether this binary was built with embedded
 // support. Always false here; embedded.go's version returns true.
@@ -22,6 +31,5 @@ func EmbeddedAvailable() bool { return false }
 // NewEmbeddedStore always fails in a no-embedded build. The provider treats
 // the error like an open failure and degrades to nop.
 func NewEmbeddedStore(_ string, _ entities.Logger) (repositories.KnowledgeGraphStore, error) {
-	return nil, fmt.Errorf(
-		"oxigraph embedded: this binary was not built with the 'oxigraph_embedded' tag")
+	return nil, ErrEmbeddedUnavailable
 }

--- a/tests/e2e/features/preset_context_reconcile.feature
+++ b/tests/e2e/features/preset_context_reconcile.feature
@@ -1,0 +1,130 @@
+@issue-510
+Feature: A built-in preset's new reference property reaches an already-provisioned database
+  As an operator upgrading WeOS across a preset that gained a reference property
+  I want the stored @context of a built-in type to gain the entry the new build declares
+  So that writes to the new reference are stored and readable instead of silently dropped
+
+  Background:
+    Given a built-in preset "catalog" declaring a "vendor" type with the properties:
+      | property | type   |
+      | name     | string |
+    And the "catalog" preset also declares a "widget" type with the properties:
+      | property | type      | references |
+      | name     | string    |            |
+      | maker    | reference | vendor     |
+    And a clean WeOS database provisioned by that build
+    And a "vendor" named "Acme" exists
+
+  @wip
+  Scenario: A reference property added to a built-in preset round-trips after restart
+    Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
+    And the twin restarts against the same database
+    When I create a "widget" named "Bolt cutter" with "supplier" referring to the "vendor" "Acme"
+    Then reading the "widget" "Bolt cutter" back over the API returns "supplier" as the "vendor" "Acme"
+
+  @wip
+  Scenario: A new reference property gains both a projection column and a context entry
+    When the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
+    And the twin restarts against the same database
+    Then the "widget" projection table has a "supplier" column
+    And the stored "widget" context has an entry for "supplier"
+
+  @wip
+  Scenario: A reference whose context entry was already stored keeps round-tripping on the same write
+    Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
+    And the twin restarts against the same database
+    When I create a "widget" named "Bolt cutter" with these references:
+      | property | vendor |
+      | maker    | Acme   |
+      | supplier | Acme   |
+    Then reading the "widget" "Bolt cutter" back over the API returns "maker" as the "vendor" "Acme"
+    And reading the "widget" "Bolt cutter" back over the API returns "supplier" as the "vendor" "Acme"
+
+  @wip
+  Scenario: A literal property added to a preset round-trips and gains no context entry
+    Given the "catalog" preset adds a "sku" string property to "widget"
+    And the twin restarts against the same database
+    When I create a "widget" named "Bolt cutter" with "sku" set to "BC-100"
+    Then reading the "widget" "Bolt cutter" back over the API returns "sku" as "BC-100"
+    And the stored "widget" context has no entry for "sku"
+
+  @wip
+  Scenario: A context entry the operator changed is held at its stored definition
+    Given the operator maps "maker" to "https://example.org/vocab/madeBy" in the stored "widget" context
+    And the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
+    When the twin restarts against the same database
+    Then the stored "widget" context still maps "maker" to "https://example.org/vocab/madeBy"
+    And the boot reconcile reports "maker" held at its stored definition for "widget"
+    And the stored "widget" context has an entry for "supplier"
+
+  @wip
+  Scenario: A held context entry still round-trips at the operator's definition
+    Given the operator maps "maker" to "https://example.org/vocab/madeBy" in the stored "widget" context
+    And the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
+    And the twin restarts against the same database
+    When I create a "widget" named "Bolt cutter" with these references:
+      | property | vendor |
+      | maker    | Acme   |
+      | supplier | Acme   |
+    Then reading the "widget" "Bolt cutter" back over the API returns "maker" as the "vendor" "Acme"
+    And reading the "widget" "Bolt cutter" back over the API returns "supplier" as the "vendor" "Acme"
+
+  @wip
+  Scenario: An operator's own context entry the preset does not declare survives the merge
+    Given the operator maps "warranty" to "https://example.org/vocab/warranty" in the stored "widget" context
+    And the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
+    When the twin restarts against the same database
+    Then the stored "widget" context still maps "warranty" to "https://example.org/vocab/warranty"
+    And the stored "widget" context has an entry for "supplier"
+
+  @wip
+  Scenario: A type with no stored context adopts the entries the preset declares
+    Given the operator clears the stored "widget" context
+    And the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
+    When the twin restarts against the same database
+    Then the stored "widget" context has an entry for "supplier"
+    And the stored "widget" context has an entry for "maker"
+
+  @wip
+  Scenario: The context merge happens once and then settles
+    Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
+    When the twin restarts against the same database
+    And the twin restarts against the same database again
+    Then exactly one resource type update is recorded for "widget"
+
+  @wip
+  Scenario: Restarting with an unchanged preset leaves an already-complete context alone
+    When the twin restarts against the same database
+    Then no resource type update is recorded for "widget"
+    And the stored "widget" context has an entry for "maker"
+
+  @wip
+  Scenario: Reporting a type as updated means its reference properties have a stored context entry
+    Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
+    When the twin restarts against the same database
+    Then the boot reconcile reports "widget" as updated
+    And every reference property the "catalog" preset declares for "widget" has a stored context entry
+
+  @wip
+  Scenario: A reference property the preset's own context never declares is not reported as updated
+    Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor" without a context entry
+    When the twin restarts against the same database
+    Then the boot reconcile does not report "widget" as updated
+    And the boot reconcile names "supplier" as a property whose writes are still dropped
+
+  @wip
+  Scenario: A reference written before the context entry existed reads back empty but survives in the canonical record
+    Given a "widget" named "Bolt cutter" is created with an undeclared "supplier" referring to the "vendor" "Acme"
+    When the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
+    And the twin restarts against the same database
+    Then reading the "widget" "Bolt cutter" back over the API returns no value for "supplier"
+    And the JSON-LD representation of the "widget" "Bolt cutter" still carries a "supplier" edge to the "vendor" "Acme"
+
+  @wip
+  Scenario: Reprojecting after the context entry lands populates the reference column
+    Given a "widget" named "Bolt cutter" is created with an undeclared "supplier" referring to the "vendor" "Acme"
+    And the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
+    And the twin restarts against the same database
+    And reading the "widget" "Bolt cutter" back over the API returns no value for "supplier"
+    When the operator reprojects the event feed
+    Then reading the "widget" "Bolt cutter" back over the API returns "supplier" as the "vendor" "Acme"

--- a/tests/e2e/features/preset_context_reconcile.feature
+++ b/tests/e2e/features/preset_context_reconcile.feature
@@ -15,21 +15,18 @@ Feature: A built-in preset's new reference property reaches an already-provision
     And a clean WeOS database provisioned by that build
     And a "vendor" named "Acme" exists
 
-  @wip
   Scenario: A reference property added to a built-in preset round-trips after restart
     Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
     And the twin restarts against the same database
     When I create a "widget" named "Bolt cutter" with "supplier" referring to the "vendor" "Acme"
     Then reading the "widget" "Bolt cutter" back over the API returns "supplier" as the "vendor" "Acme"
 
-  @wip
   Scenario: A new reference property gains both a projection column and a context entry
     When the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
     And the twin restarts against the same database
     Then the "widget" projection table has a "supplier" column
     And the stored "widget" context has an entry for "supplier"
 
-  @wip
   Scenario: A reference whose context entry was already stored keeps round-tripping on the same write
     Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
     And the twin restarts against the same database
@@ -40,7 +37,6 @@ Feature: A built-in preset's new reference property reaches an already-provision
     Then reading the "widget" "Bolt cutter" back over the API returns "maker" as the "vendor" "Acme"
     And reading the "widget" "Bolt cutter" back over the API returns "supplier" as the "vendor" "Acme"
 
-  @wip
   Scenario: A literal property added to a preset round-trips and gains no context entry
     Given the "catalog" preset adds a "sku" string property to "widget"
     And the twin restarts against the same database
@@ -48,7 +44,6 @@ Feature: A built-in preset's new reference property reaches an already-provision
     Then reading the "widget" "Bolt cutter" back over the API returns "sku" as "BC-100"
     And the stored "widget" context has no entry for "sku"
 
-  @wip
   Scenario: A context entry the operator changed is held at its stored definition
     Given the operator maps "maker" to "https://example.org/vocab/madeBy" in the stored "widget" context
     And the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
@@ -57,7 +52,6 @@ Feature: A built-in preset's new reference property reaches an already-provision
     And the boot reconcile reports "maker" held at its stored definition for "widget"
     And the stored "widget" context has an entry for "supplier"
 
-  @wip
   Scenario: A held context entry still round-trips at the operator's definition
     Given the operator maps "maker" to "https://example.org/vocab/madeBy" in the stored "widget" context
     And the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
@@ -69,7 +63,6 @@ Feature: A built-in preset's new reference property reaches an already-provision
     Then reading the "widget" "Bolt cutter" back over the API returns "maker" as the "vendor" "Acme"
     And reading the "widget" "Bolt cutter" back over the API returns "supplier" as the "vendor" "Acme"
 
-  @wip
   Scenario: An operator's own context entry the preset does not declare survives the merge
     Given the operator maps "warranty" to "https://example.org/vocab/warranty" in the stored "widget" context
     And the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
@@ -77,7 +70,6 @@ Feature: A built-in preset's new reference property reaches an already-provision
     Then the stored "widget" context still maps "warranty" to "https://example.org/vocab/warranty"
     And the stored "widget" context has an entry for "supplier"
 
-  @wip
   Scenario: A type with no stored context adopts the entries the preset declares
     Given the operator clears the stored "widget" context
     And the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
@@ -85,34 +77,29 @@ Feature: A built-in preset's new reference property reaches an already-provision
     Then the stored "widget" context has an entry for "supplier"
     And the stored "widget" context has an entry for "maker"
 
-  @wip
   Scenario: The context merge happens once and then settles
     Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
     When the twin restarts against the same database
     And the twin restarts against the same database again
     Then exactly one resource type update is recorded for "widget"
 
-  @wip
   Scenario: Restarting with an unchanged preset leaves an already-complete context alone
     When the twin restarts against the same database
     Then no resource type update is recorded for "widget"
     And the stored "widget" context has an entry for "maker"
 
-  @wip
   Scenario: Reporting a type as updated means its reference properties have a stored context entry
     Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
     When the twin restarts against the same database
     Then the boot reconcile reports "widget" as updated
     And every reference property the "catalog" preset declares for "widget" has a stored context entry
 
-  @wip
   Scenario: A reference property the preset's own context never declares is not reported as updated
     Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor" without a context entry
     When the twin restarts against the same database
     Then the boot reconcile does not report "widget" as updated
     And the boot reconcile names "supplier" as a property whose writes are still dropped
 
-  @wip
   Scenario: A reference written before the context entry existed reads back empty but survives in the canonical record
     Given a "widget" named "Bolt cutter" is created with an undeclared "supplier" referring to the "vendor" "Acme"
     When the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
@@ -120,7 +107,6 @@ Feature: A built-in preset's new reference property reaches an already-provision
     Then reading the "widget" "Bolt cutter" back over the API returns no value for "supplier"
     And the JSON-LD representation of the "widget" "Bolt cutter" still carries a "supplier" edge to the "vendor" "Acme"
 
-  @wip
   Scenario: Reprojecting after the context entry lands populates the reference column
     Given a "widget" named "Bolt cutter" is created with an undeclared "supplier" referring to the "vendor" "Acme"
     And the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"

--- a/tests/e2e/preset_context_reconcile_test.go
+++ b/tests/e2e/preset_context_reconcile_test.go
@@ -1,0 +1,872 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/cucumber/godog"
+	"go.uber.org/fx"
+	"gorm.io/gorm"
+
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/internal/config"
+	"github.com/wepala/weos/v3/pkg/jsonld"
+)
+
+// TestPresetContextReconcile is the acceptance suite for issue #510: a built-in
+// preset that gains a REFERENCE property must reach a database provisioned by
+// an older build with its `@context` entry, not just its projection column.
+//
+// Issue #379's reconcile gave the column. Without the context entry the edge
+// has no reverse mapping, FlattenGraph skips it, and the write is dropped while
+// the API answers 201 — which is why this suite asserts round-trips, not just
+// stored shape.
+func TestPresetContextReconcile(t *testing.T) {
+	tags := "~@wip"
+	if override := os.Getenv("GODOG_TAGS"); override != "" {
+		tags = override
+	}
+	suite := godog.TestSuite{
+		Name:                "preset-context-reconcile",
+		ScenarioInitializer: initPresetContextScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"features/preset_context_reconcile.feature"},
+			Tags:     tags,
+			Strict:   true,
+			TestingT: t,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatal("preset_context_reconcile acceptance scenarios failed")
+	}
+}
+
+// contextWorld holds one scenario's database plus the shape the "catalog"
+// preset declares on the next boot. Mutating the type shapes then restarting is
+// how a scenario expresses "a new build of WeOS".
+type contextWorld struct {
+	tmpDir string
+	dsn    string
+
+	app    *fx.App
+	cancel context.CancelFunc
+
+	rts application.ResourceTypeService
+	rs  application.ResourceService
+	db  *gorm.DB
+
+	// vendorProps and widgetProps are the two types' schema properties in
+	// declaration order, as the preset would declare them on the next boot.
+	vendorProps []contextProperty
+	widgetProps []contextProperty
+
+	// bootReport captures what the LAST boot's reconcile reported, read back
+	// from the log lines reconcilePresetSchemas emits — the operator-facing
+	// surface, since ReconcilePresetResult never leaves the boot hook.
+	bootReport *reconcileLog
+
+	createdIDs map[string]string
+}
+
+// contextProperty is one schema property. references is empty for a literal and
+// names the target type slug for a reference. noContextEntry reproduces a
+// preset packaging bug: a reference the preset's OWN context never declares, so
+// there is nothing for an additive merge to add.
+type contextProperty struct {
+	name           string
+	jsonTyp        string
+	references     string
+	noContextEntry bool
+}
+
+func initPresetContextScenario(sc *godog.ScenarioContext) {
+	w := &contextWorld{createdIDs: map[string]string{}}
+
+	sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
+		w.teardown()
+		return ctx, nil
+	})
+
+	sc.Step(`^a built-in preset "catalog" declaring a "vendor" type with the properties:$`, w.aVendorTypeDeclaring)
+	sc.Step(`^the "catalog" preset also declares a "widget" type with the properties:$`, w.aWidgetTypeDeclaring)
+	sc.Step(`^a clean WeOS database provisioned by that build$`, w.aCleanDatabase)
+	sc.Step(`^a "vendor" named "([^"]*)" exists$`, w.aVendorExists)
+
+	sc.Step(`^the "catalog" preset adds a "([^"]*)" reference property to "widget" targeting "([^"]*)"$`,
+		w.thePresetAddsReference)
+	sc.Step(`^the "catalog" preset adds a "([^"]*)" reference property to "widget" targeting "([^"]*)" `+
+		`without a context entry$`, w.thePresetAddsReferenceWithoutContextEntry)
+	sc.Step(`^the "catalog" preset adds a "([^"]*)" (\w+) property to "widget"$`, w.thePresetAddsLiteral)
+
+	sc.Step(`^the operator maps "([^"]*)" to "([^"]*)" in the stored "widget" context$`, w.theOperatorMapsTerm)
+	sc.Step(`^the operator clears the stored "widget" context$`, w.theOperatorClearsContext)
+
+	sc.Step(`^the twin restarts against the same database$`, w.theTwinRestarts)
+	sc.Step(`^the twin restarts against the same database again$`, w.theTwinRestarts)
+	sc.Step(`^the operator reprojects the event feed$`, w.theOperatorReprojects)
+
+	sc.Step(`^I create a "widget" named "([^"]*)" with "([^"]*)" referring to the "vendor" "([^"]*)"$`,
+		w.iCreateWidgetWithReference)
+	sc.Step(`^I create a "widget" named "([^"]*)" with these references:$`, w.iCreateWidgetWithReferences)
+	sc.Step(`^I create a "widget" named "([^"]*)" with "([^"]*)" set to "([^"]*)"$`, w.iCreateWidgetWithLiteral)
+	sc.Step(`^a "widget" named "([^"]*)" is created with an undeclared "([^"]*)" referring to the "vendor" "([^"]*)"$`,
+		w.aWidgetCreatedWithUndeclaredReference)
+
+	sc.Step(`^reading the "widget" "([^"]*)" back over the API returns "([^"]*)" as the "vendor" "([^"]*)"$`,
+		w.readingReturnsReference)
+	sc.Step(`^reading the "widget" "([^"]*)" back over the API returns "([^"]*)" as "([^"]*)"$`, w.readingReturnsLiteral)
+	sc.Step(`^reading the "widget" "([^"]*)" back over the API returns no value for "([^"]*)"$`, w.readingReturnsNoValue)
+	sc.Step(`^the JSON-LD representation of the "widget" "([^"]*)" still carries a "([^"]*)" edge `+
+		`to the "vendor" "([^"]*)"$`, w.canonicalStillCarriesEdge)
+
+	sc.Step(`^the "widget" projection table has a "([^"]*)" column$`, w.theProjectionTableHasColumn)
+	sc.Step(`^the stored "widget" context has an entry for "([^"]*)"$`, w.theStoredContextHasEntry)
+	sc.Step(`^the stored "widget" context has no entry for "([^"]*)"$`, w.theStoredContextHasNoEntry)
+	sc.Step(`^the stored "widget" context still maps "([^"]*)" to "([^"]*)"$`, w.theStoredContextStillMaps)
+	sc.Step(`^every reference property the "catalog" preset declares for "widget" has a stored context entry$`,
+		w.everyReferenceHasAStoredEntry)
+
+	sc.Step(`^no resource type update is recorded for "([^"]*)"$`, w.noUpdateRecorded)
+	sc.Step(`^exactly one resource type update is recorded for "([^"]*)"$`, w.exactlyOneUpdateRecorded)
+
+	sc.Step(`^the boot reconcile reports "([^"]*)" held at its stored definition for "([^"]*)"$`, w.bootReportsHeld)
+	sc.Step(`^the boot reconcile reports "([^"]*)" as updated$`, w.bootReportsUpdated)
+	sc.Step(`^the boot reconcile does not report "([^"]*)" as updated$`, w.bootDoesNotReportUpdated)
+	sc.Step(`^the boot reconcile names "([^"]*)" as a property whose writes are still dropped$`, w.bootNamesDropped)
+}
+
+// --- preset shaping ---
+
+func (w *contextWorld) aVendorTypeDeclaring(table *godog.Table) error {
+	props, err := readPropertyTable(table)
+	if err != nil {
+		return err
+	}
+	w.vendorProps = props
+	return nil
+}
+
+func (w *contextWorld) aWidgetTypeDeclaring(table *godog.Table) error {
+	props, err := readPropertyTable(table)
+	if err != nil {
+		return err
+	}
+	w.widgetProps = props
+	return nil
+}
+
+// readPropertyTable reads a | property | type | references | table. The
+// references column is optional so the same reader serves a literal-only type.
+func readPropertyTable(table *godog.Table) ([]contextProperty, error) {
+	if len(table.Rows) == 0 {
+		return nil, fmt.Errorf("property table has no header row")
+	}
+	header := make([]string, 0, len(table.Rows[0].Cells))
+	for _, cell := range table.Rows[0].Cells {
+		header = append(header, strings.TrimSpace(cell.Value))
+	}
+	var props []contextProperty
+	for _, row := range table.Rows[1:] {
+		var p contextProperty
+		for i, cell := range row.Cells {
+			if i >= len(header) {
+				return nil, fmt.Errorf("property row has more cells than the header declares")
+			}
+			value := strings.TrimSpace(cell.Value)
+			switch header[i] {
+			case "property":
+				p.name = value
+			case "type":
+				p.jsonTyp = value
+			case "references":
+				p.references = value
+			default:
+				return nil, fmt.Errorf("unknown property table column %q", header[i])
+			}
+		}
+		if p.name == "" {
+			return nil, fmt.Errorf("a property row declares no name")
+		}
+		// "reference" is the table's word for a resource reference; the stored
+		// JSON type of a reference is a string holding the target's URN.
+		if p.references != "" {
+			p.jsonTyp = "string"
+		}
+		props = append(props, p)
+	}
+	return props, nil
+}
+
+func (w *contextWorld) addWidgetProperty(p contextProperty) error {
+	for _, existing := range w.widgetProps {
+		if existing.name == p.name {
+			return fmt.Errorf("property %q is already declared on widget", p.name)
+		}
+	}
+	w.widgetProps = append(w.widgetProps, p)
+	return nil
+}
+
+func (w *contextWorld) thePresetAddsReference(name, target string) error {
+	return w.addWidgetProperty(contextProperty{name: name, jsonTyp: "string", references: target})
+}
+
+// thePresetAddsReferenceWithoutContextEntry reproduces a preset packaging bug:
+// the schema marks the property as a reference but the preset's own context
+// never declares a term for it, so an additive merge has nothing to add and the
+// writes stay dropped.
+func (w *contextWorld) thePresetAddsReferenceWithoutContextEntry(name, target string) error {
+	return w.addWidgetProperty(
+		contextProperty{name: name, jsonTyp: "string", references: target, noContextEntry: true})
+}
+
+func (w *contextWorld) thePresetAddsLiteral(name, jsonTyp string) error {
+	return w.addWidgetProperty(contextProperty{name: name, jsonTyp: jsonTyp})
+}
+
+// presetType renders one type's schema and context from its property list. A
+// reference contributes an x-resource-type marker to the schema AND a term to
+// the context — declaring one without the other is exactly the defect, so the
+// two are built side by side here where the asymmetry is visible.
+func presetType(name, slug string, props []contextProperty) application.PresetResourceType {
+	schemaProps := make([]string, 0, len(props))
+	terms := []string{`"@vocab":"https://schema.org/"`}
+	for _, p := range props {
+		if p.references == "" {
+			schemaProps = append(schemaProps, fmt.Sprintf("%q:{\"type\":%q}", p.name, p.jsonTyp))
+			continue
+		}
+		schemaProps = append(schemaProps,
+			fmt.Sprintf("%q:{\"type\":\"string\",\"x-resource-type\":%q,\"x-display-property\":\"name\"}",
+				p.name, p.references))
+		if p.noContextEntry {
+			continue
+		}
+		terms = append(terms,
+			fmt.Sprintf("%q:{\"@id\":\"https://weos.org/vocab/catalog#%s\",\"@type\":\"@id\"}", p.name, p.name))
+	}
+	return application.PresetResourceType{
+		Name:        name,
+		Slug:        slug,
+		Description: "issue #510 acceptance type",
+		Context:     json.RawMessage("{" + strings.Join(terms, ",") + "}"),
+		Schema: json.RawMessage(fmt.Sprintf(`{"type":"object","properties":{%s}}`,
+			strings.Join(schemaProps, ","))),
+	}
+}
+
+// catalogRegistry builds the preset registry for the next boot from the world's
+// current type shapes. AutoInstall routes it through ensureBuiltInResourceTypes
+// — the startup path under test. Vendor is declared first so it exists before
+// widget's references point at it.
+func (w *contextWorld) catalogRegistry() *application.PresetRegistry {
+	registry := application.NewPresetRegistry()
+	registry.MustAdd(application.PresetDefinition{
+		Name:        "catalog",
+		Description: "issue #510 acceptance preset",
+		AutoInstall: true,
+		Types: []application.PresetResourceType{
+			presetType("Vendor", "vendor", w.vendorProps),
+			presetType("Widget", "widget", w.widgetProps),
+		},
+	})
+	return registry
+}
+
+// --- boot / restart ---
+
+// reconcileLog captures the boot reconcile's operator-facing log lines. The
+// scenarios assert on what an operator would SEE, so reading the log is the
+// honest surface: ReconcilePresetResult itself never leaves the boot hook.
+type reconcileLog struct {
+	mu sync.Mutex
+	// updated, held and dropped are keyed by slug.
+	updated map[string]bool
+	held    map[string][]string
+	dropped map[string]string
+}
+
+func newReconcileLog() *reconcileLog {
+	return &reconcileLog{updated: map[string]bool{}, held: map[string][]string{}, dropped: map[string]string{}}
+}
+
+// capturingLogger records the reconcile lines and discards everything else.
+type capturingLogger struct {
+	inner entities.Logger
+	log   *reconcileLog
+}
+
+func (c *capturingLogger) Debug(ctx context.Context, msg string, fields ...interface{}) {
+	c.inner.Debug(ctx, msg, fields...)
+}
+
+func (c *capturingLogger) Info(ctx context.Context, msg string, fields ...interface{}) {
+	if strings.Contains(msg, "reconciled resource type schema from preset") {
+		if slug, ok := fieldValue(fields, "slug"); ok {
+			c.log.mu.Lock()
+			c.log.updated[slug] = true
+			c.log.mu.Unlock()
+		}
+	}
+	c.inner.Info(ctx, msg, fields...)
+}
+
+func (c *capturingLogger) Warn(ctx context.Context, msg string, fields ...interface{}) {
+	if strings.Contains(msg, "held at their stored definition") {
+		if slug, ok := fieldValue(fields, "slug"); ok {
+			terms, _ := fieldValue(fields, "heldContextTerms")
+			props, _ := fieldValue(fields, "heldProperties")
+			c.log.mu.Lock()
+			c.log.held[slug] = append(c.log.held[slug], terms, props)
+			c.log.mu.Unlock()
+		}
+	}
+	c.inner.Warn(ctx, msg, fields...)
+}
+
+func (c *capturingLogger) Error(ctx context.Context, msg string, fields ...interface{}) {
+	if strings.Contains(msg, "resource type NOT reconciled") {
+		if slug, ok := fieldValue(fields, "slug"); ok {
+			reason, _ := fieldValue(fields, "reason")
+			c.log.mu.Lock()
+			c.log.dropped[slug] = reason
+			c.log.mu.Unlock()
+		}
+	}
+	c.inner.Error(ctx, msg, fields...)
+}
+
+// fieldValue reads a key's value out of the variadic key-value pairs the Logger
+// interface takes, rendering it as a string for substring assertions.
+func fieldValue(fields []interface{}, key string) (string, bool) {
+	for i := 0; i+1 < len(fields); i += 2 {
+		if name, ok := fields[i].(string); ok && name == key {
+			return fmt.Sprintf("%v", fields[i+1]), true
+		}
+	}
+	return "", false
+}
+
+func (w *contextWorld) aCleanDatabase() error {
+	dir, err := os.MkdirTemp("", "weos-preset-context-e2e-")
+	if err != nil {
+		return err
+	}
+	w.tmpDir = dir
+	w.dsn = filepath.Join(dir, "test.db")
+	return w.boot()
+}
+
+// boot starts a fresh Fx app against the world's existing database file, with
+// the reconcile's log lines captured. It is the "restart" primitive: the
+// process and its preset registry are new, the data is not.
+func (w *contextWorld) boot() error {
+	cfg := config.Default()
+	cfg.DatabaseDSN = w.dsn
+	cfg.LogLevel = "error"
+	if lvl := os.Getenv("E2E_LOG_LEVEL"); lvl != "" {
+		cfg.LogLevel = lvl
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	w.cancel = cancel
+
+	captured := newReconcileLog()
+	var rts application.ResourceTypeService
+	var rs application.ResourceService
+	var db *gorm.DB
+
+	app := fx.New(
+		fx.NopLogger,
+		application.Module(cfg, w.catalogRegistry()),
+		// Decorating the Logger is what makes the boot reconcile observable
+		// without a production seam existing only for the tests.
+		fx.Decorate(func(inner entities.Logger) entities.Logger {
+			return &capturingLogger{inner: inner, log: captured}
+		}),
+		fx.Populate(&rts, &rs, &db),
+	)
+	startCtx, startCancel := context.WithTimeout(ctx, fx.DefaultTimeout)
+	defer startCancel()
+	if err := app.Start(startCtx); err != nil {
+		return fmt.Errorf("failed to start app: %w", err)
+	}
+	w.app, w.rts, w.rs, w.db = app, rts, rs, db
+	w.bootReport = captured
+	return nil
+}
+
+func (w *contextWorld) stop() {
+	if w.app != nil {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		_ = w.app.Stop(stopCtx)
+		stopCancel()
+		w.app = nil
+	}
+	if w.cancel != nil {
+		w.cancel()
+		w.cancel = nil
+	}
+}
+
+func (w *contextWorld) theTwinRestarts() error {
+	w.stop()
+	return w.boot()
+}
+
+func (w *contextWorld) teardown() {
+	w.stop()
+	if w.tmpDir != "" {
+		_ = os.RemoveAll(w.tmpDir)
+		w.tmpDir = ""
+	}
+}
+
+// --- operator customisation of the STORED context ---
+
+// storedContextOf reads a type's context as a term map.
+func (w *contextWorld) storedContextOf(slug string) (map[string]any, error) {
+	rt, err := w.rts.GetBySlug(context.Background(), slug)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load the %q type: %w", slug, err)
+	}
+	terms := map[string]any{}
+	if len(rt.Context()) == 0 {
+		return terms, nil
+	}
+	if err := json.Unmarshal(rt.Context(), &terms); err != nil {
+		return nil, fmt.Errorf("stored context for %q is not a JSON object: %w", slug, err)
+	}
+	return terms, nil
+}
+
+// writeStoredContext rewrites a type's stored context in place, standing in for
+// an operator editing it through the API. Everything else about the type is
+// read back and passed through so only the context changes.
+func (w *contextWorld) writeStoredContext(slug string, terms map[string]any) error {
+	rt, err := w.rts.GetBySlug(context.Background(), slug)
+	if err != nil {
+		return fmt.Errorf("failed to load the %q type: %w", slug, err)
+	}
+	var raw json.RawMessage
+	if terms != nil {
+		encoded, mErr := json.Marshal(terms)
+		if mErr != nil {
+			return fmt.Errorf("failed to encode the operator's context: %w", mErr)
+		}
+		raw = encoded
+	}
+	_, err = w.rts.Update(context.Background(), application.UpdateResourceTypeCommand{
+		ID:          rt.GetID(),
+		Name:        rt.Name(),
+		Slug:        rt.Slug(),
+		Description: rt.Description(),
+		Status:      rt.Status(),
+		Context:     raw,
+		Schema:      rt.Schema(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to rewrite the stored context for %q: %w", slug, err)
+	}
+	return nil
+}
+
+func (w *contextWorld) theOperatorMapsTerm(term, iri string) error {
+	terms, err := w.storedContextOf("widget")
+	if err != nil {
+		return err
+	}
+	terms[term] = iri
+	return w.writeStoredContext("widget", terms)
+}
+
+func (w *contextWorld) theOperatorClearsContext() error {
+	return w.writeStoredContext("widget", map[string]any{})
+}
+
+// --- writes ---
+
+func (w *contextWorld) createResource(slug, name string, data map[string]any) error {
+	if name == "" {
+		return fmt.Errorf("a %s must be created with a name", slug)
+	}
+	data["name"] = name
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	res, err := w.rs.Create(context.Background(), application.CreateResourceCommand{TypeSlug: slug, Data: raw})
+	if err != nil {
+		return fmt.Errorf("failed to create %s %q: %w", slug, name, err)
+	}
+	w.createdIDs[slug+"/"+name] = res.GetID()
+	return nil
+}
+
+func (w *contextWorld) aVendorExists(name string) error {
+	return w.createResource("vendor", name, map[string]any{})
+}
+
+func (w *contextWorld) vendorID(name string) (string, error) {
+	id, ok := w.createdIDs["vendor/"+name]
+	if !ok {
+		return "", fmt.Errorf("no vendor named %q was created in this scenario", name)
+	}
+	return id, nil
+}
+
+func (w *contextWorld) iCreateWidgetWithReference(name, property, vendorName string) error {
+	id, err := w.vendorID(vendorName)
+	if err != nil {
+		return err
+	}
+	return w.createResource("widget", name, map[string]any{property: id})
+}
+
+func (w *contextWorld) iCreateWidgetWithReferences(name string, table *godog.Table) error {
+	if len(table.Rows) == 0 {
+		return fmt.Errorf("reference table has no header row")
+	}
+	data := map[string]any{}
+	for _, row := range table.Rows[1:] {
+		if len(row.Cells) != 2 {
+			return fmt.Errorf("expected 2 columns per reference row, got %d", len(row.Cells))
+		}
+		property := strings.TrimSpace(row.Cells[0].Value)
+		id, err := w.vendorID(strings.TrimSpace(row.Cells[1].Value))
+		if err != nil {
+			return err
+		}
+		data[property] = id
+	}
+	return w.createResource("widget", name, data)
+}
+
+func (w *contextWorld) iCreateWidgetWithLiteral(name, property, value string) error {
+	return w.createResource("widget", name, map[string]any{property: value})
+}
+
+// aWidgetCreatedWithUndeclaredReference writes a reference the CURRENT schema
+// does not declare — the state the bug leaves behind: the value reaches the
+// canonical record with nowhere in the projection to land.
+func (w *contextWorld) aWidgetCreatedWithUndeclaredReference(name, property, vendorName string) error {
+	return w.iCreateWidgetWithReference(name, property, vendorName)
+}
+
+// --- reads and assertions ---
+
+// flatRead reads a widget back through the projection (GetFlat), which is the
+// surface the silent drop actually shows up on.
+func (w *contextWorld) flatRead(name string) (map[string]any, error) {
+	id, ok := w.createdIDs["widget/"+name]
+	if !ok {
+		return nil, fmt.Errorf("no widget named %q was created in this scenario", name)
+	}
+	row, err := w.rs.GetFlat(context.Background(), "widget", id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read widget %q back: %w", name, err)
+	}
+	return row, nil
+}
+
+func (w *contextWorld) readingReturnsReference(name, property, vendorName string) error {
+	want, err := w.vendorID(vendorName)
+	if err != nil {
+		return err
+	}
+	row, err := w.flatRead(name)
+	if err != nil {
+		return err
+	}
+	got, ok := row[property]
+	if !ok {
+		return fmt.Errorf("read of %q carries no %q key — the reference was dropped (keys: %s)",
+			name, property, mapKeys(row))
+	}
+	if fmt.Sprintf("%v", got) != want {
+		return fmt.Errorf("read of %q returned %s = %v, want the %q vendor %s", name, property, got, vendorName, want)
+	}
+	return nil
+}
+
+func (w *contextWorld) readingReturnsLiteral(name, property, want string) error {
+	row, err := w.flatRead(name)
+	if err != nil {
+		return err
+	}
+	got, ok := row[property]
+	if !ok {
+		return fmt.Errorf("read of %q carries no %q key (keys: %s)", name, property, mapKeys(row))
+	}
+	if fmt.Sprintf("%v", got) != want {
+		return fmt.Errorf("read of %q returned %s = %v, want %q", name, property, got, want)
+	}
+	return nil
+}
+
+func (w *contextWorld) readingReturnsNoValue(name, property string) error {
+	row, err := w.flatRead(name)
+	if err != nil {
+		return err
+	}
+	return assertEmpty(row, property)
+}
+
+// canonicalStillCarriesEdge reads the canonical JSON-LD blob rather than the
+// projection, proving the event store never lost the reference even while the
+// context entry was missing.
+func (w *contextWorld) canonicalStillCarriesEdge(name, property, vendorName string) error {
+	want, err := w.vendorID(vendorName)
+	if err != nil {
+		return err
+	}
+	id, ok := w.createdIDs["widget/"+name]
+	if !ok {
+		return fmt.Errorf("no widget named %q was created in this scenario", name)
+	}
+	res, err := w.rs.GetByID(context.Background(), id)
+	if err != nil {
+		return fmt.Errorf("failed to read widget %q by id: %w", name, err)
+	}
+	rt, err := w.rts.GetBySlug(context.Background(), "widget")
+	if err != nil {
+		return fmt.Errorf("failed to load the widget type: %w", err)
+	}
+	for _, got := range application.EdgeValues(res.Data(), rt.Context(), property) {
+		if got == want {
+			return nil
+		}
+	}
+	// The edge is keyed by its predicate IRI, so a missing context term hides it
+	// from EdgeValues too. Fall back to the raw payload before declaring loss.
+	if strings.Contains(string(res.Data()), want) {
+		return nil
+	}
+	return fmt.Errorf("canonical record for %q lost its %q edge to %s (payload: %s)",
+		name, property, want, res.Data())
+}
+
+func (w *contextWorld) theProjectionTableHasColumn(column string) error {
+	if !w.db.Migrator().HasColumn("widgets", column) {
+		return fmt.Errorf("projection table `widgets` has no %q column", column)
+	}
+	return nil
+}
+
+func (w *contextWorld) theStoredContextHasEntry(term string) error {
+	terms, err := w.storedContextOf("widget")
+	if err != nil {
+		return err
+	}
+	if _, ok := terms[term]; !ok {
+		return fmt.Errorf("stored widget context has no entry for %q (terms: %v)", term, sortedTermNames(terms))
+	}
+	return nil
+}
+
+func (w *contextWorld) theStoredContextHasNoEntry(term string) error {
+	terms, err := w.storedContextOf("widget")
+	if err != nil {
+		return err
+	}
+	if _, ok := terms[term]; ok {
+		return fmt.Errorf("stored widget context unexpectedly has an entry for %q", term)
+	}
+	return nil
+}
+
+func (w *contextWorld) theStoredContextStillMaps(term, iri string) error {
+	terms, err := w.storedContextOf("widget")
+	if err != nil {
+		return err
+	}
+	got, ok := terms[term]
+	if !ok {
+		return fmt.Errorf("stored widget context lost its entry for %q", term)
+	}
+	if fmt.Sprintf("%v", got) != iri {
+		return fmt.Errorf("stored widget context maps %q to %v, want %q — the operator's edit was overwritten",
+			term, got, iri)
+	}
+	return nil
+}
+
+// everyReferenceHasAStoredEntry mirrors the read path: a reference survives only
+// if the reverse map resolves its predicate IRI back to its own property name.
+func (w *contextWorld) everyReferenceHasAStoredEntry() error {
+	rt, err := w.rts.GetBySlug(context.Background(), "widget")
+	if err != nil {
+		return fmt.Errorf("failed to load the widget type: %w", err)
+	}
+	reverse := jsonld.BuildReverseMap(rt.Context())
+	var dropped []string
+	for _, ref := range application.ExtractReferenceProperties(rt.Schema(), rt.Context()) {
+		if reverse[ref.PredicateIRI] != ref.PropertyName {
+			dropped = append(dropped, ref.PropertyName)
+		}
+	}
+	if len(dropped) > 0 {
+		return fmt.Errorf("reference properties %v have no usable stored context entry, so their writes are dropped",
+			dropped)
+	}
+	return nil
+}
+
+func sortedTermNames(terms map[string]any) string {
+	names := make([]string, 0, len(terms))
+	for k := range terms {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+// --- event-store and boot-report assertions ---
+
+func (w *contextWorld) countTypeUpdates(slug string) (int64, error) {
+	var n int64
+	err := w.db.Table("events").
+		Where("aggregate_id = ? AND event_type = ?", "urn:type:"+slug, "ResourceType.Updated").
+		Count(&n).Error
+	if err != nil {
+		return 0, fmt.Errorf("failed to count ResourceType.Updated events: %w", err)
+	}
+	return n, nil
+}
+
+func (w *contextWorld) noUpdateRecorded(slug string) error {
+	n, err := w.countTypeUpdates(slug)
+	if err != nil {
+		return err
+	}
+	if n != 0 {
+		return fmt.Errorf("expected no ResourceType.Updated events for %q, got %d", slug, n)
+	}
+	return nil
+}
+
+func (w *contextWorld) exactlyOneUpdateRecorded(slug string) error {
+	n, err := w.countTypeUpdates(slug)
+	if err != nil {
+		return err
+	}
+	if n != 1 {
+		return fmt.Errorf("expected exactly 1 ResourceType.Updated event for %q, got %d", slug, n)
+	}
+	return nil
+}
+
+func (w *contextWorld) report() (*reconcileLog, error) {
+	if w.bootReport == nil {
+		return nil, fmt.Errorf("no boot has been observed in this scenario")
+	}
+	return w.bootReport, nil
+}
+
+func (w *contextWorld) bootReportsHeld(term, slug string) error {
+	r, err := w.report()
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, line := range r.held[slug] {
+		if strings.Contains(line, term) {
+			return nil
+		}
+	}
+	return fmt.Errorf("boot reconcile did not report %q held for %q (held lines: %v)", term, slug, r.held[slug])
+}
+
+func (w *contextWorld) bootReportsUpdated(slug string) error {
+	r, err := w.report()
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.updated[slug] {
+		return fmt.Errorf("boot reconcile did not report %q as updated (dropped: %v)", slug, r.dropped[slug])
+	}
+	return nil
+}
+
+func (w *contextWorld) bootDoesNotReportUpdated(slug string) error {
+	r, err := w.report()
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.updated[slug] {
+		return fmt.Errorf("boot reconcile reported %q as updated, but writes to it are still dropped", slug)
+	}
+	return nil
+}
+
+func (w *contextWorld) bootNamesDropped(property string) error {
+	r, err := w.report()
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for slug, reason := range r.dropped {
+		if strings.Contains(reason, property) {
+			return nil
+		}
+		_ = slug
+	}
+	return fmt.Errorf("boot reconcile never named %q as a property whose writes are dropped (reported: %v)",
+		property, r.dropped)
+}
+
+// theOperatorReprojects runs the same replay rail `weos worker reproject`
+// drives, against the stopped-then-restarted database.
+func (w *contextWorld) theOperatorReprojects() error {
+	w.stop()
+
+	cfg := config.Default()
+	cfg.DatabaseDSN = w.dsn
+	cfg.LogLevel = "error"
+
+	var rt application.ReprojectRuntime
+	app := fx.New(fx.NopLogger, application.ReprojectModule(cfg), fx.Populate(&rt))
+	startCtx, startCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+	defer startCancel()
+	if err := app.Start(startCtx); err != nil {
+		return fmt.Errorf("failed to start the reproject runtime: %w", err)
+	}
+	_, err := application.Reproject(context.Background(), rt, application.ReprojectOptions{})
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+	_ = app.Stop(stopCtx)
+	stopCancel()
+	if err != nil {
+		return fmt.Errorf("reproject failed: %w", err)
+	}
+	return w.boot()
+}

--- a/tests/e2e/preset_context_reconcile_test.go
+++ b/tests/e2e/preset_context_reconcile_test.go
@@ -661,9 +661,17 @@ func (w *contextWorld) canonicalStillCarriesEdge(name, property, vendorName stri
 			return nil
 		}
 	}
-	// The edge is keyed by its predicate IRI, so a missing context term hides it
-	// from EdgeValues too. Fall back to the raw payload before declaring loss.
-	if strings.Contains(string(res.Data()), want) {
+	// A value written BEFORE the schema declared the property was never a
+	// reference at write time, so it landed in the entity node as a plain
+	// value rather than the edges node — EdgeValues cannot see it. Look it up
+	// by name instead. Deliberately NOT a substring search over the payload:
+	// that would pass on the URN appearing under any other key, which is the
+	// exact loss this step exists to catch.
+	var data map[string]any
+	if err := json.Unmarshal(res.Data(), &data); err != nil {
+		return fmt.Errorf("canonical data for %q is not a JSON object: %w", name, err)
+	}
+	if got, ok := jsonLDField(data, property); ok && fmt.Sprintf("%v", got) == want {
 		return nil
 	}
 	return fmt.Errorf("canonical record for %q lost its %q edge to %s (payload: %s)",

--- a/tests/e2e/preset_context_reconcile_test.go
+++ b/tests/e2e/preset_context_reconcile_test.go
@@ -325,7 +325,10 @@ func (c *capturingLogger) Debug(ctx context.Context, msg string, fields ...inter
 }
 
 func (c *capturingLogger) Info(ctx context.Context, msg string, fields ...interface{}) {
-	if strings.Contains(msg, "reconciled resource type schema from preset") {
+	// Matched on a stable prefix rather than the whole message: the wording
+	// names which halves were reconciled and has already changed once, and a
+	// test that silently stops matching would report every type as un-updated.
+	if strings.Contains(msg, "reconciled resource type") {
 		if slug, ok := fieldValue(fields, "slug"); ok {
 			c.log.mu.Lock()
 			c.log.updated[slug] = true

--- a/tests/e2e/preset_context_repair_test.go
+++ b/tests/e2e/preset_context_repair_test.go
@@ -1,0 +1,249 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/fx"
+	"gorm.io/gorm"
+
+	"github.com/wepala/weos/v3/application"
+	"github.com/wepala/weos/v3/application/presets"
+	"github.com/wepala/weos/v3/domain/entities"
+	"github.com/wepala/weos/v3/internal/config"
+	"github.com/wepala/weos/v3/pkg/jsonld"
+)
+
+// The acceptance suite in preset_context_reconcile_test.go proves the mechanism
+// on a synthetic two-type preset. These two tests prove it on the ACTUAL
+// shipped preset tree, which is what every real deployment boots — the issue
+// reported 36 reference fields across 24 types stuck in the broken state on a
+// real instance, and a synthetic preset cannot speak to that.
+
+// bootRealPresets starts an app against dsn with the real preset registry,
+// capturing the reconcile's operator-facing report.
+func bootRealPresets(t *testing.T, dsn string, report *reconcileLog) (
+	*gorm.DB, application.ResourceTypeService, func(),
+) {
+	t.Helper()
+
+	cfg := config.Default()
+	cfg.DatabaseDSN = dsn
+	cfg.LogLevel = "error"
+
+	registry := application.NewPresetRegistry()
+	presets.RegisterAll(registry)
+
+	var rts application.ResourceTypeService
+	var db *gorm.DB
+	app := fx.New(
+		fx.NopLogger,
+		application.Module(cfg, registry),
+		fx.Decorate(func(inner entities.Logger) entities.Logger {
+			return &capturingLogger{inner: inner, log: report}
+		}),
+		fx.Populate(&rts, &db),
+	)
+	startCtx, startCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+	defer startCancel()
+	if err := app.Start(startCtx); err != nil {
+		t.Fatalf("boot against the real preset tree failed: %v", err)
+	}
+	return db, rts, func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		_ = app.Stop(stopCtx)
+		stopCancel()
+	}
+}
+
+// uncoveredReferences names every installed reference property whose predicate
+// IRI the stored context cannot map back — exactly the set FlattenGraph drops.
+func uncoveredReferences(t *testing.T, rts application.ResourceTypeService) []string {
+	t.Helper()
+
+	page, err := rts.List(context.Background(), "", 500)
+	if err != nil {
+		t.Fatalf("failed to list resource types: %v", err)
+	}
+	if len(page.Data) == 0 {
+		t.Fatal("no resource types were enumerated, so this audit would be vacuous")
+	}
+	var uncovered []string
+	for _, rt := range page.Data {
+		reverse := jsonld.BuildReverseMap(rt.Context())
+		for _, ref := range application.ExtractReferenceProperties(rt.Schema(), rt.Context()) {
+			if reverse[ref.PredicateIRI] != ref.PropertyName {
+				uncovered = append(uncovered, rt.Slug()+"."+ref.PropertyName)
+			}
+		}
+	}
+	return uncovered
+}
+
+func countTypeUpdateEvents(t *testing.T, db *gorm.DB) int64 {
+	t.Helper()
+	var n int64
+	if err := db.Table("events").
+		Where("event_type = ?", "ResourceType.Updated").Count(&n).Error; err != nil {
+		t.Fatalf("failed to count ResourceType.Updated events: %v", err)
+	}
+	return n
+}
+
+// installEveryPreset installs the presets that are not AutoInstall too. A bare
+// boot installs only the handful marked for it, which would leave this audit
+// covering three types instead of the whole tree.
+func installEveryPreset(t *testing.T, rts application.ResourceTypeService) {
+	t.Helper()
+	registry := application.NewPresetRegistry()
+	presets.RegisterAll(registry)
+	for _, preset := range registry.List() {
+		if _, err := rts.InstallPreset(context.Background(), preset.Name, false); err != nil {
+			t.Fatalf("failed to install preset %q: %v", preset.Name, err)
+		}
+	}
+}
+
+// TestRealPresetsInstallWithEveryReferenceResolvable covers the FRESH install,
+// which has no stored context to reconcile against and so cannot be repaired by
+// a merge. A preset shipped with a missing term drops writes here permanently.
+func TestRealPresetsInstallWithEveryReferenceResolvable(t *testing.T) {
+	dsn := filepath.Join(t.TempDir(), "fresh.db")
+	report := newReconcileLog()
+
+	db, rts, stop := bootRealPresets(t, dsn, report)
+	installEveryPreset(t, rts)
+	if uncovered := uncoveredReferences(t, rts); len(uncovered) > 0 {
+		t.Errorf("a fresh install leaves %d reference properties unresolvable, so their writes are dropped: %v",
+			len(uncovered), uncovered)
+	}
+	baseline := countTypeUpdateEvents(t, db)
+	stop()
+
+	// A second boot over an already-correct database must be silent, or every
+	// restart of every deployment appends an event per type.
+	db2, _, stop2 := bootRealPresets(t, dsn, report)
+	after := countTypeUpdateEvents(t, db2)
+	stop2()
+	if after != baseline {
+		t.Errorf("a no-op boot emitted %d ResourceType.Updated events; the reconcile is not idempotent",
+			after-baseline)
+	}
+}
+
+// TestRealPresetsRepairAnAgedDatabase reproduces the state the issue reports
+// from production: a database whose stored contexts predate the reference
+// properties their schemas declare. Every such term is stripped, then the real
+// tree boots — which is the upgrade every deployment performs on this release.
+func TestRealPresetsRepairAnAgedDatabase(t *testing.T) {
+	dsn := filepath.Join(t.TempDir(), "aged.db")
+	report := newReconcileLog()
+
+	db, rts, stop := bootRealPresets(t, dsn, report)
+	installEveryPreset(t, rts)
+	stripped := ageStoredContexts(t, rts)
+	if stripped == 0 {
+		t.Fatal("no context terms were stripped, so this test would prove nothing")
+	}
+	t.Logf("aged the database by stripping %d reference context terms", stripped)
+	baseline := countTypeUpdateEvents(t, db)
+	stop()
+
+	// The upgrade boot.
+	upgrade := newReconcileLog()
+	db2, rts2, stop2 := bootRealPresets(t, dsn, upgrade)
+	repaired := countTypeUpdateEvents(t, db2) - baseline
+	uncovered := uncoveredReferences(t, rts2)
+	stop2()
+
+	upgrade.mu.Lock()
+	failed := fmt.Sprintf("%v", upgrade.dropped)
+	failedCount := len(upgrade.dropped)
+	upgrade.mu.Unlock()
+
+	if len(uncovered) > 0 {
+		t.Errorf("the upgrade boot left %d reference properties unrepaired: %v", len(uncovered), uncovered)
+	}
+	if failedCount > 0 {
+		t.Errorf("the upgrade boot reported %d types as NOT reconciled: %s", failedCount, failed)
+	}
+	t.Logf("the upgrade boot repaired %d types", repaired)
+
+	// The repair must settle: a deployment that restarts hourly must not append
+	// an event per type per boot forever.
+	settled := newReconcileLog()
+	db3, _, stop3 := bootRealPresets(t, dsn, settled)
+	extra := countTypeUpdateEvents(t, db3) - (baseline + repaired)
+	stop3()
+	if extra != 0 {
+		t.Errorf("the repair did not settle: the next boot emitted %d more ResourceType.Updated events", extra)
+	}
+}
+
+// ageStoredContexts deletes every stored context term that a reference property
+// depends on, leaving the schema and the projection column in place — the exact
+// shape issue #510 reports, where the type looks migrated and silently is not.
+func ageStoredContexts(t *testing.T, rts application.ResourceTypeService) int {
+	t.Helper()
+
+	page, err := rts.List(context.Background(), "", 500)
+	if err != nil {
+		t.Fatalf("failed to list resource types: %v", err)
+	}
+	stripped := 0
+	for _, rt := range page.Data {
+		refs := application.ExtractReferenceProperties(rt.Schema(), rt.Context())
+		if len(refs) == 0 || len(rt.Context()) == 0 {
+			continue
+		}
+		terms := map[string]any{}
+		if err := json.Unmarshal(rt.Context(), &terms); err != nil {
+			continue
+		}
+		removed := false
+		for _, ref := range refs {
+			if _, ok := terms[ref.PropertyName]; ok {
+				delete(terms, ref.PropertyName)
+				removed = true
+				stripped++
+			}
+		}
+		if !removed {
+			continue
+		}
+		raw, mErr := json.Marshal(terms)
+		if mErr != nil {
+			t.Fatalf("failed to encode the aged context for %q: %v", rt.Slug(), mErr)
+		}
+		if _, err := rts.Update(context.Background(), application.UpdateResourceTypeCommand{
+			ID:          rt.GetID(),
+			Name:        rt.Name(),
+			Slug:        rt.Slug(),
+			Description: rt.Description(),
+			Status:      rt.Status(),
+			Context:     raw,
+			Schema:      rt.Schema(),
+		}); err != nil {
+			t.Fatalf("failed to age the stored context for %q: %v", rt.Slug(), err)
+		}
+	}
+	return stripped
+}

--- a/tests/e2e/preset_context_repair_test.go
+++ b/tests/e2e/preset_context_repair_test.go
@@ -215,8 +215,12 @@ func ageStoredContexts(t *testing.T, rts application.ResourceTypeService) int {
 			continue
 		}
 		terms := map[string]any{}
+		// Skipping a type whose context will not decode would under-reproduce
+		// the broken state, and the test would then pass on a database that was
+		// never fully aged — the silent-skip failure this whole change exists to
+		// end. Fail instead, so the setup is provably complete.
 		if err := json.Unmarshal(rt.Context(), &terms); err != nil {
-			continue
+			t.Fatalf("stored context for %q is not a JSON object, so it cannot be aged: %v", rt.Slug(), err)
 		}
 		removed := false
 		for _, ref := range refs {


### PR DESCRIPTION
Closes #510

## The defect

Issue #379 taught the boot reconcile to merge a preset's JSON Schema additively and confirm the projection column landed. It left the stored `@context` alone.

A **reference** property — one the schema marks with `x-resource-type` — is stored as a JSON-LD edge keyed by its predicate IRI. `FlattenGraph` maps that IRI back to a property name through `jsonld.BuildReverseMap`, which only ever sees **explicit** context terms: `ParseContext` skips every `@`-prefixed keyword, so `@vocab` never appears in it. An edge whose IRI has no reverse entry is skipped outright.

So the column arrived, the schema declared the property, and every write to it was dropped — while the API answered `201` and the reconcile reported the type as `Updated`. Literals are unaffected: they live in the graph's entity node, which `FlattenGraph` copies verbatim without consulting the context.

## The fix

`reconcileAdditiveContext` is the sibling of `reconcileAdditiveSchema` and follows its rules for its reasons:

- a term the preset declares and the stored context lacks is **merged in**;
- a term only the operator declared is **preserved**;
- a term in both whose definition differs is **held** at its stored definition and reported.

Holding matters more here than for a schema property: repointing a term orphans every edge already written under the stored IRI, which is worse than the drop this fixes. Keywords get the same treatment with no special-casing — silently repointing `@vocab` would move every unmapped property's predicate at once. This keeps the constraint `docs/decisions/projection-schema-migration.md` protects: boot never overwrites operator customisation.

Held terms are reported apart from held schema properties (`RefusedContext`). They read alike on a boot line but need different fixes — one is a disagreement about a column's shape, the other about which predicate a reference is keyed by.

The post-write check now covers the context the way `missingColumns` covers columns. A successful `Update` vouches for neither, and a type whose references still have nowhere to resolve is not a completed reconcile — it is the same silent drop, so it is reported `Failed` and names the properties rather than being counted as `Updated`.

## Two shipped presets had the gap on their own side

That check found meal-planning's `ingredient` and `meal-plan` declaring `suitableForDiet` as a reference with no term for it, where `recipe` declared it correctly. An additive merge cannot fix those — there is nothing to merge in — so they are fixed here, with a test asserting every preset type declares a term for each of its reference properties. That guard also covers **fresh installs**, which have no stored context to reconcile against at all and so can never be repaired by a merge.

## Verification

- **14 acceptance scenarios** (`tests/e2e/features/preset_context_reconcile.feature`), committed before the fix and verified to fail on the unfixed code — 9 of 14 red, including the headline round-trip. All 14 pass now and are selected by the default gate (no `@wip`).
- **Real-tree audits** (`tests/e2e/preset_context_repair_test.go`), because the synthetic preset says nothing about the tree deployments actually boot. One covers a fresh install; the other reproduces the reported production state by stripping every reference term from a fully installed tree (23 terms), boots, and asserts every one is repaired, nothing is reported failed, and the following boot emits no further events. The upgrade boot repairs 14 types and then settles.
- Unit tests for the merge rules, including the prefix-form terms every meal-planning type uses.

## Two gate fixes, because the gate could not report on any of the above

Both pre-existing on `v3`, which has been red since 2026-08-20 for reasons unrelated to this change.

**The `test` job was being killed mid-run.** `go test` applies a 600s default timeout per package and the workflow passed none, while `tests/e2e` needs about 13.5 minutes on a runner. Raised to `-timeout 20m`, measured: with the timeout raised the job passes in **13m34s**.

**The `lint` job was failing on `SA4023`** in `infrastructure/graph/{provider,stores}.go`. The no-embedded oxigraph stub built a fresh `fmt.Errorf` per call, so it provably never returned nil and both callers' `if err != nil` read as always true — though the call is unreachable in that build, gated by `EmbeddedAvailable()`. A package-level sentinel typed `error` settles it and gives callers an `errors.Is` target the anonymous error never offered.

Worth noting: CI installs golangci-lint `latest` while local runs lag. `2.13.1` reports those four findings and none of the six that `2.11.3` reports, so "lint passes locally" has not meant much on this repo. Verified against `2.13.1`: 0 issues.

Raising the timeout buys time; it does not make the suite fast. `tests/e2e` boots a real Fx app per scenario and is now the dominant cost of the gate. Sharding it, or trimming the per-scenario boot, is the real fix and deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)