### PR TITLE
Give the test gate enough time to finish tests/e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,14 @@ jobs:
         run: go mod download
 
       - name: Run tests
-        run: go test -v -race -coverprofile=coverage.out ./...
+        # tests/e2e takes ~504s under -race on a developer machine and more on
+        # a runner, against `go test`'s 600s default per-package timeout. The
+        # package was being killed mid-run and reported as a failure, which is
+        # why the gate has been red on v3 since 2026-08-20 regardless of the
+        # change under test. Raised with headroom rather than set just above
+        # the current figure, so the gate does not go red again on the next
+        # scenario added.
+        run: go test -v -race -timeout 20m -coverprofile=coverage.out ./...
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
## Why

The `test` job has been failing on `v3` since 2026-08-20 with `FAIL github.com/wepala/weos/v3/tests/e2e 600.232s`, and every PR into `v3` inherits that red — so the gate currently cannot tell anyone whether a branch is safe.

Nothing is wrong with the tests. `go test` applies a **600s default timeout per package** and the workflow passes none. `tests/e2e` takes **~504s under `-race`** on a developer machine (measured locally, exit 0) and longer on a runner, so the package is killed partway through and reported as a failure.

## What

One line: `-timeout 20m`.

Raised well above the current figure rather than just past it, so the next scenario added does not put the gate straight back into the red.

## What this does not fix

It buys time; it does not make the suite fast. `tests/e2e` boots a real Fx app per scenario and is now the dominant cost of the gate. Sharding it, or trimming the per-scenario boot, is the real fix and deserves its own change.

Found while running #510 through the pipeline — that PR (#511) is red on this and on nothing it caused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)