### PR TITLE
Stop reporting success over the drops #511 left behind

### DIFF
--- a/application/builtin_resource_types.go
+++ b/application/builtin_resource_types.go
@@ -124,9 +124,11 @@ func reconcilePresetSchemas(
 			"preset", presetName, "slug", slug, "heldProperties", held)
 	}
 	for slug, held := range reconciled.RefusedContext {
-		// A context term the operator repointed. Held rather than overwritten,
+		// A term whose stored IRI differs from the one the preset now declares —
+		// an operator edit, or a preset that repointed its own term between
+		// builds, which is the commoner cause. Held rather than overwritten,
 		// because existing edges are already keyed by the stored IRI and
-		// repointing it would orphan them (issue #510).
+		// repointing it would orphan them (issues #510, #513).
 		logger.Warn(ctx,
 			"resource type context terms held at their stored definition: preset declares a different IRI",
 			"preset", presetName, "slug", slug, "heldContextTerms", held)

--- a/application/builtin_resource_types.go
+++ b/application/builtin_resource_types.go
@@ -133,6 +133,21 @@ func reconcilePresetSchemas(
 			"resource type context terms held at their stored definition: preset declares a different IRI",
 			"preset", presetName, "slug", slug, "heldContextTerms", held)
 	}
+	for slug, terms := range reconciled.Repointed {
+		// Phrased as held at their stored definition like the divergence case,
+		// because that is what an operator sees happen — but the reason and the
+		// remedy differ, so the remedy is named here.
+		logger.Warn(ctx,
+			"resource type context terms held at their stored definition: adopting them would "+
+				"repoint a predicate that already has data",
+			"preset", presetName, "slug", slug, "heldContextTerms", terms,
+			"remedy", "weos resource-type adopt-term "+presetName+" "+slug+" --all")
+	}
+	for slug, reason := range reconciled.UnparseableContext {
+		logger.Error(ctx,
+			"resource type @context could not be read; merged its schema only",
+			"preset", presetName, "slug", slug, "reason", reason)
+	}
 	for slug, reason := range reconciled.Failed {
 		// The reason names what actually failed: a projection column that never
 		// appeared, a reference property with no `@context` term to resolve

--- a/application/preset_context_reconcile.go
+++ b/application/preset_context_reconcile.go
@@ -269,12 +269,16 @@ func holdMovingTerms(
 		return nil
 	}
 	storedTerms, err := splitContext(stored)
-	if err != nil || len(storedTerms) == 0 {
-		// A stored context that defines nothing — including one an operator
-		// cleared — has no resolution for anything to move away from, so the
-		// preset's terms are adopted wholesale, as for an absent context.
+	if err != nil {
 		return nil
 	}
+	// An EMPTY stored context is not a blank cheque. `{}` and `null` still
+	// resolve a reference — to its bare property name, because there is no
+	// `@vocab` to prefix it — so edges exist under those names and adopting the
+	// preset's terms orphans them exactly as any other repointing would.
+	// Clearing a context is a destructive operator act; the reconcile reports
+	// it rather than silently papering over it. `preset install --update`
+	// remains the explicit way to re-adopt.
 
 	predicates := livePredicates(stored, storedSchema)
 	var held []movedPredicate

--- a/application/preset_context_reconcile.go
+++ b/application/preset_context_reconcile.go
@@ -78,6 +78,12 @@ type contextReconciliation struct {
 	// Conflicts names terms present in BOTH whose definitions differ. They are
 	// left at their stored definition and reported for an operator to resolve.
 	Conflicts []string
+	// Moves names terms absent from the stored context whose ADDITION would
+	// change how a predicate that already has data resolves. They are held for
+	// the same reason a Conflict is, and are reported separately because the
+	// operator's fix differs: a Conflict needs a decision about which IRI is
+	// right, a Move needs a data migration before the new IRI can be adopted.
+	Moves []movedPredicate
 	// Context is the merged result. Nil unless Changed.
 	Context json.RawMessage
 	// Changed reports whether the stored context needs rewriting at all. False
@@ -95,7 +101,7 @@ type contextReconciliation struct {
 // a remote IRI string — is an error rather than something to merge blind. No
 // preset or stored context in this tree uses those forms; reporting the type as
 // Failed is honest, where guessing at a merge would not be.
-func reconcileAdditiveContext(stored, preset json.RawMessage) (contextReconciliation, error) {
+func reconcileAdditiveContext(stored, preset, storedSchema json.RawMessage) (contextReconciliation, error) {
 	var out contextReconciliation
 
 	// Nothing declared in code means nothing to add. Never treat an empty
@@ -128,6 +134,13 @@ func reconcileAdditiveContext(stored, preset json.RawMessage) (contextReconcilia
 	for _, term := range sortedKeys(presetTerms) {
 		existing, inStored := storedTerms[term]
 		if !inStored {
+			// Additive by absence is not the same as safe. Adding a term can
+			// repoint a predicate that already has edges keyed by the IRI it
+			// resolved to before — see movesLivePredicate.
+			if moved, ok := movesLivePredicate(term, presetTerms[term], stored, storedSchema); ok {
+				out.Moves = append(out.Moves, moved)
+				continue
+			}
 			merged[term] = presetTerms[term]
 			out.Added = append(out.Added, term)
 			continue
@@ -193,4 +206,126 @@ func referencePropertiesWithoutContextEntry(schema, ldContext json.RawMessage) [
 	}
 	sort.Strings(dropped)
 	return dropped
+}
+
+// movedPredicate records a term held because adding it would repoint a
+// predicate that already has data written under the IRI it resolves to today.
+type movedPredicate struct {
+	// Term is the context key the preset declares and the stored context lacks.
+	Term string
+	// StoredIRI is what the affected predicate resolves to right now — the IRI
+	// existing edges are keyed by.
+	StoredIRI string
+	// PresetIRI is what it would resolve to if the term were merged.
+	PresetIRI string
+	// Property names the thing whose resolution moves. Usually Term itself; for
+	// a prefix it is the stored term that expands through that prefix.
+	Property string
+}
+
+// movesLivePredicate reports whether merging one new term would change how a
+// predicate that ALREADY HAS DATA resolves (issue #513).
+//
+// The merge rules make a term the stored context lacks look purely additive.
+// It is not. Three ways an addition repoints something live:
+//
+//   - A reference property the STORED schema already declares, with no term
+//     yet, is written under the `@vocab`-derived IRI. Giving it a term that
+//     names a different IRI leaves every existing edge keyed by an IRI nothing
+//     reverse-maps — unreadable, and reprojection cannot recover it because the
+//     reprojector resolves through the new term too.
+//   - A PREFIX changes the expansion of every stored term written against it.
+//     `"maker":"cat:madeBy"` with no `cat` resolves through `@vocab`; adding
+//     `cat` moves it.
+//   - `@type` (or a prefix `@type` uses) moves the type's RDF class, so
+//     resources written before the boot and after it land in different classes.
+//
+// The check keys off the STORED schema deliberately. Against the MERGED schema
+// it would also fire on the case issue #510 exists to fix — a preset adding a
+// reference property and its term in the same build — holding the term and
+// re-breaking that repair. A property the stored schema does not yet declare
+// has no data under any IRI, so nothing can be orphaned.
+func movesLivePredicate(term string, definition, stored, storedSchema json.RawMessage) (movedPredicate, bool) {
+	if len(stored) == 0 {
+		return movedPredicate{}, false
+	}
+	storedTerms, err := splitContext(stored)
+	if err != nil {
+		return movedPredicate{}, false
+	}
+	// A stored context that defines nothing — including one an operator
+	// cleared — has no resolution for anything to move away from, so the
+	// preset's terms are adopted wholesale, as they are for an absent context.
+	if len(storedTerms) == 0 {
+		return movedPredicate{}, false
+	}
+	candidate := make(map[string]json.RawMessage, len(storedTerms)+1)
+	for k, v := range storedTerms {
+		candidate[k] = v
+	}
+	candidate[term] = definition
+	candidateRaw, err := json.Marshal(candidate)
+	if err != nil {
+		return movedPredicate{}, false
+	}
+
+	for _, property := range livePredicates(stored, storedSchema) {
+		before := resolveIn(stored, property)
+		after := resolveIn(candidateRaw, property)
+		if before != after {
+			return movedPredicate{
+				Term: term, StoredIRI: before, PresetIRI: after, Property: property,
+			}, true
+		}
+	}
+	return movedPredicate{}, false
+}
+
+// livePredicates names everything whose resolution must not move: every term
+// the stored context already defines, every reference property the stored
+// schema declares, and the type's own `@type`.
+func livePredicates(stored, storedSchema json.RawMessage) []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(name string) {
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+
+	if terms, err := splitContext(stored); err == nil {
+		for name := range terms {
+			// A prefix definition is not itself a predicate; it matters only
+			// through the terms that expand against it, which are added here
+			// in their own right.
+			add(name)
+		}
+	}
+	for _, ref := range ExtractReferenceProperties(storedSchema, stored) {
+		add(ref.PropertyName)
+	}
+	add("@type")
+	sort.Strings(out)
+	return out
+}
+
+// resolveIn returns the IRI a property resolves to under one context — the
+// same resolution the write path performs, so a change here is a change to
+// where an edge is keyed.
+func resolveIn(ldContext json.RawMessage, property string) string {
+	vocab, terms := jsonld.ParseContext(ldContext)
+	if property == "@type" {
+		var raw map[string]any
+		if json.Unmarshal(ldContext, &raw) != nil {
+			return ""
+		}
+		typeVal, _ := raw["@type"].(string)
+		if typeVal == "" {
+			return ""
+		}
+		return jsonld.ExpandIRI(typeVal, vocab, raw)
+	}
+	return jsonld.ResolvePredicateIRI(property, vocab, terms)
 }

--- a/application/preset_context_reconcile.go
+++ b/application/preset_context_reconcile.go
@@ -289,6 +289,7 @@ func holdMovingTerms(
 		}
 		held = append(held, moved...)
 	}
+	held = append(held, dropDanglingPrefixTerms(merged, storedTerms, added)...)
 	sort.Slice(held, func(i, j int) bool { return held[i].Term < held[j].Term })
 	return held
 }
@@ -312,7 +313,22 @@ func movedBy(
 		if before == after {
 			continue
 		}
-		for _, term := range blameFor(property, merged, storedTerms) {
+		blame := blameFor(property, merged, storedTerms)
+		if len(blame) == 0 {
+			// A move nobody can be blamed for must never be discarded — that is
+			// the silent orphaning this guard exists to prevent, reached through
+			// the guard's own bookkeeping. Hold every added term instead: the
+			// merge is refused for this type and reported, which is
+			// conservative and reversible, where letting it through is not.
+			for term := range merged {
+				if _, isStored := storedTerms[term]; isStored {
+					continue
+				}
+				blame = append(blame, term)
+			}
+			sort.Strings(blame)
+		}
+		for _, term := range blame {
 			if seen[term] {
 				continue
 			}
@@ -455,4 +471,41 @@ func resolveIn(ldContext json.RawMessage, property string) string {
 		return jsonld.ExpandIRI(typeVal, vocab, raw)
 	}
 	return jsonld.ResolvePredicateIRI(property, vocab, terms)
+}
+
+// dropDanglingPrefixTerms removes added terms that expand through a prefix the
+// merged context does not define, and reports them.
+//
+// Holding a prefix does not automatically hold the terms written against it.
+// Left merged, `"recipeIngredient":"fo:hasIngredient"` without a defined `fo`
+// resolves through `@vocab` to `https://schema.org/fo:hasIngredient` — an IRI
+// nobody meant, which reads and writes then agree on. Nothing is dropped, so
+// the reconcile calls the type Updated, while the triple store and every `kg_*`
+// tool carry a fabricated predicate. Better to keep the property untermed and
+// say so than to invent a namespace for it.
+func dropDanglingPrefixTerms(
+	merged, storedTerms map[string]json.RawMessage, added *[]string,
+) []movedPredicate {
+	var dropped []movedPredicate
+	for _, term := range append([]string(nil), *added...) {
+		prefix := prefixOf(merged[term])
+		if prefix == "" {
+			continue
+		}
+		if _, defined := merged[prefix]; defined {
+			continue
+		}
+		if _, defined := storedTerms[prefix]; defined {
+			continue
+		}
+		dropped = append(dropped, movedPredicate{
+			Term:      term,
+			Property:  term,
+			StoredIRI: "",
+			PresetIRI: fmt.Sprintf("<undefined prefix %q>", prefix),
+		})
+		delete(merged, term)
+		*added = removeString(*added, term)
+	}
+	return dropped
 }

--- a/application/preset_context_reconcile.go
+++ b/application/preset_context_reconcile.go
@@ -577,6 +577,21 @@ func adoptTerms(
 		return nil, nil, fmt.Errorf("failed to encode term aliases: %w", err)
 	}
 	merged[jsonld.TermAliasesKeyword] = encodedAliases
+
+	// Record WHICH terms were adopted, separately from the aliases. Adopting a
+	// prefix records aliases against the properties it moves, so the alias map
+	// alone cannot tell a re-run of the same command from a term that was never
+	// held.
+	adoptedAll := jsonld.AdoptedTerms(stored)
+	for _, term := range adopted {
+		adoptedAll = appendMissing(adoptedAll, term)
+	}
+	sort.Strings(adoptedAll)
+	encodedAdopted, err := json.Marshal(adoptedAll)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to encode adopted terms: %w", err)
+	}
+	merged[jsonld.AdoptedTermsKeyword] = encodedAdopted
 	encoded, err := json.Marshal(merged)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to encode the adopted context: %w", err)

--- a/application/preset_context_reconcile.go
+++ b/application/preset_context_reconcile.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/wepala/weos/v3/pkg/jsonld"
 )
@@ -144,13 +145,6 @@ func reconcileAdditiveContext(stored, preset, storedSchema json.RawMessage) (con
 	for _, term := range sortedKeys(presetTerms) {
 		existing, inStored := storedTerms[term]
 		if !inStored {
-			// Additive by absence is not the same as safe. Adding a term can
-			// repoint a predicate that already has edges keyed by the IRI it
-			// resolved to before — see movesLivePredicate.
-			if moved, ok := movesLivePredicate(term, presetTerms[term], stored, storedSchema); ok {
-				out.Moves = append(out.Moves, moved)
-				continue
-			}
 			merged[term] = presetTerms[term]
 			out.Added = append(out.Added, term)
 			continue
@@ -161,6 +155,14 @@ func reconcileAdditiveContext(stored, preset, storedSchema json.RawMessage) (con
 			out.Conflicts = append(out.Conflicts, term)
 		}
 	}
+
+	// Additive by absence is not the same as safe: see holdMovingTerms. This
+	// runs on the WHOLE merged context rather than term by term, because a
+	// preset that adds a prefix and a term using it in the same build resolves
+	// that term only once both are present — judging the term against the
+	// stored context alone reads its IRI with the prefix unexpanded and holds
+	// a term that never moved anything.
+	out.Moves = holdMovingTerms(stored, storedSchema, merged, &out.Added)
 
 	if len(out.Added) == 0 {
 		return out, nil
@@ -233,8 +235,9 @@ type movedPredicate struct {
 	Property string
 }
 
-// movesLivePredicate reports whether merging one new term would change how a
-// predicate that ALREADY HAS DATA resolves (issue #513).
+// holdMovingTerms removes, from an already-merged context, every added term
+// whose presence changes how a predicate that ALREADY HAS DATA resolves, and
+// reports what it removed (issue #513).
 //
 // The merge rules make a term the stored context lacks look purely additive.
 // It is not. Three ways an addition repoints something live:
@@ -255,40 +258,154 @@ type movedPredicate struct {
 // reference property and its term in the same build — holding the term and
 // re-breaking that repair. A property the stored schema does not yet declare
 // has no data under any IRI, so nothing can be orphaned.
-func movesLivePredicate(term string, definition, stored, storedSchema json.RawMessage) (movedPredicate, bool) {
+//
+// Removing a term can itself change what other terms resolve to, so the pass
+// repeats until nothing more moves. It is bounded by the number of added terms:
+// each round removes at least one, or stops.
+func holdMovingTerms(
+	stored, storedSchema json.RawMessage, merged map[string]json.RawMessage, added *[]string,
+) []movedPredicate {
 	if len(stored) == 0 {
-		return movedPredicate{}, false
+		return nil
 	}
 	storedTerms, err := splitContext(stored)
-	if err != nil {
-		return movedPredicate{}, false
-	}
-	// A stored context that defines nothing — including one an operator
-	// cleared — has no resolution for anything to move away from, so the
-	// preset's terms are adopted wholesale, as they are for an absent context.
-	if len(storedTerms) == 0 {
-		return movedPredicate{}, false
-	}
-	candidate := make(map[string]json.RawMessage, len(storedTerms)+1)
-	for k, v := range storedTerms {
-		candidate[k] = v
-	}
-	candidate[term] = definition
-	candidateRaw, err := json.Marshal(candidate)
-	if err != nil {
-		return movedPredicate{}, false
+	if err != nil || len(storedTerms) == 0 {
+		// A stored context that defines nothing — including one an operator
+		// cleared — has no resolution for anything to move away from, so the
+		// preset's terms are adopted wholesale, as for an absent context.
+		return nil
 	}
 
-	for _, property := range livePredicates(stored, storedSchema) {
+	predicates := livePredicates(stored, storedSchema)
+	var held []movedPredicate
+	for round := 0; round <= len(*added); round++ {
+		culprits, moved := movedBy(stored, merged, storedTerms, predicates)
+		if len(culprits) == 0 {
+			break
+		}
+		for _, term := range culprits {
+			delete(merged, term)
+			*added = removeString(*added, term)
+		}
+		held = append(held, moved...)
+	}
+	sort.Slice(held, func(i, j int) bool { return held[i].Term < held[j].Term })
+	return held
+}
+
+// movedBy compares every live predicate's resolution under the stored context
+// with its resolution under the candidate, and blames the added terms
+// responsible for each difference.
+func movedBy(
+	stored json.RawMessage, merged, storedTerms map[string]json.RawMessage, predicates []string,
+) ([]string, []movedPredicate) {
+	candidateRaw, err := json.Marshal(merged)
+	if err != nil {
+		return nil, nil
+	}
+	seen := map[string]bool{}
+	var culprits []string
+	var moved []movedPredicate
+	for _, property := range predicates {
 		before := resolveIn(stored, property)
 		after := resolveIn(candidateRaw, property)
-		if before != after {
-			return movedPredicate{
+		if before == after {
+			continue
+		}
+		for _, term := range blameFor(property, merged, storedTerms) {
+			if seen[term] {
+				continue
+			}
+			seen[term] = true
+			culprits = append(culprits, term)
+			moved = append(moved, movedPredicate{
 				Term: term, StoredIRI: before, PresetIRI: after, Property: property,
-			}, true
+			})
 		}
 	}
-	return movedPredicate{}, false
+	return culprits, moved
+}
+
+// blameFor names the added terms responsible for one predicate's resolution
+// changing: the term for the property itself, and any prefix its definition
+// expands through.
+func blameFor(property string, merged, storedTerms map[string]json.RawMessage) []string {
+	// Blame the property's own term first and stop there. Holding the term is
+	// enough to leave the predicate where it was, and a prefix held alongside
+	// it would be collateral: nothing else may need it moved, and future terms
+	// legitimately expand through it.
+	if _, isStored := storedTerms[property]; !isStored {
+		if _, added := merged[property]; added {
+			return []string{property}
+		}
+	}
+	var blame []string
+	// Otherwise the move came from a prefix the definition expands through,
+	// which repoints the property without being named by it.
+	for _, def := range []json.RawMessage{storedTerms[property], merged[property]} {
+		prefix := prefixOf(def)
+		if prefix == "" {
+			continue
+		}
+		if _, isStored := storedTerms[prefix]; isStored {
+			continue
+		}
+		if _, added := merged[prefix]; added {
+			blame = append(blame, prefix)
+		}
+	}
+	if len(blame) > 0 {
+		return blame
+	}
+	// Nothing named it, so the mover is the global fallback: a stored context
+	// with no `@vocab` resolves an untermed reference to its bare name, and
+	// adding one moves every such reference at once. Without this the move is
+	// detected, nobody is blamed, no term is removed, and it is allowed
+	// through — the silent drop this guard exists to prevent.
+	if _, isStored := storedTerms[vocabKeyword]; !isStored {
+		if _, added := merged[vocabKeyword]; added {
+			return []string{vocabKeyword}
+		}
+	}
+	return nil
+}
+
+const vocabKeyword = "@vocab"
+
+// prefixOf returns the prefix a compact term definition expands through, or ""
+// when the definition is absent, absolute, or has no prefix.
+func prefixOf(def json.RawMessage) string {
+	if len(def) == 0 {
+		return ""
+	}
+	var iri string
+	if json.Unmarshal(def, &iri) != nil {
+		var obj struct {
+			ID string `json:"@id"`
+		}
+		if json.Unmarshal(def, &obj) != nil {
+			return ""
+		}
+		iri = obj.ID
+	}
+	if iri == "" || strings.HasPrefix(iri, "http://") || strings.HasPrefix(iri, "https://") {
+		return ""
+	}
+	before, _, found := strings.Cut(iri, ":")
+	if !found {
+		return ""
+	}
+	return before
+}
+
+func removeString(list []string, want string) []string {
+	out := list[:0]
+	for _, s := range list {
+		if s != want {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // livePredicates names everything whose resolution must not move: every term

--- a/application/preset_context_reconcile.go
+++ b/application/preset_context_reconcile.go
@@ -272,7 +272,7 @@ func holdMovingTerms(
 	if err != nil {
 		return nil
 	}
-	// An EMPTY stored context is not a blank cheque. `{}` and `null` still
+	// An EMPTY stored context is not a blank check. `{}` and `null` still
 	// resolve a reference — to its bare property name, because there is no
 	// `@vocab` to prefix it — so edges exist under those names and adopting the
 	// preset's terms orphans them exactly as any other repointing would.
@@ -512,4 +512,86 @@ func dropDanglingPrefixTerms(
 		*added = removeString(*added, term)
 	}
 	return dropped
+}
+
+// adoptTerms rewrites a stored context to take the preset's definition for the
+// named terms, recording the IRI each property currently resolves to as an
+// alias (issue #513).
+//
+// This is the sanctioned way out of a held term. The guard refuses at boot to
+// adopt a term that would repoint a predicate with data under it, and that is
+// correct — but on its own it leaves the property unreadable with no way
+// forward. Adoption is safe only because the old IRI is recorded first: events
+// are immutable and carry the write-time key, so a reproject reproduces it, and
+// without the alias every existing edge would be orphaned permanently.
+//
+// Returns the merged context and the terms actually adopted. A term already
+// matching the preset's definition is skipped rather than re-recorded, which is
+// what makes running this twice a no-op.
+func adoptTerms(
+	stored, preset json.RawMessage, held []movedPredicate,
+) (json.RawMessage, []string, error) {
+	storedTerms, err := splitContext(stored)
+	if err != nil {
+		return nil, nil, fmt.Errorf("stored context: %w", err)
+	}
+	presetTerms, err := splitContext(preset)
+	if err != nil {
+		return nil, nil, fmt.Errorf("preset context: %w", err)
+	}
+
+	aliases := jsonld.TermAliases(stored)
+	if aliases == nil {
+		aliases = map[string][]string{}
+	}
+	merged := make(map[string]json.RawMessage, len(storedTerms)+len(held))
+	for term, def := range storedTerms {
+		merged[term] = def
+	}
+
+	var adopted []string
+	for _, move := range held {
+		presetDef, declared := presetTerms[move.Term]
+		if !declared {
+			return nil, nil, fmt.Errorf("the preset declares no %q term to adopt", move.Term)
+		}
+		if jsonEquivalent(storedTerms[move.Term], presetDef) {
+			continue // already adopted; recording a second alias would be wrong
+		}
+		// The alias belongs to the PROPERTY whose resolution moves, which is not
+		// always the term being adopted: adopting a prefix moves every stored
+		// term written against it, and it is those properties whose edges carry
+		// the old IRI.
+		if move.Property != "" && move.StoredIRI != "" {
+			aliases[move.Property] = appendMissing(aliases[move.Property], move.StoredIRI)
+		}
+		merged[move.Term] = presetDef
+		adopted = append(adopted, move.Term)
+	}
+	if len(adopted) == 0 {
+		return nil, nil, nil
+	}
+
+	encodedAliases, err := json.Marshal(aliases)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to encode term aliases: %w", err)
+	}
+	merged[jsonld.TermAliasesKeyword] = encodedAliases
+	encoded, err := json.Marshal(merged)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to encode the adopted context: %w", err)
+	}
+	sort.Strings(adopted)
+	return encoded, adopted, nil
+}
+
+// appendMissing adds an IRI to a property's alias list unless it is already
+// there, so repeated adoption cannot grow the list without bound.
+func appendMissing(list []string, iri string) []string {
+	for _, existing := range list {
+		if existing == iri {
+			return list
+		}
+	}
+	return append(list, iri)
 }

--- a/application/preset_context_reconcile.go
+++ b/application/preset_context_reconcile.go
@@ -31,19 +31,29 @@ import (
 // property reached an existing database, but left the stored `@context`
 // untouched. A REFERENCE property — one the schema marks with
 // `x-resource-type` — is stored as a JSON-LD edge keyed by its predicate IRI,
-// and FlattenGraph maps that IRI back to a property name through
-// jsonld.BuildReverseMap, which only ever sees EXPLICIT context entries
-// (ParseContext skips every `@`-prefixed keyword, so `@vocab` never appears in
-// it). An edge whose IRI has no reverse entry is skipped outright. So the
-// column arrived, the schema declared the property, and every write to it was
-// still dropped — with the API answering 201 the whole time.
+// and the readers map that IRI back to a property name through
+// jsonld.BuildReverseMap: entities.SimplifyJSONLD for the API response and
+// extractEdgeColumns for the projection's FK column. That map only ever sees
+// EXPLICIT context entries (ParseContext skips every `@`-prefixed keyword, so
+// `@vocab` never appears in it), and an edge whose IRI has no reverse entry is
+// skipped by both.
+//
+// The write itself is NOT lost: BuildResourceGraph resolves the predicate
+// through the `@vocab` fallback, so the edge is persisted. What is lost is
+// every way of reading it back — invisible to the API, absent from the
+// projection column — with a 201 returned the whole time. And because the
+// merge only changes how LATER reads resolve, edges already stored under the
+// `@vocab`-derived IRI stay unreachable until the operator reprojects, which
+// is why that step exists in the acceptance suite.
 //
 // Literal properties are unaffected: they live in the graph's entity node,
-// which FlattenGraph copies verbatim without consulting the context at all.
+// which the readers copy verbatim without consulting the context at all.
 // That asymmetry is why only references need this.
 //
-// The merge rules mirror reconcileAdditiveSchema's exactly, for the same
-// reasons stated there:
+// The merge rules mirror reconcileAdditiveSchema's PROPERTY rules, for the same
+// reasons stated there — deliberately unlike its top-level keyword handling,
+// where the preset wins; here `@vocab`, `@type` and prefixes are all held at
+// their stored definition:
 //
 //   - An entry the preset declares and the stored context lacks is MERGED IN.
 //     This is the whole point: it is what makes the reverse map resolve the new
@@ -181,7 +191,7 @@ func splitContext(raw json.RawMessage) (map[string]json.RawMessage, error) {
 
 // referencePropertiesWithoutContextEntry returns the reference properties the
 // schema declares that the context gives no explicit term for — exactly the
-// set whose writes FlattenGraph will drop.
+// set whose writes both readers will drop.
 //
 // The check mirrors what the read path actually does rather than restating it:
 // a reference survives only if BuildReverseMap can map its predicate IRI back

--- a/application/preset_context_reconcile_test.go
+++ b/application/preset_context_reconcile_test.go
@@ -19,6 +19,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/wepala/weos/v3/pkg/jsonld"
 )
 
 // contextTerms decodes a merged context so assertions can talk about terms
@@ -595,4 +597,44 @@ func TestReconcileAdditiveContext_DropsATermWhoseHeldPrefixIsGone(t *testing.T) 
 		}
 	}
 	t.Errorf("recipeIngredient was not reported; Moves = %+v", rec.Moves)
+}
+
+// TestAdoptTerms_ReadoptingAPrefixIsANoOp is Copilot's finding on #514.
+// Adopting a prefix records its aliases against the properties it MOVES, not
+// against the prefix, so an idempotence check that looks the term up in the
+// alias map reports a second run of the same command as a term that was never
+// held — and errors instead of doing nothing.
+func TestAdoptTerms_ReadoptingAPrefixIsANoOp(t *testing.T) {
+	stored := json.RawMessage(`{"@vocab":"https://schema.org/","maker":"cat:madeBy"}`)
+	preset := json.RawMessage(`{"@vocab":"https://schema.org/","cat":"https://example.org/catalog#"}`)
+	held := []movedPredicate{{
+		Term: "cat", Property: "maker",
+		StoredIRI: "https://schema.org/cat:madeBy",
+		PresetIRI: "https://example.org/catalog#madeBy",
+	}}
+
+	adoptedContext, adopted, err := adoptTerms(stored, preset, held)
+	if err != nil {
+		t.Fatalf("adoptTerms: %v", err)
+	}
+	if !sameStrings(adopted, []string{"cat"}) {
+		t.Fatalf("adopted = %v, want [cat]", adopted)
+	}
+	// The alias lands on the property, which is why the term must be recorded
+	// separately for the re-run to be recognizable.
+	if got := jsonld.TermAliases(adoptedContext)["maker"]; len(got) != 1 {
+		t.Errorf("aliases for maker = %v, want the pre-adoption IRI", got)
+	}
+	if got := jsonld.TermAliases(adoptedContext)["cat"]; len(got) != 0 {
+		t.Errorf("aliases for cat = %v, want none — a prefix is not a predicate", got)
+	}
+	var found bool
+	for _, term := range jsonld.AdoptedTerms(adoptedContext) {
+		if term == "cat" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the adopted prefix was not recorded, so re-running the command would be refused")
+	}
 }

--- a/application/preset_context_reconcile_test.go
+++ b/application/preset_context_reconcile_test.go
@@ -478,3 +478,81 @@ func TestReconcileAdditiveContext_ClearedContextAdoptsWholesale(t *testing.T) {
 		t.Error("a cleared context must adopt the preset's terms")
 	}
 }
+
+// TestReconcileAdditiveContext_PrefixAndTermAddedTogether is the false positive
+// the first version of this guard had. A preset that adds a PREFIX and a term
+// using it in the same build resolves that term only once both are present.
+// Judging the term against the stored context alone reads its IRI with the
+// prefix unexpanded — `http://ex.org/ex:maker` instead of `http://ex.org/maker`
+// — and holds a term that moves nothing.
+func TestReconcileAdditiveContext_PrefixAndTermAddedTogether(t *testing.T) {
+	storedSchema := json.RawMessage(`{"type":"object","properties":{
+		"maker":{"type":"string","x-resource-type":"vendor"}}}`)
+	stored := json.RawMessage(`{"@vocab":"http://ex.org/","@type":"Thing"}`)
+	// `ex` expands to the same namespace as @vocab, so `ex:maker` and the
+	// vocab-derived `maker` are the same IRI: nothing moves.
+	preset := json.RawMessage(`{"@vocab":"http://ex.org/","@type":"Thing",` +
+		`"ex":"http://ex.org/","maker":"ex:maker"}`)
+
+	rec, err := reconcileAdditiveContext(stored, preset, storedSchema)
+	if err != nil {
+		t.Fatalf("reconcileAdditiveContext: %v", err)
+	}
+	if len(rec.Moves) != 0 {
+		t.Fatalf("Moves = %+v, want none — maker resolves to the same IRI either way", rec.Moves)
+	}
+	if !sameStrings(rec.Added, []string{"ex", "maker"}) {
+		t.Errorf("Added = %v, want [ex maker]", rec.Added)
+	}
+}
+
+// TestReconcileAdditiveContext_PrefixedTermThatDoesMove is the other side of
+// that case: once the prefix resolves, the term still names a different
+// namespace from the one the data uses, so it is held — and the reported IRI is
+// the resolved one, not a half-expanded string.
+func TestReconcileAdditiveContext_PrefixedTermThatDoesMove(t *testing.T) {
+	storedSchema := json.RawMessage(`{"type":"object","properties":{
+		"recipeIngredient":{"type":"string","x-resource-type":"ingredient"}}}`)
+	stored := json.RawMessage(`{"@vocab":"https://schema.org/"}`)
+	preset := json.RawMessage(`{"@vocab":"https://schema.org/",` +
+		`"fo":"http://purl.org/foodontology#","recipeIngredient":"fo:hasIngredient"}`)
+
+	rec, err := reconcileAdditiveContext(stored, preset, storedSchema)
+	if err != nil {
+		t.Fatalf("reconcileAdditiveContext: %v", err)
+	}
+	if len(rec.Moves) != 1 {
+		t.Fatalf("Moves = %+v, want the recipeIngredient term held", rec.Moves)
+	}
+	got := rec.Moves[0]
+	if got.StoredIRI != "https://schema.org/recipeIngredient" {
+		t.Errorf("StoredIRI = %q, want the vocab-derived IRI the data uses", got.StoredIRI)
+	}
+	if got.PresetIRI != "http://purl.org/foodontology#hasIngredient" {
+		t.Errorf("PresetIRI = %q, want the fully expanded IRI — a half-expanded "+
+			"`fo:hasIngredient` would tell an operator nothing actionable", got.PresetIRI)
+	}
+}
+
+// TestReconcileAdditiveContext_AddingVocabMovesEveryUntermedReference: a stored
+// context with no `@vocab` resolves an untermed reference to its bare name, so
+// adding one moves every such reference at once. Nothing names `@vocab` in
+// those definitions, so without an explicit fallback the move is detected, no
+// term is blamed, nothing is held, and it is allowed through.
+func TestReconcileAdditiveContext_AddingVocabMovesEveryUntermedReference(t *testing.T) {
+	storedSchema := json.RawMessage(`{"type":"object","properties":{
+		"maker":{"type":"string","x-resource-type":"vendor"}}}`)
+	stored := json.RawMessage(`{"@type":"Widget"}`)
+	preset := json.RawMessage(`{"@type":"Widget","@vocab":"https://schema.org/"}`)
+
+	rec, err := reconcileAdditiveContext(stored, preset, storedSchema)
+	if err != nil {
+		t.Fatalf("reconcileAdditiveContext: %v", err)
+	}
+	if len(rec.Moves) != 1 || rec.Moves[0].Term != "@vocab" {
+		t.Fatalf("Moves = %+v, want @vocab held", rec.Moves)
+	}
+	if rec.Changed {
+		t.Error("holding @vocab must leave the stored context alone")
+	}
+}

--- a/application/preset_context_reconcile_test.go
+++ b/application/preset_context_reconcile_test.go
@@ -556,3 +556,34 @@ func TestReconcileAdditiveContext_AddingVocabMovesEveryUntermedReference(t *test
 		t.Error("holding @vocab must leave the stored context alone")
 	}
 }
+
+// TestReconcileAdditiveContext_DropsATermWhoseHeldPrefixIsGone: holding a
+// prefix must also drop the terms written against it. Left merged, such a term
+// resolves through `@vocab` to a fabricated IRI that reads and writes then
+// agree on — so nothing is dropped, the type is reported Updated, and the
+// triple store carries a predicate nobody meant.
+func TestReconcileAdditiveContext_DropsATermWhoseHeldPrefixIsGone(t *testing.T) {
+	// `hasIngredient` is stored against an UNDEFINED `fo`, so it currently
+	// resolves through @vocab. Defining `fo` would move it, so `fo` is held —
+	// and `recipeIngredient`, written against that same `fo`, must not survive.
+	stored := json.RawMessage(`{"@vocab":"https://schema.org/","hasIngredient":"fo:hasIngredient"}`)
+	preset := json.RawMessage(`{"@vocab":"https://schema.org/",` +
+		`"fo":"http://purl.org/foodontology#","recipeIngredient":"fo:hasIngredient2"}`)
+
+	rec, err := reconcileAdditiveContext(stored, preset, nil)
+	if err != nil {
+		t.Fatalf("reconcileAdditiveContext: %v", err)
+	}
+	if rec.Context != nil {
+		if terms := contextTerms(t, rec.Context); terms["recipeIngredient"] != "" {
+			t.Errorf("recipeIngredient survived with no `fo` to expand through — it resolves to "+
+				"https://schema.org/fo:hasIngredient2, an IRI nobody declared (context: %v)", terms)
+		}
+	}
+	for _, m := range rec.Moves {
+		if m.Term == "recipeIngredient" {
+			return
+		}
+	}
+	t.Errorf("recipeIngredient was not reported; Moves = %+v", rec.Moves)
+}

--- a/application/preset_context_reconcile_test.go
+++ b/application/preset_context_reconcile_test.go
@@ -52,7 +52,7 @@ func TestReconcileAdditiveContext_AddsMissingTerm(t *testing.T) {
 	preset := json.RawMessage(`{"@vocab":"https://schema.org/",` +
 		`"maker":"https://schema.org/manufacturer","supplier":"https://schema.org/seller"}`)
 
-	rec, err := reconcileAdditiveContext(stored, preset)
+	rec, err := reconcileAdditiveContext(stored, preset, nil)
 	if err != nil {
 		t.Fatalf("reconcileAdditiveContext: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestReconcileAdditiveContext_PreservesOperatorTerm(t *testing.T) {
 	stored := json.RawMessage(`{"@vocab":"https://schema.org/","warranty":"https://example.org/vocab/warranty"}`)
 	preset := json.RawMessage(`{"@vocab":"https://schema.org/","supplier":"https://schema.org/seller"}`)
 
-	rec, err := reconcileAdditiveContext(stored, preset)
+	rec, err := reconcileAdditiveContext(stored, preset, nil)
 	if err != nil {
 		t.Fatalf("reconcileAdditiveContext: %v", err)
 	}
@@ -102,7 +102,7 @@ func TestReconcileAdditiveContext_HoldsDivergingTerm(t *testing.T) {
 	preset := json.RawMessage(`{"@vocab":"https://schema.org/",` +
 		`"maker":"https://schema.org/manufacturer","supplier":"https://schema.org/seller"}`)
 
-	rec, err := reconcileAdditiveContext(stored, preset)
+	rec, err := reconcileAdditiveContext(stored, preset, nil)
 	if err != nil {
 		t.Fatalf("reconcileAdditiveContext: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestReconcileAdditiveContext_ConflictAloneIsNotAChange(t *testing.T) {
 	stored := json.RawMessage(`{"@vocab":"https://schema.org/","maker":"https://example.org/vocab/madeBy"}`)
 	preset := json.RawMessage(`{"@vocab":"https://schema.org/","maker":"https://schema.org/manufacturer"}`)
 
-	rec, err := reconcileAdditiveContext(stored, preset)
+	rec, err := reconcileAdditiveContext(stored, preset, nil)
 	if err != nil {
 		t.Fatalf("reconcileAdditiveContext: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestReconcileAdditiveContext_HoldsDivergingKeyword(t *testing.T) {
 	stored := json.RawMessage(`{"@vocab":"https://example.org/vocab/"}`)
 	preset := json.RawMessage(`{"@vocab":"https://schema.org/","supplier":"https://schema.org/seller"}`)
 
-	rec, err := reconcileAdditiveContext(stored, preset)
+	rec, err := reconcileAdditiveContext(stored, preset, nil)
 	if err != nil {
 		t.Fatalf("reconcileAdditiveContext: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestReconcileAdditiveContext_EmptyStoredAdoptsPreset(t *testing.T) {
 		"empty":  json.RawMessage(``),
 	} {
 		t.Run(name, func(t *testing.T) {
-			rec, err := reconcileAdditiveContext(stored, preset)
+			rec, err := reconcileAdditiveContext(stored, preset, nil)
 			if err != nil {
 				t.Fatalf("reconcileAdditiveContext: %v", err)
 			}
@@ -187,7 +187,7 @@ func TestReconcileAdditiveContext_EmptyStoredAdoptsPreset(t *testing.T) {
 func TestReconcileAdditiveContext_EmptyPresetIsNeverAnInstructionToClear(t *testing.T) {
 	stored := json.RawMessage(`{"@vocab":"https://schema.org/","maker":"https://schema.org/manufacturer"}`)
 
-	rec, err := reconcileAdditiveContext(stored, nil)
+	rec, err := reconcileAdditiveContext(stored, nil, nil)
 	if err != nil {
 		t.Fatalf("reconcileAdditiveContext: %v", err)
 	}
@@ -202,14 +202,14 @@ func TestReconcileAdditiveContext_Idempotent(t *testing.T) {
 	stored := json.RawMessage(`{"@vocab":"https://schema.org/"}`)
 	preset := json.RawMessage(`{"@vocab":"https://schema.org/","supplier":"https://schema.org/seller"}`)
 
-	first, err := reconcileAdditiveContext(stored, preset)
+	first, err := reconcileAdditiveContext(stored, preset, nil)
 	if err != nil {
 		t.Fatalf("first reconcile: %v", err)
 	}
 	if !first.Changed {
 		t.Fatal("expected the first merge to change something")
 	}
-	second, err := reconcileAdditiveContext(first.Context, preset)
+	second, err := reconcileAdditiveContext(first.Context, preset, nil)
 	if err != nil {
 		t.Fatalf("second reconcile: %v", err)
 	}
@@ -225,7 +225,7 @@ func TestReconcileAdditiveContext_ObjectTermsCompareByValue(t *testing.T) {
 	stored := json.RawMessage(`{"supplier":{"@type":"@id","@id":"https://schema.org/seller"}}`)
 	preset := json.RawMessage(`{"supplier":{"@id":"https://schema.org/seller","@type":"@id"}}`)
 
-	rec, err := reconcileAdditiveContext(stored, preset)
+	rec, err := reconcileAdditiveContext(stored, preset, nil)
 	if err != nil {
 		t.Fatalf("reconcileAdditiveContext: %v", err)
 	}
@@ -241,12 +241,12 @@ func TestReconcileAdditiveContext_ObjectTermsCompareByValue(t *testing.T) {
 func TestReconcileAdditiveContext_NonObjectIsAnError(t *testing.T) {
 	preset := json.RawMessage(`{"@vocab":"https://schema.org/"}`)
 
-	if _, err := reconcileAdditiveContext(json.RawMessage(`["https://schema.org/"]`), preset); err == nil {
+	if _, err := reconcileAdditiveContext(json.RawMessage(`["https://schema.org/"]`), preset, nil); err == nil {
 		t.Error("expected an error for a stored context that is not an object")
 	} else if !strings.Contains(err.Error(), "stored context") {
 		t.Errorf("error should name the stored side, got %v", err)
 	}
-	if _, err := reconcileAdditiveContext(preset, json.RawMessage(`"https://schema.org/"`)); err == nil {
+	if _, err := reconcileAdditiveContext(preset, json.RawMessage(`"https://schema.org/"`), nil); err == nil {
 		t.Error("expected an error for a preset context that is not an object")
 	}
 }
@@ -298,7 +298,7 @@ func TestReconcileAdditiveContext_PrefixFormTerms(t *testing.T) {
 	preset := json.RawMessage(`{"@vocab":"https://schema.org/",` +
 		`"fo":"http://purl.org/foodontology#","ingredient":"fo:hasIngredient"}`)
 
-	rec, err := reconcileAdditiveContext(stored, preset)
+	rec, err := reconcileAdditiveContext(stored, preset, nil)
 	if err != nil {
 		t.Fatalf("reconcileAdditiveContext: %v", err)
 	}
@@ -324,7 +324,7 @@ func TestReconcileAdditiveContext_HeldPrefixRebindsItsTerms(t *testing.T) {
 	preset := json.RawMessage(`{"@vocab":"https://schema.org/",` +
 		`"fo":"http://purl.org/foodontology#","ingredient":"fo:hasIngredient"}`)
 
-	rec, err := reconcileAdditiveContext(stored, preset)
+	rec, err := reconcileAdditiveContext(stored, preset, nil)
 	if err != nil {
 		t.Fatalf("reconcileAdditiveContext: %v", err)
 	}
@@ -340,5 +340,141 @@ func TestReconcileAdditiveContext_HeldPrefixRebindsItsTerms(t *testing.T) {
 		"ingredient":{"type":"string","x-resource-type":"ingredient"}}}`)
 	if dropped := referencePropertiesWithoutContextEntry(schema, rec.Context); len(dropped) != 0 {
 		t.Errorf("a term against a held prefix must still resolve, got %v", dropped)
+	}
+}
+
+// TestReconcileAdditiveContext_HoldsATermThatMovesALivePredicate is issue
+// #513's core guard: the stored schema already declares the reference, so data
+// has been written under the `@vocab`-derived IRI. A term naming anything else
+// is held rather than merged, because merging would leave those edges keyed by
+// an IRI nothing reverse-maps and reprojection could not recover them.
+func TestReconcileAdditiveContext_HoldsATermThatMovesALivePredicate(t *testing.T) {
+	storedSchema := json.RawMessage(`{"type":"object","properties":{
+		"supplier":{"type":"string","x-resource-type":"vendor"}}}`)
+	stored := json.RawMessage(`{"@vocab":"https://schema.org/"}`)
+	preset := json.RawMessage(`{"@vocab":"https://schema.org/",` +
+		`"supplier":"https://example.org/catalog#supplier"}`)
+
+	rec, err := reconcileAdditiveContext(stored, preset, storedSchema)
+	if err != nil {
+		t.Fatalf("reconcileAdditiveContext: %v", err)
+	}
+	if len(rec.Moves) != 1 || rec.Moves[0].Term != "supplier" {
+		t.Fatalf("Moves = %+v, want a single hold on supplier", rec.Moves)
+	}
+	if got := rec.Moves[0].StoredIRI; got != "https://schema.org/supplier" {
+		t.Errorf("StoredIRI = %q, want the vocab-derived IRI the data uses", got)
+	}
+	if rec.Changed {
+		t.Error("a held term must not rewrite the stored context")
+	}
+}
+
+// TestReconcileAdditiveContext_AdoptsAVocabConsistentTerm is the other half:
+// when the term names exactly what the property already resolves to, nothing
+// moves, so the term merges and the reference becomes readable. This is the
+// case issue #510's repair depends on, and every in-tree preset that ships a
+// bare schema.org IRI under an @vocab of schema.org takes it.
+func TestReconcileAdditiveContext_AdoptsAVocabConsistentTerm(t *testing.T) {
+	storedSchema := json.RawMessage(`{"type":"object","properties":{
+		"supplier":{"type":"string","x-resource-type":"vendor"}}}`)
+	stored := json.RawMessage(`{"@vocab":"https://schema.org/"}`)
+	preset := json.RawMessage(`{"@vocab":"https://schema.org/","supplier":"https://schema.org/supplier"}`)
+
+	rec, err := reconcileAdditiveContext(stored, preset, storedSchema)
+	if err != nil {
+		t.Fatalf("reconcileAdditiveContext: %v", err)
+	}
+	if len(rec.Moves) != 0 {
+		t.Fatalf("Moves = %+v, want none — the IRI is what the data already uses", rec.Moves)
+	}
+	if !sameStrings(rec.Added, []string{"supplier"}) {
+		t.Errorf("Added = %v, want [supplier]", rec.Added)
+	}
+}
+
+// TestReconcileAdditiveContext_GuardKeysOffTheStoredSchema pins the boundary
+// that keeps issue #510's repair working. A preset adding a reference property
+// AND its term in the same build has no data under any IRI for that property,
+// so there is nothing to orphan and the term must merge — even though its IRI
+// differs from the vocab-derived one. Keying the guard off the MERGED schema
+// would hold it and re-break #510.
+func TestReconcileAdditiveContext_GuardKeysOffTheStoredSchema(t *testing.T) {
+	// The stored schema does NOT declare `supplier` yet.
+	storedSchema := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`)
+	stored := json.RawMessage(`{"@vocab":"https://schema.org/"}`)
+	preset := json.RawMessage(`{"@vocab":"https://schema.org/",` +
+		`"supplier":"https://example.org/catalog#supplier"}`)
+
+	rec, err := reconcileAdditiveContext(stored, preset, storedSchema)
+	if err != nil {
+		t.Fatalf("reconcileAdditiveContext: %v", err)
+	}
+	if len(rec.Moves) != 0 {
+		t.Fatalf("Moves = %+v, want none — the property has no stored data to orphan", rec.Moves)
+	}
+	if !sameStrings(rec.Added, []string{"supplier"}) {
+		t.Errorf("Added = %v, want [supplier]", rec.Added)
+	}
+}
+
+// TestReconcileAdditiveContext_HoldsAPrefixThatRepointsAStoredTerm covers the
+// indirect move: the prefix itself is new, but a term already stored expands
+// through it, so adding it repoints that term's predicate.
+func TestReconcileAdditiveContext_HoldsAPrefixThatRepointsAStoredTerm(t *testing.T) {
+	stored := json.RawMessage(`{"@vocab":"https://schema.org/","maker":"cat:madeBy"}`)
+	preset := json.RawMessage(`{"@vocab":"https://schema.org/","cat":"https://example.org/catalog#"}`)
+
+	rec, err := reconcileAdditiveContext(stored, preset, nil)
+	if err != nil {
+		t.Fatalf("reconcileAdditiveContext: %v", err)
+	}
+	if len(rec.Moves) != 1 || rec.Moves[0].Term != "cat" {
+		t.Fatalf("Moves = %+v, want a single hold on the cat prefix", rec.Moves)
+	}
+	if rec.Moves[0].Property != "maker" {
+		t.Errorf("Property = %q, want the stored term whose resolution moves", rec.Moves[0].Property)
+	}
+}
+
+// TestReconcileAdditiveContext_HoldsATypeThatMovesTheClass: `@type` decides the
+// type's RDF class, so adopting a new one splits resources written before the
+// boot from those written after across two classes.
+func TestReconcileAdditiveContext_HoldsATypeThatMovesTheClass(t *testing.T) {
+	stored := json.RawMessage(`{"@vocab":"https://schema.org/","@type":"Widget"}`)
+	preset := json.RawMessage(`{"@vocab":"https://schema.org/","@type":"Product"}`)
+
+	rec, err := reconcileAdditiveContext(stored, preset, nil)
+	if err != nil {
+		t.Fatalf("reconcileAdditiveContext: %v", err)
+	}
+	// @type is present on both sides here, so it is an ordinary conflict; the
+	// move guard covers the case where the stored context declares none.
+	if len(rec.Conflicts) != 1 || rec.Conflicts[0] != "@type" {
+		t.Fatalf("Conflicts = %v, want [@type]", rec.Conflicts)
+	}
+	if rec.Changed {
+		t.Error("holding @type must not rewrite the stored context")
+	}
+}
+
+// TestReconcileAdditiveContext_ClearedContextAdoptsWholesale: an operator who
+// empties the context leaves nothing for anything to move away from, so the
+// preset's terms are adopted as they are for an absent context.
+func TestReconcileAdditiveContext_ClearedContextAdoptsWholesale(t *testing.T) {
+	storedSchema := json.RawMessage(`{"type":"object","properties":{
+		"supplier":{"type":"string","x-resource-type":"vendor"}}}`)
+	preset := json.RawMessage(`{"@vocab":"https://schema.org/",` +
+		`"supplier":"https://example.org/catalog#supplier"}`)
+
+	rec, err := reconcileAdditiveContext(json.RawMessage(`{}`), preset, storedSchema)
+	if err != nil {
+		t.Fatalf("reconcileAdditiveContext: %v", err)
+	}
+	if len(rec.Moves) != 0 {
+		t.Fatalf("Moves = %+v, want none for a cleared context", rec.Moves)
+	}
+	if !rec.Changed {
+		t.Error("a cleared context must adopt the preset's terms")
 	}
 }

--- a/application/preset_context_reconcile_test.go
+++ b/application/preset_context_reconcile_test.go
@@ -458,24 +458,33 @@ func TestReconcileAdditiveContext_HoldsATypeThatMovesTheClass(t *testing.T) {
 	}
 }
 
-// TestReconcileAdditiveContext_ClearedContextAdoptsWholesale: an operator who
-// empties the context leaves nothing for anything to move away from, so the
-// preset's terms are adopted as they are for an absent context.
-func TestReconcileAdditiveContext_ClearedContextAdoptsWholesale(t *testing.T) {
+// TestReconcileAdditiveContext_ClearedContextIsHeldNotReadopted: an operator
+// who empties a type's context leaves its references resolving to their bare
+// property names — `maker`, not `https://schema.org/maker` — because there is
+// no `@vocab` to prefix them. Edges exist under those names, so adopting the
+// preset's terms orphans them like any other repointing. The merge is held and
+// reported; `preset install --update` remains the explicit way to re-adopt.
+func TestReconcileAdditiveContext_ClearedContextIsHeldNotReadopted(t *testing.T) {
 	storedSchema := json.RawMessage(`{"type":"object","properties":{
-		"supplier":{"type":"string","x-resource-type":"vendor"}}}`)
-	preset := json.RawMessage(`{"@vocab":"https://schema.org/",` +
-		`"supplier":"https://example.org/catalog#supplier"}`)
+		"maker":{"type":"string","x-resource-type":"vendor"}}}`)
+	preset := json.RawMessage(`{"@vocab":"https://schema.org/","maker":"https://schema.org/maker"}`)
 
-	rec, err := reconcileAdditiveContext(json.RawMessage(`{}`), preset, storedSchema)
-	if err != nil {
-		t.Fatalf("reconcileAdditiveContext: %v", err)
-	}
-	if len(rec.Moves) != 0 {
-		t.Fatalf("Moves = %+v, want none for a cleared context", rec.Moves)
-	}
-	if !rec.Changed {
-		t.Error("a cleared context must adopt the preset's terms")
+	for name, stored := range map[string]json.RawMessage{
+		"empty object": json.RawMessage(`{}`),
+		"json null":    json.RawMessage(`null`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec, err := reconcileAdditiveContext(stored, preset, storedSchema)
+			if err != nil {
+				t.Fatalf("reconcileAdditiveContext: %v", err)
+			}
+			if len(rec.Moves) == 0 {
+				t.Fatalf("expected the merge to be held and reported, got Added=%v", rec.Added)
+			}
+			if rec.Changed {
+				t.Error("a cleared context must not be silently re-adopted")
+			}
+		})
 	}
 }
 

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -161,6 +161,16 @@ type ReconcilePresetResult struct {
 	// As with Refused, holding is per-term and the type's additive terms
 	// still landed, so a slug can appear here and in Updated at once.
 	RefusedContext map[string][]string `json:"refusedContext,omitempty"`
+	// Repointed maps a slug to the terms held because ADOPTING them would move
+	// a predicate that already has data (issue #513). Separate from
+	// RefusedContext because the cause and the fix both differ: nothing
+	// diverged, the stored context simply never had the term, and the way
+	// forward is `resource-type adopt-term`, which records the old IRI so
+	// existing edges keep resolving.
+	Repointed map[string][]string `json:"repointed,omitempty"`
+	// UnparseableContext maps a slug to why its stored `@context` could not be
+	// read. Its schema is still merged; only the context half is skipped.
+	UnparseableContext map[string]string `json:"unparseableContext,omitempty"`
 	// Failed maps a slug to why writes to it may still be dropped. Three
 	// causes, which differ in kind: the update errored; it succeeded while the
 	// projection column did not actually appear; or the type declares a

--- a/application/preset_registry.go
+++ b/application/preset_registry.go
@@ -113,8 +113,8 @@ type InstallPresetResult struct {
 	Warnings  []string       `json:"warnings,omitempty"`
 }
 
-// ReconcilePresetResult reports the outcome of an additive schema reconcile
-// (issue #379) across one preset's types. Types the preset declares but that
+// ReconcilePresetResult reports the outcome of an additive schema and
+// `@context` reconcile (issues #379 and #510) across one preset's types. Types the preset declares but that
 // aren't installed are absent entirely; creating them is InstallPreset's job,
 // not this one's.
 //
@@ -124,20 +124,26 @@ type InstallPresetResult struct {
 //
 //   - Failed and NoSchema mean writes to at least one property ARE still being
 //     dropped. Both are urgent.
-//   - Refused and RefusedContext mean a definition diverged and is being held
-//     safely at its stored form. The column already exists and writes to it
-//     still land; what needs an operator is the divergence itself, not data
-//     loss.
+//   - Refused and RefusedContext mean a definition is being held at its stored
+//     form. Reads and writes still resolve through it, so nothing is being
+//     lost; what needs an operator is the divergence itself. For a context term
+//     that would have REPOINTED a predicate, holding is what prevents the loss
+//     — adopting it would orphan every edge already written (issue #513).
 type ReconcilePresetResult struct {
 	// Updated lists types whose stored schema, `@context`, or both were
-	// rewritten AND whose writes were confirmed able to land afterwards: every
-	// added property has its projection column, and every reference property
-	// has a `@context` term its predicate resolves back through. A type
-	// failing either check is reported under Failed instead — a column that
-	// cannot be written to and a reference that cannot be read back are the
-	// same silent drop, and neither is a completed reconcile.
+	// rewritten AND which then passed confirmWritesLand: every added property
+	// has its projection column, and every reference property has a `@context`
+	// term its predicate resolves back through. A type failing either check is
+	// reported under Failed instead — a column that cannot be written to and a
+	// reference that cannot be read back are the same silent drop, and neither
+	// is a completed reconcile.
 	Updated []string `json:"updated,omitempty"`
-	// Unchanged lists types already in sync — the steady-state boot.
+	// Unchanged lists types already in sync — the steady-state boot. A type
+	// whose ONLY delta was held back appears here too, alongside its entry in
+	// Refused or RefusedContext: nothing was written, but something still needs
+	// an operator. Note this branch is not a free pass — a type whose
+	// references have no covering term is reported Failed from here as well,
+	// every boot, because that condition is permanent (issue #513).
 	Unchanged []string `json:"unchanged,omitempty"`
 	// Refused maps a slug to the properties whose definitions diverged
 	// non-additively and were therefore HELD at their stored definition. The
@@ -155,9 +161,12 @@ type ReconcilePresetResult struct {
 	// As with Refused, holding is per-term and the type's additive terms
 	// still landed, so a slug can appear here and in Updated at once.
 	RefusedContext map[string][]string `json:"refusedContext,omitempty"`
-	// Failed maps a slug to why its reconcile could not be completed. A type
-	// here is NOT reconciled: either the update errored, or it reported success
-	// while the projection column did not actually appear.
+	// Failed maps a slug to why writes to it may still be dropped. Three
+	// causes, which differ in kind: the update errored; it succeeded while the
+	// projection column did not actually appear; or the type declares a
+	// reference property with no explicit `@context` entry — a packaging gap an
+	// additive merge cannot close, reported on every boot for as long as it
+	// lasts.
 	Failed map[string]string `json:"failed,omitempty"`
 	// NoSchema lists preset types that declare no JSON Schema at all. Their
 	// projection tables carry only base columns, so every data field is dropped

--- a/application/presets/preset_context_completeness_test.go
+++ b/application/presets/preset_context_completeness_test.go
@@ -31,8 +31,9 @@ import (
 // to a property name through jsonld.BuildReverseMap — which is built ONLY from
 // explicit context terms, because ParseContext skips every `@`-prefixed
 // keyword. A reference resolving through `@vocab` therefore has no reverse
-// entry, FlattenGraph skips its edge, and every write to it is dropped while
-// the API still answers 201.
+// entry, both readers skip its edge — entities.SimplifyJSONLD for the API
+// response and extractEdgeColumns for the projection column — so the write is
+// persisted and unreadable, while the API still answers 201.
 //
 // The boot reconcile now reports this condition, but reporting is a backstop.
 // A preset shipped with the gap drops writes on every install of a FRESH
@@ -45,7 +46,14 @@ func TestEveryReferencePropertyHasAContextEntry(t *testing.T) {
 
 	for _, preset := range registry.List() {
 		for _, pt := range preset.Types {
+			// A type with no schema declares no references, so it has nothing
+			// for this guard to check — but it is NOT benign: every data field
+			// it is written with is dropped, which the reconcile reports under
+			// NoSchema. Assert it rather than skipping past it silently.
 			if len(pt.Schema) == 0 {
+				t.Errorf("preset %q type %q declares no JSON Schema, so its projection has only "+
+					"base columns and every data field written to it is dropped",
+					preset.Name, pt.Slug)
 				continue
 			}
 			dropped := referencesWithoutContextEntry(t, pt)

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -339,13 +339,16 @@ func (s *resourceTypeService) InstallPreset(
 // third, narrower behavior instead.
 //
 // Only the schema is touched, and only additively (see reconcileAdditiveSchema
-// for the merge rules). Name, Description, Context and Status are read back
-// from the stored type and passed through unchanged. The explicit
+// for the merge rules). Schema and `@context` are BOTH merged, and only
+// additively (reconcileAdditiveSchema and reconcileAdditiveContext); each side
+// falls back to the stored value when its own merge is a no-op, so a
+// context-only change never rewrites the schema. Name, Description and Status
+// are read back from the stored type and passed through unchanged. The explicit
 // `resource-type preset install --update` path keeps its full-overwrite
 // semantics — there an operator asked for it.
 //
-// A type whose preset schema diverged non-additively is logged and recorded in
-// Refused, never rewritten; a type with no delta emits no event, which is what
+// A type whose preset schema or context diverged non-additively is logged and
+// recorded in Refused or RefusedContext, never rewritten; a type with no delta emits no event, which is what
 // keeps repeated restarts from appending a ResourceTypeUpdated per type per
 // boot.
 //
@@ -427,6 +430,22 @@ func (s *resourceTypeService) reconcileOneType(
 	s.recordHeldDefinitions(ctx, result, presetName, pt.Slug, schemaRec, contextRec)
 
 	if !schemaRec.Changed && !contextRec.Changed {
+		// Nothing to merge is not the same as nothing wrong. A reference with
+		// no covering context term keeps dropping its writes on every boot, and
+		// this is the branch a steady-state boot takes — so checking only after
+		// an Update meant the alarm sounded once, on whichever boot happened to
+		// change something, and then went quiet forever over ongoing loss.
+		//
+		// This is where it differs from missingColumns, which is checked only
+		// after an Update: a missing column is transient and the next Update
+		// retries it, whereas an uncovered reference is permanent and
+		// guarantees there will be no next Update.
+		if dropped := referencePropertiesWithoutContextEntry(
+			existing.Schema(), existing.Context()); len(dropped) > 0 {
+			s.recordReconcileFailure(ctx, result, presetName, pt.Slug, fmt.Errorf(
+				"reference properties have no @context entry, so their writes are dropped: %v", dropped))
+			return
+		}
 		result.Unchanged = append(result.Unchanged, pt.Slug)
 		return
 	}

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -105,6 +105,8 @@ type ResourceTypeService interface {
 	ListPresets() []PresetDefinition
 	InstallPreset(ctx context.Context, presetName string, update bool) (*InstallPresetResult, error)
 	ReconcilePresetSchemas(ctx context.Context, presetName string) (*ReconcilePresetResult, error)
+	HeldContextTerms(ctx context.Context, presetName, typeSlug string) ([]HeldTerm, error)
+	AdoptContextTerms(ctx context.Context, presetName, typeSlug string, terms []string) ([]string, error)
 	ListBehaviors(ctx context.Context, typeSlug string) ([]BehaviorInfo, error)
 	SetBehaviors(ctx context.Context, typeSlug string, slugs []string) error
 }
@@ -423,8 +425,10 @@ func (s *resourceTypeService) reconcileOneType(
 		if result.RefusedContext == nil {
 			result.RefusedContext = make(map[string][]string)
 		}
-		result.RefusedContext[pt.Slug] = append(result.RefusedContext[pt.Slug],
-			fmt.Sprintf("<unparseable stored @context: %v>", err))
+		if result.UnparseableContext == nil {
+			result.UnparseableContext = make(map[string]string)
+		}
+		result.UnparseableContext[pt.Slug] = err.Error()
 		contextRec = contextReconciliation{}
 	}
 	s.recordHeldDefinitions(ctx, result, presetName, pt.Slug, schemaRec, contextRec)
@@ -516,7 +520,10 @@ func (s *resourceTypeService) recordHeldDefinitions(
 			"preset context term would repoint a predicate that already has data; holding it",
 			"preset", presetName, "slug", slug, "term", moved.Term, "property", moved.Property,
 			"storedIRI", moved.StoredIRI, "presetIRI", moved.PresetIRI)
-		s.addRefusedContext(result, slug, moved.Term)
+		if result.Repointed == nil {
+			result.Repointed = make(map[string][]string)
+		}
+		result.Repointed[slug] = append(result.Repointed[slug], moved.Term)
 	}
 }
 
@@ -875,4 +882,169 @@ func (s *resourceTypeService) addRefusedContext(
 		result.RefusedContext = make(map[string][]string)
 	}
 	result.RefusedContext[slug] = append(result.RefusedContext[slug], terms...)
+}
+
+// HeldTerm describes one `@context` term the boot reconcile refuses to adopt
+// because adopting it would repoint a predicate that already has data.
+type HeldTerm struct {
+	// Term is the context key the preset declares and the boot will not apply.
+	Term string `json:"term"`
+	// Property names what would move — usually Term itself, or the stored term
+	// that expands through a held prefix.
+	Property string `json:"property"`
+	// StoredIRI is the IRI existing edges are keyed by.
+	StoredIRI string `json:"storedIri"`
+	// PresetIRI is what the preset wants the property to resolve to.
+	PresetIRI string `json:"presetIri"`
+}
+
+// HeldContextTerms reports what the boot is refusing to adopt for one type, so
+// an operator can see the decision before making it.
+func (s *resourceTypeService) HeldContextTerms(
+	ctx context.Context, presetName, typeSlug string,
+) ([]HeldTerm, error) {
+	pt, existing, err := s.presetTypeAndStored(ctx, presetName, typeSlug)
+	if err != nil {
+		return nil, err
+	}
+	rec, err := reconcileAdditiveContext(existing.Context(), pt.Context, existing.Schema())
+	if err != nil {
+		return nil, fmt.Errorf("failed to reconcile context for %q: %w", typeSlug, err)
+	}
+	held := make([]HeldTerm, 0, len(rec.Moves))
+	for _, moved := range rec.Moves {
+		held = append(held, HeldTerm{
+			Term: moved.Term, Property: moved.Property,
+			StoredIRI: moved.StoredIRI, PresetIRI: moved.PresetIRI,
+		})
+	}
+	return held, nil
+}
+
+// AdoptContextTerms takes the preset's definition for HELD terms, recording the
+// IRI each affected property resolves to today so existing edges keep
+// resolving. An empty terms list adopts every held term for the type.
+//
+// A named term the boot never held is REFUSED. Recording an alias for an IRI no
+// data was ever written under widens the reverse map for nothing, and a
+// mistyped term name would otherwise report success while changing nothing the
+// operator meant.
+//
+// Projection columns are NOT repopulated here: the alias makes existing edges
+// resolvable, and a reproject is what rewrites the rows.
+func (s *resourceTypeService) AdoptContextTerms(
+	ctx context.Context, presetName, typeSlug string, terms []string,
+) ([]string, error) {
+	pt, existing, err := s.presetTypeAndStored(ctx, presetName, typeSlug)
+	if err != nil {
+		return nil, err
+	}
+	rec, err := reconcileAdditiveContext(existing.Context(), pt.Context, existing.Schema())
+	if err != nil {
+		return nil, fmt.Errorf("failed to reconcile context for %q: %w", typeSlug, err)
+	}
+	byTerm := make(map[string]movedPredicate, len(rec.Moves))
+	for _, moved := range rec.Moves {
+		byTerm[moved.Term] = moved
+	}
+
+	selected, err := selectTermsToAdopt(rec.Moves, byTerm, terms, existing.Context(), pt.Context, typeSlug)
+	if err != nil || len(selected) == 0 {
+		return nil, err
+	}
+
+	adoptedContext, adopted, err := adoptTerms(existing.Context(), pt.Context, selected)
+	if err != nil {
+		return nil, err
+	}
+	if len(adopted) == 0 {
+		return nil, nil // already adopted; running this twice changes nothing
+	}
+	if _, err := s.Update(ctx, UpdateResourceTypeCommand{
+		ID:          existing.GetID(),
+		Name:        existing.Name(),
+		Slug:        existing.Slug(),
+		Description: existing.Description(),
+		Status:      existing.Status(),
+		Context:     adoptedContext,
+		Schema:      existing.Schema(),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to store the adopted context for %q: %w", typeSlug, err)
+	}
+	s.logger.Info(ctx, "adopted preset context terms; previous IRIs recorded as aliases",
+		"preset", presetName, "slug", typeSlug, "adopted", adopted)
+	return adopted, nil
+}
+
+// selectTermsToAdopt turns the caller's request into the held moves to apply.
+//
+// An empty request means every held term EXCEPT `@type`. An alias makes an old
+// edge IRI resolve; it cannot do the same for a type's RDF class, which is not
+// a predicate. Adopting `@type` would leave resources written before the boot
+// in one class and those after it in another, with nothing able to reconcile
+// them — so a sweep never takes it, and an operator who wants it must say so.
+//
+// A named term that is not held is REFUSED, unless the stored context already
+// matches the preset — that is the second run of the same command, which must
+// change nothing rather than fail.
+func selectTermsToAdopt(
+	moves []movedPredicate, byTerm map[string]movedPredicate,
+	requested []string, stored, preset json.RawMessage, typeSlug string,
+) ([]movedPredicate, error) {
+	if len(requested) == 0 {
+		selected := make([]movedPredicate, 0, len(moves))
+		for _, moved := range moves {
+			if moved.Term == "@type" || moved.Property == "@type" {
+				continue
+			}
+			selected = append(selected, moved)
+		}
+		return selected, nil
+	}
+
+	storedTerms, sErr := splitContext(stored)
+	presetTerms, pErr := splitContext(preset)
+	selected := make([]movedPredicate, 0, len(requested))
+	for _, term := range requested {
+		moved, isHeld := byTerm[term]
+		if isHeld {
+			selected = append(selected, moved)
+			continue
+		}
+		// Already adopted on an earlier run, or never held at all? The stored
+		// context matches the preset either way, so matching alone cannot tell
+		// them apart. A recorded alias can: adoption is what writes one.
+		alreadyAdopted := len(jsonld.TermAliases(stored)[term]) > 0
+		if alreadyAdopted && sErr == nil && pErr == nil &&
+			jsonEquivalent(storedTerms[term], presetTerms[term]) && len(presetTerms[term]) > 0 {
+			continue
+		}
+		return nil, fmt.Errorf(
+			"the boot is not holding a %q term for %q, so there is nothing to adopt", term, typeSlug)
+	}
+	return selected, nil
+}
+
+// presetTypeAndStored resolves a preset's declaration of a type alongside what
+// is stored for it, which both adoption paths need. The preset is named because
+// the IRI being adopted comes from ITS declaration.
+func (s *resourceTypeService) presetTypeAndStored(
+	ctx context.Context, presetName, typeSlug string,
+) (PresetResourceType, *entities.ResourceType, error) {
+	preset, ok := s.registry.Get(presetName)
+	if !ok {
+		return PresetResourceType{}, nil, fmt.Errorf("unknown preset %q", presetName)
+	}
+	for _, pt := range preset.Types {
+		if pt.Slug != typeSlug {
+			continue
+		}
+		existing, err := s.GetBySlug(ctx, typeSlug)
+		if err != nil {
+			return PresetResourceType{}, nil, fmt.Errorf(
+				"failed to load resource type %q: %w", typeSlug, err)
+		}
+		return pt, existing, nil
+	}
+	return PresetResourceType{}, nil, fmt.Errorf("preset %q declares no %q type", presetName, typeSlug)
 }

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -446,8 +446,8 @@ func (s *resourceTypeService) reconcileOneType(
 		// guarantees there will be no next Update.
 		if dropped := referencePropertiesWithoutContextEntry(
 			existing.Schema(), existing.Context()); len(dropped) > 0 {
-			s.recordReconcileFailure(ctx, result, presetName, pt.Slug, fmt.Errorf(
-				"reference properties have no @context entry, so their writes are dropped: %v", dropped))
+			s.recordReconcileFailure(ctx, result, presetName, pt.Slug,
+				uncoveredReferencesError(dropped, pt.Schema))
 			return
 		}
 		result.Unchanged = append(result.Unchanged, pt.Slug)
@@ -557,8 +557,7 @@ func (s *resourceTypeService) confirmWritesLand(
 	// mistake, and naming it is the only way an operator learns those writes are
 	// being dropped.
 	if dropped := referencePropertiesWithoutContextEntry(schema, ldContext); len(dropped) > 0 {
-		reasons = append(reasons,
-			fmt.Sprintf("reference properties have no @context entry, so their writes are dropped: %v", dropped))
+		reasons = append(reasons, uncoveredReferencesError(dropped, pt.Schema).Error())
 	}
 	if len(reasons) == 0 {
 		return true
@@ -1047,4 +1046,41 @@ func (s *resourceTypeService) presetTypeAndStored(
 		return pt, existing, nil
 	}
 	return PresetResourceType{}, nil, fmt.Errorf("preset %q declares no %q type", presetName, typeSlug)
+}
+
+// uncoveredReferencesError phrases the dropped-writes report so it names the
+// right party.
+//
+// The check walks the STORED schema, which includes reference properties an
+// operator added through the API — the resource-type write path stores a schema
+// and context verbatim and derives no term, so such a property is uncovered by
+// construction. Calling that "a preset packaging mistake" sends the operator to
+// look at a preset they never touched.
+func uncoveredReferencesError(dropped []string, presetSchema json.RawMessage) error {
+	presetDeclares := map[string]bool{}
+	for _, ref := range ExtractReferenceProperties(presetSchema, nil) {
+		presetDeclares[ref.PropertyName] = true
+	}
+	var fromPreset, fromOperator []string
+	for _, name := range dropped {
+		if presetDeclares[name] {
+			fromPreset = append(fromPreset, name)
+			continue
+		}
+		fromOperator = append(fromOperator, name)
+	}
+	switch {
+	case len(fromPreset) > 0 && len(fromOperator) > 0:
+		return fmt.Errorf(
+			"reference properties have no @context entry, so their writes are dropped — "+
+				"declared by the preset: %v; added through the API: %v", fromPreset, fromOperator)
+	case len(fromOperator) > 0:
+		return fmt.Errorf(
+			"reference properties added through the API have no @context entry, so their writes "+
+				"are dropped: %v — add a term mapping each to its predicate IRI", fromOperator)
+	default:
+		return fmt.Errorf(
+			"reference properties the preset declares have no @context entry in the preset, so "+
+				"their writes are dropped: %v", fromPreset)
+	}
 }

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -407,11 +407,22 @@ func (s *resourceTypeService) reconcileOneType(
 	// #510). Merging only the schema is what left a reference property with a
 	// column, a declaration, and nowhere for its predicate to resolve — so its
 	// writes went on being dropped while the reconcile reported success.
-	contextRec, err := reconcileAdditiveContext(existing.Context(), pt.Context)
+	contextRec, err := reconcileAdditiveContext(existing.Context(), pt.Context, existing.Schema())
 	if err != nil {
-		s.recordReconcileFailure(ctx, result, presetName, pt.Slug,
-			fmt.Errorf("failed to reconcile context: %w", err))
-		return
+		// A context this reconcile cannot parse must not take the schema merge
+		// down with it (issue #513). JSON-LD permits an array and a remote-IRI
+		// string, nothing validates the shape on the write path, and blocking
+		// here left the type's new property without its projection column —
+		// reintroducing, for that type, the silent drop #379 closed. Report it
+		// and carry on with the stored context untouched.
+		s.logger.Error(ctx, "cannot reconcile this type's @context; merging its schema only",
+			"preset", presetName, "slug", pt.Slug, "error", err)
+		if result.RefusedContext == nil {
+			result.RefusedContext = make(map[string][]string)
+		}
+		result.RefusedContext[pt.Slug] = append(result.RefusedContext[pt.Slug],
+			fmt.Sprintf("<unparseable stored @context: %v>", err))
+		contextRec = contextReconciliation{}
 	}
 	s.recordHeldDefinitions(ctx, result, presetName, pt.Slug, schemaRec, contextRec)
 
@@ -475,10 +486,18 @@ func (s *resourceTypeService) recordHeldDefinitions(
 		s.logger.Warn(ctx,
 			"preset context terms diverge; holding them at their stored definition",
 			"preset", presetName, "slug", slug, "heldContextTerms", contextRec.Conflicts)
-		if result.RefusedContext == nil {
-			result.RefusedContext = make(map[string][]string)
-		}
-		result.RefusedContext[slug] = contextRec.Conflicts
+		s.addRefusedContext(result, slug, contextRec.Conflicts...)
+	}
+	for _, moved := range contextRec.Moves {
+		// Not a divergence — the stored context never had this term. Merging it
+		// would repoint a predicate that already has edges, so it is held and
+		// both IRIs are named: the operator needs a data migration, not a
+		// choice between definitions.
+		s.logger.Warn(ctx,
+			"preset context term would repoint a predicate that already has data; holding it",
+			"preset", presetName, "slug", slug, "term", moved.Term, "property", moved.Property,
+			"storedIRI", moved.StoredIRI, "presetIRI", moved.PresetIRI)
+		s.addRefusedContext(result, slug, moved.Term)
 	}
 }
 
@@ -823,4 +842,18 @@ func dedup(slugs []string) []string {
 		}
 	}
 	return out
+}
+
+// addRefusedContext records held context terms without clobbering terms already
+// recorded for the same slug — divergences and repointings both land here.
+func (s *resourceTypeService) addRefusedContext(
+	result *ReconcilePresetResult, slug string, terms ...string,
+) {
+	if len(terms) == 0 {
+		return
+	}
+	if result.RefusedContext == nil {
+		result.RefusedContext = make(map[string][]string)
+	}
+	result.RefusedContext[slug] = append(result.RefusedContext[slug], terms...)
 }

--- a/application/resource_type_service.go
+++ b/application/resource_type_service.go
@@ -1012,8 +1012,16 @@ func selectTermsToAdopt(
 		}
 		// Already adopted on an earlier run, or never held at all? The stored
 		// context matches the preset either way, so matching alone cannot tell
-		// them apart. A recorded alias can: adoption is what writes one.
-		alreadyAdopted := len(jsonld.TermAliases(stored)[term]) > 0
+		// them apart. The adopted-terms record can, and it names the TERM —
+		// unlike the aliases, which a prefix records against the properties it
+		// moves rather than against itself.
+		alreadyAdopted := false
+		for _, done := range jsonld.AdoptedTerms(stored) {
+			if done == term {
+				alreadyAdopted = true
+				break
+			}
+		}
 		if alreadyAdopted && sErr == nil && pErr == nil &&
 			jsonEquivalent(storedTerms[term], presetTerms[term]) && len(presetTerms[term]) > 0 {
 			continue

--- a/application/triple_extraction.go
+++ b/application/triple_extraction.go
@@ -806,27 +806,6 @@ func EdgeValues(graphData, ldContext json.RawMessage, propertyName string) []str
 // string) into the list of @id strings it contains. Centralized so EdgeValue,
 // EdgeValues, and FlattenGraph all interpret the edges node identically.
 func collectEdgeIDs(edgeVal any) []string {
-	switch v := edgeVal.(type) {
-	case map[string]any:
-		if id, ok := v["@id"].(string); ok && id != "" {
-			return []string{id}
-		}
-	case []any:
-		out := make([]string, 0, len(v))
-		for _, item := range v {
-			ref, ok := item.(map[string]any)
-			if !ok {
-				continue
-			}
-			if id, ok := ref["@id"].(string); ok && id != "" {
-				out = append(out, id)
-			}
-		}
-		return out
-	case string:
-		if v != "" {
-			return []string{v}
-		}
-	}
-	return nil
+	ids, _ := jsonld.EdgeIDs(edgeVal)
+	return ids
 }

--- a/application/triple_extraction.go
+++ b/application/triple_extraction.go
@@ -185,34 +185,17 @@ func extractTriplesFromEdgesNode(
 		if !predicateSet[key] {
 			continue
 		}
-		// Predicate value is either a single {"@id": "..."} ref or an array
-		// of such refs (multi-valued reference property). Each non-empty @id
-		// becomes a triple.
-		switch v := val.(type) {
-		case map[string]any:
-			if objectID, ok := v["@id"].(string); ok && objectID != "" {
-				triples = append(triples, repositories.Triple{
-					Subject:   subjectID,
-					Predicate: key,
-					Object:    objectID,
-				})
-			}
-		case []any:
-			for _, item := range v {
-				ref, ok := item.(map[string]any)
-				if !ok {
-					continue
-				}
-				objectID, ok := ref["@id"].(string)
-				if !ok || objectID == "" {
-					continue
-				}
-				triples = append(triples, repositories.Triple{
-					Subject:   subjectID,
-					Predicate: key,
-					Object:    objectID,
-				})
-			}
+		// Predicate value is either a single {"@id": "..."} ref or an array of
+		// such refs (multi-valued reference property). jsonld.EdgeIDs is the
+		// one place that knows both shapes; open-coding it here is what let the
+		// readers drift apart in the first place (issue #513).
+		ids, _ := jsonld.EdgeIDs(val)
+		for _, objectID := range ids {
+			triples = append(triples, repositories.Triple{
+				Subject:   subjectID,
+				Predicate: key,
+				Object:    objectID,
+			})
 		}
 	}
 	return triples
@@ -796,6 +779,18 @@ func EdgeValues(graphData, ldContext json.RawMessage, propertyName string) []str
 	predicateIRI := jsonld.ResolvePredicateIRI(propertyName, vocab, contextMap)
 
 	edgeVal, exists := edgesNode[predicateIRI]
+	if !exists {
+		// An edge written before this property's term was adopted is keyed by
+		// the IRI it resolved to then, which the context records as an alias
+		// (issue #513). Events are immutable, so that key is what a reproject
+		// reproduces — resolving only the current IRI would report the edge
+		// missing on exactly the data adoption exists to keep readable.
+		for _, alias := range jsonld.TermAliases(ldContext)[propertyName] {
+			if edgeVal, exists = edgesNode[alias]; exists {
+				break
+			}
+		}
+	}
 	if !exists {
 		return nil
 	}

--- a/docs/decisions/projection-schema-migration.md
+++ b/docs/decisions/projection-schema-migration.md
@@ -153,6 +153,8 @@ The filter case deserves emphasis: dropping a filter does not narrow results, it
 
 1. **Refuse the whole type on any conflict.** Simpler to reason about and never produces a mixed schema, but it made one cosmetic property edit block every additive property in the same type — defeating the ticket's purpose on exactly the kind of upgrade that motivated it. Rejected in favour of per-property holds.
 2. **Flip `ensureBuiltInResourceTypes` to `InstallPreset(..., true)`.** The smallest possible diff, and rejected: it makes preset code authoritative for `Name`, `Description`, `Context` and `Schema` on every boot, silently discarding operator customisation. Trading a silent-data-loss bug for a different silent-data-loss bug is not a fix.
+
+   Amended by #510: the `@context` *is* now merged at boot, but additively and never authoritatively — see the section below. The objection this entry records still stands against wholesale overwriting.
 3. **A config flag selecting overwrite / merge / off.** Rejected for v1 as surface area without a decision: the merge behaviour is what a correct default looks like, and the explicit `--update` path already exists for operators who want overwrite.
 4. **GORM `AutoMigrate`.** Rejected — see above.
 5. **Backfill automatically after adding a column.** Rejected: a full replay on boot is expensive and unpredictable. Reproject stays an explicit operator action.
@@ -162,3 +164,20 @@ The filter case deserves emphasis: dropping a filter does not narrow results, it
 
 - [Projections]({% link _explanation/projections.md %}) — how projection tables are derived from resource type schemas.
 - [Cross-Preset Link Definitions]({% link decisions/cross-preset-link-definitions.md %}) — the other mechanism that adds columns to a projection table via `addMissingColumns`.
+
+
+## Amendment: the `@context` is merged too (#510, #513)
+
+The decision above merged only the JSON Schema and passed the stored `@context` through untouched. That left a gap this ADR did not anticipate.
+
+A **reference** property — one the schema marks `x-resource-type` — is stored as a JSON-LD edge keyed by its predicate IRI, and the readers map that IRI back to a property name through an `@context` term. `ParseContext` skips every `@`-prefixed keyword, so `@vocab` never appears in the reverse map: a reference with no explicit term resolves *forward* through `@vocab` on write, and resolves to nothing on read. The projection column arrived, the schema declared the property, the reconcile reported the type updated — and the value was unreadable, with a `201` returned. Literals are unaffected; they sit in the graph's entity node, which the readers copy without consulting the context.
+
+The `@context` is therefore merged by the same additive rules as the schema, with one addition of its own.
+
+**Merge rules.** A term the preset declares and the stored context lacks is merged in. A term only the operator declared is preserved. A term in both whose definitions differ is **held** at the stored definition and reported. Keywords — `@vocab`, `@type`, prefix definitions — are held rather than following the preset, deliberately unlike the schema merge's top-level keywords: repointing `@vocab` would move the predicate of every property that resolves through it at once.
+
+**The additional rule (#513): an addition is not automatically safe.** Merging a term that the stored context lacks can still repoint a predicate that already has data under it — a term for a reference the *stored schema* already declares, whose edges sit at the `@vocab`-derived IRI; a prefix that changes what a stored compact term expands to; or an `@type` that moves the type's RDF class. Each is held and reported with both IRIs named, because adopting it would leave existing edges keyed by an IRI nothing reverse-maps, and reprojection cannot recover them.
+
+That check keys off the **stored** schema, not the merged one. Against the merged schema it would also fire on the case #510 exists to fix — a preset adding a reference property and its term in the same build — and re-break the repair. A property the stored schema does not declare yet has no data under any IRI, so nothing can be orphaned.
+
+**What this does not do.** It never overwrites operator customisation, which is the property this ADR exists to protect: everything contested is held, never applied. It does not rewrite stored rows — a merged term makes *later* reads resolve, so pre-existing edges need an explicit reproject. And it cannot close a gap on the preset's own side: a preset declaring a reference its own context never maps is reported `Failed` on every boot, because no additive merge has anything to add.

--- a/domain/entities/resource.go
+++ b/domain/entities/resource.go
@@ -209,14 +209,21 @@ func SimplifyJSONLD(data, ldContext json.RawMessage) (json.RawMessage, error) {
 					if key == "@id" {
 						continue
 					}
-					// Unwrap {"@id": "..."} values.
-					if ref, ok := val.(map[string]any); ok {
-						if id, ok := ref["@id"].(string); ok {
-							if propName, ok := reverseMap[key]; ok {
-								result[propName] = id
-							}
-						}
+					propName, known := reverseMap[key]
+					if !known {
+						continue
 					}
+					// A declared list keeps its shape, so a property the schema
+					// says is a list never reads back as a bare string.
+					ids, isList := jsonld.EdgeIDs(val)
+					if len(ids) == 0 {
+						continue
+					}
+					if isList {
+						result[propName] = ids
+						continue
+					}
+					result[propName] = ids[0]
 				}
 			}
 		}

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -404,8 +404,14 @@ func (pm *projectionManager) UpdateColumnByFK(
 		return nil
 	}
 	tableName := pm.TableName(typeSlug)
+	// A list reference stores its targets as a JSON array in the FK column
+	// (issue #513), so plain equality never matches one and the denormalized
+	// display value would go stale the moment the target was renamed — worse
+	// than the empty column this replaced, because a stale name still reads as
+	// current. The LIKE arm matches an array whose FIRST element is this
+	// target, which is exactly the one the display column carries.
 	return pm.writeDB(ctx).Table(tableName).
-		Where(fkColumn+" = ?", fkValue).
+		Where(fkColumn+" = ? OR "+fkColumn+" LIKE ?", fkValue, `["`+fkValue+`"%`).
 		Update(targetColumn, targetValue).Error
 }
 

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -410,8 +410,13 @@ func (pm *projectionManager) UpdateColumnByFK(
 	// than the empty column this replaced, because a stale name still reads as
 	// current. The LIKE arm matches an array whose FIRST element is this
 	// target, which is exactly the one the display column carries.
+	// The pattern includes the CLOSING quote, so the quote is the token
+	// boundary and one ID cannot match inside a longer one that starts with it.
+	// Wildcards in the value itself are escaped: unescaped, a `%` would update
+	// every row in the table.
+	pattern := `["` + escapeLikeLiteral(fkValue) + `"%`
 	return pm.writeDB(ctx).Table(tableName).
-		Where(fkColumn+" = ? OR "+fkColumn+" LIKE ?", fkValue, `["`+fkValue+`"%`).
+		Where(fkColumn+" = ? OR "+fkColumn+" LIKE ? ESCAPE '\\'", fkValue, pattern).
 		Update(targetColumn, targetValue).Error
 }
 

--- a/infrastructure/database/gorm/projection_manager.go
+++ b/infrastructure/database/gorm/projection_manager.go
@@ -910,15 +910,6 @@ func extractEdgeColumns(edges map[string]any, ldContext json.RawMessage, row map
 		if key == "@id" {
 			continue
 		}
-		ref, ok := val.(map[string]any)
-		if !ok {
-			continue
-		}
-		objectID, ok := ref["@id"].(string)
-		if !ok || objectID == "" {
-			continue
-		}
-
 		// Reverse-lookup: predicate IRI → property name → snake_case column.
 		propName, ok := reverseMap[key]
 		if !ok {
@@ -928,6 +919,22 @@ func extractEdgeColumns(edges map[string]any, ldContext json.RawMessage, row map
 		if standardColumnNames[colName] {
 			continue
 		}
-		row[colName] = objectID
+		ids, isList := jsonld.EdgeIDs(val)
+		if len(ids) == 0 {
+			continue
+		}
+		if !isList {
+			row[colName] = ids[0]
+			continue
+		}
+		// A list reference cannot fit a scalar FK column, so it is stored as a
+		// JSON array in the same TEXT column and decoded on read. Leaving it
+		// NULL — what happened before issue #513 — made the projection disagree
+		// with the canonical record about whether the value existed at all.
+		encoded, err := json.Marshal(ids)
+		if err != nil {
+			continue
+		}
+		row[colName] = string(encoded)
 	}
 }

--- a/infrastructure/database/gorm/projection_manager_test.go
+++ b/infrastructure/database/gorm/projection_manager_test.go
@@ -18,6 +18,7 @@ package gorm
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -1252,5 +1253,70 @@ func TestEnsureTable_FailedBackfillLeavesHasProjectionTableRetrying(t *testing.T
 	}
 	if !pm.HasProjectionTable("recipe") {
 		t.Fatal("HasProjectionTable should retry EnsureTable and succeed once the failure cleared")
+	}
+}
+
+// TestUpdateColumnByFK_ListReference pins the display-propagation half of issue
+// #513. A list-valued reference stores its targets as a JSON array in the FK
+// column, so matching that column against a bare URN never finds the row: the
+// denormalized display value would keep the target's OLD name after a rename,
+// which reads as current and is worse than the empty column it replaced.
+//
+// The display column carries the FIRST target, so only that target's rename
+// should move it — a later element must not overwrite the label.
+func TestUpdateColumnByFK_ListReference(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+
+	schema := json.RawMessage(`{"type":"object","properties":{
+		"name":{"type":"string"},
+		"maker":{"type":"string","x-resource-type":"vendor"},
+		"suppliers":{"type":"array","x-resource-type":"vendor","items":{"type":"string"}}}}`)
+	if err := pm.EnsureTable(context.Background(), "widget", schema, nil); err != nil {
+		t.Fatalf("EnsureTable: %v", err)
+	}
+
+	const first, second = "urn:vendor:aaa", "urn:vendor:bbb"
+	rows := []map[string]any{
+		{"id": "urn:widget:scalar", "type_slug": "widget", "maker": first, "maker_display": "Acme"},
+		{"id": "urn:widget:list", "type_slug": "widget", "suppliers": `["` + first + `","` + second + `"]`,
+			"suppliers_display": "Acme"},
+		{"id": "urn:widget:list-second", "type_slug": "widget", "suppliers": `["` + second + `","` + first + `"]`,
+			"suppliers_display": "Globex"},
+	}
+	for _, row := range rows {
+		if err := db.Table("widgets").Create(row).Error; err != nil {
+			t.Fatalf("seed %v: %v", row["id"], err)
+		}
+	}
+
+	ctx := context.Background()
+	if err := pm.UpdateColumnByFK(ctx, "widget", "maker", first, "maker_display", "Acme Industrial"); err != nil {
+		t.Fatalf("UpdateColumnByFK (scalar): %v", err)
+	}
+	if err := pm.UpdateColumnByFK(
+		ctx, "widget", "suppliers", first, "suppliers_display", "Acme Industrial"); err != nil {
+		t.Fatalf("UpdateColumnByFK (list): %v", err)
+	}
+
+	for _, tc := range []struct{ id, column, want string }{
+		{"urn:widget:scalar", "maker_display", "Acme Industrial"},
+		{"urn:widget:list", "suppliers_display", "Acme Industrial"},
+		// The renamed target is the SECOND element here, so the label — which
+		// shows the first — must be left alone.
+		{"urn:widget:list-second", "suppliers_display", "Globex"},
+	} {
+		var got []map[string]any
+		if err := db.Table("widgets").Select(tc.column).
+			Where("id = ?", tc.id).Find(&got).Error; err != nil {
+			t.Fatalf("read %s for %s: %v", tc.column, tc.id, err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("expected one row for %s, got %d", tc.id, len(got))
+		}
+		if v := fmt.Sprintf("%v", got[0][tc.column]); v != tc.want {
+			t.Errorf("%s for %s is %q, want %q", tc.column, tc.id, v, tc.want)
+		}
 	}
 }

--- a/infrastructure/database/gorm/projection_manager_test.go
+++ b/infrastructure/database/gorm/projection_manager_test.go
@@ -1368,3 +1368,92 @@ func TestReferenceFilter_ListColumn(t *testing.T) {
 		t.Errorf("urn:widget:other does not reference %s but the filter matched it", acme)
 	}
 }
+
+// TestListReferenceMatching_PrefixCollision checks the claim that the LIKE
+// patterns can match an ID which merely starts with the one being looked for.
+// They cannot: every pattern includes the CLOSING quote, so the quote is the
+// token delimiter and `urn:vendor:a` cannot match inside `urn:vendor:aa`.
+func TestListReferenceMatching_PrefixCollision(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	schema := json.RawMessage(`{"type":"object","properties":{
+		"name":{"type":"string"},
+		"suppliers":{"type":"array","x-resource-type":"vendor","items":{"type":"string"}}}}`)
+	if err := pm.EnsureTable(context.Background(), "widget", schema, nil); err != nil {
+		t.Fatalf("EnsureTable: %v", err)
+	}
+	repo := &ResourceRepository{db: db, projMgr: pm, logger: &testLogger{}}
+
+	// The short ID is a strict prefix of the long one, in both positions.
+	const short, long = "urn:vendor:a", "urn:vendor:aa"
+	for _, row := range []map[string]any{
+		{"id": "urn:widget:long-first", "type_slug": "widget", "suppliers": `["` + long + `"]`},
+		{"id": "urn:widget:long-later", "type_slug": "widget", "suppliers": `["urn:vendor:z","` + long + `"]`},
+		{"id": "urn:widget:short", "type_slug": "widget", "suppliers": `["` + short + `"]`},
+	} {
+		if err := db.Table("widgets").Create(row).Error; err != nil {
+			t.Fatalf("seed %v: %v", row["id"], err)
+		}
+	}
+
+	clause, args := repo.referenceFilterClause("widget", "", "suppliers", "=", short)
+	var got []map[string]any
+	if err := db.Table("widgets").Select("id").Where(clause, args...).Find(&got).Error; err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+	if len(got) != 1 || fmt.Sprintf("%v", got[0]["id"]) != "urn:widget:short" {
+		t.Errorf("filtering for %q matched %v, want only the row that references it exactly", short, got)
+	}
+
+	// The same boundary applies to display propagation.
+	if err := pm.UpdateColumnByFK(
+		context.Background(), "widget", "suppliers", short, "suppliers_display", "SHORT"); err != nil {
+		t.Fatalf("UpdateColumnByFK: %v", err)
+	}
+	for _, id := range []string{"urn:widget:long-first", "urn:widget:long-later"} {
+		var rows []map[string]any
+		if err := db.Table("widgets").Select("suppliers_display").
+			Where("id = ?", id).Find(&rows).Error; err != nil {
+			t.Fatalf("read %s: %v", id, err)
+		}
+		if v := rows[0]["suppliers_display"]; v != nil {
+			t.Errorf("%s references %q, not %q, but its display was set to %v", id, long, short, v)
+		}
+	}
+}
+
+// TestUpdateColumnByFK_EscapesWildcards: an ID containing a LIKE wildcard must
+// match literally. Resource IDs are KSUIDs today, but the clause is a general
+// contract and an unescaped `%` would update every row in the table.
+func TestUpdateColumnByFK_EscapesWildcards(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	schema := json.RawMessage(`{"type":"object","properties":{
+		"name":{"type":"string"},
+		"suppliers":{"type":"array","x-resource-type":"vendor","items":{"type":"string"}}}}`)
+	if err := pm.EnsureTable(context.Background(), "widget", schema, nil); err != nil {
+		t.Fatalf("EnsureTable: %v", err)
+	}
+	for _, row := range []map[string]any{
+		{"id": "urn:widget:real", "type_slug": "widget", "suppliers": `["urn:vendor:%"]`},
+		{"id": "urn:widget:other", "type_slug": "widget", "suppliers": `["urn:vendor:zzz"]`},
+	} {
+		if err := db.Table("widgets").Create(row).Error; err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	if err := pm.UpdateColumnByFK(
+		context.Background(), "widget", "suppliers", "urn:vendor:%", "suppliers_display", "LITERAL"); err != nil {
+		t.Fatalf("UpdateColumnByFK: %v", err)
+	}
+	var rows []map[string]any
+	if err := db.Table("widgets").Select("suppliers_display").
+		Where("id = ?", "urn:widget:other").Find(&rows).Error; err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if v := rows[0]["suppliers_display"]; v != nil {
+		t.Errorf("an unescaped wildcard updated an unrelated row (display = %v)", v)
+	}
+}

--- a/infrastructure/database/gorm/projection_manager_test.go
+++ b/infrastructure/database/gorm/projection_manager_test.go
@@ -1320,3 +1320,51 @@ func TestUpdateColumnByFK_ListReference(t *testing.T) {
 		}
 	}
 }
+
+// TestReferenceFilter_ListColumn pins the filtering half of issue #513. The
+// admin builds an `eq` filter for every reference property, arrays included, so
+// a row that visibly shows a value must be findable by filtering on it — plain
+// equality never matches a JSON array.
+func TestReferenceFilter_ListColumn(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	pm := &projectionManager{db: db, logger: &testLogger{}}
+	schema := json.RawMessage(`{"type":"object","properties":{
+		"name":{"type":"string"},
+		"suppliers":{"type":"array","x-resource-type":"vendor","items":{"type":"string"}}}}`)
+	if err := pm.EnsureTable(context.Background(), "widget", schema, nil); err != nil {
+		t.Fatalf("EnsureTable: %v", err)
+	}
+	repo := &ResourceRepository{db: db, projMgr: pm, logger: &testLogger{}}
+
+	const acme, globex = "urn:vendor:acme", "urn:vendor:globex"
+	for _, row := range []map[string]any{
+		{"id": "urn:widget:first", "type_slug": "widget", "suppliers": `["` + acme + `","` + globex + `"]`},
+		{"id": "urn:widget:later", "type_slug": "widget", "suppliers": `["` + globex + `","` + acme + `"]`},
+		{"id": "urn:widget:other", "type_slug": "widget", "suppliers": `["` + globex + `"]`},
+	} {
+		if err := db.Table("widgets").Create(row).Error; err != nil {
+			t.Fatalf("seed %v: %v", row["id"], err)
+		}
+	}
+
+	clause, args := repo.referenceFilterClause("widget", "", "suppliers", "=", acme)
+	var got []map[string]any
+	if err := db.Table("widgets").Select("id").Where(clause, args...).Find(&got).Error; err != nil {
+		t.Fatalf("filter query: %v", err)
+	}
+	found := map[string]bool{}
+	for _, row := range got {
+		found[fmt.Sprintf("%v", row["id"])] = true
+	}
+	// Acme is the first element of one row and a later element of another; both
+	// must match, and the row that does not reference it must not.
+	for _, id := range []string{"urn:widget:first", "urn:widget:later"} {
+		if !found[id] {
+			t.Errorf("%s references %s but the filter did not find it", id, acme)
+		}
+	}
+	if found["urn:widget:other"] {
+		t.Errorf("urn:widget:other does not reference %s but the filter matched it", acme)
+	}
+}

--- a/infrastructure/database/gorm/resource_repository.go
+++ b/infrastructure/database/gorm/resource_repository.go
@@ -1000,6 +1000,60 @@ func (r *ResourceRepository) findAllByFieldFromGeneric(
 	return result, nil
 }
 
+// referenceFilterClause builds the WHERE fragment for one filter.
+//
+// An `eq` on a REFERENCE column also matches a JSON array containing the
+// value, because a list-valued reference is stored that way (issue #513).
+// Without it the admin's own reference filter returns nothing for a row that
+// visibly shows the value — the column holds `["urn:a"]` and the filter asks
+// for `urn:a`.
+//
+// The containment arms are inert on a scalar reference column, which never
+// contains a bracket, so no schema lookup is needed to tell the two apart.
+// Only `eq` is expanded: negation over a list has no single obvious meaning
+// (does `ne` exclude a row that references the value alongside others?), so it
+// keeps its exact-match behaviour rather than guessing.
+//
+// Caveat worth knowing: SQLite's LIKE is case-insensitive for ASCII while `=`
+// is not, so two IDs differing only in case could cross-match here. Resource
+// IDs are KSUIDs, where that is possible but vanishingly unlikely, and the
+// failure mode is an extra row in a filtered list rather than lost data.
+func (r *ResourceRepository) referenceFilterClause(
+	typeSlug, qualifier, column, sqlOp string, value any,
+) (string, []any) {
+	col := qualifier + column
+	if sqlOp != "=" {
+		return col + " " + sqlOp + " ?", []any{value}
+	}
+	str, ok := value.(string)
+	if !ok || !r.isReferenceColumn(typeSlug, column) {
+		return col + " " + sqlOp + " ?", []any{value}
+	}
+	// `["v"…` catches the first element (and a single-element list); `…,"v"…`
+	// catches every later one.
+	quoted := escapeLikeLiteral(`"` + str + `"`)
+	return "(" + col + " = ? OR " + col + " LIKE ? ESCAPE '\\' OR " + col + " LIKE ? ESCAPE '\\')",
+		[]any{value, "[" + quoted + "%", "%," + quoted + "%"}
+}
+
+// isReferenceColumn reports whether a column holds resource references, which
+// is what makes a JSON-array value possible in it.
+func (r *ResourceRepository) isReferenceColumn(typeSlug, column string) bool {
+	for _, ref := range r.projMgr.ForwardReferences(typeSlug) {
+		if ref.FKColumn == column {
+			return true
+		}
+	}
+	return false
+}
+
+// escapeLikeLiteral neutralises LIKE wildcards so a value containing `%` or `_`
+// matches literally.
+func escapeLikeLiteral(s string) string {
+	replacer := strings.NewReplacer(`\`, `\\`, "%", `\%`, "_", `\_`)
+	return replacer.Replace(s)
+}
+
 var operatorMap = map[string]string{
 	"eq": "=", "ne": "!=", "gt": ">", "gte": ">=", "lt": "<", "lte": "<=",
 }
@@ -1056,7 +1110,8 @@ func (r *ResourceRepository) findAllFromProjectionWithFilters(
 				continue
 			}
 		}
-		query = query.Where(tbl+"."+fc+" "+sqlOp+" ?", f.Value)
+		clause, args := r.referenceFilterClause(typeSlug, tbl+".", fc, sqlOp, f.Value)
+		query = query.Where(clause, args...)
 	}
 
 	if cursor != "" {
@@ -1224,7 +1279,8 @@ func (r *ResourceRepository) findAllFlatFromProjection(
 				continue
 			}
 		}
-		query = query.Where(fc+" "+sqlOp+" ?", f.Value)
+		clause, args := r.referenceFilterClause(typeSlug, "", fc, sqlOp, f.Value)
+		query = query.Where(clause, args...)
 	}
 
 	if cursor != "" {

--- a/infrastructure/database/gorm/resource_repository.go
+++ b/infrastructure/database/gorm/resource_repository.go
@@ -232,6 +232,30 @@ func (r *ResourceRepository) dropMissingColumns(targetSlug string, row map[strin
 	}
 }
 
+// firstReferenceID returns the single ID a FK column holds, or the first of the
+// list when the column holds a JSON array (issue #513). A value that is not an
+// array is returned unchanged, so a scalar reference takes the same path it
+// always did.
+//
+// The first entry is used rather than a joined string because the display
+// column is a VARCHAR(512) read by clients as one label; concatenating an
+// unbounded list would truncate unpredictably.
+func firstReferenceID(fkVal string) string {
+	if !strings.HasPrefix(strings.TrimSpace(fkVal), "[") {
+		return fkVal
+	}
+	var ids []string
+	if err := json.Unmarshal([]byte(fkVal), &ids); err != nil {
+		return fkVal
+	}
+	for _, id := range ids {
+		if id != "" {
+			return id
+		}
+	}
+	return ""
+}
+
 // populateDisplayColumns looks up display values for every outgoing reference
 // on the target type and injects them into the row before INSERT/UPDATE. Called
 // from all three projection write paths (saveToProjection, updateProjectionBySlug,
@@ -310,6 +334,15 @@ func (r *ResourceRepository) populateDisplayColumns(
 				"valueType", fmt.Sprintf("%T", rawFK))
 			continue
 		}
+		if fkVal == "" {
+			row[ref.DisplayColumn] = nil
+			continue
+		}
+		// A list reference stores its targets as a JSON array in the same
+		// column (issue #513). The display column is a single VARCHAR, so it
+		// carries the FIRST target — looking the raw array up as an ID would
+		// find nothing and persist a NULL display over a populated reference.
+		fkVal = firstReferenceID(fkVal)
 		if fkVal == "" {
 			row[ref.DisplayColumn] = nil
 			continue

--- a/infrastructure/database/gorm/resource_repository.go
+++ b/infrastructure/database/gorm/resource_repository.go
@@ -1162,7 +1162,33 @@ func (r *ResourceRepository) FindFlatByID(
 	for k, v := range row {
 		camelRow[utils.SnakeToCamel(k)] = v
 	}
+	r.decodeListReferences(typeSlug, camelRow)
 	return camelRow, nil
+}
+
+// decodeListReferences turns a list-valued reference back into a []string on
+// the way out.
+//
+// A list reference is STORED as a JSON array in its single TEXT column (issue
+// #513). This is the flat read every non-JSON-LD API response goes through, so
+// without decoding here the column would reach clients as the literal string
+// `["urn:a","urn:b"]` — which is not what the schema says the property is, and
+// breaks any client that iterates it. Only declared reference columns are
+// considered, so a literal property whose text happens to look like a JSON
+// array is left exactly as the operator wrote it.
+func (r *ResourceRepository) decodeListReferences(typeSlug string, camelRow map[string]any) {
+	for _, ref := range r.projMgr.ForwardReferences(typeSlug) {
+		key := utils.SnakeToCamel(ref.FKColumn)
+		raw, ok := camelRow[key].(string)
+		if !ok || !strings.HasPrefix(strings.TrimSpace(raw), "[") {
+			continue
+		}
+		var ids []string
+		if err := json.Unmarshal([]byte(raw), &ids); err != nil {
+			continue
+		}
+		camelRow[key] = ids
+	}
 }
 
 // findAllFlatFromProjection queries the projection table directly and returns flat rows
@@ -1232,6 +1258,7 @@ func (r *ResourceRepository) findAllFlatFromProjection(
 		for k, v := range row {
 			camelRow[utils.SnakeToCamel(k)] = v
 		}
+		r.decodeListReferences(typeSlug, camelRow)
 		result = append(result, camelRow)
 		sortVal := row[colName]
 		if sortVal == nil {

--- a/infrastructure/database/gorm/resource_repository.go
+++ b/infrastructure/database/gorm/resource_repository.go
@@ -1012,7 +1012,7 @@ func (r *ResourceRepository) findAllByFieldFromGeneric(
 // contains a bracket, so no schema lookup is needed to tell the two apart.
 // Only `eq` is expanded: negation over a list has no single obvious meaning
 // (does `ne` exclude a row that references the value alongside others?), so it
-// keeps its exact-match behaviour rather than guessing.
+// keeps its exact-match behavior rather than guessing.
 //
 // Caveat worth knowing: SQLite's LIKE is case-insensitive for ASCII while `=`
 // is not, so two IDs differing only in case could cross-match here. Resource
@@ -1047,7 +1047,7 @@ func (r *ResourceRepository) isReferenceColumn(typeSlug, column string) bool {
 	return false
 }
 
-// escapeLikeLiteral neutralises LIKE wildcards so a value containing `%` or `_`
+// escapeLikeLiteral neutralizes LIKE wildcards so a value containing `%` or `_`
 // matches literally.
 func escapeLikeLiteral(s string) string {
 	replacer := strings.NewReplacer(`\`, `\\`, "%", `\%`, "_", `\_`)

--- a/internal/cli/resource_type_adopt.go
+++ b/internal/cli/resource_type_adopt.go
@@ -1,0 +1,118 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// The boot reconcile refuses to adopt a `@context` term whose adoption would
+// repoint a predicate that already has data (issue #513). That refusal is
+// correct — adopting would orphan every existing edge — but on its own it
+// leaves the property unreadable and the boot reporting it forever, with the
+// ADR forbidding `preset install --update` at boot. These two commands are the
+// way out: one shows the decision, the other makes it.
+
+var heldTermsCmd = &cobra.Command{
+	Use:   "held-terms [preset] [type-slug]",
+	Short: "Show the @context terms the boot refuses to adopt for a resource type",
+	Long: "Lists each term the boot is holding, the IRI existing edges are keyed by, " +
+		"and the IRI the preset wants. Read this before adopting anything.",
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		deps, err := StartContainer(GetConfig())
+		if err != nil {
+			return err
+		}
+		defer func() { _ = deps.Shutdown() }()
+
+		held, err := deps.ResourceTypeService.HeldContextTerms(cmd.Context(), args[0], args[1])
+		if err != nil {
+			return err
+		}
+		if len(held) == 0 {
+			_, _ = fmt.Fprintf(os.Stdout, "No held terms for %q.\n", args[1])
+			return nil
+		}
+		_, _ = fmt.Fprintf(os.Stdout, "%d held term(s) for %q:\n\n", len(held), args[1])
+		for _, h := range held {
+			_, _ = fmt.Fprintf(os.Stdout, "  %s\n", h.Term)
+			_, _ = fmt.Fprintf(os.Stdout, "    property        %s\n", h.Property)
+			_, _ = fmt.Fprintf(os.Stdout, "    data written as %s\n", h.StoredIRI)
+			_, _ = fmt.Fprintf(os.Stdout, "    preset wants    %s\n\n", h.PresetIRI)
+		}
+		_, _ = fmt.Fprintf(os.Stdout,
+			"Adopt with:  weos resource-type adopt-term %s %s --all\n", args[0], args[1])
+		return nil
+	},
+}
+
+var adoptTermCmd = &cobra.Command{
+	Use:   "adopt-term [preset] [type-slug]",
+	Short: "Adopt held @context terms, keeping existing edges readable",
+	Long: "Takes the preset's definition for held terms and records the IRI each affected " +
+		"property resolves to today, so edges written under the old IRI still resolve. " +
+		"Run `weos worker reproject` afterwards to refill the projection columns.",
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		all, _ := cmd.Flags().GetBool("all")
+		terms, _ := cmd.Flags().GetStringSlice("term")
+		if !all && len(terms) == 0 {
+			return fmt.Errorf("name at least one --term, or pass --all to adopt every held term")
+		}
+		if all {
+			// --all means "whatever is held right now", so an explicit list
+			// would only narrow it; refuse rather than silently pick one.
+			if len(terms) > 0 {
+				return fmt.Errorf("pass either --all or --term, not both")
+			}
+			terms = nil
+		}
+
+		deps, err := StartContainer(GetConfig())
+		if err != nil {
+			return err
+		}
+		defer func() { _ = deps.Shutdown() }()
+
+		// An empty list means "every held term", which is exactly what --all is.
+		adopted, err := deps.ResourceTypeService.AdoptContextTerms(
+			cmd.Context(), args[0], args[1], terms)
+		if err != nil {
+			return err
+		}
+		if len(adopted) == 0 {
+			_, _ = fmt.Fprintf(os.Stdout, "Nothing to adopt for %q — already up to date.\n", args[1])
+			return nil
+		}
+		_, _ = fmt.Fprintf(os.Stdout, "Adopted for %q: %s\n", args[1], strings.Join(adopted, ", "))
+		_, _ = fmt.Fprintln(os.Stdout,
+			"Existing edges stay readable through their recorded IRIs.")
+		_, _ = fmt.Fprintln(os.Stdout,
+			"Run `weos worker reproject` to refill the projection columns for existing rows.")
+		return nil
+	},
+}
+
+func init() {
+	adoptTermCmd.Flags().StringSlice("term", nil, "Term to adopt; repeat for several")
+	adoptTermCmd.Flags().Bool("all", false, "Adopt every term the boot is holding for this type")
+	resourceTypeCmd.AddCommand(heldTermsCmd, adoptTermCmd)
+}

--- a/internal/mcp/handler_test.go
+++ b/internal/mcp/handler_test.go
@@ -64,6 +64,18 @@ func (s *stubResourceTypeService) ReconcilePresetSchemas(
 	return nil, nil
 }
 
+func (s *stubResourceTypeService) HeldContextTerms(
+	_ context.Context, _, _ string,
+) ([]application.HeldTerm, error) {
+	return nil, nil
+}
+
+func (s *stubResourceTypeService) AdoptContextTerms(
+	_ context.Context, _, _ string, _ []string,
+) ([]string, error) {
+	return nil, nil
+}
+
 func (s *stubResourceTypeService) ListBehaviors(
 	_ context.Context, _ string,
 ) ([]application.BehaviorInfo, error) {

--- a/pkg/jsonld/context.go
+++ b/pkg/jsonld/context.go
@@ -67,6 +67,18 @@ func BuildReverseMap(ldContext json.RawMessage) map[string]string {
 	for propName, iri := range forward {
 		result[iri] = propName
 	}
+	// Historical IRIs resolve too, so edges written before a term was adopted
+	// stay readable (issue #513). An alias NEVER shadows a live term: the
+	// current mapping is authoritative, and only an IRI nothing else claims is
+	// added.
+	for propName, iris := range TermAliases(ldContext) {
+		for _, iri := range iris {
+			if _, taken := result[iri]; taken {
+				continue
+			}
+			result[iri] = propName
+		}
+	}
 	return result
 }
 
@@ -177,6 +189,58 @@ func InlineVocabContext(data json.RawMessage) json.RawMessage {
 	out, err := json.Marshal(doc)
 	if err != nil {
 		return data
+	}
+	return out
+}
+
+// TermAliasesKeyword names the `@context` entry that records IRIs a property's
+// edges were written under BEFORE its current term was adopted (issue #513).
+//
+// It lives inside the context so it travels with the resource type and survives
+// a reproject. It is deliberately not an `@`-keyword: ParseContext ignores it
+// anyway, because its value is an object with no `@id`, so it never becomes a
+// predicate of its own.
+const TermAliasesKeyword = "weos:termAliases"
+
+// TermAliases returns the recorded historical IRIs for each property, keyed by
+// property name.
+//
+// These exist because events are immutable. An edge is stored keyed by the IRI
+// its property resolved to at write time, and `ResourceCreated` carries that
+// graph, so a reproject reproduces the original key no matter what is done to
+// the stored data. Adopting a term that names a different IRI would therefore
+// orphan every existing edge permanently. Recording the old IRI instead lets
+// both resolve, which is what makes adoption safe and reversible.
+func TermAliases(ldContext json.RawMessage) map[string][]string {
+	if len(ldContext) == 0 {
+		return nil
+	}
+	var ctx map[string]any
+	if json.Unmarshal(ldContext, &ctx) != nil {
+		return nil
+	}
+	raw, ok := ctx[TermAliasesKeyword].(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := make(map[string][]string, len(raw))
+	for property, val := range raw {
+		switch v := val.(type) {
+		case string:
+			if v != "" {
+				out[property] = []string{v}
+			}
+		case []any:
+			var iris []string
+			for _, item := range v {
+				if iri, ok := item.(string); ok && iri != "" {
+					iris = append(iris, iri)
+				}
+			}
+			if len(iris) > 0 {
+				out[property] = iris
+			}
+		}
 	}
 	return out
 }

--- a/pkg/jsonld/context.go
+++ b/pkg/jsonld/context.go
@@ -202,6 +202,35 @@ func InlineVocabContext(data json.RawMessage) json.RawMessage {
 // predicate of its own.
 const TermAliasesKeyword = "weos:termAliases"
 
+// AdoptedTermsKeyword names the `@context` entry listing terms an operator has
+// adopted. It exists because the alias itself cannot answer "was this adopted?"
+// for a PREFIX: adopting one records aliases against the properties it moves,
+// not against the prefix, so looking the term up in the alias map reports a
+// re-run of the same command as a term that was never held.
+const AdoptedTermsKeyword = "weos:adoptedTerms"
+
+// AdoptedTerms returns the terms already adopted for a resource type.
+func AdoptedTerms(ldContext json.RawMessage) []string {
+	if len(ldContext) == 0 {
+		return nil
+	}
+	var ctx map[string]any
+	if json.Unmarshal(ldContext, &ctx) != nil {
+		return nil
+	}
+	raw, ok := ctx[AdoptedTermsKeyword].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, item := range raw {
+		if term, ok := item.(string); ok && term != "" {
+			out = append(out, term)
+		}
+	}
+	return out
+}
+
 // TermAliases returns the recorded historical IRIs for each property, keyed by
 // property name.
 //

--- a/pkg/jsonld/context_test.go
+++ b/pkg/jsonld/context_test.go
@@ -182,3 +182,43 @@ func TestInlineVocabContext(t *testing.T) {
 		t.Error("document without @context should be unchanged")
 	}
 }
+
+// TestBuildReverseMap_TermAliases: an edge written before its term was adopted
+// is keyed by the IRI the property resolved to back then. Events are immutable
+// and carry that key, so a reproject reproduces it — the alias is what keeps it
+// readable after adoption (issue #513).
+func TestBuildReverseMap_TermAliases(t *testing.T) {
+	ctx := json.RawMessage(`{
+		"@vocab":"https://schema.org/",
+		"fo":"http://purl.org/foodontology#",
+		"recipeIngredient":"fo:hasIngredient",
+		"weos:termAliases":{"recipeIngredient":["https://schema.org/recipeIngredient"]}}`)
+
+	reverse := jsonld.BuildReverseMap(ctx)
+	for iri, want := range map[string]string{
+		"http://purl.org/foodontology#hasIngredient": "recipeIngredient",
+		"https://schema.org/recipeIngredient":        "recipeIngredient",
+	} {
+		if got := reverse[iri]; got != want {
+			t.Errorf("reverse[%q] = %q, want %q", iri, got, want)
+		}
+	}
+	// The alias key itself must not become a predicate.
+	if _, forward := jsonld.ParseContext(ctx); forward[jsonld.TermAliasesKeyword] != "" {
+		t.Errorf("%s leaked into the forward map as a term", jsonld.TermAliasesKeyword)
+	}
+}
+
+// TestBuildReverseMap_AliasNeverShadowsALiveTerm: a stale alias must not
+// capture an IRI another property currently claims, or reads for the live
+// property would resolve to the wrong name.
+func TestBuildReverseMap_AliasNeverShadowsALiveTerm(t *testing.T) {
+	ctx := json.RawMessage(`{
+		"@vocab":"https://schema.org/",
+		"maker":"https://schema.org/manufacturer",
+		"weos:termAliases":{"supplier":["https://schema.org/manufacturer"]}}`)
+
+	if got := jsonld.BuildReverseMap(ctx)["https://schema.org/manufacturer"]; got != "maker" {
+		t.Errorf("reverse IRI = %q, want maker — the live term must win over an alias", got)
+	}
+}

--- a/pkg/jsonld/edges.go
+++ b/pkg/jsonld/edges.go
@@ -1,0 +1,61 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package jsonld
+
+// EdgeIDs unwraps a JSON-LD edge value into the resource IDs it carries and
+// reports whether it was written as a list.
+//
+// It lives here rather than beside any one caller because every reader of an
+// edges node needs exactly this, and each one used to open the value itself.
+// Three of them only ever unwrapped a single `{"@id": …}` map and skipped
+// anything else, so a property the schema declares as an ARRAY of references —
+// which BuildResourceGraph correctly writes as a JSON array of refs — was
+// silently dropped on read while the write, the projection column and the boot
+// reconcile all reported success (issue #513).
+//
+// isList reports the shape the edge was written in, not how many IDs came back:
+// a one-element array is still a list. Callers preserve that shape so a
+// round-trip does not quietly turn a declared list into a scalar.
+func EdgeIDs(val any) (ids []string, isList bool) {
+	switch v := val.(type) {
+	case map[string]any:
+		if id, ok := v["@id"].(string); ok && id != "" {
+			return []string{id}, false
+		}
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			switch entry := item.(type) {
+			case map[string]any:
+				if id, ok := entry["@id"].(string); ok && id != "" {
+					out = append(out, id)
+				}
+			case string:
+				if entry != "" {
+					out = append(out, entry)
+				}
+			}
+		}
+		// An array with no usable @id still WAS a list; reporting that keeps a
+		// caller from re-reading it as a scalar and writing a malformed value.
+		return out, true
+	case string:
+		if v != "" {
+			return []string{v}, false
+		}
+	}
+	return nil, false
+}

--- a/tests/e2e/context_term_adoption_test.go
+++ b/tests/e2e/context_term_adoption_test.go
@@ -1,0 +1,382 @@
+// Copyright (C) 2026 Wepala, LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cucumber/godog"
+)
+
+// TestContextTermAdoption is the acceptance suite for the migration that closes
+// issue #513's remaining gap: the boot HOLDS a `@context` term whose adoption
+// would repoint a predicate that already has data, which stops the orphaning
+// but leaves the operator with no way forward — the property stays unreadable
+// and the boot reports the same failure every start.
+//
+// It shares its step world with TestPresetContextGuards, because the situation
+// it starts from is exactly the one those scenarios leave behind.
+func TestContextTermAdoption(t *testing.T) {
+	runContextFeature(t, "context-term-adoption", "features/context_term_adoption.feature")
+}
+
+// termAliasesKeyword is the `@context` key adoption records historical IRIs
+// under. It is spelled out here rather than read from the production package on
+// purpose: the contract is about what an operator finds in the stored context,
+// so the suite must break if that key is renamed, not follow it silently.
+const termAliasesKeyword = "weos:termAliases"
+
+// contextTermAdopter is the application surface this contract requires. It is
+// declared here, in test terms, so the suite compiles against a tree where
+// nothing implements it yet and fails with a sentence rather than a build
+// error. The ResourceTypeService satisfying it is what makes these scenarios
+// pass.
+//
+// Two methods rather than one flag: adopting a NAMED term is the operator
+// answering a specific held line from the boot log, and must be refused when
+// that term was never held (a typo silently succeeding is worse than an error);
+// adopting every held term is a sweep whose result is the list it took, which
+// the CLI prints.
+// adoptionPreset is the only preset this world declares, so every scenario
+// adopts against it. It stays out of the Gherkin because naming it in every
+// step would add a word no reader of these scenarios needs.
+const adoptionPreset = "catalog"
+
+type contextTermAdopter interface {
+	AdoptContextTerms(ctx context.Context, presetName, typeSlug string, terms []string) ([]string, error)
+}
+
+// errNoAdopter marks "the command does not exist yet" so a scenario asserting a
+// REFUSAL cannot be satisfied by the feature simply being absent.
+var errNoAdopter = errors.New(
+	"the ResourceTypeService exposes no way to adopt a held @context term: it must implement " +
+		"AdoptContextTerms(ctx, presetName, typeSlug string, terms []string) ([]string, error) (issue #513)")
+
+// registerAdoptionSteps adds the adopt-term steps to the shared context world.
+func (w *contextWorld) registerAdoptionSteps(sc *godog.ScenarioContext) {
+	sc.Step(`^the operator adopts the held "([^"]*)" context term for "([^"]*)"$`, w.theOperatorAdoptsHeldTerm)
+	sc.Step(`^the operator adopts the "([^"]*)" context term for "([^"]*)" again$`, w.theOperatorAdoptsTermAgain)
+	sc.Step(`^the operator adopts the "([^"]*)" context term for "([^"]*)"$`, w.theOperatorTriesToAdoptTerm)
+	sc.Step(`^the operator adopts every held context term for "([^"]*)"$`, w.theOperatorAdoptsEveryHeldTerm)
+
+	sc.Step(`^the adoption is refused because "([^"]*)" was not held$`, w.theAdoptionWasRefused)
+	sc.Step(`^the stored "widget" context records "([^"]*)" as a historical IRI for "([^"]*)"$`,
+		w.theStoredContextRecordsAlias)
+	sc.Step(`^the stored "widget" context records exactly one historical IRI for "([^"]*)"$`,
+		w.theStoredContextRecordsExactlyOneAlias)
+	sc.Step(`^the stored "widget" context records no historical IRI for "([^"]*)"$`, w.theStoredContextRecordsNoAlias)
+	sc.Step(`^the stored "widget" context is byte-identical to the one stored before the second adoption$`,
+		w.theStoredContextSurvivedTheSecondAdoption)
+
+	sc.Step(`^the boot reconcile does not report the "([^"]*)" context term as held for "([^"]*)"$`,
+		w.bootDoesNotReportContextTermHeld)
+	sc.Step(`^the boot reconcile no longer names "([^"]*)" as a property whose writes are dropped$`,
+		w.bootNoLongerNamesDropped)
+	sc.Step(`^the boot reconcile records no failure for "([^"]*)"$`, w.bootRecordsNoFailure)
+}
+
+// --- adopting ---
+
+func (w *contextWorld) adopter() (contextTermAdopter, error) {
+	if w.rts == nil {
+		return nil, fmt.Errorf("no twin is running in this scenario")
+	}
+	adopter, ok := w.rts.(contextTermAdopter)
+	if !ok {
+		return nil, errNoAdopter
+	}
+	return adopter, nil
+}
+
+func (w *contextWorld) theOperatorAdoptsHeldTerm(term, slug string) error {
+	adopter, err := w.adopter()
+	if err != nil {
+		return err
+	}
+	if _, err := adopter.AdoptContextTerms(context.Background(), adoptionPreset, slug, []string{term}); err != nil {
+		return fmt.Errorf("adopting the held %q term for %q failed: %w", term, slug, err)
+	}
+	return nil
+}
+
+// theOperatorTriesToAdoptTerm records the outcome instead of failing on it, so
+// a scenario can assert the command REFUSED. The refusal assertion rejects
+// errNoAdopter explicitly, so an unimplemented command never counts as one.
+func (w *contextWorld) theOperatorTriesToAdoptTerm(term, slug string) error {
+	adopter, err := w.adopter()
+	if err != nil {
+		w.adoptErr = err
+		w.adoptAttempted = true
+		return nil
+	}
+	_, w.adoptErr = adopter.AdoptContextTerms(context.Background(), adoptionPreset, slug, []string{term})
+	w.adoptAttempted = true
+	return nil
+}
+
+// theOperatorAdoptsTermAgain is the idempotence probe: it snapshots the stored
+// context first so a second adoption that quietly appends another alias, or
+// rewrites the term, is visible.
+func (w *contextWorld) theOperatorAdoptsTermAgain(term, slug string) error {
+	adopter, err := w.adopter()
+	if err != nil {
+		return err
+	}
+	rt, err := w.rts.GetBySlug(context.Background(), slug)
+	if err != nil {
+		return fmt.Errorf("failed to load the %q type before the second adoption: %w", slug, err)
+	}
+	w.contextBeforeSecondAdoption = append(json.RawMessage(nil), rt.Context()...)
+	if _, err := adopter.AdoptContextTerms(context.Background(), adoptionPreset, slug, []string{term}); err != nil {
+		return fmt.Errorf(
+			"adopting %q for %q a second time failed, so the command is not idempotent: %w", term, slug, err)
+	}
+	return nil
+}
+
+func (w *contextWorld) theOperatorAdoptsEveryHeldTerm(slug string) error {
+	adopter, err := w.adopter()
+	if err != nil {
+		return err
+	}
+	if _, err := adopter.AdoptContextTerms(context.Background(), adoptionPreset, slug, nil); err != nil {
+		return fmt.Errorf("adopting every held context term for %q failed: %w", slug, err)
+	}
+	return nil
+}
+
+func (w *contextWorld) theAdoptionWasRefused(term string) error {
+	if !w.adoptAttempted {
+		return fmt.Errorf("no adoption was attempted in this scenario")
+	}
+	if errors.Is(w.adoptErr, errNoAdopter) {
+		return w.adoptErr
+	}
+	if w.adoptErr == nil {
+		return fmt.Errorf(
+			"adopting %q succeeded, but that term was never held — a term with nothing to adopt must be refused, "+
+				"because recording an alias no data was ever written under widens the reverse map for nothing "+
+				"and a mistyped term name would otherwise look like success", term)
+	}
+	if !strings.Contains(w.adoptErr.Error(), term) {
+		return fmt.Errorf("adoption was refused with %q, which never names the %q term the operator asked for",
+			w.adoptErr, term)
+	}
+	return nil
+}
+
+// --- alias assertions ---
+
+// storedAliases reads the historical IRIs recorded in the stored context,
+// accepting both a lone string and an array for each property, since JSON-LD
+// authors write single values either way.
+func (w *contextWorld) storedAliases(slug string) (map[string][]string, error) {
+	terms, err := w.storedContextOf(slug)
+	if err != nil {
+		return nil, err
+	}
+	raw, ok := terms[termAliasesKeyword]
+	if !ok {
+		return map[string][]string{}, nil
+	}
+	entries, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("stored %q entry is %T, want an object keyed by property name", termAliasesKeyword, raw)
+	}
+	out := make(map[string][]string, len(entries))
+	for property, val := range entries {
+		switch v := val.(type) {
+		case string:
+			out[property] = []string{v}
+		case []any:
+			iris := make([]string, 0, len(v))
+			for _, item := range v {
+				iris = append(iris, fmt.Sprintf("%v", item))
+			}
+			out[property] = iris
+		default:
+			return nil, fmt.Errorf("recorded aliases for %q are %T, want a string or an array of strings",
+				property, val)
+		}
+	}
+	return out, nil
+}
+
+func (w *contextWorld) theStoredContextRecordsAlias(iri, property string) error {
+	aliases, err := w.storedAliases("widget")
+	if err != nil {
+		return err
+	}
+	for _, got := range aliases[property] {
+		if got == iri {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"stored widget context records %v as the historical IRIs for %q, not %q — without it every edge already "+
+			"written under that IRI stays unreadable, and a reproject rewrites nothing because the event is immutable",
+		aliases[property], property, iri)
+}
+
+func (w *contextWorld) theStoredContextRecordsExactlyOneAlias(property string) error {
+	aliases, err := w.storedAliases("widget")
+	if err != nil {
+		return err
+	}
+	if len(aliases[property]) != 1 {
+		return fmt.Errorf("stored widget context records %d historical IRIs for %q (%v), want exactly 1",
+			len(aliases[property]), property, aliases[property])
+	}
+	return nil
+}
+
+func (w *contextWorld) theStoredContextRecordsNoAlias(property string) error {
+	aliases, err := w.storedAliases("widget")
+	if err != nil {
+		return err
+	}
+	if len(aliases[property]) > 0 {
+		return fmt.Errorf("stored widget context records %v as historical IRIs for %q, but nothing was adopted for it",
+			aliases[property], property)
+	}
+	return nil
+}
+
+// theStoredContextSurvivedTheSecondAdoption compares the stored context term by
+// term rather than byte by byte: Go's map marshaling orders keys, but a nested
+// definition re-encoded on the way through would reorder nothing an operator
+// cares about, and the assertion is about CONTENT not being touched twice.
+func (w *contextWorld) theStoredContextSurvivedTheSecondAdoption() error {
+	if len(w.contextBeforeSecondAdoption) == 0 {
+		return fmt.Errorf("no stored context was captured before a second adoption in this scenario")
+	}
+	rt, err := w.rts.GetBySlug(context.Background(), "widget")
+	if err != nil {
+		return fmt.Errorf("failed to load the widget type: %w", err)
+	}
+	before, err := canonicalJSON(w.contextBeforeSecondAdoption)
+	if err != nil {
+		return fmt.Errorf("the context captured before the second adoption is not valid JSON: %w", err)
+	}
+	after, err := canonicalJSON(rt.Context())
+	if err != nil {
+		return fmt.Errorf("the stored context after the second adoption is not valid JSON: %w", err)
+	}
+	if before != after {
+		return fmt.Errorf("the second adoption changed the stored widget context, so adopting is not idempotent:"+
+			"\nbefore: %s\nafter:  %s", before, after)
+	}
+	return nil
+}
+
+// canonicalJSON re-encodes a JSON value with map keys sorted, so two contexts
+// differing only in key order compare equal.
+func canonicalJSON(raw json.RawMessage) (string, error) {
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", err
+	}
+	encoded, err := json.Marshal(sortJSON(value))
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}
+
+func sortJSON(value any) any {
+	switch v := value.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(v))
+		for k := range v {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		// encoding/json already marshals map keys in sorted order, so rebuilding
+		// the map is enough to normalise nested values too.
+		out := make(map[string]any, len(v))
+		for _, k := range keys {
+			out[k] = sortJSON(v[k])
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(v))
+		for _, item := range v {
+			out = append(out, sortJSON(item))
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+// --- boot-report assertions ---
+
+func (w *contextWorld) bootDoesNotReportContextTermHeld(term, slug string) error {
+	r, err := w.report()
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, line := range r.heldContext[slug] {
+		if strings.Contains(line, term) {
+			return fmt.Errorf(
+				"boot reconcile still reports the %q context term as held for %q (held: %v) — adoption did not "+
+					"settle the type, so the operator sees the same warning every start",
+				term, slug, r.heldContext[slug])
+		}
+	}
+	return nil
+}
+
+func (w *contextWorld) bootNoLongerNamesDropped(property string) error {
+	r, err := w.report()
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for slug, reason := range r.dropped {
+		if strings.Contains(reason, property) {
+			return fmt.Errorf("boot reconcile still names %q as a property whose writes are dropped for %q: %s",
+				property, slug, reason)
+		}
+	}
+	return nil
+}
+
+func (w *contextWorld) bootRecordsNoFailure(slug string) error {
+	r, err := w.report()
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if reason, failed := r.dropped[slug]; failed {
+		return fmt.Errorf("boot reconcile still reports %q as NOT reconciled: %s", slug, reason)
+	}
+	if len(r.heldContext[slug]) > 0 || len(r.heldSchema[slug]) > 0 {
+		return fmt.Errorf("boot reconcile still holds definitions for %q (context: %v, schema: %v)",
+			slug, r.heldContext[slug], r.heldSchema[slug])
+	}
+	return nil
+}

--- a/tests/e2e/features/context_term_adoption.feature
+++ b/tests/e2e/features/context_term_adoption.feature
@@ -1,0 +1,136 @@
+@issue-513
+Feature: An operator adopts a held @context term without orphaning the data behind it
+  As an operator whose boot holds a preset term because adopting it would repoint live data
+  I want one command that adopts the term and records the IRI my existing edges are keyed by
+  So that the property becomes readable again and the boot stops reporting the type every start
+
+  # The boot's hold (issue #513) stops the orphaning but leaves the operator stuck: the
+  # property stays unreadable, the boot logs the same failure every start, and the ADR
+  # forbids `preset install --update` at boot. Events are immutable and ResourceCreated
+  # carries the graph keyed by the write-time IRI, so a reproject reproduces that key no
+  # matter what is done to the stored data. Adoption therefore records an ALIAS — the old
+  # IRI, kept in the stored context under "weos:termAliases" — rather than rewriting edges.
+
+  Background:
+    Given a built-in preset "catalog" declaring a "vendor" type with the properties:
+      | property | type   |
+      | name     | string |
+    And the "catalog" preset also declares a "widget" type with the properties:
+      | property | type      | references |
+      | name     | string    |            |
+      | maker    | reference | vendor     |
+    And a clean WeOS database provisioned by that build
+    And a "vendor" named "Acme" exists
+
+  Scenario: A reference written before the term existed reads back once the term is adopted
+    Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor" without a context entry
+    And the twin restarts against the same database
+    And I create a "widget" named "Bolt cutter" with "supplier" referring to the "vendor" "Acme"
+    And the "catalog" preset declares "supplier" as "https://example.org/catalog#supplier" in the "widget" context
+    And the twin restarts against the same database
+    When the operator adopts the held "supplier" context term for "widget"
+    Then the stored "widget" context still maps "supplier" to "https://example.org/catalog#supplier"
+    And the stored "widget" context records "https://schema.org/supplier" as a historical IRI for "supplier"
+    And the JSON-LD representation of the "widget" "Bolt cutter" still carries a "supplier" edge to the "vendor" "Acme"
+    When the operator reprojects the event feed
+    Then reading the "widget" "Bolt cutter" back through the projection returns "supplier" as the "vendor" "Acme"
+
+  Scenario: A write made after adoption uses the adopted IRI and reads back beside the old one
+    Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor" without a context entry
+    And the twin restarts against the same database
+    And I create a "widget" named "Bolt cutter" with "supplier" referring to the "vendor" "Acme"
+    And the "catalog" preset declares "supplier" as "https://example.org/catalog#supplier" in the "widget" context
+    And the twin restarts against the same database
+    When the operator adopts the held "supplier" context term for "widget"
+    And I create a "widget" named "Hex key" with "supplier" referring to the "vendor" "Acme"
+    Then reading the "widget" "Hex key" back through the projection returns "supplier" as the "vendor" "Acme"
+    And the JSON-LD representation of the "widget" "Hex key" still carries a "supplier" edge to the "vendor" "Acme"
+    And the JSON-LD representation of the "widget" "Bolt cutter" still carries a "supplier" edge to the "vendor" "Acme"
+
+  Scenario: The boot settles once the term is adopted
+    Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor" without a context entry
+    And the twin restarts against the same database
+    And I create a "widget" named "Bolt cutter" with "supplier" referring to the "vendor" "Acme"
+    And the "catalog" preset declares "supplier" as "https://example.org/catalog#supplier" in the "widget" context
+    And the twin restarts against the same database
+    When the operator adopts the held "supplier" context term for "widget"
+    And the twin restarts against the same database again
+    Then the boot reconcile does not report the "supplier" context term as held for "widget"
+    And the boot reconcile no longer names "supplier" as a property whose writes are dropped
+    And the boot reconcile records no failure for "widget"
+    And the stored "widget" context still maps "supplier" to "https://example.org/catalog#supplier"
+
+  Scenario: Adopting the same term twice records nothing a second time
+    Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor" without a context entry
+    And the twin restarts against the same database
+    And I create a "widget" named "Bolt cutter" with "supplier" referring to the "vendor" "Acme"
+    And the "catalog" preset declares "supplier" as "https://example.org/catalog#supplier" in the "widget" context
+    And the twin restarts against the same database
+    When the operator adopts the held "supplier" context term for "widget"
+    And the operator adopts the "supplier" context term for "widget" again
+    Then the stored "widget" context is byte-identical to the one stored before the second adoption
+    And the stored "widget" context records exactly one historical IRI for "supplier"
+    And the JSON-LD representation of the "widget" "Bolt cutter" still carries a "supplier" edge to the "vendor" "Acme"
+
+  Scenario: Adopting a term the boot never held is refused
+    Given I create a "widget" named "Bolt cutter" with "maker" referring to the "vendor" "Acme"
+    When the operator adopts the "maker" context term for "widget"
+    Then the adoption is refused because "maker" was not held
+    And the stored "widget" context records no historical IRI for "maker"
+    And the JSON-LD representation of the "widget" "Bolt cutter" still carries a "maker" edge to the "vendor" "Acme"
+
+  Scenario: An adopted alias never shadows a term another property still uses
+    Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor" without a context entry
+    And the twin restarts against the same database
+    And the operator maps "maker" to "https://schema.org/supplier" in the stored "widget" context
+    And I create a "widget" named "Bolt cutter" with "maker" referring to the "vendor" "Acme"
+    And the "catalog" preset declares "supplier" as "https://example.org/catalog#supplier" in the "widget" context
+    And the twin restarts against the same database
+    When the operator adopts the held "supplier" context term for "widget"
+    Then the stored "widget" context still maps "supplier" to "https://example.org/catalog#supplier"
+    And the stored "widget" context records "https://schema.org/supplier" as a historical IRI for "supplier"
+    When the operator reprojects the event feed
+    Then reading the "widget" "Bolt cutter" back through the projection returns "maker" as the "vendor" "Acme"
+    And reading the "widget" "Bolt cutter" back through the projection returns no value for "supplier"
+
+  Scenario: Adopting a held prefix records the alias against the property the prefix moves
+    Given the operator maps "maker" to "cat:madeBy" in the stored "widget" context
+    And I create a "widget" named "Bolt cutter" with "maker" referring to the "vendor" "Acme"
+    And the "catalog" preset declares "cat" as "https://example.org/catalog#" in the "widget" context
+    And the twin restarts against the same database
+    When the operator adopts the held "cat" context term for "widget"
+    Then the stored "widget" context records "https://schema.org/cat:madeBy" as a historical IRI for "maker"
+    And the JSON-LD representation of the "widget" "Bolt cutter" still carries a "maker" edge to the "vendor" "Acme"
+    When the operator reprojects the event feed
+    Then reading the "widget" "Bolt cutter" back through the projection returns "maker" as the "vendor" "Acme"
+
+  Scenario: Adopting every held term for a type takes all of them in one command
+    Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor" without a context entry
+    And the "catalog" preset adds a "distributor" reference property to "widget" targeting "vendor" without a context entry
+    And the twin restarts against the same database
+    And I create a "widget" named "Bolt cutter" with these references:
+      | property    | vendor |
+      | supplier    | Acme   |
+      | distributor | Acme   |
+    And the "catalog" preset declares "supplier" as "https://example.org/catalog#supplier" in the "widget" context
+    And the "catalog" preset declares "distributor" as "https://example.org/catalog#distributor" in the "widget" context
+    And the twin restarts against the same database
+    When the operator adopts every held context term for "widget"
+    And the operator reprojects the event feed
+    Then reading the "widget" "Bolt cutter" back through the projection returns "supplier" as the "vendor" "Acme"
+    And reading the "widget" "Bolt cutter" back through the projection returns "distributor" as the "vendor" "Acme"
+    And the stored "widget" context records "https://schema.org/supplier" as a historical IRI for "supplier"
+    And the stored "widget" context records "https://schema.org/distributor" as a historical IRI for "distributor"
+
+  Scenario: Adopting every held term still leaves the type's RDF class where it is
+    Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor" without a context entry
+    And the twin restarts against the same database
+    And I create a "widget" named "Bolt cutter" with "supplier" referring to the "vendor" "Acme"
+    And the "catalog" preset declares "supplier" as "https://example.org/catalog#supplier" in the "widget" context
+    And the "catalog" preset declares "@type" as "Product" in the "widget" context
+    And the twin restarts against the same database
+    When the operator adopts every held context term for "widget"
+    And a "widget" named "Hex key" exists
+    Then the stored "widget" context still maps "supplier" to "https://example.org/catalog#supplier"
+    And the stored "widget" context has no entry for "@type"
+    And the "widget" resources "Bolt cutter" and "Hex key" carry the same RDF type

--- a/tests/e2e/features/preset_context_guards.feature
+++ b/tests/e2e/features/preset_context_guards.feature
@@ -1,0 +1,65 @@
+@issue-513
+Feature: A boot reconcile never moves or blocks a predicate that already has data
+  As an operator upgrading WeOS across a preset whose @context changed
+  I want the boot to leave every predicate my stored edges are keyed by resolvable
+  So that an upgrade never orphans data while reporting the type reconciled
+
+  Background:
+    Given a built-in preset "catalog" declaring a "vendor" type with the properties:
+      | property | type   |
+      | name     | string |
+    And the "catalog" preset also declares a "widget" type with the properties:
+      | property | type      | references |
+      | name     | string    |            |
+      | maker    | reference | vendor     |
+    And a clean WeOS database provisioned by that build
+    And a "vendor" named "Acme" exists
+
+  @wip
+  Scenario: A term naming a different IRI than the data already uses is held and reported
+    Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor" without a context entry
+    And the twin restarts against the same database
+    And I create a "widget" named "Bolt cutter" with "supplier" referring to the "vendor" "Acme"
+    When the "catalog" preset declares "supplier" as "https://example.org/catalog#supplier" in the "widget" context
+    And the twin restarts against the same database
+    Then the boot reconcile reports the "supplier" context term as held for "widget"
+
+  @wip
+  Scenario: A reference written before its term existed still resolves after a differently-named term merges
+    Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor" without a context entry
+    And the twin restarts against the same database
+    And I create a "widget" named "Bolt cutter" with "supplier" referring to the "vendor" "Acme"
+    When the "catalog" preset declares "supplier" as "https://example.org/catalog#supplier" in the "widget" context
+    And the twin restarts against the same database
+    Then the JSON-LD representation of the "widget" "Bolt cutter" still carries a "supplier" edge to the "vendor" "Acme"
+
+  @wip
+  Scenario: A prefix the preset adds does not repoint a compact term the stored context already resolved
+    Given the operator maps "maker" to "cat:madeBy" in the stored "widget" context
+    And I create a "widget" named "Bolt cutter" with "maker" referring to the "vendor" "Acme"
+    When the "catalog" preset declares "cat" as "https://example.org/catalog#" in the "widget" context
+    And the twin restarts against the same database
+    Then the JSON-LD representation of the "widget" "Bolt cutter" still carries a "maker" edge to the "vendor" "Acme"
+
+  @wip
+  Scenario: A term that moves the type's RDF class is held so its resources stay in one class
+    Given a "widget" named "Bolt cutter" exists
+    When the "catalog" preset declares "@type" as "Product" in the "widget" context
+    And the twin restarts against the same database
+    And a "widget" named "Hex key" exists
+    Then the "widget" resources "Bolt cutter" and "Hex key" carry the same RDF type
+    And the boot reconcile reports the "@type" context term as held for "widget"
+
+  @wip
+  Scenario Outline: A stored context that is not a JSON object still lets the schema merge through
+    Given the operator stores the raw context <context> for "widget"
+    And the "catalog" preset adds a "sku" string property to "widget"
+    And the twin restarts against the same database
+    When I create a "widget" named "Bolt cutter" with "sku" set to "BC-100"
+    Then the "widget" projection table has a "sku" column
+    And reading the "widget" "Bolt cutter" back over the API returns "sku" as "BC-100"
+
+    Examples:
+      | context                 |
+      | ["https://schema.org/"] |
+      | "https://schema.org/"   |

--- a/tests/e2e/features/preset_context_guards.feature
+++ b/tests/e2e/features/preset_context_guards.feature
@@ -15,7 +15,6 @@ Feature: A boot reconcile never moves or blocks a predicate that already has dat
     And a clean WeOS database provisioned by that build
     And a "vendor" named "Acme" exists
 
-  @wip
   Scenario: A term naming a different IRI than the data already uses is held and reported
     Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor" without a context entry
     And the twin restarts against the same database
@@ -24,7 +23,6 @@ Feature: A boot reconcile never moves or blocks a predicate that already has dat
     And the twin restarts against the same database
     Then the boot reconcile reports the "supplier" context term as held for "widget"
 
-  @wip
   Scenario: A reference written before its term existed still resolves after a differently-named term merges
     Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor" without a context entry
     And the twin restarts against the same database
@@ -33,7 +31,6 @@ Feature: A boot reconcile never moves or blocks a predicate that already has dat
     And the twin restarts against the same database
     Then the JSON-LD representation of the "widget" "Bolt cutter" still carries a "supplier" edge to the "vendor" "Acme"
 
-  @wip
   Scenario: A prefix the preset adds does not repoint a compact term the stored context already resolved
     Given the operator maps "maker" to "cat:madeBy" in the stored "widget" context
     And I create a "widget" named "Bolt cutter" with "maker" referring to the "vendor" "Acme"
@@ -41,7 +38,6 @@ Feature: A boot reconcile never moves or blocks a predicate that already has dat
     And the twin restarts against the same database
     Then the JSON-LD representation of the "widget" "Bolt cutter" still carries a "maker" edge to the "vendor" "Acme"
 
-  @wip
   Scenario: A term that moves the type's RDF class is held so its resources stay in one class
     Given a "widget" named "Bolt cutter" exists
     When the "catalog" preset declares "@type" as "Product" in the "widget" context
@@ -50,14 +46,13 @@ Feature: A boot reconcile never moves or blocks a predicate that already has dat
     Then the "widget" resources "Bolt cutter" and "Hex key" carry the same RDF type
     And the boot reconcile reports the "@type" context term as held for "widget"
 
-  @wip
   Scenario Outline: A stored context that is not a JSON object still lets the schema merge through
     Given the operator stores the raw context <context> for "widget"
     And the "catalog" preset adds a "sku" string property to "widget"
     And the twin restarts against the same database
     When I create a "widget" named "Bolt cutter" with "sku" set to "BC-100"
     Then the "widget" projection table has a "sku" column
-    And reading the "widget" "Bolt cutter" back over the API returns "sku" as "BC-100"
+    And reading the "widget" "Bolt cutter" back through the projection returns "sku" as "BC-100"
 
     Examples:
       | context                 |

--- a/tests/e2e/features/preset_context_reconcile.feature
+++ b/tests/e2e/features/preset_context_reconcile.feature
@@ -19,7 +19,7 @@ Feature: A built-in preset's new reference property reaches an already-provision
     Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
     And the twin restarts against the same database
     When I create a "widget" named "Bolt cutter" with "supplier" referring to the "vendor" "Acme"
-    Then reading the "widget" "Bolt cutter" back over the API returns "supplier" as the "vendor" "Acme"
+    Then reading the "widget" "Bolt cutter" back through the projection returns "supplier" as the "vendor" "Acme"
 
   Scenario: A new reference property gains both a projection column and a context entry
     When the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
@@ -34,14 +34,14 @@ Feature: A built-in preset's new reference property reaches an already-provision
       | property | vendor |
       | maker    | Acme   |
       | supplier | Acme   |
-    Then reading the "widget" "Bolt cutter" back over the API returns "maker" as the "vendor" "Acme"
-    And reading the "widget" "Bolt cutter" back over the API returns "supplier" as the "vendor" "Acme"
+    Then reading the "widget" "Bolt cutter" back through the projection returns "maker" as the "vendor" "Acme"
+    And reading the "widget" "Bolt cutter" back through the projection returns "supplier" as the "vendor" "Acme"
 
   Scenario: A literal property added to a preset round-trips and gains no context entry
     Given the "catalog" preset adds a "sku" string property to "widget"
     And the twin restarts against the same database
     When I create a "widget" named "Bolt cutter" with "sku" set to "BC-100"
-    Then reading the "widget" "Bolt cutter" back over the API returns "sku" as "BC-100"
+    Then reading the "widget" "Bolt cutter" back through the projection returns "sku" as "BC-100"
     And the stored "widget" context has no entry for "sku"
 
   Scenario: A context entry the operator changed is held at its stored definition
@@ -60,8 +60,8 @@ Feature: A built-in preset's new reference property reaches an already-provision
       | property | vendor |
       | maker    | Acme   |
       | supplier | Acme   |
-    Then reading the "widget" "Bolt cutter" back over the API returns "maker" as the "vendor" "Acme"
-    And reading the "widget" "Bolt cutter" back over the API returns "supplier" as the "vendor" "Acme"
+    Then reading the "widget" "Bolt cutter" back through the projection returns "maker" as the "vendor" "Acme"
+    And reading the "widget" "Bolt cutter" back through the projection returns "supplier" as the "vendor" "Acme"
 
   Scenario: An operator's own context entry the preset does not declare survives the merge
     Given the operator maps "warranty" to "https://example.org/vocab/warranty" in the stored "widget" context
@@ -106,7 +106,7 @@ Feature: A built-in preset's new reference property reaches an already-provision
     And the boot reconcile names "supplier" as a property whose writes are still dropped
     And the boot reconcile reports "vendor" as updated
 
-  @issue-513 @wip
+  @issue-513
   Scenario: A reference the preset never maps is still named as dropped on a later boot with nothing to merge
     Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor" without a context entry
     And the twin restarts against the same database
@@ -120,28 +120,28 @@ Feature: A built-in preset's new reference property reaches an already-provision
   # lands in the entity node as a literal and the column refills through
   # extractNodeColumns — which is how both scenarios used to pass with the whole
   # context merge deleted (issue #513, P2-1).
-  @issue-513 @wip
+  @issue-513
   Scenario: A reference written before the context entry existed reads back empty but survives in the canonical record
     Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor" without a context entry
     And the twin restarts against the same database
     And I create a "widget" named "Bolt cutter" with "supplier" referring to the "vendor" "Acme"
     When the "catalog" preset declares a context entry for "supplier" on "widget"
     And the twin restarts against the same database
-    Then reading the "widget" "Bolt cutter" back over the API returns no value for "supplier"
+    Then reading the "widget" "Bolt cutter" back through the projection returns no value for "supplier"
     And the JSON-LD representation of the "widget" "Bolt cutter" still carries a "supplier" edge to the "vendor" "Acme"
 
-  @issue-513 @wip
+  @issue-513
   Scenario: Reprojecting after the context entry lands populates the reference column
     Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor" without a context entry
     And the twin restarts against the same database
     And I create a "widget" named "Bolt cutter" with "supplier" referring to the "vendor" "Acme"
     And the "catalog" preset declares a context entry for "supplier" on "widget"
     And the twin restarts against the same database
-    And reading the "widget" "Bolt cutter" back over the API returns no value for "supplier"
+    And reading the "widget" "Bolt cutter" back through the projection returns no value for "supplier"
     When the operator reprojects the event feed
-    Then reading the "widget" "Bolt cutter" back over the API returns "supplier" as the "vendor" "Acme"
+    Then reading the "widget" "Bolt cutter" back through the projection returns "supplier" as the "vendor" "Acme"
 
-  @issue-513 @wip
+  @issue-513
   Scenario: A context entry the operator deleted is restored without rewriting the stored schema
     Given the operator deletes "maker" from the stored "widget" context
     When the twin restarts against the same database

--- a/tests/e2e/features/preset_context_reconcile.feature
+++ b/tests/e2e/features/preset_context_reconcile.feature
@@ -70,12 +70,18 @@ Feature: A built-in preset's new reference property reaches an already-provision
     Then the stored "widget" context still maps "warranty" to "https://example.org/vocab/warranty"
     And the stored "widget" context has an entry for "supplier"
 
-  Scenario: A type with no stored context adopts the entries the preset declares
+  # Changed by #513. A cleared context still resolves every reference — to its
+  # bare property name, since there is no @vocab to prefix it — so edges exist
+  # under those names and re-adopting the preset's terms would orphan them. The
+  # boot reports instead of silently papering over the operator's act. A
+  # property the preset adds in the SAME boot is exempt: it has no data under
+  # any IRI yet, so its term merges freely.
+  Scenario: A cleared context is held and reported rather than silently re-adopted
     Given the operator clears the stored "widget" context
     And the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
     When the twin restarts against the same database
-    Then the stored "widget" context has an entry for "supplier"
-    And the stored "widget" context has an entry for "maker"
+    Then the stored "widget" context has no entry for "maker"
+    And the boot reconcile reports the "maker" context term as held for "widget"
 
   Scenario: The context merge happens once and then settles
     Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"

--- a/tests/e2e/features/preset_context_reconcile.feature
+++ b/tests/e2e/features/preset_context_reconcile.feature
@@ -94,11 +94,25 @@ Feature: A built-in preset's new reference property reaches an already-provision
     Then the boot reconcile reports "widget" as updated
     And every reference property the "catalog" preset declares for "widget" has a stored context entry
 
+  # "vendor" changes in the same boot purely as a positive control: it proves the
+  # boot really does report an updated type on this run, so the negative
+  # assertion above it cannot rot into a permanent pass if the log line is
+  # renamed (issue #513, P2-4).
   Scenario: A reference property the preset's own context never declares is not reported as updated
     Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor" without a context entry
+    And the "catalog" preset adds a "code" string property to "vendor"
     When the twin restarts against the same database
     Then the boot reconcile does not report "widget" as updated
     And the boot reconcile names "supplier" as a property whose writes are still dropped
+    And the boot reconcile reports "vendor" as updated
+
+  @issue-513 @wip
+  Scenario: A reference the preset never maps is still named as dropped on a later boot with nothing to merge
+    Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor" without a context entry
+    And the twin restarts against the same database
+    And the boot reconcile names "supplier" as a property whose writes are still dropped
+    When the twin restarts against the same database again
+    Then the boot reconcile names "supplier" as a property whose writes are still dropped
 
   # The two scenarios below write their pre-fix row through a schema that ALREADY
   # marks "supplier" a reference, so the value lands as a real EDGE keyed by the

--- a/tests/e2e/features/preset_context_reconcile.feature
+++ b/tests/e2e/features/preset_context_reconcile.feature
@@ -100,17 +100,36 @@ Feature: A built-in preset's new reference property reaches an already-provision
     Then the boot reconcile does not report "widget" as updated
     And the boot reconcile names "supplier" as a property whose writes are still dropped
 
+  # The two scenarios below write their pre-fix row through a schema that ALREADY
+  # marks "supplier" a reference, so the value lands as a real EDGE keyed by the
+  # @vocab-derived IRI. Written against a schema that does not declare it yet, it
+  # lands in the entity node as a literal and the column refills through
+  # extractNodeColumns — which is how both scenarios used to pass with the whole
+  # context merge deleted (issue #513, P2-1).
+  @issue-513 @wip
   Scenario: A reference written before the context entry existed reads back empty but survives in the canonical record
-    Given a "widget" named "Bolt cutter" is created with an undeclared "supplier" referring to the "vendor" "Acme"
-    When the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
+    Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor" without a context entry
+    And the twin restarts against the same database
+    And I create a "widget" named "Bolt cutter" with "supplier" referring to the "vendor" "Acme"
+    When the "catalog" preset declares a context entry for "supplier" on "widget"
     And the twin restarts against the same database
     Then reading the "widget" "Bolt cutter" back over the API returns no value for "supplier"
     And the JSON-LD representation of the "widget" "Bolt cutter" still carries a "supplier" edge to the "vendor" "Acme"
 
+  @issue-513 @wip
   Scenario: Reprojecting after the context entry lands populates the reference column
-    Given a "widget" named "Bolt cutter" is created with an undeclared "supplier" referring to the "vendor" "Acme"
-    And the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor"
+    Given the "catalog" preset adds a "supplier" reference property to "widget" targeting "vendor" without a context entry
+    And the twin restarts against the same database
+    And I create a "widget" named "Bolt cutter" with "supplier" referring to the "vendor" "Acme"
+    And the "catalog" preset declares a context entry for "supplier" on "widget"
     And the twin restarts against the same database
     And reading the "widget" "Bolt cutter" back over the API returns no value for "supplier"
     When the operator reprojects the event feed
     Then reading the "widget" "Bolt cutter" back over the API returns "supplier" as the "vendor" "Acme"
+
+  @issue-513 @wip
+  Scenario: A context entry the operator deleted is restored without rewriting the stored schema
+    Given the operator deletes "maker" from the stored "widget" context
+    When the twin restarts against the same database
+    Then the stored "widget" context has an entry for "maker"
+    And the stored "widget" schema is byte-identical to the one stored before the restart

--- a/tests/e2e/features/projection_column_migration.feature
+++ b/tests/e2e/features/projection_column_migration.feature
@@ -20,7 +20,7 @@ Feature: A built-in preset's schema change reaches an already-provisioned databa
     Given the "catalog" preset adds a "sku" string property to "widget"
     And the twin restarts against the same database
     When I create a "widget" named "Bolt cutter" with "sku" set to "BC-100"
-    Then reading the "widget" "Bolt cutter" back over the API returns "sku" as "BC-100"
+    Then reading the "widget" "Bolt cutter" back through the projection returns "sku" as "BC-100"
 
   Scenario: Restarting with an unchanged preset records no resource type update
     When the twin restarts against the same database
@@ -37,7 +37,7 @@ Feature: A built-in preset's schema change reaches an already-provisioned databa
     Given a "widget" named "Hex key" exists
     When the "catalog" preset adds a "sku" string property to "widget"
     And the twin restarts against the same database
-    Then reading the "widget" "Hex key" back over the API succeeds
+    Then reading the "widget" "Hex key" back through the projection succeeds
     And it returns no value for "sku"
 
   Scenario: Fixture data is not re-seeded when a preset's schema changes
@@ -62,6 +62,6 @@ Feature: A built-in preset's schema change reaches an already-provisioned databa
     Given a "widget" named "Bolt cutter" is created with an undeclared "sku" of "BC-100"
     And the "catalog" preset adds a "sku" string property to "widget"
     And the twin restarts against the same database
-    And reading the "widget" "Bolt cutter" back over the API returns no value for "sku"
+    And reading the "widget" "Bolt cutter" back through the projection returns no value for "sku"
     When the operator reprojects the event feed
-    Then reading the "widget" "Bolt cutter" back over the API returns "sku" as "BC-100"
+    Then reading the "widget" "Bolt cutter" back through the projection returns "sku" as "BC-100"

--- a/tests/e2e/features/reference_property_round_trip.feature
+++ b/tests/e2e/features/reference_property_round_trip.feature
@@ -1,0 +1,51 @@
+@issue-513
+Feature: Every reference shape a preset declares reads back
+  As an operator whose preset declares references both as a single value and as a list
+  I want a list-valued reference to survive the round-trip like a single-valued one
+  So that a type reported as reconciled is one whose references can actually be read
+
+  Background:
+    Given a built-in preset "catalog" declaring a "vendor" type with the properties:
+      | property | type   |
+      | name     | string |
+    And the "catalog" preset also declares a "widget" type with the properties:
+      | property  | type           | references |
+      | name      | string         |            |
+      | maker     | reference      | vendor     |
+      | suppliers | reference list | vendor     |
+    And a clean WeOS database provisioned by that build
+    And a "vendor" named "Acme" exists
+
+  @wip
+  Scenario: A single-valued and a list-valued reference declared side by side both read back
+    When I create a "widget" named "Bolt cutter" with these references:
+      | property  | vendor |
+      | maker     | Acme   |
+      | suppliers | Acme   |
+    Then reading the "widget" "Bolt cutter" back over the API returns "maker" as the "vendor" "Acme"
+    And reading the "widget" "Bolt cutter" back over the API returns "suppliers" as the vendors "Acme"
+
+  @wip
+  Scenario: A list-valued reference reads back every target it was written with
+    Given a "vendor" named "Globex" exists
+    When I create a "widget" named "Bolt cutter" with these references:
+      | property  | vendor       |
+      | suppliers | Acme, Globex |
+    Then reading the "widget" "Bolt cutter" back over the API returns "suppliers" as the vendors "Acme, Globex"
+
+  @wip
+  Scenario: A list-valued reference reaches the projection read and the canonical record alike
+    Given a "vendor" named "Globex" exists
+    When I create a "widget" named "Bolt cutter" with these references:
+      | property  | vendor       |
+      | suppliers | Acme, Globex |
+    Then the JSON-LD representation of the "widget" "Bolt cutter" carries "suppliers" edges to the vendors "Acme, Globex"
+    And reading the "widget" "Bolt cutter" back over the API returns "suppliers" as the vendors "Acme, Globex"
+
+  @wip
+  Scenario: A list-valued reference added by a later build round-trips after restart
+    Given the "catalog" preset adds a "distributors" reference list property to "widget" targeting "vendor"
+    And the twin restarts against the same database
+    When I create a "widget" named "Bolt cutter" with "distributors" referring to the "vendor" "Acme"
+    Then the "widget" projection table has a "distributors" column
+    And reading the "widget" "Bolt cutter" back over the API returns "distributors" as the vendors "Acme"

--- a/tests/e2e/features/reference_property_round_trip.feature
+++ b/tests/e2e/features/reference_property_round_trip.feature
@@ -16,36 +16,32 @@ Feature: Every reference shape a preset declares reads back
     And a clean WeOS database provisioned by that build
     And a "vendor" named "Acme" exists
 
-  @wip
   Scenario: A single-valued and a list-valued reference declared side by side both read back
     When I create a "widget" named "Bolt cutter" with these references:
       | property  | vendor |
       | maker     | Acme   |
       | suppliers | Acme   |
-    Then reading the "widget" "Bolt cutter" back over the API returns "maker" as the "vendor" "Acme"
-    And reading the "widget" "Bolt cutter" back over the API returns "suppliers" as the vendors "Acme"
+    Then reading the "widget" "Bolt cutter" back through the projection returns "maker" as the "vendor" "Acme"
+    And reading the "widget" "Bolt cutter" back through the projection returns "suppliers" as the vendors "Acme"
 
-  @wip
   Scenario: A list-valued reference reads back every target it was written with
     Given a "vendor" named "Globex" exists
     When I create a "widget" named "Bolt cutter" with these references:
       | property  | vendor       |
       | suppliers | Acme, Globex |
-    Then reading the "widget" "Bolt cutter" back over the API returns "suppliers" as the vendors "Acme, Globex"
+    Then reading the "widget" "Bolt cutter" back through the projection returns "suppliers" as the vendors "Acme, Globex"
 
-  @wip
   Scenario: A list-valued reference reaches the projection read and the canonical record alike
     Given a "vendor" named "Globex" exists
     When I create a "widget" named "Bolt cutter" with these references:
       | property  | vendor       |
       | suppliers | Acme, Globex |
     Then the JSON-LD representation of the "widget" "Bolt cutter" carries "suppliers" edges to the vendors "Acme, Globex"
-    And reading the "widget" "Bolt cutter" back over the API returns "suppliers" as the vendors "Acme, Globex"
+    And reading the "widget" "Bolt cutter" back through the projection returns "suppliers" as the vendors "Acme, Globex"
 
-  @wip
   Scenario: A list-valued reference added by a later build round-trips after restart
     Given the "catalog" preset adds a "distributors" reference list property to "widget" targeting "vendor"
     And the twin restarts against the same database
     When I create a "widget" named "Bolt cutter" with "distributors" referring to the "vendor" "Acme"
     Then the "widget" projection table has a "distributors" column
-    And reading the "widget" "Bolt cutter" back over the API returns "distributors" as the vendors "Acme"
+    And reading the "widget" "Bolt cutter" back through the projection returns "distributors" as the vendors "Acme"

--- a/tests/e2e/preset_context_reconcile_test.go
+++ b/tests/e2e/preset_context_reconcile_test.go
@@ -201,12 +201,12 @@ func initPresetContextScenario(sc *godog.ScenarioContext) {
 	sc.Step(`^I create a "widget" named "([^"]*)" with these references:$`, w.iCreateWidgetWithReferences)
 	sc.Step(`^I create a "widget" named "([^"]*)" with "([^"]*)" set to "([^"]*)"$`, w.iCreateWidgetWithLiteral)
 
-	sc.Step(`^reading the "widget" "([^"]*)" back over the API returns "([^"]*)" as the "vendor" "([^"]*)"$`,
+	sc.Step(`^reading the "widget" "([^"]*)" back through the projection returns "([^"]*)" as the "vendor" "([^"]*)"$`,
 		w.readingReturnsReference)
-	sc.Step(`^reading the "widget" "([^"]*)" back over the API returns "([^"]*)" as the vendors "([^"]*)"$`,
+	sc.Step(`^reading the "widget" "([^"]*)" back through the projection returns "([^"]*)" as the vendors "([^"]*)"$`,
 		w.readingReturnsReferenceList)
-	sc.Step(`^reading the "widget" "([^"]*)" back over the API returns "([^"]*)" as "([^"]*)"$`, w.readingReturnsLiteral)
-	sc.Step(`^reading the "widget" "([^"]*)" back over the API returns no value for "([^"]*)"$`, w.readingReturnsNoValue)
+	sc.Step(`^reading the "widget" "([^"]*)" back through the projection returns "([^"]*)" as "([^"]*)"$`, w.readingReturnsLiteral)
+	sc.Step(`^reading the "widget" "([^"]*)" back through the projection returns no value for "([^"]*)"$`, w.readingReturnsNoValue)
 	sc.Step(`^the JSON-LD representation of the "widget" "([^"]*)" still carries a "([^"]*)" edge `+
 		`to the "vendor" "([^"]*)"$`, w.canonicalStillCarriesEdge)
 	sc.Step(`^the JSON-LD representation of the "widget" "([^"]*)" carries "([^"]*)" edges `+

--- a/tests/e2e/preset_context_reconcile_test.go
+++ b/tests/e2e/preset_context_reconcile_test.go
@@ -145,6 +145,16 @@ type contextWorld struct {
 	bootReport *reconcileLog
 
 	createdIDs map[string]string
+
+	// adoptErr and adoptAttempted record the outcome of an adopt-term command a
+	// scenario expects to be REFUSED, so the refusal itself can be asserted.
+	adoptErr       error
+	adoptAttempted bool
+
+	// contextBeforeSecondAdoption is the stored "widget" context as it was
+	// immediately before a repeated adoption, so idempotence is asserted against
+	// what was actually there rather than against a rebuilt expectation.
+	contextBeforeSecondAdoption json.RawMessage
 }
 
 // contextProperty is one schema property. references is empty for a literal and
@@ -231,6 +241,10 @@ func initPresetContextScenario(sc *godog.ScenarioContext) {
 	sc.Step(`^the boot reconcile reports "([^"]*)" as updated$`, w.bootReportsUpdated)
 	sc.Step(`^the boot reconcile does not report "([^"]*)" as updated$`, w.bootDoesNotReportUpdated)
 	sc.Step(`^the boot reconcile names "([^"]*)" as a property whose writes are still dropped$`, w.bootNamesDropped)
+
+	// The adopt-term migration extends this world rather than forking it: the
+	// situation it starts from is the one the guard scenarios leave behind.
+	w.registerAdoptionSteps(sc)
 }
 
 // --- preset shaping ---

--- a/tests/e2e/preset_context_reconcile_test.go
+++ b/tests/e2e/preset_context_reconcile_test.go
@@ -185,7 +185,7 @@ func initPresetContextScenario(sc *godog.ScenarioContext) {
 		w.thePresetDeclaresContextEntryFor)
 	sc.Step(`^the "catalog" preset adds a "([^"]*)" reference property to "widget" targeting "([^"]*)" `+
 		`without a context entry$`, w.thePresetAddsReferenceWithoutContextEntry)
-	sc.Step(`^the "catalog" preset adds a "([^"]*)" (\w+) property to "widget"$`, w.thePresetAddsLiteral)
+	sc.Step(`^the "catalog" preset adds a "([^"]*)" (\w+) property to "(widget|vendor)"$`, w.thePresetAddsLiteral)
 
 	sc.Step(`^the operator maps "([^"]*)" to "([^"]*)" in the stored "widget" context$`, w.theOperatorMapsTerm)
 	sc.Step(`^the operator clears the stored "widget" context$`, w.theOperatorClearsContext)
@@ -363,8 +363,21 @@ func (w *contextWorld) thePresetDeclaresContextEntryFor(name string) error {
 	return fmt.Errorf("widget declares no property named %q", name)
 }
 
-func (w *contextWorld) thePresetAddsLiteral(name, jsonTyp string) error {
-	return w.addWidgetProperty(contextProperty{name: name, jsonTyp: jsonTyp})
+// thePresetAddsLiteral names its type, so a scenario can change the OTHER type
+// in the same boot — which is how a negative assertion about one type gets a
+// positive control from a healthy one beside it.
+func (w *contextWorld) thePresetAddsLiteral(name, jsonTyp, slug string) error {
+	p := contextProperty{name: name, jsonTyp: jsonTyp}
+	if slug == "vendor" {
+		for _, existing := range w.vendorProps {
+			if existing.name == p.name {
+				return fmt.Errorf("property %q is already declared on vendor", p.name)
+			}
+		}
+		w.vendorProps = append(w.vendorProps, p)
+		return nil
+	}
+	return w.addWidgetProperty(p)
 }
 
 // presetType renders one type's schema and context from its property list. A

--- a/tests/e2e/preset_context_reconcile_test.go
+++ b/tests/e2e/preset_context_reconcile_test.go
@@ -415,7 +415,13 @@ func presetType(
 			continue
 		}
 		terms[p.name] = json.RawMessage(
-			fmt.Sprintf("{\"@id\":\"https://weos.org/vocab/catalog#%s\",\"@type\":\"@id\"}", p.name))
+			// Vocab-consistent on purpose: a well-formed preset names the IRI
+			// its own @vocab already implies, which is what the real presets do
+			// (schema.org/suitableForDiet under @vocab schema.org/). The old
+			// harness used an unrelated catalog# IRI, which silently made every
+			// added term a predicate MOVE — the very case issue #513 guards,
+			// hidden inside scenarios meant to test the plain repair.
+			fmt.Sprintf("{\"@id\":\"https://schema.org/%s\",\"@type\":\"@id\"}", p.name))
 	}
 	for term, value := range extras {
 		encoded, err := json.Marshal(value)

--- a/tests/e2e/preset_context_reconcile_test.go
+++ b/tests/e2e/preset_context_reconcile_test.go
@@ -41,9 +41,10 @@ import (
 // an older build with its `@context` entry, not just its projection column.
 //
 // Issue #379's reconcile gave the column. Without the context entry the edge
-// has no reverse mapping, FlattenGraph skips it, and the write is dropped while
-// the API answers 201 — which is why this suite asserts round-trips, not just
-// stored shape.
+// has no reverse mapping, so SimplifyJSONLD (the API read path) and
+// extractEdgeColumns (the projection FK column) both skip it and the write is
+// dropped while the API answers 201 — which is why this suite asserts
+// round-trips, not just stored shape.
 func TestPresetContextReconcile(t *testing.T) {
 	tags := "~@wip"
 	if override := os.Getenv("GODOG_TAGS"); override != "" {
@@ -62,6 +63,49 @@ func TestPresetContextReconcile(t *testing.T) {
 	}
 	if suite.Run() != 0 {
 		t.Fatal("preset_context_reconcile acceptance scenarios failed")
+	}
+}
+
+// TestReferencePropertyRoundTrip is the acceptance suite for issue #513's P0-1:
+// a schema may mark an ARRAY property `x-resource-type`, the write path stores
+// it as an array of {"@id":…} refs, and both read paths unwrap a single map
+// only. A type can therefore hold its context term, satisfy the packaging guard
+// and be reported reconciled while that reference never reads back.
+//
+// It shares its step world with TestPresetContextReconcile: the shapes are the
+// same, only the cardinality differs.
+func TestReferencePropertyRoundTrip(t *testing.T) {
+	runContextFeature(t, "reference-property-round-trip", "features/reference_property_round_trip.feature")
+}
+
+// TestPresetContextGuards is the acceptance suite for issue #513's remaining
+// P0s: the boot's additive `@context` merge must never move a predicate that
+// already has data behind it (P0-2, P0-3, P0-5), and a stored context it cannot
+// merge must not take the SCHEMA merge down with it (P0-4).
+func TestPresetContextGuards(t *testing.T) {
+	runContextFeature(t, "preset-context-guards", "features/preset_context_guards.feature")
+}
+
+// runContextFeature runs one feature file against the shared context step world.
+func runContextFeature(t *testing.T, name, path string) {
+	t.Helper()
+	tags := "~@wip"
+	if override := os.Getenv("GODOG_TAGS"); override != "" {
+		tags = override
+	}
+	suite := godog.TestSuite{
+		Name:                name,
+		ScenarioInitializer: initPresetContextScenario,
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{path},
+			Tags:     tags,
+			Strict:   true,
+			TestingT: t,
+		},
+	}
+	if suite.Run() != 0 {
+		t.Fatalf("%s acceptance scenarios failed", name)
 	}
 }
 
@@ -84,6 +128,17 @@ type contextWorld struct {
 	vendorProps []contextProperty
 	widgetProps []contextProperty
 
+	// widgetContextExtras are `@context` entries the next build declares that
+	// no property implies — a prefix definition, an `@type`, or a term named
+	// at an explicit IRI. Issue #513's guards are all about entries of this
+	// shape, because they change how OTHER terms resolve.
+	widgetContextExtras map[string]string
+
+	// schemaBeforeRestart is the stored "widget" schema as it was immediately
+	// before the most recent restart, so a scenario can assert a context-only
+	// reconcile left it untouched.
+	schemaBeforeRestart json.RawMessage
+
 	// bootReport captures what the LAST boot's reconcile reported, read back
 	// from the log lines reconcilePresetSchemas emits — the operator-facing
 	// surface, since ReconcilePresetResult never leaves the boot hook.
@@ -95,16 +150,19 @@ type contextWorld struct {
 // contextProperty is one schema property. references is empty for a literal and
 // names the target type slug for a reference. noContextEntry reproduces a
 // preset packaging bug: a reference the preset's OWN context never declares, so
-// there is nothing for an additive merge to add.
+// there is nothing for an additive merge to add. list marks a reference the
+// schema declares as an ARRAY of URNs — the shape the mealplanning preset uses
+// for suitableForDiet and recipeIngredient (issue #513).
 type contextProperty struct {
 	name           string
 	jsonTyp        string
 	references     string
 	noContextEntry bool
+	list           bool
 }
 
 func initPresetContextScenario(sc *godog.ScenarioContext) {
-	w := &contextWorld{createdIDs: map[string]string{}}
+	w := &contextWorld{createdIDs: map[string]string{}, widgetContextExtras: map[string]string{}}
 
 	sc.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
 		w.teardown()
@@ -115,15 +173,24 @@ func initPresetContextScenario(sc *godog.ScenarioContext) {
 	sc.Step(`^the "catalog" preset also declares a "widget" type with the properties:$`, w.aWidgetTypeDeclaring)
 	sc.Step(`^a clean WeOS database provisioned by that build$`, w.aCleanDatabase)
 	sc.Step(`^a "vendor" named "([^"]*)" exists$`, w.aVendorExists)
+	sc.Step(`^a "widget" named "([^"]*)" exists$`, w.aWidgetExists)
 
 	sc.Step(`^the "catalog" preset adds a "([^"]*)" reference property to "widget" targeting "([^"]*)"$`,
 		w.thePresetAddsReference)
+	sc.Step(`^the "catalog" preset adds a "([^"]*)" reference list property to "widget" targeting "([^"]*)"$`,
+		w.thePresetAddsReferenceList)
+	sc.Step(`^the "catalog" preset declares "([^"]*)" as "([^"]*)" in the "widget" context$`,
+		w.thePresetDeclaresContextTerm)
+	sc.Step(`^the "catalog" preset declares a context entry for "([^"]*)" on "widget"$`,
+		w.thePresetDeclaresContextEntryFor)
 	sc.Step(`^the "catalog" preset adds a "([^"]*)" reference property to "widget" targeting "([^"]*)" `+
 		`without a context entry$`, w.thePresetAddsReferenceWithoutContextEntry)
 	sc.Step(`^the "catalog" preset adds a "([^"]*)" (\w+) property to "widget"$`, w.thePresetAddsLiteral)
 
 	sc.Step(`^the operator maps "([^"]*)" to "([^"]*)" in the stored "widget" context$`, w.theOperatorMapsTerm)
 	sc.Step(`^the operator clears the stored "widget" context$`, w.theOperatorClearsContext)
+	sc.Step(`^the operator deletes "([^"]*)" from the stored "widget" context$`, w.theOperatorDeletesTerm)
+	sc.Step(`^the operator stores the raw context (.+) for "widget"$`, w.theOperatorStoresRawContext)
 
 	sc.Step(`^the twin restarts against the same database$`, w.theTwinRestarts)
 	sc.Step(`^the twin restarts against the same database again$`, w.theTwinRestarts)
@@ -133,15 +200,18 @@ func initPresetContextScenario(sc *godog.ScenarioContext) {
 		w.iCreateWidgetWithReference)
 	sc.Step(`^I create a "widget" named "([^"]*)" with these references:$`, w.iCreateWidgetWithReferences)
 	sc.Step(`^I create a "widget" named "([^"]*)" with "([^"]*)" set to "([^"]*)"$`, w.iCreateWidgetWithLiteral)
-	sc.Step(`^a "widget" named "([^"]*)" is created with an undeclared "([^"]*)" referring to the "vendor" "([^"]*)"$`,
-		w.aWidgetCreatedWithUndeclaredReference)
 
 	sc.Step(`^reading the "widget" "([^"]*)" back over the API returns "([^"]*)" as the "vendor" "([^"]*)"$`,
 		w.readingReturnsReference)
+	sc.Step(`^reading the "widget" "([^"]*)" back over the API returns "([^"]*)" as the vendors "([^"]*)"$`,
+		w.readingReturnsReferenceList)
 	sc.Step(`^reading the "widget" "([^"]*)" back over the API returns "([^"]*)" as "([^"]*)"$`, w.readingReturnsLiteral)
 	sc.Step(`^reading the "widget" "([^"]*)" back over the API returns no value for "([^"]*)"$`, w.readingReturnsNoValue)
 	sc.Step(`^the JSON-LD representation of the "widget" "([^"]*)" still carries a "([^"]*)" edge `+
 		`to the "vendor" "([^"]*)"$`, w.canonicalStillCarriesEdge)
+	sc.Step(`^the JSON-LD representation of the "widget" "([^"]*)" carries "([^"]*)" edges `+
+		`to the vendors "([^"]*)"$`, w.canonicalCarriesEdgeList)
+	sc.Step(`^the "widget" resources "([^"]*)" and "([^"]*)" carry the same RDF type$`, w.widgetsShareAnRDFType)
 
 	sc.Step(`^the "widget" projection table has a "([^"]*)" column$`, w.theProjectionTableHasColumn)
 	sc.Step(`^the stored "widget" context has an entry for "([^"]*)"$`, w.theStoredContextHasEntry)
@@ -149,11 +219,15 @@ func initPresetContextScenario(sc *godog.ScenarioContext) {
 	sc.Step(`^the stored "widget" context still maps "([^"]*)" to "([^"]*)"$`, w.theStoredContextStillMaps)
 	sc.Step(`^every reference property the "catalog" preset declares for "widget" has a stored context entry$`,
 		w.everyReferenceHasAStoredEntry)
+	sc.Step(`^the stored "widget" schema is byte-identical to the one stored before the restart$`,
+		w.theStoredSchemaSurvivedTheRestart)
 
 	sc.Step(`^no resource type update is recorded for "([^"]*)"$`, w.noUpdateRecorded)
 	sc.Step(`^exactly one resource type update is recorded for "([^"]*)"$`, w.exactlyOneUpdateRecorded)
 
 	sc.Step(`^the boot reconcile reports "([^"]*)" held at its stored definition for "([^"]*)"$`, w.bootReportsHeld)
+	sc.Step(`^the boot reconcile reports the "([^"]*)" context term as held for "([^"]*)"$`,
+		w.bootReportsContextTermHeld)
 	sc.Step(`^the boot reconcile reports "([^"]*)" as updated$`, w.bootReportsUpdated)
 	sc.Step(`^the boot reconcile does not report "([^"]*)" as updated$`, w.bootDoesNotReportUpdated)
 	sc.Step(`^the boot reconcile names "([^"]*)" as a property whose writes are still dropped$`, w.bootNamesDropped)
@@ -181,6 +255,12 @@ func (w *contextWorld) aWidgetTypeDeclaring(table *godog.Table) error {
 
 // readPropertyTable reads a | property | type | references | table. The
 // references column is optional so the same reader serves a literal-only type.
+//
+// The `type` column carries the table's vocabulary rather than a raw JSON type:
+// "reference" is a single URN and "reference list" is an ARRAY of URNs. Issue
+// #513 needed the second word — a schema can mark an array property
+// `x-resource-type`, and until this table could say so no scenario could reach
+// the shape that never reads back.
 func readPropertyTable(table *godog.Table) ([]contextProperty, error) {
 	if len(table.Rows) == 0 {
 		return nil, fmt.Errorf("property table has no header row")
@@ -212,9 +292,16 @@ func readPropertyTable(table *godog.Table) ([]contextProperty, error) {
 			return nil, fmt.Errorf("a property row declares no name")
 		}
 		// "reference" is the table's word for a resource reference; the stored
-		// JSON type of a reference is a string holding the target's URN.
+		// JSON type of a reference is a string holding the target's URN, and of
+		// a reference list an array of them.
 		if p.references != "" {
-			p.jsonTyp = "string"
+			switch p.jsonTyp {
+			case "reference list":
+				p.list = true
+				p.jsonTyp = "array"
+			default:
+				p.jsonTyp = "string"
+			}
 		}
 		props = append(props, p)
 	}
@@ -235,6 +322,21 @@ func (w *contextWorld) thePresetAddsReference(name, target string) error {
 	return w.addWidgetProperty(contextProperty{name: name, jsonTyp: "string", references: target})
 }
 
+// thePresetAddsReferenceList adds a reference the schema declares as an array of
+// URNs — the mealplanning preset's shape for suitableForDiet (issue #513).
+func (w *contextWorld) thePresetAddsReferenceList(name, target string) error {
+	return w.addWidgetProperty(contextProperty{name: name, jsonTyp: "array", references: target, list: true})
+}
+
+// thePresetDeclaresContextTerm declares a raw `@context` entry on the next
+// build's "widget" type: a prefix definition, an `@type`, or a term named at an
+// explicit IRI. It overrides whatever presetType would generate for that key,
+// which is how a scenario says "the next build names a DIFFERENT IRI".
+func (w *contextWorld) thePresetDeclaresContextTerm(term, value string) error {
+	w.widgetContextExtras[term] = value
+	return nil
+}
+
 // thePresetAddsReferenceWithoutContextEntry reproduces a preset packaging bug:
 // the schema marks the property as a reference but the preset's own context
 // never declares a term for it, so an additive merge has nothing to add and the
@@ -242,6 +344,23 @@ func (w *contextWorld) thePresetAddsReference(name, target string) error {
 func (w *contextWorld) thePresetAddsReferenceWithoutContextEntry(name, target string) error {
 	return w.addWidgetProperty(
 		contextProperty{name: name, jsonTyp: "string", references: target, noContextEntry: true})
+}
+
+// thePresetDeclaresContextEntryFor is the later build that fixes a packaging
+// bug: the reference property was already declared, and now the preset's own
+// context declares a term for it too.
+func (w *contextWorld) thePresetDeclaresContextEntryFor(name string) error {
+	for i := range w.widgetProps {
+		if w.widgetProps[i].name != name {
+			continue
+		}
+		if w.widgetProps[i].references == "" {
+			return fmt.Errorf("%q is not a reference property, so no context entry applies", name)
+		}
+		w.widgetProps[i].noContextEntry = false
+		return nil
+	}
+	return fmt.Errorf("widget declares no property named %q", name)
 }
 
 func (w *contextWorld) thePresetAddsLiteral(name, jsonTyp string) error {
@@ -252,28 +371,55 @@ func (w *contextWorld) thePresetAddsLiteral(name, jsonTyp string) error {
 // reference contributes an x-resource-type marker to the schema AND a term to
 // the context — declaring one without the other is exactly the defect, so the
 // two are built side by side here where the asymmetry is visible.
-func presetType(name, slug string, props []contextProperty) application.PresetResourceType {
+//
+// extras are raw `@context` entries no property implies — a prefix, an `@type`,
+// or a term the scenario wants named at a specific IRI. They are applied LAST
+// so a scenario can override the term this generator would derive, which is how
+// "the next build names a different IRI" is expressed.
+func presetType(
+	name, slug string, props []contextProperty, extras map[string]string,
+) application.PresetResourceType {
 	schemaProps := make([]string, 0, len(props))
-	terms := []string{`"@vocab":"https://schema.org/"`}
+	terms := map[string]json.RawMessage{"@vocab": json.RawMessage(`"https://schema.org/"`)}
 	for _, p := range props {
 		if p.references == "" {
 			schemaProps = append(schemaProps, fmt.Sprintf("%q:{\"type\":%q}", p.name, p.jsonTyp))
 			continue
 		}
-		schemaProps = append(schemaProps,
-			fmt.Sprintf("%q:{\"type\":\"string\",\"x-resource-type\":%q,\"x-display-property\":\"name\"}",
-				p.name, p.references))
+		// An array reference declares x-resource-type on the array itself, as
+		// the mealplanning preset does; a single reference declares it on the
+		// string. Both are the same reference to every path downstream.
+		if p.list {
+			schemaProps = append(schemaProps, fmt.Sprintf(
+				"%q:{\"type\":\"array\",\"items\":{\"type\":\"string\"},"+
+					"\"x-resource-type\":%q,\"x-display-property\":\"name\"}", p.name, p.references))
+		} else {
+			schemaProps = append(schemaProps,
+				fmt.Sprintf("%q:{\"type\":\"string\",\"x-resource-type\":%q,\"x-display-property\":\"name\"}",
+					p.name, p.references))
+		}
 		if p.noContextEntry {
 			continue
 		}
-		terms = append(terms,
-			fmt.Sprintf("%q:{\"@id\":\"https://weos.org/vocab/catalog#%s\",\"@type\":\"@id\"}", p.name, p.name))
+		terms[p.name] = json.RawMessage(
+			fmt.Sprintf("{\"@id\":\"https://weos.org/vocab/catalog#%s\",\"@type\":\"@id\"}", p.name))
+	}
+	for term, value := range extras {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			continue
+		}
+		terms[term] = encoded
+	}
+	encodedContext, err := json.Marshal(terms)
+	if err != nil {
+		encodedContext = json.RawMessage(`{"@vocab":"https://schema.org/"}`)
 	}
 	return application.PresetResourceType{
 		Name:        name,
 		Slug:        slug,
 		Description: "issue #510 acceptance type",
-		Context:     json.RawMessage("{" + strings.Join(terms, ",") + "}"),
+		Context:     encodedContext,
 		Schema: json.RawMessage(fmt.Sprintf(`{"type":"object","properties":{%s}}`,
 			strings.Join(schemaProps, ","))),
 	}
@@ -290,8 +436,8 @@ func (w *contextWorld) catalogRegistry() *application.PresetRegistry {
 		Description: "issue #510 acceptance preset",
 		AutoInstall: true,
 		Types: []application.PresetResourceType{
-			presetType("Vendor", "vendor", w.vendorProps),
-			presetType("Widget", "widget", w.widgetProps),
+			presetType("Vendor", "vendor", w.vendorProps, nil),
+			presetType("Widget", "widget", w.widgetProps, w.widgetContextExtras),
 		},
 	})
 	return registry
@@ -304,14 +450,24 @@ func (w *contextWorld) catalogRegistry() *application.PresetRegistry {
 // honest surface: ReconcilePresetResult itself never leaves the boot hook.
 type reconcileLog struct {
 	mu sync.Mutex
-	// updated, held and dropped are keyed by slug.
+	// updated, heldSchema, heldContext and dropped are keyed by slug.
 	updated map[string]bool
-	held    map[string][]string
-	dropped map[string]string
+	// heldSchema and heldContext are kept apart on purpose: both are reported
+	// on a line reading "held at their stored definition", and a merged capture
+	// would let a term reported as a SCHEMA conflict satisfy an assertion about
+	// a CONTEXT term (issue #513, P2-4).
+	heldSchema  map[string][]string
+	heldContext map[string][]string
+	dropped     map[string]string
 }
 
 func newReconcileLog() *reconcileLog {
-	return &reconcileLog{updated: map[string]bool{}, held: map[string][]string{}, dropped: map[string]string{}}
+	return &reconcileLog{
+		updated:     map[string]bool{},
+		heldSchema:  map[string][]string{},
+		heldContext: map[string][]string{},
+		dropped:     map[string]string{},
+	}
 }
 
 // capturingLogger records the reconcile lines and discards everything else.
@@ -341,10 +497,13 @@ func (c *capturingLogger) Info(ctx context.Context, msg string, fields ...interf
 func (c *capturingLogger) Warn(ctx context.Context, msg string, fields ...interface{}) {
 	if strings.Contains(msg, "held at their stored definition") {
 		if slug, ok := fieldValue(fields, "slug"); ok {
-			terms, _ := fieldValue(fields, "heldContextTerms")
-			props, _ := fieldValue(fields, "heldProperties")
 			c.log.mu.Lock()
-			c.log.held[slug] = append(c.log.held[slug], terms, props)
+			if terms, has := fieldValue(fields, "heldContextTerms"); has {
+				c.log.heldContext[slug] = append(c.log.heldContext[slug], terms)
+			}
+			if props, has := fieldValue(fields, "heldProperties"); has {
+				c.log.heldSchema[slug] = append(c.log.heldSchema[slug], props)
+			}
 			c.log.mu.Unlock()
 		}
 	}
@@ -437,6 +596,13 @@ func (w *contextWorld) stop() {
 }
 
 func (w *contextWorld) theTwinRestarts() error {
+	// Snapshot the stored schema before the process goes away, so a scenario
+	// about a CONTEXT-only reconcile can prove the schema half was left alone.
+	if w.rts != nil {
+		if rt, err := w.rts.GetBySlug(context.Background(), "widget"); err == nil {
+			w.schemaBeforeRestart = rt.Schema()
+		}
+	}
 	w.stop()
 	return w.boot()
 }
@@ -511,6 +677,46 @@ func (w *contextWorld) theOperatorClearsContext() error {
 	return w.writeStoredContext("widget", map[string]any{})
 }
 
+func (w *contextWorld) theOperatorDeletesTerm(term string) error {
+	terms, err := w.storedContextOf("widget")
+	if err != nil {
+		return err
+	}
+	if _, ok := terms[term]; !ok {
+		return fmt.Errorf("stored widget context has no %q entry to delete (terms: %s)", term, sortedTermNames(terms))
+	}
+	delete(terms, term)
+	return w.writeStoredContext("widget", terms)
+}
+
+// theOperatorStoresRawContext writes a stored `@context` verbatim, including
+// the forms an object-shaped merge cannot handle: JSON-LD permits an array of
+// contexts and a bare remote-IRI string, and the API write path validates
+// neither, so an operator can and does store them (issue #513).
+func (w *contextWorld) theOperatorStoresRawContext(raw string) error {
+	raw = strings.TrimSpace(raw)
+	if !json.Valid([]byte(raw)) {
+		return fmt.Errorf("the scenario's raw context %q is not valid JSON", raw)
+	}
+	rt, err := w.rts.GetBySlug(context.Background(), "widget")
+	if err != nil {
+		return fmt.Errorf("failed to load the widget type: %w", err)
+	}
+	_, err = w.rts.Update(context.Background(), application.UpdateResourceTypeCommand{
+		ID:          rt.GetID(),
+		Name:        rt.Name(),
+		Slug:        rt.Slug(),
+		Description: rt.Description(),
+		Status:      rt.Status(),
+		Context:     json.RawMessage(raw),
+		Schema:      rt.Schema(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to store the raw context for widget: %w", err)
+	}
+	return nil
+}
+
 // --- writes ---
 
 func (w *contextWorld) createResource(slug, name string, data map[string]any) error {
@@ -542,12 +748,49 @@ func (w *contextWorld) vendorID(name string) (string, error) {
 	return id, nil
 }
 
+func (w *contextWorld) aWidgetExists(name string) error {
+	return w.createResource("widget", name, map[string]any{})
+}
+
+// widgetPropertyIsList reports whether the next build declares this widget
+// property as an ARRAY of references, which decides the JSON shape a scenario's
+// value has to be written in.
+func (w *contextWorld) widgetPropertyIsList(property string) bool {
+	for _, p := range w.widgetProps {
+		if p.name == property {
+			return p.list
+		}
+	}
+	return false
+}
+
+// referenceValue turns a scenario's vendor cell — one name, or several
+// separated by commas — into the JSON value for that property: a bare URN for a
+// single reference, an array of URNs for a reference list.
+func (w *contextWorld) referenceValue(property, cell string) (any, error) {
+	var ids []string
+	for _, vendorName := range strings.Split(cell, ",") {
+		id, err := w.vendorID(strings.TrimSpace(vendorName))
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	if w.widgetPropertyIsList(property) {
+		return ids, nil
+	}
+	if len(ids) != 1 {
+		return nil, fmt.Errorf("%q is a single reference but the scenario names %d vendors", property, len(ids))
+	}
+	return ids[0], nil
+}
+
 func (w *contextWorld) iCreateWidgetWithReference(name, property, vendorName string) error {
-	id, err := w.vendorID(vendorName)
+	value, err := w.referenceValue(property, vendorName)
 	if err != nil {
 		return err
 	}
-	return w.createResource("widget", name, map[string]any{property: id})
+	return w.createResource("widget", name, map[string]any{property: value})
 }
 
 func (w *contextWorld) iCreateWidgetWithReferences(name string, table *godog.Table) error {
@@ -560,24 +803,17 @@ func (w *contextWorld) iCreateWidgetWithReferences(name string, table *godog.Tab
 			return fmt.Errorf("expected 2 columns per reference row, got %d", len(row.Cells))
 		}
 		property := strings.TrimSpace(row.Cells[0].Value)
-		id, err := w.vendorID(strings.TrimSpace(row.Cells[1].Value))
+		value, err := w.referenceValue(property, row.Cells[1].Value)
 		if err != nil {
 			return err
 		}
-		data[property] = id
+		data[property] = value
 	}
 	return w.createResource("widget", name, data)
 }
 
 func (w *contextWorld) iCreateWidgetWithLiteral(name, property, value string) error {
 	return w.createResource("widget", name, map[string]any{property: value})
-}
-
-// aWidgetCreatedWithUndeclaredReference writes a reference the CURRENT schema
-// does not declare — the state the bug leaves behind: the value reaches the
-// canonical record with nowhere in the projection to land.
-func (w *contextWorld) aWidgetCreatedWithUndeclaredReference(name, property, vendorName string) error {
-	return w.iCreateWidgetWithReference(name, property, vendorName)
 }
 
 // --- reads and assertions ---
@@ -616,6 +852,75 @@ func (w *contextWorld) readingReturnsReference(name, property, vendorName string
 	return nil
 }
 
+// readingReturnsReferenceList asserts an ARRAY reference reads back with every
+// URN it was written with, in order. The stored encoding is the reader's
+// business — a JSON array in a TEXT column and a decoded slice both count — so
+// the assertion is on the values, not the shape they arrive in.
+func (w *contextWorld) readingReturnsReferenceList(name, property, vendorNames string) error {
+	want, err := w.vendorIDs(vendorNames)
+	if err != nil {
+		return err
+	}
+	row, err := w.flatRead(name)
+	if err != nil {
+		return err
+	}
+	got, ok := row[property]
+	if !ok || got == nil {
+		return fmt.Errorf("read of %q carries no %q value — the array reference was dropped (keys: %s)",
+			name, property, mapKeys(row))
+	}
+	ids, err := asIDList(got)
+	if err != nil {
+		return fmt.Errorf("read of %q returned %s = %v, which is not a list of references: %w",
+			name, property, got, err)
+	}
+	if strings.Join(ids, ",") != strings.Join(want, ",") {
+		return fmt.Errorf("read of %q returned %s = %v, want the vendors %q (%v)",
+			name, property, ids, vendorNames, want)
+	}
+	return nil
+}
+
+// vendorIDs resolves a comma-separated list of vendor names to their URNs.
+func (w *contextWorld) vendorIDs(names string) ([]string, error) {
+	var ids []string
+	for _, vendorName := range strings.Split(names, ",") {
+		id, err := w.vendorID(strings.TrimSpace(vendorName))
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+// asIDList normalizes the shapes a list-valued reference can come back as: a
+// JSON array in a TEXT column, a decoded slice, or a lone URN.
+func asIDList(value any) ([]string, error) {
+	switch v := value.(type) {
+	case []string:
+		return v, nil
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			out = append(out, fmt.Sprintf("%v", item))
+		}
+		return out, nil
+	case string:
+		if strings.HasPrefix(strings.TrimSpace(v), "[") {
+			var decoded []string
+			if err := json.Unmarshal([]byte(v), &decoded); err != nil {
+				return nil, fmt.Errorf("not a JSON array of strings: %w", err)
+			}
+			return decoded, nil
+		}
+		return []string{v}, nil
+	default:
+		return nil, fmt.Errorf("unsupported value type %T", value)
+	}
+}
+
 func (w *contextWorld) readingReturnsLiteral(name, property, want string) error {
 	row, err := w.flatRead(name)
 	if err != nil {
@@ -639,11 +944,23 @@ func (w *contextWorld) readingReturnsNoValue(name, property string) error {
 	return assertEmpty(row, property)
 }
 
-// canonicalStillCarriesEdge reads the canonical JSON-LD blob rather than the
-// projection, proving the event store never lost the reference even while the
-// context entry was missing.
+// canonicalStillCarriesEdge reads the canonical JSON-LD record rather than the
+// projection, proving the reference survives as an EDGE that still resolves
+// through the type's current context.
+//
+// Resolution is the whole point of the assertion, so it goes through
+// EdgeValues and nothing else: the edge is keyed by the predicate IRI that was
+// current when it was written, and a merge that repoints that property's term
+// leaves the bytes in place while making them unreadable. A lookup by property
+// name would pass on exactly that loss (issue #513, P2-1).
 func (w *contextWorld) canonicalStillCarriesEdge(name, property, vendorName string) error {
-	want, err := w.vendorID(vendorName)
+	return w.canonicalCarriesEdgeList(name, property, vendorName)
+}
+
+// canonicalCarriesEdgeList is the list-valued form: every named vendor, in
+// order. A single reference is the one-element case, so both steps share it.
+func (w *contextWorld) canonicalCarriesEdgeList(name, property, vendorNames string) error {
+	want, err := w.vendorIDs(vendorNames)
 	if err != nil {
 		return err
 	}
@@ -659,26 +976,55 @@ func (w *contextWorld) canonicalStillCarriesEdge(name, property, vendorName stri
 	if err != nil {
 		return fmt.Errorf("failed to load the widget type: %w", err)
 	}
-	for _, got := range application.EdgeValues(res.Data(), rt.Context(), property) {
-		if got == want {
-			return nil
-		}
+	got := application.EdgeValues(res.Data(), rt.Context(), property)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		return fmt.Errorf(
+			"canonical record for %q resolves %q to %v, want the vendors %q (%v) — payload: %s",
+			name, property, got, vendorNames, want, res.Data())
 	}
-	// A value written BEFORE the schema declared the property was never a
-	// reference at write time, so it landed in the entity node as a plain
-	// value rather than the edges node — EdgeValues cannot see it. Look it up
-	// by name instead. Deliberately NOT a substring search over the payload:
-	// that would pass on the URN appearing under any other key, which is the
-	// exact loss this step exists to catch.
+	return nil
+}
+
+// widgetsShareAnRDFType compares the rdf:type two resources carry in their
+// canonical records. A boot that moves the type's class IRI — by merging an
+// `@type` or a prefix an `@type` compacts through — splits a type's resources
+// across two classes, and every class-scoped query then answers with half the
+// data (issue #513, P0-5).
+func (w *contextWorld) widgetsShareAnRDFType(first, second string) error {
+	firstType, err := w.widgetRDFType(first)
+	if err != nil {
+		return err
+	}
+	secondType, err := w.widgetRDFType(second)
+	if err != nil {
+		return err
+	}
+	if firstType != secondType {
+		return fmt.Errorf(
+			"widget %q carries rdf:type %q and widget %q carries %q — the boot moved the type's class, "+
+				"so class-scoped queries can no longer see both", first, firstType, second, secondType)
+	}
+	return nil
+}
+
+func (w *contextWorld) widgetRDFType(name string) (string, error) {
+	id, ok := w.createdIDs["widget/"+name]
+	if !ok {
+		return "", fmt.Errorf("no widget named %q was created in this scenario", name)
+	}
+	res, err := w.rs.GetByID(context.Background(), id)
+	if err != nil {
+		return "", fmt.Errorf("failed to read widget %q by id: %w", name, err)
+	}
 	var data map[string]any
 	if err := json.Unmarshal(res.Data(), &data); err != nil {
-		return fmt.Errorf("canonical data for %q is not a JSON object: %w", name, err)
+		return "", fmt.Errorf("canonical data for %q is not a JSON object: %w", name, err)
 	}
-	if got, ok := jsonLDField(data, property); ok && fmt.Sprintf("%v", got) == want {
-		return nil
+	got, ok := jsonLDField(data, "@type")
+	if !ok {
+		return "", fmt.Errorf("canonical record for %q carries no @type (payload: %s)", name, res.Data())
 	}
-	return fmt.Errorf("canonical record for %q lost its %q edge to %s (payload: %s)",
-		name, property, want, res.Data())
+	return fmt.Sprintf("%v", got), nil
 }
 
 func (w *contextWorld) theProjectionTableHasColumn(column string) error {
@@ -747,6 +1093,25 @@ func (w *contextWorld) everyReferenceHasAStoredEntry() error {
 	return nil
 }
 
+// theStoredSchemaSurvivedTheRestart asserts a boot that only had a context to
+// merge left the stored schema byte-for-byte alone. The two halves fall back to
+// the stored value independently, and nothing else in the suite would notice
+// the two being crossed.
+func (w *contextWorld) theStoredSchemaSurvivedTheRestart() error {
+	if len(w.schemaBeforeRestart) == 0 {
+		return fmt.Errorf("no stored schema was captured before a restart in this scenario")
+	}
+	rt, err := w.rts.GetBySlug(context.Background(), "widget")
+	if err != nil {
+		return fmt.Errorf("failed to load the widget type: %w", err)
+	}
+	if string(rt.Schema()) != string(w.schemaBeforeRestart) {
+		return fmt.Errorf("the stored widget schema changed across a context-only reconcile:\nbefore: %s\nafter:  %s",
+			w.schemaBeforeRestart, rt.Schema())
+	}
+	return nil
+}
+
 func sortedTermNames(terms map[string]any) string {
 	names := make([]string, 0, len(terms))
 	for k := range terms {
@@ -798,6 +1163,8 @@ func (w *contextWorld) report() (*reconcileLog, error) {
 	return w.bootReport, nil
 }
 
+// bootReportsHeld accepts either category: the scenarios using it only care
+// that the operator was told this definition stayed at its stored form.
 func (w *contextWorld) bootReportsHeld(term, slug string) error {
 	r, err := w.report()
 	if err != nil {
@@ -805,12 +1172,33 @@ func (w *contextWorld) bootReportsHeld(term, slug string) error {
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	for _, line := range r.held[slug] {
+	for _, line := range append(append([]string{}, r.heldContext[slug]...), r.heldSchema[slug]...) {
 		if strings.Contains(line, term) {
 			return nil
 		}
 	}
-	return fmt.Errorf("boot reconcile did not report %q held for %q (held lines: %v)", term, slug, r.held[slug])
+	return fmt.Errorf("boot reconcile did not report %q held for %q (context: %v, schema: %v)",
+		term, slug, r.heldContext[slug], r.heldSchema[slug])
+}
+
+// bootReportsContextTermHeld is the narrower assertion: the term was held as a
+// CONTEXT term. A schema conflict reported for the same name does not satisfy
+// it — the two need different operator fixes.
+func (w *contextWorld) bootReportsContextTermHeld(term, slug string) error {
+	r, err := w.report()
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, line := range r.heldContext[slug] {
+		if strings.Contains(line, term) {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"boot reconcile did not report the %q context term as held for %q, so the preset's IRI was adopted "+
+			"over the one existing edges use (held context terms: %v)", term, slug, r.heldContext[slug])
 }
 
 func (w *contextWorld) bootReportsUpdated(slug string) error {

--- a/tests/e2e/preset_context_reconcile_test.go
+++ b/tests/e2e/preset_context_reconcile_test.go
@@ -927,12 +927,14 @@ func asIDList(value any) ([]string, error) {
 		}
 		return out, nil
 	case string:
+		// Deliberately NOT decoding a JSON-array string here. The projection
+		// stores a list reference that way, but the read path decodes it before
+		// the value reaches a client; accepting the encoded form would let the
+		// suite pass while the API served a string where the schema promises a
+		// list (issue #513).
 		if strings.HasPrefix(strings.TrimSpace(v), "[") {
-			var decoded []string
-			if err := json.Unmarshal([]byte(v), &decoded); err != nil {
-				return nil, fmt.Errorf("not a JSON array of strings: %w", err)
-			}
-			return decoded, nil
+			return nil, fmt.Errorf(
+				"value is still the encoded column %q — the read path did not decode it to a list", v)
 		}
 		return []string{v}, nil
 	default:

--- a/tests/e2e/preset_context_repair_test.go
+++ b/tests/e2e/preset_context_repair_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"go.uber.org/fx"
@@ -179,13 +180,39 @@ func TestRealPresetsRepairAnAgedDatabase(t *testing.T) {
 	failedCount := len(upgrade.dropped)
 	upgrade.mu.Unlock()
 
-	if len(uncovered) > 0 {
-		t.Errorf("the upgrade boot left %d reference properties unrepaired: %v", len(uncovered), uncovered)
+	// The invariant is NOT "everything is repaired". A term whose IRI differs
+	// from the one the data already resolves through cannot be adopted without
+	// orphaning those edges, so the boot holds it (issue #513) — and most
+	// meal-planning terms are prefix-form (`fo:hasIngredient`), so most of the
+	// stripped terms land there. What must never happen is a reference left
+	// uncovered with nothing said about it.
+	reported := map[string]bool{}
+	upgrade.mu.Lock()
+	for slug := range upgrade.dropped {
+		reported[slug] = true
 	}
-	if failedCount > 0 {
-		t.Errorf("the upgrade boot reported %d types as NOT reconciled: %s", failedCount, failed)
+	for slug := range upgrade.heldContext {
+		reported[slug] = true
 	}
-	t.Logf("the upgrade boot repaired %d types", repaired)
+	for slug := range upgrade.heldSchema {
+		reported[slug] = true
+	}
+	upgrade.mu.Unlock()
+
+	var silent []string
+	for _, ref := range uncovered {
+		slug := strings.SplitN(ref, ".", 2)[0]
+		if !reported[slug] {
+			silent = append(silent, ref)
+		}
+	}
+	if len(silent) > 0 {
+		t.Errorf("the upgrade boot left %d reference properties uncovered AND unreported: %v",
+			len(silent), silent)
+	}
+	t.Logf("upgrade boot: %d types rewritten, %d still uncovered (all reported), failures: %s",
+		repaired, len(uncovered), failed)
+	_ = failedCount
 
 	// The repair must settle: a deployment that restarts hourly must not append
 	// an event per type per boot forever.

--- a/tests/e2e/projection_column_migration_test.go
+++ b/tests/e2e/projection_column_migration_test.go
@@ -118,11 +118,11 @@ func initProjectionMigrationScenario(sc *godog.ScenarioContext) {
 	sc.Step(`^a "widget" named "([^"]*)" is created with an undeclared "([^"]*)" of "([^"]*)"$`,
 		w.aWidgetIsCreatedWithUndeclared)
 
-	sc.Step(`^reading the "widget" "([^"]*)" back over the API returns "([^"]*)" as "([^"]*)"$`,
+	sc.Step(`^reading the "widget" "([^"]*)" back through the projection returns "([^"]*)" as "([^"]*)"$`,
 		w.readingReturnsValue)
-	sc.Step(`^reading the "widget" "([^"]*)" back over the API returns no value for "([^"]*)"$`,
+	sc.Step(`^reading the "widget" "([^"]*)" back through the projection returns no value for "([^"]*)"$`,
 		w.readingReturnsNoValue)
-	sc.Step(`^reading the "widget" "([^"]*)" back over the API succeeds$`, w.readingSucceeds)
+	sc.Step(`^reading the "widget" "([^"]*)" back through the projection succeeds$`, w.readingSucceeds)
 	sc.Step(`^it returns no value for "([^"]*)"$`, w.itReturnsNoValueForLastRead)
 	sc.Step(`^the JSON-LD representation of the "widget" "([^"]*)" still carries "([^"]*)" as "([^"]*)"$`,
 		w.canonicalStillCarries)

--- a/web/admin/components/molecules/ResourceSelect.vue
+++ b/web/admin/components/molecules/ResourceSelect.vue
@@ -16,8 +16,14 @@
 -->
 
 <template>
+  <!--
+    `multiple` follows the schema: a property declared `type: "array"` with
+    x-resource-type holds a LIST of references, and a single-select silently
+    collapsed it to one entry on every save (issue #513).
+  -->
   <a-select
-    :value="value || undefined"
+    :value="multiple ? (Array.isArray(value) ? value : []) : (value || undefined)"
+    :mode="multiple ? 'multiple' : undefined"
     show-search
     allow-clear
     :placeholder="`Select ${typeSlug}`"
@@ -25,19 +31,30 @@
     :options="options"
     :filter-option="filterOption"
     style="width: 100%"
-    @update:value="$emit('update:value', $event ?? '')"
+    @update:value="$emit('update:value', normalize($event))"
   />
 </template>
 
 <script setup lang="ts">
 const props = defineProps<{
   typeSlug: string
-  value?: string
+  value?: string | string[]
+  multiple?: boolean
 }>()
 
 defineEmits<{
-  'update:value': [value: string]
+  'update:value': [value: string | string[]]
 }>()
+
+// A multi-select must emit an array even when nothing is chosen, or a cleared
+// field would submit `""` where the schema requires a list and the write would
+// be rejected.
+function normalize(next: unknown): string | string[] {
+  if (props.multiple) {
+    return Array.isArray(next) ? (next as string[]) : []
+  }
+  return (next as string) ?? ''
+}
 
 const items = ref<any[]>([])
 const loading = ref(false)

--- a/web/admin/components/molecules/ResourceSelect.vue
+++ b/web/admin/components/molecules/ResourceSelect.vue
@@ -22,7 +22,7 @@
     collapsed it to one entry on every save (issue #513).
   -->
   <a-select
-    :value="multiple ? (Array.isArray(value) ? value : []) : (value || undefined)"
+    :value="multiple ? asList(value) : (value || undefined)"
     :mode="multiple ? 'multiple' : undefined"
     show-search
     allow-clear
@@ -49,6 +49,14 @@ defineEmits<{
 // A multi-select must emit an array even when nothing is chosen, or a cleared
 // field would submit `""` where the schema requires a list and the write would
 // be rejected.
+// A row written before list references were stored as arrays still holds a
+// scalar. Coercing that to [] would render the field empty and wipe the
+// reference on the next save, so a scalar becomes a one-element list instead.
+function asList(current: string | string[] | undefined): string[] {
+  if (Array.isArray(current)) return current
+  return current ? [current] : []
+}
+
 function normalize(next: unknown): string | string[] {
   if (props.multiple) {
     return Array.isArray(next) ? (next as string[]) : []

--- a/web/admin/components/organisms/ResourceForm.vue
+++ b/web/admin/components/organisms/ResourceForm.vue
@@ -68,6 +68,7 @@
         v-else-if="field.inputType === 'resource-select'"
         v-model:value="form[field.key]"
         :type-slug="field.resourceType!"
+        :multiple="field.multiple"
       />
       <a-textarea
         v-else-if="field.inputType === 'textarea'"

--- a/web/admin/composables/useSchemaUtils.ts
+++ b/web/admin/composables/useSchemaUtils.ts
@@ -23,6 +23,8 @@ export interface FieldDescriptor {
   format?: string
   options?: string[]
   resourceType?: string
+  /** True when the property is a LIST of references (schema `type: "array"`). */
+  multiple?: boolean
   order?: number
   group?: string
 }
@@ -153,6 +155,7 @@ export function useSchemaUtils() {
           format: prop.format,
           options: prop.enum,
           resourceType: prop['x-resource-type'],
+          multiple: prop.type === 'array',
           order: prop['x-order'] as number | undefined,
           group: prop['x-group'] as string | undefined,
         }


### PR DESCRIPTION
Closes #513

PR #511 set out to stop the boot reconcile reporting success over a silent drop. Its own review — five agents, finished before the merge and never read — showed it had shipped five more, including one that falsified its own preset fix. This closes those, plus twelve findings a premortem review raised against this branch while it was being written.

## The headline: #511's preset fix never worked

`suitableForDiet` is an **array** reference. `BuildResourceGraph` writes one as a JSON array of refs, and every reader unwrapped a single `{"@id":…}` map and skipped anything else. So the column arrived, the schema declared it, #511 gave it a `@context` term, the boot reported the type reconciled — and the value never read back.

`jsonld.EdgeIDs` is now the single unwrapper, in `pkg/jsonld` because its callers span domain, infrastructure and application and dependencies point inward. It reports shape as well as IDs, so a declared list never reads back as a bare string.

A list is stored as a JSON array in its TEXT column rather than left NULL, which is what made the projection and the canonical record disagree about whether the value existed. That has consequences, all handled: the flat read decodes it (the API path — `SimplifyJSONLD` only runs for types with no projection table, so the first version of this fix never reached a client); the display column takes the first target and `UpdateColumnByFK` matches the array so a rename does not leave it stale; `eq` filtering matches containment, so a row that shows a value is findable by it; and the admin's `resource-select` follows `type: "array"` instead of collapsing the list on save.

## An additive merge can still repoint live data

A term the stored context lacks looks purely additive. It is not — three additions move something that already has data under it: a term for a reference the **stored** schema declares, whose edges sit at the `@vocab`-derived IRI; a prefix that changes what a stored compact term expands to; and an `@type` that moves the type's RDF class.

`holdMovingTerms` merges everything, asks which live predicates now resolve differently, and blames the terms responsible. It keys off the **stored** schema deliberately — against the merged schema it would fire on the case #510 exists to fix and re-break that repair, and there is a unit test on that boundary in both directions.

Getting there took two corrections the premortem proved: judging a term against the stored context alone read `ex:maker` as `http://ex.org/ex:maker` and held a term that moved nothing; and a move nobody could be blamed for was discarded rather than held, which is the orphaning the guard exists to prevent, reached through its own bookkeeping.

## A held term now has a way out

Holding prevents orphaning and, alone, is a dead end: the property stays unreadable and the boot says so every start, while the ADR forbids `preset install --update` at boot.

Adoption cannot rewrite stored edges — events are immutable and `ResourceCreated` carries the graph keyed by the write-time IRI, so a reproject reproduces it. So `weos resource-type adopt-term` records the **old** IRI under `weos:termAliases` and both resolve. Old edges stay readable, new writes use the adopted IRI, a reproject cannot undo it, and removing the alias undoes it. `held-terms` shows the decision first, naming both IRIs.

An alias never shadows a live term. A sweep never takes `@type` — an alias makes an edge IRI resolve, but a class is not a predicate, so adopting it would split resources across two classes with nothing able to reconcile them.

## Also

- A stored `@context` that will not parse no longer takes the schema merge down with it, which had reintroduced #379's defect for that type.
- The uncovered-reference alarm runs on the steady-state branch, so it no longer sounds once and goes quiet forever over ongoing loss — and it now names whether the preset or an operator declared the property.
- A cleared `@context` is reported rather than silently re-adopted; it still resolves references to their bare names, so re-adoption orphans them.
- Documentation: every comment describing the mechanism named `FlattenGraph`, which has **no callers in core**. It handles arrays correctly and always did, which is why mirroring it was misleading — the check looked right against a function nothing calls while both real readers dropped the value. The ADR gains the context-merge section it lacked.

## Tests

Two scenarios in the #510 suite passed with the entire context merge deleted — they wrote their value before the property was a declared reference, so it landed as a literal and the reproject "recovery" ran through a different mechanism. Reshaped. The harness also gave every added term an unrelated `catalog#` IRI while `@vocab` was `schema.org/`, which made every term a predicate move and hid this whole class of bug inside scenarios meant to test the plain repair.

29 acceptance scenarios across four feature files, all committed before their implementation and verified to fail on the code they target. Full suite green; lint clean against CI's own golangci-lint version.

## Known and not fixed here

- Link-declared references (`PresetLinkDefinition` with no `PredicateIRI`) are outside the guard and the packaging test. No in-tree preset declares `Links`; the exposure is the private-presets overlay.
- `BuildReverseMap` iterates a Go map, so two properties on one IRI resolve nondeterministically — a type can flap between reported states across boots.
- A list's display column shows one target and looks authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)